### PR TITLE
8242454: [lworld] TestLWorld::test63 fails with "no exception thrown"

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -495,6 +495,10 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
 
   // Attempt stack-locking ...
   orptr (tmpReg, markWord::unlocked_value);
+  if (EnableValhalla && !UseBiasedLocking) {
+    // Mask always_locked bit such that we go to the slow path if object is a value type
+    andptr(tmpReg, ~((int) markWord::biased_lock_bit_in_place));
+  }
   movptr(Address(boxReg, 0), tmpReg);          // Anticipate successful CAS
   lock();
   cmpxchgptr(boxReg, Address(objReg, oopDesc::mark_offset_in_bytes()));      // Updates tmpReg


### PR DESCRIPTION
The merge from mainline that moved the fast_lock method accidentally removed a Valhalla specific change.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8242454](https://bugs.openjdk.java.net/browse/JDK-8242454): [lworld] TestLWorld::test63 fails with "no exception thrown"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/16/head:pull/16`
`$ git checkout pull/16`
