### PR TITLE
8241764: [lworld] TestC2CCalls fails with SIGSEGV in frame::sender_for_compiled_frame

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -480,7 +480,8 @@ int LIR_Assembler::emit_unwind_handler() {
   }
 
   // remove the activation and dispatch to the unwind handler
-  __ remove_frame(in_bytes(frame_map()->framesize_in_bytes()), needs_stack_repair());
+  int initial_framesize = initial_frame_size_in_bytes();
+  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
   __ jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
   // Emit the slow path assembly
@@ -546,7 +547,8 @@ void LIR_Assembler::return_op(LIR_Opr result) {
   }
 
   // Pop the stack before the safepoint code
-  __ remove_frame(in_bytes(frame_map()->framesize_in_bytes()), needs_stack_repair());
+  int initial_framesize = initial_frame_size_in_bytes();
+  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -480,7 +480,7 @@ int LIR_Assembler::emit_unwind_handler() {
   }
 
   // remove the activation and dispatch to the unwind handler
-  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
+  __ remove_frame(in_bytes(frame_map()->framesize_in_bytes()), needs_stack_repair());
   __ jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
   // Emit the slow path assembly
@@ -546,7 +546,7 @@ void LIR_Assembler::return_op(LIR_Opr result) {
   }
 
   // Pop the stack before the safepoint code
-  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
+  __ remove_frame(in_bytes(frame_map()->framesize_in_bytes()), needs_stack_repair());
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -451,8 +451,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // It is only an FP if the sender is an interpreter frame (or C1?).
   intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - frame::sender_sp_offset);
 
-  // TODO move this up and refactor in method?
-  // Repair the sender sp if this is a method required stack extension
+  // Repair the sender sp if the frame has been extended
   sender_sp = repair_sender_sp(sender_sp, saved_fp_addr);
 
   // On Intel the return_address is always the word on the stack

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -451,7 +451,8 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
   // It is only an FP if the sender is an interpreter frame (or C1?).
   intptr_t** saved_fp_addr = (intptr_t**) (sender_sp - frame::sender_sp_offset);
 
-  // Repair the sender sp if this is a method with scalarized value type args
+  // TODO move this up and refactor in method?
+  // Repair the sender sp if this is a method required stack extension
   sender_sp = repair_sender_sp(sender_sp, saved_fp_addr);
 
   // On Intel the return_address is always the word on the stack
@@ -714,11 +715,7 @@ intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr)
     // The stack increment resides just below the saved rbp on the stack
     // and does not account for the return address.
     intptr_t* real_frame_size_addr = (intptr_t*) (saved_fp_addr - 1);
