### PR TITLE
8241918: [lworld] Build failures after JDK-8236522

### DIFF
--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -75,8 +75,8 @@ class StringMatcher {
   // These do not get properly inlined.
   // For full performance, this should be a template class
   // parameterized by two function arguments.
-  const getc_function_t* _pattern_getc;
-  const getc_function_t* _string_getc;
+  getc_function_t* _pattern_getc;
+  getc_function_t* _string_getc;
 
  public:
   StringMatcher(getc_function_t pattern_getc,
@@ -309,7 +309,7 @@ static bool class_list_match_sane() {
   class_list_match_sane("\\*foo", "*foo");
   const char* foo = "foo!";
   char buf[100], buf2[100];
-  const int m = strlen(foo);
+  const int m = (int)strlen(foo);
   for (int n = 0; n <= 1; n++) {  // neg: 0=>pos
     for (int a = -1; a <= 1; a++) {  // alt: -1/X,T 0/T 1/T,Y
       for (int i = 0; i <= m; i++) {  // 1st substring [i:j]

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -273,7 +273,7 @@ class ClassListMatcher : public StringMatcher {
   }
 };
 
-static bool class_list_match_sane();
+DEBUG_ONLY(static bool class_list_match_sane();)
 
 bool StringUtils::class_list_match(const char* class_pattern_list,
                                    const char* class_name) {
@@ -285,8 +285,7 @@ bool StringUtils::class_list_match(const char* class_pattern_list,
 }
 
 #ifdef ASSERT
-static void
-class_list_match_sane(const char* pat, const char* str, bool result = true) {
+static void class_list_match_sane(const char* pat, const char* str, bool result = true) {
   if (result) {
     assert(StringUtils::class_list_match(pat, str), "%s ~ %s", pat, str);
   } else {
@@ -294,8 +293,7 @@ class_list_match_sane(const char* pat, const char* str, bool result = true) {
   }
 }
 
-static bool
-class_list_match_sane() {
+static bool class_list_match_sane() {
   static bool done = false;
   if (done)  return true;
   done = true;


### PR DESCRIPTION
workspace/open/src/hotspot/share/utilities/stringUtils.cpp:276:13: error: 'bool class_list_match_sane()' declared 'static' but never defined [-Werror=unused-function]
[2020-03-31T06:37:08,459Z] static bool class_list_match_sane();
[2020-03-31T06:37:08,459Z] ^~~~~~~~~~~~~~~~~~~~~
[2020-03-31T06:37:08,822Z] cc1plus: all warnings being treated as errors
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8241918](https://bugs.openjdk.java.net/browse/JDK-8241918): [lworld] Build failures after JDK-8236522


### Reviewers
 * David Simms ([dsimms](@MrSimms) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/9/head:pull/9`
`$ git checkout pull/9`
