### PR TITLE
8236522: NonTearable marker interface for inline classes

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -73,6 +73,7 @@ class FieldLayoutInfo : public ResourceObj {
   int _nonstatic_field_size;
   int _static_field_size;
   bool  _has_nonstatic_fields;
+  bool  _is_naturally_atomic;
 };
 
 // Parser for for .class files
@@ -199,6 +200,8 @@ class ClassFileParser {
 
   bool _has_flattenable_fields;
   bool _is_empty_value;
+  bool _is_naturally_atomic;
+  bool _is_declared_atomic;
 
   // precomputed flags
   bool _has_finalizer;
@@ -246,6 +249,7 @@ class ClassFileParser {
                         const int itfs_len,
                         ConstantPool* const cp,
                         bool* has_nonstatic_concrete_methods,
+                        bool* is_declared_atomic,
                         TRAPS);
 
   const InstanceKlass* parse_super_class(ConstantPool* const cp,

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -539,7 +539,10 @@ FieldLayoutBuilder::FieldLayoutBuilder(const Symbol* classname, const InstanceKl
   _has_nonstatic_fields(false),
   _is_contended(is_contended),
   _is_value_type(is_value_type),
-  _has_flattening_information(is_value_type) {}
+  _has_flattening_information(is_value_type),
+  _has_nonatomic_values(false),
+  _atomic_field_count(0)
+ {}
 
 FieldGroup* FieldLayoutBuilder::get_or_create_contended_group(int g) {
   assert(g > 0, "must only be called for named contended groups");
@@ -579,6 +582,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
       group = _static_fields;
     } else {
       _has_nonstatic_fields = true;
+      _atomic_field_count++;  // we might decrement this
       if (fs.is_contended()) {
         int g = fs.contended_group();
         if (g == 0) {
@@ -626,14 +630,23 @@ void FieldLayoutBuilder::regular_field_sorting() {
                                                                 _protection_domain, true, THREAD);
         assert(klass != NULL, "Sanity check");
         ValueKlass* vk = ValueKlass::cast(klass);
-        bool has_flattenable_size = (ValueFieldMaxFlatSize < 0)
-                                   || (vk->size_helper() * HeapWordSize) <= ValueFieldMaxFlatSize;
-        // volatile fields are currently never flattened, this could change in the future
-        bool flattened = !fs.access_flags().is_volatile() && has_flattenable_size;
-        if (flattened) {
+        bool too_big_to_flatten = (ValueFieldMaxFlatSize >= 0 &&
+                                   (vk->size_helper() * HeapWordSize) > ValueFieldMaxFlatSize);
+        bool too_atomic_to_flatten = vk->is_declared_atomic();
+        bool too_volatile_to_flatten = fs.access_flags().is_volatile();
+        if (vk->is_naturally_atomic()) {
+          too_atomic_to_flatten = false;
+          //too_volatile_to_flatten = false; //FIXME
+          // volatile fields are currently never flattened, this could change in the future
+        }
+        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten)) {
           group->add_flattened_field(fs, vk);
           _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
           fs.set_flattened(true);
+          if (!vk->is_atomic()) {  // flat and non-atomic: take note
+            _has_nonatomic_values = true;
+            _atomic_field_count--;  // every other field is atomic but this one
+          }
         } else {
           _nonstatic_oopmap_count++;
           group->add_oop_field(fs);
@@ -674,6 +687,7 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
       group = _static_fields;
     } else {
       _has_nonstatic_fields = true;
+      _atomic_field_count++;  // we might decrement this
       group = _root_group;
     }
     assert(group != NULL, "invariant");
@@ -716,13 +730,24 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
                 _protection_domain, true, CHECK);
         assert(klass != NULL, "Sanity check");
         ValueKlass* vk = ValueKlass::cast(klass);
-        bool flattened = (ValueFieldMaxFlatSize < 0)
-                         || (vk->size_helper() * HeapWordSize) <= ValueFieldMaxFlatSize;
-        if (flattened) {
+        bool too_big_to_flatten = (ValueFieldMaxFlatSize >= 0 &&
+                                   (vk->size_helper() * HeapWordSize) > ValueFieldMaxFlatSize);
+        bool too_atomic_to_flatten = vk->is_declared_atomic();
+        bool too_volatile_to_flatten = fs.access_flags().is_volatile();
+        if (vk->is_naturally_atomic()) {
+          too_atomic_to_flatten = false;
+          //too_volatile_to_flatten = false; //FIXME
+          // volatile fields are currently never flattened, this could change in the future
+        }
+        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten)) {
           group->add_flattened_field(fs, vk);
           _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
           field_alignment = vk->get_alignment();
           fs.set_flattened(true);
+          if (!vk->is_atomic()) {  // flat and non-atomic: take note
+            _has_nonatomic_values = true;
+            _atomic_field_count--;  // every other field is atomic but this one
+          }
         } else {
           _nonstatic_oopmap_count++;
           field_alignment = type2aelembytes(T_OBJECT);
@@ -982,6 +1007,19 @@ void FieldLayoutBuilder::epilogue() {
   _info->_static_field_size = static_fields_size;
   _info->_nonstatic_field_size = (nonstatic_field_end - instanceOopDesc::base_offset_in_bytes()) / heapOopSize;
   _info->_has_nonstatic_fields = _has_nonstatic_fields;
+
+  // A value type is naturally atomic if it has just one field, and
+  // that field is simple enough.
+  _info->_is_naturally_atomic = (_is_value_type &&
+                                 (_atomic_field_count <= 1) &&
+                                 !_has_nonatomic_values &&
+                                 _contended_groups.is_empty());
+  // This may be too restrictive, since if all the fields fit in 64
+  // bits we could make the decision to align instances of this class
+  // to 64-bit boundaries, and load and store them as single words.
+  // And on machines which supported larger atomics we could similarly
+  // allow larger values to be atomic, if properly aligned.
+
 
   if (PrintFieldLayout) {
     ResourceMark rm;

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -256,6 +256,8 @@ class FieldLayoutBuilder : public ResourceObj {
   bool _is_contended;
   bool _is_value_type;
   bool _has_flattening_information;
+  bool _has_nonatomic_values;
+  int _atomic_field_count;
 
   FieldGroup* get_or_create_contended_group(int g);
 

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -64,6 +64,7 @@
   template(java_lang_Thread,                          "java/lang/Thread")                         \
   template(java_lang_ThreadGroup,                     "java/lang/ThreadGroup")                    \
   template(java_lang_Cloneable,                       "java/lang/Cloneable")                      \
+  template(java_lang_NonTearable,                     "java/lang/NonTearable")                    \
   template(java_lang_Throwable,                       "java/lang/Throwable")                      \
   template(java_lang_ClassLoader,                     "java/lang/ClassLoader")                    \
   template(java_lang_ClassLoader_NativeLibrary,       "java/lang/ClassLoader\x024NativeLibrary")  \

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -69,6 +69,10 @@ class ArrayKlass: public Klass {
   // Presented with an ArrayKlass, which storage_properties should be encoded into arrayOop
   virtual ArrayStorageProperties storage_properties() { return ArrayStorageProperties::empty; }
 
+  // Are loads and stores to this concrete array type atomic?
+  // Note that Object[] is naturally atomic, but its subtypes may not be.
+  virtual bool element_access_is_atomic() { return true; }
+
   // Testing operation
   DEBUG_ONLY(bool is_array_klass_slow() const { return true; })
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -291,7 +291,9 @@ class InstanceKlass: public Klass {
     _misc_is_being_redefined                  = 1 << 17, // used for locking redefinition
     _misc_has_contended_annotations           = 1 << 18, // has @Contended annotation
     _misc_has_value_fields                    = 1 << 19, // has value fields and related embedded section is not empty
-    _misc_is_empty_value                      = 1 << 20  // empty value type
+    _misc_is_empty_value                      = 1 << 20, // empty value type
+    _misc_is_naturally_atomic                 = 1 << 21, // loaded/stored in one instruction
+    _misc_is_declared_atomic                  = 1 << 22  // implements jl.NonTearable
   };
   u2 loader_type_bits() {
     return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
@@ -430,6 +432,32 @@ class InstanceKlass: public Klass {
   }
   void set_is_empty_value() {
     _misc_flags |= _misc_is_empty_value;
+  }
+
+  // Note:  The naturally_atomic property only applies to
+  // inline classes; it is never true on identity classes.
+  // The bit is placed on instanceKlass for convenience.
+
+  // Query if h/w provides atomic load/store for instances.
+  bool is_naturally_atomic() const {
+    return (_misc_flags & _misc_is_naturally_atomic) != 0;
+  }
+  // Initialized in the class file parser, not changed later.
+  void set_is_naturally_atomic() {
+    _misc_flags |= _misc_is_naturally_atomic;
+  }
+
+  // Query if this class implements jl.NonTearable or was
+  // mentioned in the JVM option AlwaysAtomicValueTypes.
+  // This bit can occur anywhere, but is only significant
+  // for inline classes *and* their super types.
+  // It inherits from supers along with NonTearable.
+  bool is_declared_atomic() const {
+    return (_misc_flags & _misc_is_declared_atomic) != 0;
+  }
+  // Initialized in the class file parser, not changed later.
+  void set_is_declared_atomic() {
+    _misc_flags |= _misc_is_declared_atomic;
   }
 
   // field sizes

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -83,7 +83,7 @@ void ValueArrayKlass::set_element_klass(Klass* k) {
 
 ValueArrayKlass* ValueArrayKlass::allocate_klass(Klass* element_klass, TRAPS) {
   assert(ValueArrayFlatten, "Flatten array required");
-  assert(ValueKlass::cast(element_klass)->is_atomic() || (!ValueArrayAtomicAccess), "Atomic by-default");
+  assert(ValueKlass::cast(element_klass)->is_naturally_atomic() || (!ValueArrayAtomicAccess), "Atomic by-default");
 
   /*
    *  MVT->LWorld, now need to allocate secondaries array types, just like objArrayKlass...

--- a/src/hotspot/share/oops/valueArrayKlass.hpp
+++ b/src/hotspot/share/oops/valueArrayKlass.hpp
@@ -87,7 +87,8 @@ class ValueArrayKlass : public ArrayKlass {
     return element_klass()->contains_oops();
   }
 
-  bool is_atomic() {
+  // Override.
+  bool element_access_is_atomic() {
     return element_klass()->is_atomic();
   }
 

--- a/src/hotspot/share/oops/valueKlass.cpp
+++ b/src/hotspot/share/oops/valueKlass.cpp
@@ -139,10 +139,6 @@ instanceOop ValueKlass::allocate_instance_buffer(TRAPS) {
   return oop;
 }
 
-bool ValueKlass::is_atomic() {
-  return (nonstatic_field_size() * heapOopSize) <= longSize;
-}
-
 int ValueKlass::nonstatic_oop_count() {
   int oops = 0;
   int map_count = nonstatic_oop_map_count();
@@ -192,6 +188,11 @@ bool ValueKlass::flatten_array() {
   }
   // Too many embedded oops
   if ((ValueArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > ValueArrayElemMaxFlatOops)) {
+    return false;
+  }
+
+  // Declared atomic but not naturally atomic.
+  if (is_declared_atomic() && !is_naturally_atomic()) {
     return false;
   }
 
@@ -253,7 +254,7 @@ Klass* ValueKlass::value_array_klass(ArrayStorageProperties storage_props, bool 
 }
 
 Klass* ValueKlass::allocate_value_array_klass(TRAPS) {
-  if (flatten_array() && (is_atomic() || (!ValueArrayAtomicAccess))) {
+  if (flatten_array() && (is_naturally_atomic() || (!ValueArrayAtomicAccess))) {
     return ValueArrayKlass::allocate_klass(ArrayStorageProperties::flattened_and_null_free, this, THREAD);
   }
   return ObjArrayKlass::allocate_objArray_klass(ArrayStorageProperties::null_free, 1, this, THREAD);

--- a/src/hotspot/share/oops/valueKlass.hpp
+++ b/src/hotspot/share/oops/valueKlass.hpp
@@ -214,8 +214,8 @@ class ValueKlass: public InstanceKlass {
   address data_for_oop(oop o) const;
   oop oop_for_data(address data) const;
 
-  // Query if h/w provides atomic load/store
-  bool is_atomic();
+  // Query if this class promises atomicity one way or another
+  bool is_atomic() { return is_naturally_atomic() || is_declared_atomic(); }
 
   bool flatten_array();
 

--- a/src/hotspot/share/opto/valuetypenode.cpp
+++ b/src/hotspot/share/opto/valuetypenode.cpp
@@ -399,6 +399,7 @@ ValueTypeBaseNode* ValueTypeBaseNode::allocate(GraphKit* kit, bool safe_for_repl
 
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
+    // FIXME: coordinate with ready_to_publish(kit, alloc_oop)
     AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop, &kit->gvn());
     assert(alloc != NULL, "must have an allocation node");
     kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
@@ -629,6 +630,7 @@ ValueTypeNode* ValueTypeNode::finish_larval(GraphKit* kit) const {
   Node* mark = kit->make_load(NULL, mark_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
   mark = kit->gvn().transform(new AndXNode(mark, kit->MakeConX(~markWord::larval_mask_in_place)));
   kit->store_to_memory(kit->control(), mark_addr, mark, TypeX_X->basic_type(), kit->gvn().type(mark_addr)->is_ptr(), MemNode::unordered);
+  ready_to_publish(kit, obj);
 
   // Do not let stores that initialize this buffer be reordered with a subsequent
   // store that would make this buffer accessible by other threads.
@@ -641,6 +643,17 @@ ValueTypeNode* ValueTypeNode::finish_larval(GraphKit* kit) const {
   res->set_type(TypeValueType::make(vk, false));
   res = kit->gvn().transform(res)->as_ValueType();
   return res;
+}
+
+void ValueTypeBaseNode::ready_to_publish(GraphKit* kit, Node* base) const {
+  // Do not let stores that initialize this buffer be reordered with
+  // a subsequent store that would make it accessible by other threads.
+  // Required for correct non-flat array element publication.
+  // (See jtreg test ValueTearing.java.)
+  Node* raw_address_proj = NULL;  //FIXME
+  kit->insert_mem_bar(Op_MemBarStoreStore, raw_address_proj);
+  // Fails to prevent array element tearing:
+  //kit->insert_mem_bar_volatile(Op_MemBarStoreStore, Compile::AliasIdxRaw, raw_address_proj);
 }
 
 Node* ValueTypeNode::is_loaded(PhaseGVN* phase, ciValueKlass* vk, Node* base, int holder_offset) {

--- a/src/hotspot/share/opto/valuetypenode.hpp
+++ b/src/hotspot/share/opto/valuetypenode.hpp
@@ -89,6 +89,9 @@ public:
   ValueTypeBaseNode* allocate(GraphKit* kit, bool safe_for_replace = true);
   bool is_allocated(PhaseGVN* phase) const;
 
+  // Ensure that writes to base are comitted before a subsequent store.
+  void ready_to_publish(GraphKit* kit, Node* base) const;
+
   void replace_call_results(GraphKit* kit, Node* call, Compile* C);
 
   // Allocate all non-flattened value type fields

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2333,10 +2333,7 @@ JVM_ENTRY(jboolean, JVM_ArrayIsAccessAtomic(JNIEnv *env, jclass unused, jobject 
   if ((o == NULL) || (!k->is_array_klass())) {
     THROW_0(vmSymbols::java_lang_IllegalArgumentException());
   }
-  if (k->is_valueArray_klass()) {
-    return ValueArrayKlass::cast(k)->is_atomic();
-  }
-  return true;
+  return ArrayKlass::cast(k)->element_access_is_atomic();
 JVM_END
 
 JVM_ENTRY(jobject, JVM_ArrayEnsureAccessAtomic(JNIEnv *env, jclass unused, jobject array))
@@ -2348,7 +2345,7 @@ JVM_ENTRY(jobject, JVM_ArrayEnsureAccessAtomic(JNIEnv *env, jclass unused, jobje
   }
   if (k->is_valueArray_klass()) {
     ValueArrayKlass* vk = ValueArrayKlass::cast(k);
-    if (!vk->is_atomic()) {
+    if (!vk->element_access_is_atomic()) {
       /**
        * Need to decide how to implement:
        *

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2520,6 +2520,11 @@ const size_t minimumSymbolTableSize = 1024;
   develop(bool, ScalarizeValueTypes, true,                                  \
           "Scalarize value types in compiled code")                         \
                                                                             \
+  diagnostic(ccstrlist, ForceNonTearable, "",                               \
+          "List of inline classes which are forced to be atomic "           \
+          "(whitespace and commas separate names, "                         \
+          "and leading and trailing stars '*' are wildcards)")              \
+                                                                            \
   product(bool, PrintNewLayout, false,                                      \
                "Print layout compute by new algorithm")                     \
                                                                             \

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/ostream.hpp"
 #include "utilities/stringUtils.hpp"
 
 int StringUtils::replace_no_expand(char* string, const char* from, const char* to) {
@@ -65,3 +66,287 @@ double StringUtils::similarity(const char* str1, size_t len1, const char* str2, 
 
   return 2.0 * (double) hit / (double) total;
 }
+
+class StringMatcher {
+ public:
+  typedef int getc_function_t(const char* &source, const char* limit);
+
+ private:
+  // These do not get properly inlined.
+  // For full performance, this should be a template class
+  // parameterized by two function arguments.
+  const getc_function_t* _pattern_getc;
+  const getc_function_t* _string_getc;
+
+ public:
+  StringMatcher(getc_function_t pattern_getc,
+                getc_function_t string_getc)
+    : _pattern_getc(pattern_getc),
+      _string_getc(string_getc)
+  { }
+
+  enum {  // special results from _pattern_getc
+    string_match_comma  = -0x100 + ',',
+    string_match_star   = -0x100 + '*',
+    string_match_eos    = -0x100 + '\0'
+  };
+
+ private:
+  const char*
+  skip_anchor_word(const char* match,
+                   const char* match_end,
+                   int anchor_length,
+                   const char* pattern,
+                   const char* pattern_end) {
+    assert(pattern < pattern_end && anchor_length > 0, "");
+    const char* begp = pattern;
+    int ch1 = _pattern_getc(begp, pattern_end);
+    // note that begp is now advanced over ch1
+    assert(ch1 > 0, "regular char only");
+    const char* matchp = match;
+    const char* limitp = match_end - anchor_length;
+    while (matchp <= limitp) {
+      int mch = _string_getc(matchp, match_end);
+      if (mch == ch1) {
+        const char* patp = begp;
+        const char* anchorp = matchp;
+        while (patp < pattern_end) {
+          char ch = _pattern_getc(patp, pattern_end);
+          char mch = _string_getc(anchorp, match_end);
+          if (mch != ch) {
+            anchorp = NULL;
+            break;
+          }
+        }
+        if (anchorp != NULL) {
+          return anchorp;  // Found a full copy of the anchor.
+        }
+        // That did not work, so restart the search for ch1.
+      }
+    }
+    return NULL;
+  }
+
+ public:
+  bool string_match(const char* pattern,
+                    const char* string) {
+    return string_match(pattern, pattern + strlen(pattern),
+                        string, string + strlen(string));
+  }
+  bool string_match(const char* pattern, const char* pattern_end,
+                    const char* string, const char* string_end) {
+    const char* patp = pattern;
+    switch (_pattern_getc(patp, pattern_end)) {
+    case string_match_eos:
+      return false;  // Empty pattern is always false.
+    case string_match_star:
+      if (patp == pattern_end) {
+        return true;   // Lone star pattern is always true.
+      }
+      break;
+    }
+    patp = pattern;  // Reset after lookahead.
+    const char* matchp = string;  // NULL if failing
+    for (;;) {
+      int ch = _pattern_getc(patp, pattern_end);
+      switch (ch) {
+      case string_match_eos:
+      case string_match_comma:
+        // End of a list item; see if it's a match.
+        if (matchp == string_end) {
+          return true;
+        }
+        if (ch == string_match_comma) {
+          // Get ready to match the next item.
+          matchp = string;
+          continue;
+        }
+        return false;  // End of all items.
+
+      case string_match_star:
+        if (matchp != NULL) {
+          // Wildcard:  Parse out following anchor word and look for it.
+          const char* begp = patp;
+          const char* endp = patp;
+          int anchor_len = 0;
+          for (;;) {
+            // get as many following regular characters as possible
+            endp = patp;
+            ch = _pattern_getc(patp, pattern_end);
+            if (ch <= 0) {
+              break;
+            }
+            anchor_len += 1;
+          }
+          // Anchor word [begp..endp) does not contain ch, so back up.
+          // Now do an eager match to the anchor word, and commit to it.
+          patp = endp;
+          if (ch == string_match_eos ||
+              ch == string_match_comma) {
+            // Anchor word is at end of pattern, so treat it as a fixed pattern.
+            const char* limitp = string_end - anchor_len;
+            matchp = limitp;
+            patp = begp;
+            // Resume normal scanning at the only possible match position.
+            continue;
+          }
+          // Find a floating occurrence of the anchor and continue matching.
+          // Note:  This is greedy; there is no backtrack here.  Good enough.
+          matchp = skip_anchor_word(matchp, string_end, anchor_len, begp, endp);
+        }
+        continue;
+      }
+      // Normal character.
+      if (matchp != NULL) {
+        int mch = _string_getc(matchp, string_end);
+        if (mch != ch) {
+          matchp = NULL;
+        }
+      }
+    }
+  }
+};
+
+// Match a wildcarded class list to a proposed class name (in internal form).
+// Commas or newlines separate multiple possible matches; stars are shell-style wildcards.
+class ClassListMatcher : public StringMatcher {
+ public:
+  ClassListMatcher()
+    : StringMatcher(pattern_list_getc, class_name_getc)
+  { }
+
+ private:
+  static int pattern_list_getc(const char* &pattern_ptr,
+                               const char* pattern_end) {
+    if (pattern_ptr == pattern_end) {
+      return string_match_eos;
+    }
+    int ch = (unsigned char) *pattern_ptr++;
+    switch (ch) {
+    case ' ': case '\t': case '\n': case '\r':
+    case ',':
+      // End of list item.
+      for (;;) {
+        switch (*pattern_ptr) {
+        case ' ': case '\t': case '\n': case '\r':
+        case ',':
+          pattern_ptr += 1;  // Collapse multiple commas or spaces.
+          continue;
+        }
+        break;
+      }
+      return string_match_comma;
+
+    case '*':
+      // Wildcard, matching any number of chars.
+      while (*pattern_ptr == '*') {
+        pattern_ptr += 1;  // Collapse multiple stars.
+      }
+      return string_match_star;
+
+    case '.':
+      ch = '/';   // Look for internal form of package separator
+      break;
+
+    case '\\':
+      // Superquote in pattern escapes * , whitespace, and itself.
+      if (pattern_ptr < pattern_end) {
+        ch = (unsigned char) *pattern_ptr++;
+      }
+      break;
+    }
+
+    assert(ch > 0, "regular char only");
+    return ch;
+  }
+
+  static int class_name_getc(const char* &name_ptr,
+                             const char* name_end) {
+    if (name_ptr == name_end) {
+      return string_match_eos;
+    }
+    int ch = (unsigned char) *name_ptr++;
+    if (ch == '.') {
+      ch = '/';   // Normalize to internal form of package separator
+    }
+    return ch;  // plain character
+  }
+};
+
+static bool class_list_match_sane();
+
+bool StringUtils::class_list_match(const char* class_pattern_list,
+                                   const char* class_name) {
+  assert(class_list_match_sane(), "");
+  if (class_pattern_list == NULL || class_name == NULL || class_name[0] == '\0')
+    return false;
+  ClassListMatcher clm;
+  return clm.string_match(class_pattern_list, class_name);
+}
+
+#ifdef ASSERT
+static void
+class_list_match_sane(const char* pat, const char* str, bool result = true) {
+  if (result) {
+    assert(StringUtils::class_list_match(pat, str), "%s ~ %s", pat, str);
+  } else {
+    assert(!StringUtils::class_list_match(pat, str), "%s !~ %s", pat, str);
+  }
+}
+
+static bool
+class_list_match_sane() {
+  static bool done = false;
+  if (done)  return true;
+  done = true;
+  class_list_match_sane("foo", "foo");
+  class_list_match_sane("foo,", "foo");
+  class_list_match_sane(",foo,", "foo");
+  class_list_match_sane("bar,foo", "foo");
+  class_list_match_sane("bar,foo,", "foo");
+  class_list_match_sane("*", "foo");
+  class_list_match_sane("foo.bar", "foo/bar");
+  class_list_match_sane("foo/bar", "foo.bar");
+  class_list_match_sane("\\foo", "foo");
+  class_list_match_sane("\\*foo", "*foo");
+  const char* foo = "foo!";
+  char buf[100], buf2[100];
+  const int m = strlen(foo);
+  for (int n = 0; n <= 1; n++) {  // neg: 0=>pos
+    for (int a = -1; a <= 1; a++) {  // alt: -1/X,T 0/T 1/T,Y
+      for (int i = 0; i <= m; i++) {  // 1st substring [i:j]
+        for (int j = i; j <= m; j++) {
+          if (j == i && j > 0)  continue; // only take 1st empty
+          for (int k = j; k <= m; k++) {  // 2nd substring [k:l]
+            if (k == j && k > i)  continue; // only take 1st empty
+            for (int l = k; l <= m; l++) {
+              if (l == k && l > j)  continue; // only take 1st empty
+              char* bp = &buf[0];
+              strncpy(bp, foo + 0, i - 0); bp += i - 0;
+              *bp++ = '*';
+              strncpy(bp, foo + j, k - j); bp += k - j;
+              *bp++ = '*';
+              strncpy(bp, foo + l, m - l); bp += m - l;
+              if (n) {
+                *bp++ = 'N';  // make it fail
+              }
+              *bp++ = '\0';
+              if (a != 0) {
+                if (a < 0) {  // X*, (test pattern)
+                  strcpy(buf2, buf);
+                  strcat(buf, "X*, ");
+                  strcat(buf, buf2);
+                } else {      // (test pattern), Y
+                  strcat(buf, ", Y");
+                }
+              }
+              class_list_match_sane(buf, foo, !n);
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+#endif //ASSERT

--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -40,6 +40,10 @@ public:
 
   // Compute string similarity based on Dice's coefficient
   static double similarity(const char* str1, size_t len1, const char* str2, size_t len2);
+
+  // Match a wildcarded class list to a proposed class name (in internal form).
+  // Commas separate multiple possible matches; stars are shell-style wildcards.
+  static bool class_list_match(const char* class_list, const char* class_name);
 };
 
 #endif // SHARE_UTILITIES_STRINGUTILS_HPP

--- a/src/java.base/share/classes/java/lang/NonTearable.java
+++ b/src/java.base/share/classes/java/lang/NonTearable.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+/**
+ * An inline class implements the {@code NonTearable} interface to
+ * request that the JVM take extra care to avoid structure tearing
+ * when loading or storing any value of the class to a field or array
+ * element.  Normally, only fields declared {@code volatile} are
+ * protected against structure tearing, but a class that implements
+ * this marker interface will never have its values torn, even when
+ * they are stored in array elements or in non-{@code volatile}
+ * fields, and even when multiple threads perform racing writes.
+ *
+ * <p> An inline instance of multiple components is said to be "torn"
+ * when two racing threads compete to write those components, and one
+ * thread writes some components while another thread writes other
+ * components, so a subsequent observer will read a hybrid composed,
+ * as if "out of thin air", of field values from both racing writes.
+ * Tearing can also occur when the effects of two non-racing writes
+ * are observed by a racing read.  In general, structure tearing
+ * requires a read and two writes (initialization counting as a write)
+ * of a multi-component value, with a race between any two of the
+ * accesses.  The effect can also be described as if the Java memory
+ * model break up inline instance reads and writes into reads and
+ * writes of their various fields, as it does with longs and doubles
+ * (JLS 17.7).
+ *
+ * <p> In extreme cases, the hybrid observed after structure tearing
+ * might be a value which is impossible to construct by normal means.
+ * If data integrity or security depends on proper construction,
+ * the class should be declared as implementing {@code NonTearable}.
+ *
+ * @author  John Rose
+ * @since   (valhalla)
+ */
+public interface NonTearable {
+    // TO DO: Finalize name.
+    // TO DO: Decide whether and how to restrict this type to to
+    // inline classes only, or if not, whether to document its
+    // non-effect on identity classes.
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
@@ -37,7 +37,9 @@ import jdk.test.lib.Asserts;
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator Point.java JumboValue.java
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator FlattenableSemanticTest.java
  * @run main/othervm -Xint -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
+ * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.FlattenableSemanticTest
  * @run main/othervm -Xcomp -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.FlattenableSemanticTest
  * // debug: -XX:+PrintValueLayout -XX:-ShowMessageBoxOnError
  */
 public class FlattenableSemanticTest {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTearing.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTearing.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.valuetypes;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.Optional;
+
+import jdk.internal.misc.Unsafe;
+import sun.hotspot.WhiteBox;
+import static jdk.test.lib.Asserts.*;
+
+/*
+ * @test ValueTearing
+ * @summary Test tearing of inline fields and array elements
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @compile ValueTearing.java
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ *                   -DSTEP_COUNT=10000
+ *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
+ *                   -DSTEP_COUNT=10000
+ *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ * @run main/othervm -Xbatch -DSTEP_COUNT=10000000
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ *                   -DTEAR_MODE=fieldonly
+ *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ *                   -DTEAR_MODE=arrayonly
+ *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
+ *                   -DTEAR_MODE=both
+ *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
+ *                                   runtime.valhalla.valuetypes.ValueTearing
+ */
+public class ValueTearing {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    private static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
+    private static final boolean ALWAYS_ATOMIC = WHITE_BOX.getStringVMFlag("ForceNonTearable").contains("*");
+    private static final String TEAR_MODE = System.getProperty("TEAR_MODE", "both");
+    private static final boolean TEAR_FIELD = !TEAR_MODE.equals("arrayonly");
+    private static final boolean TEAR_ARRAY = !TEAR_MODE.equals("fieldonly");
+    private static final int STEP_COUNT = Integer.getInteger("STEP_COUNT", 100_000);
+    private static final boolean TFIELD_FLAT, TARRAY_FLAT;
+    private static final boolean NTFIELD_FLAT, NTARRAY_FLAT;
+    static {
+        try {
+            Field TPB_field = TPointBox.class.getDeclaredField("field");
+            Field TPB_array = TPointBox.class.getDeclaredField("array");
+            Field NTPB_field = NTPointBox.class.getDeclaredField("field");
+            Field NTPB_array = NTPointBox.class.getDeclaredField("array");
+            TFIELD_FLAT = UNSAFE.isFlattened(TPB_field);
+            TARRAY_FLAT = UNSAFE.isFlattenedArray(TPB_array.getType());
+            NTFIELD_FLAT = UNSAFE.isFlattened(NTPB_field);
+            NTARRAY_FLAT = UNSAFE.isFlattenedArray(NTPB_array.getType());
+        } catch (ReflectiveOperationException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+    private static final String SETTINGS =
+        String.format("USE_COMPILER=%s ALWAYS_ATOMIC=%s TEAR_MODE=%s STEP_COUNT=%s FLAT TF/TA=%s/%s NTF/NTA=%s/%s",
+                      USE_COMPILER, ALWAYS_ATOMIC, TEAR_MODE, STEP_COUNT,
+                      TFIELD_FLAT, TARRAY_FLAT, NTFIELD_FLAT, NTARRAY_FLAT);
+    private static final String NOTE_TORN_POINT = "Note: torn point";
+
+    public static void main(String[] args) throws Exception {
+        System.out.println(SETTINGS);
+        ValueTearing valueTearing = new ValueTearing();
+        valueTearing.run();
+        // Extra representation check:
+        assert(!NTFIELD_FLAT) : "NT field must be indirect not flat";
+        assert(!NTARRAY_FLAT) : "NT array must be indirect not flat";
+        if (ALWAYS_ATOMIC) {
+            assert(!TFIELD_FLAT) : "field must be indirect not flat";
+            assert(!TARRAY_FLAT) : "array must be indirect not flat";
+        }
+    }
+
+    // A normally tearable inline value.
+    static inline class TPoint {
+        TPoint(long x, long y) { this.x = x; this.y = y; }
+        final long x, y;
+        public String toString() { return String.format("(%d,%d)", x, y); }
+    }
+
+    static class TooTearable extends AssertionError {
+        final Object badPoint;
+        TooTearable(String msg, Object badPoint) {
+            super(msg);
+            this.badPoint = badPoint;
+        }
+    }
+
+    interface PointBox {
+        void step();    // mutate inline value state
+        void check();   // check sanity of inline value state
+    }
+
+    class TPointBox implements PointBox {
+        TPoint field;
+        TPoint[] array = new TPoint[1];
+        // Step the points forward by incrementing their components
+        // "simultaneously".  A racing thread will catch flaws in the
+        // simultaneity.
+        TPoint step(TPoint p) {
+            return new TPoint(p.x + 1, p.y + 1);
+        }
+        public @Override
+        void step() {
+            if (TEAR_FIELD) {
+                field = step(field);
+            }
+            if (TEAR_ARRAY) {
+                array[0] = step(array[0]);
+            }
+            check();
+        }
+        // Invariant:  The components of each point are "always" equal.
+        // As long as simultaneity is preserved, this is true.
+        public @Override
+        void check() {
+            if (TEAR_FIELD) {
+                check(field, "field");
+            }
+            if (TEAR_ARRAY) {
+                check(array[0], "array element");
+            }
+        }
+        void check(TPoint p, String where) {
+            if (p.x == p.y)  return;
+            String msg = String.format("%s %s in %s; settings = %s",
+                                       NOTE_TORN_POINT,
+                                       p, where, SETTINGS);
+            throw new TooTearable(msg, p);
+        }
+        public String toString() {
+            return String.format("TPB[%s, {%s}]", field, array[0]);
+        }
+    }
+
+    // Add an indirection, as an extra test.
+    interface NT extends NonTearable { }
+
+    // A hardened, non-tearable version of TPoint.
+    static inline class NTPoint implements NT {
+        NTPoint(long x, long y) { this.x = x; this.y = y; }
+        final long x, y;
+        public String toString() { return String.format("(%d,%d)", x, y); }
+    }
+
+    class NTPointBox implements PointBox {
+        NTPoint field;
+        NTPoint[] array = new NTPoint[1];
+        // Step the points forward by incrementing their components
+        // "simultaneously".  A racing thread will catch flaws in the
+        // simultaneity.
+        NTPoint step(NTPoint p) {
+            return new NTPoint(p.x + 1, p.y + 1);
+        }
+        public @Override
+        void step() {
+            field = step(field);
+            array[0] = step(array[0]);
+            check();
+        }
+        // Invariant:  The components of each point are "always" equal.
+        public @Override
+        void check() {
+            check(field, "field");
+            check(array[0], "array element");
+        }
+        void check(NTPoint p, String where) {
+            if (p.x == p.y)  return;
+            String msg = String.format("%s *NonTearable* %s in %s; settings = %s",
+                                       NOTE_TORN_POINT,
+                                       p, where, SETTINGS);
+            throw new TooTearable(msg, p);
+        }
+        public String toString() {
+            return String.format("NTPB[%s, {%s}]", field, array[0]);
+        }
+    }
+
+    class AsyncObserver extends Thread {
+        volatile boolean done;
+        long observationCount;
+        final PointBox pointBox;
+        volatile Object badPointObserved;
+        AsyncObserver(PointBox pointBox) {
+            this.pointBox = pointBox;
+        }
+        public void run() {
+            try {
+                while (!done) {
+                    observationCount++;
+                    pointBox.check();
+                }
+            } catch (TooTearable ex) {
+                done = true;
+                badPointObserved = ex.badPoint;
+                System.out.println(ex);
+                if (ALWAYS_ATOMIC || ex.badPoint instanceof NonTearable) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    public void run() throws Exception {
+        System.out.println("Test for tearing of NTPoint, which must not happen...");
+        run(new NTPointBox(), false);
+        System.out.println("Test for tearing of TPoint, which "+
+                           (ALWAYS_ATOMIC ? "must not" : "is allowed to")+
+                           " happen...");
+        run(new TPointBox(), ALWAYS_ATOMIC ? false : true);
+    }
+    public void run(PointBox pointBox, boolean canTear) throws Exception {
+        var observer = new AsyncObserver(pointBox);
+        observer.start();
+        for (int i = 0; i < STEP_COUNT; i++) {
+            pointBox.step();
+            if (observer.done)  break;
+        }
+        observer.done = true;
+        observer.join();
+        var obCount = observer.observationCount;
+        var badPoint = observer.badPointObserved;
+        System.out.println(String.format("finished after %d observations at %s; %s",
+                                         obCount, pointBox,
+                                         (badPoint == null
+                                          ? "no tearing observed"
+                                          : "bad point = " + badPoint)));
+        if (canTear && badPoint == null) {
+            var complain = String.format("%s NOT observed after %d observations",
+                                         NOTE_TORN_POINT, obCount);
+            System.out.println("?????? "+complain);
+            if (STEP_COUNT >= 3_000_000) {
+                // If it's a small count, OK, but if it's big the test is broken.
+                throw new AssertionError(complain + ", but it should have been");
+            }
+        }
+        if (!canTear && badPoint != null) {
+            throw new AssertionError("should not reach here; other thread must throw");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -39,6 +39,7 @@ import static jdk.test.lib.Asserts.*;
  * @run main/othervm -Xint  -XX:ValueArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
  * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
  * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.ValueTypeArray
  */
 public class ValueTypeArray {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
@@ -39,6 +39,9 @@ import jdk.test.lib.Asserts;
  * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI ValueTypeDensity
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions
+ *                   -Xbootclasspath/a:. -XX:ForceNonTearable=*
+ *                   -XX:+WhiteBoxAPI ValueTypeDensity
  */
 
 public class ValueTypeDensity {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypesTest.java
@@ -62,6 +62,12 @@ import javax.tools.*;
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
  *                   runtime.valhalla.valuetypes.ValueTypesTest
+ * @run main/othervm -Xbatch -Xmx128m -XX:-ShowMessageBoxOnError
+ *                   -XX:+ExplicitGCInvokesConcurrent
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
+ *                   -XX:ForceNonTearable=*
+ *                   runtime.valhalla.valuetypes.ValueTypesTest
  */
 public class ValueTypesTest {
 


### PR DESCRIPTION
Reviewed on valhalla-dev as https://mail.openjdk.java.net/pipermail/valhalla-dev/2020-March/006879.html

(Note:  The design is also under discussion by valhalla-spec-experts.)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8236522](https://bugs.openjdk.java.net/browse/JDK-8236522): NonTearable marker interface for inline classes to enforce atomicity


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/7/head:pull/7`
`$ git checkout pull/7`
