### PR TITLE
8241533: [lworld] PhaseMacroExpand::migrate_outs should be replaced b…

### DIFF
--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -199,7 +199,6 @@ private:
   void expand_subtypecheck_node(SubTypeCheckNode *check);
 
   int replace_input(Node *use, Node *oldref, Node *newref);
-  void migrate_outs(Node *old, Node *target);
   Node* opt_bits_test(Node* ctrl, Node* region, int edge, Node* word, int mask, int bits, bool return_fast_path = false);
   void copy_predefined_input_for_runtime_call(Node * ctrl, CallNode* oldcall, CallNode* call);
   CallNode* make_slow_call(CallNode *oldcall, const TypeFunc* slow_call_type, address slow_call,

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1496,6 +1496,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
 }
 
 void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
+  assert(n != NULL, "sanity");
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* u = n->fast_out(i);
     if (u != n) {
@@ -1504,6 +1505,7 @@ void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
       --i, imax -= nb;
     }
   }
+  assert(n->outcnt() == 0, "all uses must be deleted");
 }
 
 //------------------------------add_users_to_worklist--------------------------


### PR DESCRIPTION
The fix for JDK-8237581 added PhaseMacroExpand::migrate_outs which can be replaced by PhaseIterGVN::replace_in_uses.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8241533](https://bugs.openjdk.java.net/browse/JDK-8241533): [lworld] PhaseMacroExpand::migrate_outs should be replaced by PhaseIterGVN::replace_in_uses


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/4/head:pull/4`
`$ git checkout pull/4`
