### PR TITLE
8241910: [lworld] C2 crashes due to duplicate storestore barrier added by JDK-8236522

### DIFF
--- a/src/hotspot/share/opto/valuetypenode.cpp
+++ b/src/hotspot/share/opto/valuetypenode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -399,7 +399,6 @@ ValueTypeBaseNode* ValueTypeBaseNode::allocate(GraphKit* kit, bool safe_for_repl
 
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
-    // FIXME: coordinate with ready_to_publish(kit, alloc_oop)
     AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop, &kit->gvn());
     assert(alloc != NULL, "must have an allocation node");
     kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
@@ -630,7 +629,6 @@ ValueTypeNode* ValueTypeNode::finish_larval(GraphKit* kit) const {
   Node* mark = kit->make_load(NULL, mark_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
   mark = kit->gvn().transform(new AndXNode(mark, kit->MakeConX(~markWord::larval_mask_in_place)));
   kit->store_to_memory(kit->control(), mark_addr, mark, TypeX_X->basic_type(), kit->gvn().type(mark_addr)->is_ptr(), MemNode::unordered);
-  ready_to_publish(kit, obj);
 
   // Do not let stores that initialize this buffer be reordered with a subsequent
   // store that would make this buffer accessible by other threads.
@@ -643,17 +641,6 @@ ValueTypeNode* ValueTypeNode::finish_larval(GraphKit* kit) const {
   res->set_type(TypeValueType::make(vk, false));
   res = kit->gvn().transform(res)->as_ValueType();
   return res;
-}
-
-void ValueTypeBaseNode::ready_to_publish(GraphKit* kit, Node* base) const {
-  // Do not let stores that initialize this buffer be reordered with
-  // a subsequent store that would make it accessible by other threads.
-  // Required for correct non-flat array element publication.
-  // (See jtreg test ValueTearing.java.)
-  Node* raw_address_proj = NULL;  //FIXME
-  kit->insert_mem_bar(Op_MemBarStoreStore, raw_address_proj);
-  // Fails to prevent array element tearing:
-  //kit->insert_mem_bar_volatile(Op_MemBarStoreStore, Compile::AliasIdxRaw, raw_address_proj);
 }
 
 Node* ValueTypeNode::is_loaded(PhaseGVN* phase, ciValueKlass* vk, Node* base, int holder_offset) {

--- a/src/hotspot/share/opto/valuetypenode.hpp
+++ b/src/hotspot/share/opto/valuetypenode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,9 +88,6 @@ public:
   // Allocates the value type (if not yet allocated)
   ValueTypeBaseNode* allocate(GraphKit* kit, bool safe_for_replace = true);
   bool is_allocated(PhaseGVN* phase) const;
-
-  // Ensure that writes to base are comitted before a subsequent store.
-  void ready_to_publish(GraphKit* kit, Node* base) const;
 
   void replace_call_results(GraphKit* kit, Node* call, Compile* C);
 


### PR DESCRIPTION
The fix for JDK-8236522 contained the partial/broken fix for a missing barrier issue that was already fixed by JDK-8238780. As a result, tests are failing:

compiler/valhalla/valuetypes/TestIntrinsics.java macosx-x64-debug Exception: java.lang.RuntimeException: Expected to get exit value of [0]
compiler/valhalla/valuetypes/TestIntrinsics.java macosx-x64-debug Exception: java.lang.RuntimeException: Expected to get exit value of [0]
compiler/valhalla/valuetypes/TestBufferTearing.java macosx-x64-debug ExitCode: 134
compiler/valhalla/valuetypes/TestBufferTearing.java macosx-x64-debug ExitCode: 134
compiler/valhalla/valuetypes/TestIntrinsics.java linux-x64-debug Exception: java.lang.RuntimeException: Expected to get exit value of [0]
compiler/valhalla/valuetypes/TestBufferTearing.java linux-x64-debug ExitCode: 134
compiler/valhalla/valuetypes/TestIntrinsics.java linux-x64-open-debug Exception: java.lang.RuntimeException: Expected to get exit value of [0]
compiler/valhalla/valuetypes/TestBufferTearing.java linux-x64-open-debug ExitCode: 134

The changes to valuetypenode.cpp/hpp should be reverted.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8241910](https://bugs.openjdk.java.net/browse/JDK-8241910): [lworld] C2 crashes due to duplicate storestore barrier added by JDK-8236522


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/8/head:pull/8`
`$ git checkout pull/8`
