### PR TITLE
8242496: [lworld] new and defaultvalue don't perform checks on class to instantiate

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -86,6 +86,7 @@ class InterpreterRuntime: AllStatic {
                                                   Klass* recvKlass,
                                                   Method* missingMethod);
 
+  static void    throw_InstantiationError(JavaThread* thread);
   static void    throw_IncompatibleClassChangeError(JavaThread* thread);
   static void    throw_IncompatibleClassChangeErrorVerbose(JavaThread* thread,
                                                            Klass* resc,

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -163,6 +163,7 @@ class InstanceKlass: public Klass {
   friend class JVMCIVMStructs;
   friend class ClassFileParser;
   friend class CompileReplay;
+  friend class TemplateTable;
 
  public:
   static const KlassID ID = InstanceKlassID;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/CreationErrorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/CreationErrorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.valuetypes;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.invoke.*;
+import java.lang.ref.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static jdk.test.lib.Asserts.*;
+
+import jdk.experimental.bytecode.MacroCodeBuilder;
+import jdk.experimental.bytecode.MacroCodeBuilder.CondKind;
+import jdk.experimental.bytecode.TypeTag;
+import jdk.test.lib.Platform;
+import jdk.test.lib.Utils;
+
+import jdk.experimental.value.MethodHandleBuilder;
+
+import javax.tools.*;
+
+/**
+ * @test CreationErrorTest
+ * @summary Test data movement with inline types
+ * @modules java.base/jdk.experimental.bytecode
+ *          java.base/jdk.experimental.value
+ * @library /test/lib
+ * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
+ *                   runtime.valhalla.valuetypes.CreationErrorTest
+ */
+
+public class CreationErrorTest {
+
+    static inline class InlineClass {
+	int i = 0;
+    }
+
+    static class IdentityClass {
+	long l = 0L;
+    }
+
+    static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    
+    public static void main(String[] args) {
+	testErroneousObjectCreation();
+	testErroneousValueCreation();
+    }
+    
+    static void testErroneousObjectCreation() {
+	MethodHandle testNewOnInlineClass = MethodHandleBuilder.loadCode(
+                LOOKUP,
+                "testNewOnInlineClass",
+                MethodType.methodType(boolean.class),
+                CODE -> {
+		    CODE.new_(InlineClass.class)
+			.iconst_1()
+			.return_(TypeTag.Z);
+                });
+	Throwable error = null;
+	try {
+	    boolean result = (boolean) testNewOnInlineClass.invokeExact();
+	} catch (Throwable t) {
+	    error = t;
+	}
+	System.out.println("error="+error);
+        assertTrue(error != null && error instanceof InstantiationError, "Invariant");
+
+    }
+
+    // Note: this test might become obsolete if defaultvalue is extended to accept identity classes
+    static void testErroneousValueCreation() {
+	MethodHandle testDefaultvalueOnIdentityClass = MethodHandleBuilder.loadCode(
+                LOOKUP,
+                "testDefaultValueOnIdentityClass",
+                MethodType.methodType(boolean.class),
+                CODE -> {
+		    CODE.defaultvalue(IdentityClass.class)
+			.iconst_1()
+			.return_(TypeTag.Z);
+                });
+	Throwable error = null;
+	try {
+	    boolean result = (boolean) testDefaultvalueOnIdentityClass.invokeExact();
+	} catch (Throwable t) {
+	    error = t;
+	}
+	System.out.println("error="+error);
+        assertTrue(error != null && error instanceof IncompatibleClassChangeError, "Invariant");
+
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/CreationErrorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/CreationErrorTest.java
@@ -60,59 +60,59 @@ import javax.tools.*;
 public class CreationErrorTest {
 
     static inline class InlineClass {
-	int i = 0;
+        int i = 0;
     }
 
     static class IdentityClass {
-	long l = 0L;
+        long l = 0L;
     }
 
     static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-    
+
     public static void main(String[] args) {
-	testErroneousObjectCreation();
-	testErroneousValueCreation();
+        testErroneousObjectCreation();
+        testErroneousValueCreation();
     }
-    
+
     static void testErroneousObjectCreation() {
-	MethodHandle testNewOnInlineClass = MethodHandleBuilder.loadCode(
+        MethodHandle testNewOnInlineClass = MethodHandleBuilder.loadCode(
                 LOOKUP,
                 "testNewOnInlineClass",
                 MethodType.methodType(boolean.class),
                 CODE -> {
-		    CODE.new_(InlineClass.class)
-			.iconst_1()
-			.return_(TypeTag.Z);
+                    CODE.new_(InlineClass.class)
+                        .iconst_1()
+                        .return_(TypeTag.Z);
                 });
-	Throwable error = null;
-	try {
-	    boolean result = (boolean) testNewOnInlineClass.invokeExact();
-	} catch (Throwable t) {
-	    error = t;
-	}
-	System.out.println("error="+error);
+        Throwable error = null;
+        try {
+            boolean result = (boolean) testNewOnInlineClass.invokeExact();
+        } catch (Throwable t) {
+            error = t;
+        }
+        System.out.println("error="+error);
         assertTrue(error != null && error instanceof InstantiationError, "Invariant");
 
     }
 
     // Note: this test might become obsolete if defaultvalue is extended to accept identity classes
     static void testErroneousValueCreation() {
-	MethodHandle testDefaultvalueOnIdentityClass = MethodHandleBuilder.loadCode(
+        MethodHandle testDefaultvalueOnIdentityClass = MethodHandleBuilder.loadCode(
                 LOOKUP,
                 "testDefaultValueOnIdentityClass",
                 MethodType.methodType(boolean.class),
                 CODE -> {
-		    CODE.defaultvalue(IdentityClass.class)
-			.iconst_1()
-			.return_(TypeTag.Z);
+                    CODE.defaultvalue(IdentityClass.class)
+                        .iconst_1()
+                        .return_(TypeTag.Z);
                 });
-	Throwable error = null;
-	try {
-	    boolean result = (boolean) testDefaultvalueOnIdentityClass.invokeExact();
-	} catch (Throwable t) {
-	    error = t;
-	}
-	System.out.println("error="+error);
+        Throwable error = null;
+        try {
+            boolean result = (boolean) testDefaultvalueOnIdentityClass.invokeExact();
+        } catch (Throwable t) {
+            error = t;
+        }
+        System.out.println("error="+error);
         assertTrue(error != null && error instanceof IncompatibleClassChangeError, "Invariant");
 
     }


### PR DESCRIPTION
The new and defaultvalue bytecodes currently lack a check to ensure that the class to instantiate is of the right kind.

These changes add checks in both slow and fast path of the interpreter.

Testing:
  - unit test added
  - mach5 tier 1 (all failures were pre-existing)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8242496](https://bugs.openjdk.java.net/browse/JDK-8242496): [lworld] new and defaultvalue don't perform checks on class to instantiate


### Reviewers
 * David Simms ([dsimms](@MrSimms) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/21/head:pull/21`
`$ git checkout pull/21`