-    int real_frame_size = (*real_frame_size_addr) / wordSize;
-    if (!cm->is_compiled_by_c1()) {
-      // Add size of return address (C1 already includes the RA size)
-      real_frame_size += 1;
-    }
+    int real_frame_size = ((*real_frame_size_addr) + wordSize) / wordSize;
     assert(real_frame_size >= _cb->frame_size(), "invalid frame size");
     sender_sp = unextended_sp() + real_frame_size;
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6422,8 +6422,8 @@ void MacroAssembler::unpack_value_args(Compile* C, bool receiver_only) {
 
 void MacroAssembler::shuffle_value_args(bool is_packing, bool receiver_only, int extra_stack_offset,
                                         BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                        int args_passed, int args_on_stack, VMRegPair* regs,            // from
-                                        int args_passed_to, int args_on_stack_to, VMRegPair* regs_to, int sp_inc) { // to
+                                        int args_passed, int args_on_stack, VMRegPair* regs,
+                                        int args_passed_to, int args_on_stack_to, VMRegPair* regs_to, int sp_inc) {
   // Check if we need to extend the stack for packing/unpacking
   if (sp_inc > 0 && !is_packing) {
     // Save the return address, adjust the stack (make sure it is properly
@@ -6455,18 +6455,15 @@ VMReg MacroAssembler::spill_reg_for(VMReg reg) {
   return reg->is_XMMRegister() ? xmm8->as_VMReg() : r14->as_VMReg();
 }
 
-void MacroAssembler::remove_frame(int framesize, bool needs_stack_repair) {
-  assert((framesize & (StackAlignmentInBytes-1)) == 0, "frame size not aligned");
-  // Remove word for return addr already pushed and RBP
-  framesize -= 2*wordSize;
-
+void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset) {
+  assert((initial_framesize & (StackAlignmentInBytes-1)) == 0, "frame size not aligned");
   if (needs_stack_repair) {
     // Restore rbp and repair rsp by adding the stack increment
-    movq(rbp, Address(rsp, framesize));
-    addq(rsp, Address(rsp, framesize - wordSize));
+    movq(rbp, Address(rsp, initial_framesize));
+    addq(rsp, Address(rsp, sp_inc_offset));
   } else {
-    if (framesize > 0) {
-      addq(rsp, framesize);
+    if (initial_framesize > 0) {
+      addq(rsp, initial_framesize);
     }
     pop(rbp);
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1717,7 +1717,7 @@ public:
   bool pack_value_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                          VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
                          int ret_off, int extra_stack_offset);
-  void remove_frame(int framesize, bool needs_stack_repair);
+  void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
 
   void shuffle_value_args(bool is_packing, bool receiver_only, int extra_stack_offset,
                           BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1717,12 +1717,12 @@ public:
   bool pack_value_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                          VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
                          int ret_off, int extra_stack_offset);
-  void restore_stack(Compile* C);
+  void remove_frame(int framesize, bool needs_stack_repair);
 
-  int shuffle_value_args(bool is_packing, bool receiver_only, int extra_stack_offset,
-                         BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                         int args_passed, int args_on_stack, VMRegPair* regs,
-                         int args_passed_to, int args_on_stack_to, VMRegPair* regs_to);
+  void shuffle_value_args(bool is_packing, bool receiver_only, int extra_stack_offset,
+                          BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
+                          int args_passed, int args_on_stack, VMRegPair* regs,
+                          int args_passed_to, int args_on_stack_to, VMRegPair* regs_to, int sp_inc);
   bool shuffle_value_args_spill(bool is_packing,  const GrowableArray<SigEntry>* sig_cc, int sig_cc_index,
                                 VMRegPair* regs_from, int from_index, int regs_from_count,
                                 RegState* reg_state, int sp_inc, int extra_stack_offset);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -963,7 +963,7 @@ void MachEpilogNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     __ vzeroupper();
   }
 
-  __ restore_stack(C);
+  __ remove_frame(C->frame_size_in_bytes(), C->needs_stack_repair());
 
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -963,8 +963,9 @@ void MachEpilogNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     __ vzeroupper();
   }
 
-  __ remove_frame(C->frame_size_in_bytes(), C->needs_stack_repair());
-
+  // Subtract two words to account for return address and rbp
+  int initial_framesize = C->frame_size_in_bytes() - 2*wordSize;
+  __ remove_frame(initial_framesize, C->needs_stack_repair(), C->sp_inc_offset());
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -166,13 +166,12 @@ int MacroAssembler::unpack_value_args_common(Compile* C, bool receiver_only) {
   int args_passed_cc = SigEntry::fill_sig_bt(sig_cc, sig_bt);
   VMRegPair* regs_cc = NEW_RESOURCE_ARRAY(VMRegPair, sig_cc->length());
   int args_on_stack_cc = SharedRuntime::java_calling_convention(sig_bt, regs_cc, args_passed_cc, false);
-
   int extra_stack_offset = wordSize; // stack has the returned address
-  int sp_inc = (args_on_stack_cc - args_on_stack) * VMRegImpl::stack_slot_size;
-  if (sp_inc > 0) {
+  // Compute stack increment
+  int sp_inc = 0;
+  if (args_on_stack_cc > args_on_stack) {
+    sp_inc = (args_on_stack_cc - args_on_stack) * VMRegImpl::stack_slot_size;
     sp_inc = align_up(sp_inc, StackAlignmentInBytes);
-  } else {
-    sp_inc = 0;
   }
   shuffle_value_args(false, receiver_only, extra_stack_offset, sig_bt, sig_cc,
                      args_passed, args_on_stack, regs,
@@ -182,8 +181,8 @@ int MacroAssembler::unpack_value_args_common(Compile* C, bool receiver_only) {
 
 void MacroAssembler::shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
                                                BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                               int args_passed, int args_on_stack, VMRegPair* regs,            // from
-                                               int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
+                                               int args_passed, int args_on_stack, VMRegPair* regs,
+                                               int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,
                                                int sp_inc, int ret_off) {
   int max_stack = MAX2(args_on_stack + sp_inc/VMRegImpl::stack_slot_size, args_on_stack_to);
   RegState* reg_state = init_reg_state(is_packing, sig_cc, regs, args_passed, sp_inc, max_stack);

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -168,17 +168,23 @@ int MacroAssembler::unpack_value_args_common(Compile* C, bool receiver_only) {
   int args_on_stack_cc = SharedRuntime::java_calling_convention(sig_bt, regs_cc, args_passed_cc, false);
 
   int extra_stack_offset = wordSize; // stack has the returned address
-  int sp_inc = shuffle_value_args(false, receiver_only, extra_stack_offset, sig_bt, sig_cc,
-                                  args_passed, args_on_stack, regs,
-                                  args_passed_cc, args_on_stack_cc, regs_cc);
+  int sp_inc = (args_on_stack_cc - args_on_stack) * VMRegImpl::stack_slot_size;
+  if (sp_inc > 0) {
+    sp_inc = align_up(sp_inc, StackAlignmentInBytes);
+  } else {
+    sp_inc = 0;
+  }
+  shuffle_value_args(false, receiver_only, extra_stack_offset, sig_bt, sig_cc,
+                     args_passed, args_on_stack, regs,
+                     args_passed_cc, args_on_stack_cc, regs_cc, sp_inc);
   return sp_inc;
 }
 
-int MacroAssembler::shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
-                                              BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                              int args_passed, int args_on_stack, VMRegPair* regs,            // from
-                                              int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
-                                              int sp_inc, int ret_off) {
+void MacroAssembler::shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
+                                               BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
+                                               int args_passed, int args_on_stack, VMRegPair* regs,            // from
+                                               int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
+                                               int sp_inc, int ret_off) {
   int max_stack = MAX2(args_on_stack + sp_inc/VMRegImpl::stack_slot_size, args_on_stack_to);
   RegState* reg_state = init_reg_state(is_packing, sig_cc, regs, args_passed, sp_inc, max_stack);
 
@@ -236,7 +242,6 @@ int MacroAssembler::shuffle_value_args_common(bool is_packing, bool receiver_onl
     }
   }
   guarantee(done, "Could not resolve circular dependency when shuffling value type arguments");
-  return sp_inc;
 }
 
 bool MacroAssembler::shuffle_value_args_spill(bool is_packing, const GrowableArray<SigEntry>* sig_cc, int sig_cc_index,

--- a/src/hotspot/share/asm/macroAssembler_common.hpp
+++ b/src/hotspot/share/asm/macroAssembler_common.hpp
@@ -42,8 +42,8 @@ private:
   int unpack_value_args_common(Compile* C, bool receiver_only);
   void shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
                                  BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                 int args_passed, int args_on_stack, VMRegPair* regs,            // from
-                                 int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
+                                 int args_passed, int args_on_stack, VMRegPair* regs,
+                                 int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,
                                  int sp_inc, int ret_off);
 
 // };

--- a/src/hotspot/share/asm/macroAssembler_common.hpp
+++ b/src/hotspot/share/asm/macroAssembler_common.hpp
@@ -40,11 +40,11 @@ private:
                            VMRegPair* regs, int num_regs, int sp_inc, int max_stack);
 
   int unpack_value_args_common(Compile* C, bool receiver_only);
-  int shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
-                                BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                int args_passed, int args_on_stack, VMRegPair* regs,            // from
-                                int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
-                                int sp_inc, int ret_off);
+  void shuffle_value_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
+                                 BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
+                                 int args_passed, int args_on_stack, VMRegPair* regs,            // from
+                                 int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,   // to
+                                 int sp_inc, int ret_off);
 
 // };
 

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -911,8 +911,7 @@ void LIR_Assembler::emit_op2(LIR_Op2* op) {
 
 void LIR_Assembler::build_frame() {
   _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), in_bytes(frame_map()->sp_offset_for_orig_pc()),
-                     compilation()->needs_stack_repair(), method()->has_scalarized_args(),
-                     &_verified_value_entry);
+                     needs_stack_repair(), method()->has_scalarized_args(), &_verified_value_entry);
 }
 
 

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -42,7 +42,6 @@ class C1_MacroAssembler: public MacroAssembler {
 
   void inline_cache_check(Register receiver, Register iCache);
   void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc = 0, bool needs_stack_repair = false, bool has_scalarized_args = false, Label* verified_value_entry_label = NULL);
-  void remove_frame(int frame_size_in_bytes, bool needs_stack_repair);
 
   int verified_entry(const CompiledEntrySignature *ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_value_entry_label) {
     return scalarized_entry(ces, frame_size_in_bytes, bang_size_in_bytes, sp_offset_for_orig_pc, verified_value_entry_label, false);

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestC2CCalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestC2CCalls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,32 +23,46 @@
 
 /**
  * @test
- * @library /test/lib
  * @summary Test value type calling convention with compiled to compiled calls.
- * @run main/othervm TestC2CCalls
- * @run main/othervm -XX:-UseBimorphicInlining -Xbatch
+ * @library /test/lib /test/lib /compiler/whitebox /
+ * @compile TestC2CCalls.java
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   TestC2CCalls
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-UseBimorphicInlining -Xbatch
  *                   -XX:CompileCommand=compileonly,TestC2CCalls*::test*
  *                   -XX:CompileCommand=dontinline,TestC2CCalls*::test*
  *                   TestC2CCalls
- * @run main/othervm -XX:-UseBimorphicInlining -Xbatch -XX:-ProfileInterpreter
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-UseBimorphicInlining -Xbatch -XX:-ProfileInterpreter
  *                   -XX:CompileCommand=compileonly,TestC2CCalls*::test*
  *                   -XX:CompileCommand=dontinline,TestC2CCalls*::test*
  *                   TestC2CCalls
- * @run main/othervm -XX:-UseBimorphicInlining -Xbatch
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-UseBimorphicInlining -Xbatch
  *                   -XX:CompileCommand=compileonly,TestC2CCalls::test*
  *                   -XX:CompileCommand=dontinline,TestC2CCalls*::test*
  *                   TestC2CCalls
- * @run main/othervm -XX:-UseBimorphicInlining -Xbatch -XX:-ProfileInterpreter
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-UseBimorphicInlining -Xbatch -XX:-ProfileInterpreter
  *                   -XX:CompileCommand=compileonly,TestC2CCalls::test*
  *                   -XX:CompileCommand=dontinline,TestC2CCalls*::test*
  *                   TestC2CCalls
  */
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
 
-public class TestC2CCalls {
+import sun.hotspot.WhiteBox;
 
+public class TestC2CCalls {
+    public static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    public static final int COMP_LEVEL_FULL_OPTIMIZATION = 4; // C2 or JVMCI
     public static final int rI = Utils.getRandomInstance().nextInt() % 1000;
 
     static inline class OtherVal {
@@ -466,6 +480,25 @@ public class TestC2CCalls {
     }
 
     public static void main(String[] args) {
+// TODO fails with -Djdk.test.lib.random.seed=-2885191669592709487
+        // Sometimes, exclude some methods from compilation with C2 to stress test the calling convention
+        if (Utils.getRandomInstance().nextBoolean()) {
+            ArrayList<Method> methods = new ArrayList<Method>();
+            Collections.addAll(methods, MyValue1.class.getDeclaredMethods());
+            Collections.addAll(methods, MyValue2.class.getDeclaredMethods());
+            Collections.addAll(methods, MyValue3.class.getDeclaredMethods());
+            Collections.addAll(methods, MyValue4.class.getDeclaredMethods());
+            Collections.addAll(methods, MyObject.class.getDeclaredMethods());
+            Collections.addAll(methods, TestC2CCalls.class.getDeclaredMethods());
+            System.out.println("Excluding methods from C2 compilation:");
+            for (Method m : methods) {
+                if (Utils.getRandomInstance().nextBoolean()) {
+                    System.out.println(m);
+                    WHITE_BOX.makeMethodNotCompilable(m, COMP_LEVEL_FULL_OPTIMIZATION, false);
+                }
+            }
+        }
+
         MyValue1 val1 = new MyValue1(rI);
         MyValue2 val2 = new MyValue2(rI+1);
         MyValue3 val3 = new MyValue3(rI+2);

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestC2CCalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestC2CCalls.java
@@ -480,7 +480,6 @@ public class TestC2CCalls {
     }
 
     public static void main(String[] args) {
-// TODO fails with -Djdk.test.lib.random.seed=-2885191669592709487
         // Sometimes, exclude some methods from compilation with C2 to stress test the calling convention
         if (Utils.getRandomInstance().nextBoolean()) {
             ArrayList<Method> methods = new ArrayList<Method>();


### PR DESCRIPTION
Problem:
We crash during frame walking because the return address on the stack is incorrect. The stack slot containing the return address was accidentally overwritten when packing value type arguments in the scalarized entry of C1 compiled code. The problem is that even after extending the stack, the same slot that contains the return address might be used for an argument and is therefore overwritten. C2 has "reserved entries" to account for that.

Solution:
C1 does not have a reserved stack slot for the return address and we therefore shouldn't reuse the callers frame when packing. Always extend the stack enough for packing to have its "own" stack space to lay out arguments. This wastes some stack space but is much simpler than the "reserved entries" solution applied by C2.

I've modified the C2CCalls test to reliable reproduce this issue by sometimes only compiling some methods with C1. Also did lots of refactoring in preparation of "Calling Convention 2.0". One goal is to get rid of "reserved entries" in C2 as well.