### PR TITLE
8242900: [lworld] Allow an inline type to declare a superclass that meets specified restrictions

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -126,6 +126,19 @@ public class Flags {
      */
     public static final int HASINIT          = 1<<18;
 
+    /** Flag is set for a class symbol if it defines one or more non-empty
+     *  instance initializer block(s). This is relevenat only for class symbols
+     *  that originate from source types. For binary types the instance initializer
+     *  blocks are "normalized" into the constructors.
+     */
+    public static final int HASINITBLOCK         = 1<<18;
+
+    /** Flag is set for a method symbol if it is an empty no-arg ctor.
+     *  i.e one that simply returns (jlO) or merely chains to a super's
+     *  EMPTYNOARGCONSTR
+     */
+    public static final int EMPTYNOARGCONSTR         = 1<<18;
+
     /** Flag is set for a value based class.
      */
     public static final int VALUEBASED       = 1<<19;
@@ -458,6 +471,8 @@ public class Flags {
         ANNOTATION(Flags.ANNOTATION),
         DEPRECATED(Flags.DEPRECATED),
         HASINIT(Flags.HASINIT),
+        HASINITBLOCK(Flags.HASINITBLOCK),
+        EMPTYNOARGCONSTR(Flags.EMPTYNOARGCONSTR),
         BLOCK(Flags.BLOCK),
         ENUM(Flags.ENUM),
         MANDATED(Flags.MANDATED),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -743,6 +743,50 @@ public class Check {
                                     : t;
         }
 
+    void checkConstraintsOfInlineSuper(DiagnosticPosition pos, ClassSymbol c) {
+        boolean indirectSuper = false;
+        for(Type st = types.supertype(c.type); st != Type.noType; indirectSuper = true, st = types.supertype(st)) {
+            if (st == null || st.tsym == null || st.tsym.kind == ERR)
+                return;
+            if  (indirectSuper && st.tsym == syms.objectType.tsym)
+                return;
+            if (!st.tsym.isAbstract()) {
+                log.error(pos, Errors.ConcreteSupertypeForInlineClass(c, st));
+            }
+            if ((st.tsym.flags() & HASINITBLOCK) != 0) {
+                log.error(pos, Errors.SuperClassDeclaresInitBlock(c, st));
+            }
+            // No instance fields and no arged constructors both mean inner classes cannot be inline supers.
+            Type encl = st.getEnclosingType();
+            if (encl != null && encl.hasTag(CLASS)) {
+                log.error(pos, Errors.SuperClassCannotBeInner(c, st));
+            }
+            for (Symbol s : st.tsym.members().getSymbols(NON_RECURSIVE)) {
+                switch (s.kind) {
+                case VAR:
+                    if ((s.flags() & STATIC) == 0) {
+                        log.error(pos, Errors.SuperFieldNotAllowed(s, c, st));
+                    }
+                    break;
+                case MTH:
+                    if ((s.flags() & SYNCHRONIZED) != 0) {
+                        log.error(pos, Errors.SuperMethodCannotBeSynchronized(s, c, st));
+                    } else if (s.isConstructor()) {
+                        MethodSymbol m = (MethodSymbol)s;
+                        if (m.getParameters().size() > 0) {
+                            log.error(pos, Errors.SuperConstructorCannotTakeArguments(m, c, st));
+                        } else {
+                            if ((m.flags() & (GENERATEDCONSTR | EMPTYNOARGCONSTR)) == 0) {
+                                log.error(pos, Errors.SuperNoArgConstructorMustBeEmpty(m, c, st));
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
     /** Check that type is a valid qualifier for a constructor reference expression
      */
     Type checkConstructorRefType(DiagnosticPosition pos, Type t) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -688,8 +688,6 @@ public class TypeEnter implements Completer {
             final boolean isValueType = (tree.mods.flags & Flags.VALUE) != 0;
 
             if (tree.extending != null) {
-                if (isValueType)
-                    log.error(tree.pos(), Errors.ValueMayNotExtend);
                 extending = clearTypeParams(tree.extending);
                 supertype = attr.attribBase(extending, baseEnv, true, false, true);
                 if (supertype == syms.recordType) {
@@ -710,7 +708,7 @@ public class TypeEnter implements Completer {
             if (injectTopInterfaceTypes) {
                 if (isValueType || types.isValue(supertype)) {
                     interfaceToInject = syms.inlineObjectType;
-                } else if ((sym.flags_field & INTERFACE) == 0) { // skip interfaces and annotations.
+                } else if ((sym.flags_field & (INTERFACE | ABSTRACT)) == 0) { // skip interfaces, abstract classes and annotations.
                     if (sym.fullname != names.java_lang_Object) {
                         interfaceToInject = syms.identityObjectType;
                     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -792,6 +792,17 @@ public class ClassReader {
 
             new AttributeReader(names.Code, V45_3, MEMBER_ATTRIBUTE) {
                 protected void read(Symbol sym, int attrLen) {
+                    if (allowInlineTypes) {
+                        if (sym.isConstructor()  && ((MethodSymbol) sym).type.getParameterTypes().size() == 0) {
+                            int code_length = buf.getInt(bp + 4);
+                            if ((code_length == 1 && buf.getByte( bp + 8) == (byte) ByteCodes.return_) ||
+                                    (code_length == 5 && buf.getByte(bp + 8) == ByteCodes.aload_0 &&
+                                        buf.getByte( bp + 9) == (byte) ByteCodes.invokespecial &&
+                                                buf.getByte( bp + 12) == (byte) ByteCodes.return_)) {
+                                    sym.flags_field |= EMPTYNOARGCONSTR;
+                            }
+                        }
+                    }
                     if (saveParameterNames)
                         ((MethodSymbol)sym).code = readCode(sym);
                     else

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
@@ -194,7 +194,6 @@ public class TransValues extends TreeTranslator {
                 MethodSymbol symbol = (MethodSymbol)TreeInfo.symbol(call.meth);
                 if (names._super.equals(name)) { // "initial" constructor.
                     // Synthesize code to allocate factory "product" via: V $this = V.default;
-                    Assert.check(symbol.owner == syms.objectType.tsym);
                     Assert.check(symbol.type.getParameterTypes().size() == 0);
                     final JCExpression type = make.Type(currentClass.type);
                     rhs = make.Select(type, new VarSymbol(STATIC, names._default, currentClass.type, currentClass.sym));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3715,3 +3715,33 @@ compiler.err.identity.type.must.not.implement.inline.object=\
 compiler.err.mutually.incompatible.interfaces=\
     The interfaces IdentityObject and InlineObject are mutually exclusive. The type {0} cannot implement both 
 
+# 0: symbol, 1: type
+compiler.err.concrete.supertype.for.inline.class=\
+    The concrete class {1} is not allowed to be a super class of the inline class {0} either directly or indirectly
+
+# 0: symbol, 1: symbol, 2: type
+compiler.err.super.method.cannot.be.synchronized=\
+    The method {0} in the super class {2} of the inline type {1} is synchronized. This is disallowed
+
+# 0: symbol, 1: symbol, 2: type
+compiler.err.super.constructor.cannot.take.arguments=\
+    The super class {2} of the inline type {1} defines a constructor {0} that takes arguments. This is disallowed
+
+# 0: symbol, 1: symbol, 2: type
+compiler.err.super.field.not.allowed=\
+    The super class {2} of the inline type {1} defines an instance field {0}. This is disallowed
+
+# 0: symbol, 1: symbol, 2: type
+compiler.err.super.no.arg.constructor.must.be.empty=\
+    The super class {2} of the inline type {1} defines a nonempty no-arg constructor {0}. This is disallowed
+
+# 0: symbol, 1: type
+compiler.err.super.class.declares.init.block=\
+    The super class {1} of the inline class {0} declares one or more non-empty instance initializer blocks. This is disallowed.
+
+# 0: symbol, 1: type
+compiler.err.super.class.cannot.be.inner=\
+    The super class {1} of the inline class {0} is an inner class. This is disallowed.
+
+
+

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -109,17 +109,20 @@ public class TreeInfo {
     }
 
     /** Is there a constructor invocation in the given list of trees?
+     *  Optionally, check only for no-arg ctor invocation
      */
-    public static Name getConstructorInvocationName(List<? extends JCTree> trees, Names names) {
+    public static Name getConstructorInvocationName(List<? extends JCTree> trees, Names names, boolean argsAllowed) {
         for (JCTree tree : trees) {
             if (tree.hasTag(EXEC)) {
                 JCExpressionStatement stat = (JCExpressionStatement)tree;
                 if (stat.expr.hasTag(APPLY)) {
                     JCMethodInvocation apply = (JCMethodInvocation)stat.expr;
-                    Name methName = TreeInfo.name(apply.meth);
-                    if (methName == names._this ||
-                        methName == names._super) {
-                        return methName;
+                    if (argsAllowed || apply.args.size() == 0) {
+                        Name methName = TreeInfo.name(apply.meth);
+                        if (methName == names._this ||
+                                methName == names._super) {
+                            return methName;
+                        }
                     }
                 }
             }

--- a/test/jdk/java/lang/annotation/TypeAnnotationReflection.java
+++ b/test/jdk/java/lang/annotation/TypeAnnotationReflection.java
@@ -74,9 +74,8 @@ public class TypeAnnotationReflection {
     private static void testInterfaces() throws Exception {
         AnnotatedType[] as;
         as = TestClassArray.class.getAnnotatedInterfaces();
-        check(as.length == 4); // Adjust as per JDK-8237952
+        check(as.length == 3);
         check(as[1].getAnnotations().length == 0);
-        check(as[3].getAnnotations().length == 0); // Adjust as per JDK-8237952
 
         Annotation[] annos;
         annos = as[0].getAnnotations();
@@ -327,9 +326,8 @@ public class TypeAnnotationReflection {
         // Base
         AnnotatedType[] as;
         as = TestParameterizedType.class.getAnnotatedInterfaces();
-        check(as.length == 2); // Adjust as per  JDK-8237952
+        check(as.length == 1);
         check(as[0].getAnnotations().length == 1);
-        check(as[1].getAnnotations().length == 0); // Adjust as per  JDK-8237952
         check(as[0].getAnnotation(TypeAnno.class).value().equals("M"));
 
         Annotation[] annos;

--- a/test/jdk/java/lang/reflect/Generics/TestC1.java
+++ b/test/jdk/java/lang/reflect/Generics/TestC1.java
@@ -80,9 +80,8 @@ public class TestC1 {
         System.out.println("testing superinterfaces");
         Type[] sis = cls.getGenericInterfaces();
         assert
-            (sis.length == 1) :  // Adjust based on JDK-8237952
-            "C1 should have one generic superinterface";  // Adjust based on JDK-8237952
-        assert (sis[0] == IdentityObject.class);  // Adjust based on JDK-8237952
+            (sis.length == 0) :
+            "C1 should have no generic superinterfaces";
     }
 
     static void testTypeParameters() {

--- a/test/jdk/java/lang/reflect/Generics/TestC2.java
+++ b/test/jdk/java/lang/reflect/Generics/TestC2.java
@@ -183,8 +183,8 @@ public class TestC2 {
         System.out.println("testing superinterfaces");
         Type[] sis = cls.getGenericInterfaces();
         assert
-            ((sis.length == 4)): // Adjust based on JDK-8237952
-            "C2 should have four generic superinterfaces"; // Adjust based on JDK-8237952
+            ((sis.length == 3)):
+            "C2 should have three generic superinterfaces";
 
         Type t = sis[0];
         assert
@@ -216,8 +216,6 @@ public class TestC2 {
         assert
             t == I3.class :
             "Third superinterface of C2 is I3";
-
-        assert (sis[3] == IdentityObject.class); // Adjust based on JDK-8237952
 
         // Test interfaces themselves
 

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -211,3 +211,10 @@ compiler.warn.this.exposed.prematurely
 compiler.err.identity.type.must.not.implement.inline.object
 compiler.err.inline.type.must.not.implement.identity.object
 compiler.err.mutually.incompatible.interfaces
+compiler.err.concrete.supertype.for.inline.class
+compiler.err.super.class.cannot.be.inner
+compiler.err.super.class.declares.init.block
+compiler.err.super.constructor.cannot.take.arguments
+compiler.err.super.field.not.allowed
+compiler.err.super.method.cannot.be.synchronized
+compiler.err.super.no.arg.constructor.must.be.empty

--- a/test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_2.out
+++ b/test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_2.out
@@ -22,7 +22,7 @@ public class GeneratedClass<T> extends java.util.ArrayList<java.lang.String> imp
 round: 2
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedSource();
 
@@ -30,7 +30,7 @@ public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.
 }
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedClass();
 
@@ -39,7 +39,7 @@ public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.N
 round: 3
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedSource();
 
@@ -47,7 +47,7 @@ public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.
 }
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedClass();
 

--- a/test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_3.out
+++ b/test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_3.out
@@ -1,7 +1,7 @@
 round: 1
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedSource();
 
@@ -9,7 +9,7 @@ public abstract class GeneratedSource<E> extends java.util.LinkedList<java.lang.
 }
 
 @javax.annotation.processing.SupportedAnnotationTypes({"*"})
-public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence, java.lang.IdentityObject {
+public abstract class GeneratedClass<E> extends java.util.LinkedList<java.lang.Number> implements java.lang.Runnable, java.lang.CharSequence {
 
   public GeneratedClass();
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
@@ -12,7 +12,7 @@ public class BinarySuperclassConstraints {
 
     // Test that super class cannot be concrete, including express jlO
     inline class I0 extends SuperclassCollections.BadSuper {} // ERROR: concrete super class
-    
+
     // Test that abstract class is allowed to be super including when extending jlO
     inline class I3 extends SuperclassCollections.GoodSuper implements SuperclassCollections.GoodSuperInterface {} // jlO can be indirect super class
     inline class I4 extends SuperclassCollections.Integer {}
@@ -31,7 +31,7 @@ public class BinarySuperclassConstraints {
     inline class I7 extends SuperclassCollections.SuperWithStaticField {} // OK.
 
     // -------------------------------------------------------------
-    
+
     // Test that no-arg constructor must be empty
     inline class I8 extends SuperclassCollections.SuperWithEmptyNoArgCtor_02 {}
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
@@ -1,0 +1,47 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8242900
+ * @summary Verify various constraints for an inline class's BINARY super types.
+ * @compile -XDallowEmptyValues -XDrawDiagnostics -XDdev SuperclassCollections.java
+ * @compile/fail/ref=BinarySuperclassConstraints.out -XDallowEmptyValues -XDrawDiagnostics -XDdev BinarySuperclassConstraints.java
+ */
+
+public class BinarySuperclassConstraints {
+
+    // -------------------------------------------------------------
+
+    // Test that super class cannot be concrete, including express jlO
+    inline class I0 extends SuperclassCollections.BadSuper {} // ERROR: concrete super class
+    
+    // Test that abstract class is allowed to be super including when extending jlO
+    inline class I3 extends SuperclassCollections.GoodSuper implements SuperclassCollections.GoodSuperInterface {} // jlO can be indirect super class
+    inline class I4 extends SuperclassCollections.Integer {}
+    inline class I5 extends Number {
+        public double doubleValue() { return 0; }
+        public float floatValue() { return 0; }
+        public long longValue() { return 0; }
+        public int intValue() { return 0; }
+    }
+
+    // -------------------------------------------------------------
+
+    // Test that super class cannot define instance fields.
+    inline class I6 extends SuperclassCollections.SuperWithInstanceField_01 {} // ERROR:
+
+    inline class I7 extends SuperclassCollections.SuperWithStaticField {} // OK.
+
+    // -------------------------------------------------------------
+    
+    // Test that no-arg constructor must be empty
+    inline class I8 extends SuperclassCollections.SuperWithEmptyNoArgCtor_02 {}
+
+    inline class I9 extends SuperclassCollections.SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
+
+    inline class I10 extends SuperclassCollections.SuperWithArgedCtor_01 {} // ERROR:
+
+    inline class I11 extends SuperclassCollections.SuperWithInstanceInit_01 {} // ERROR:
+
+    inline class I12 extends SuperclassCollections.SuperWithSynchronizedMethod_1 {} // ERROR:
+
+    inline class I13 extends SuperclassCollections.InnerSuper {}
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
@@ -1,0 +1,8 @@
+BinarySuperclassConstraints.java:14:12: compiler.err.inline.type.must.not.implement.identity.object: BinarySuperclassConstraints.I0
+BinarySuperclassConstraints.java:29:12: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
+BinarySuperclassConstraints.java:38:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
+BinarySuperclassConstraints.java:40:12: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor
+BinarySuperclassConstraints.java:42:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithInstanceInit(), BinarySuperclassConstraints.I11, SuperclassCollections.SuperWithInstanceInit
+BinarySuperclassConstraints.java:44:12: compiler.err.super.method.cannot.be.synchronized: foo(), BinarySuperclassConstraints.I12, SuperclassCollections.SuperWithSynchronizedMethod
+BinarySuperclassConstraints.java:46:12: compiler.err.encl.class.required: SuperclassCollections.InnerSuper
+7 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Values may not extend
  *
- * @compile/fail/ref=CheckExtends.out -XDrawDiagnostics CheckExtends.java
+ * @compile/fail/ref=CheckExtends.out -XDallowEmptyValues -XDrawDiagnostics CheckExtends.java
  */
 
 final inline class CheckExtends extends Object {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:8:14: compiler.err.value.may.not.extend
+CheckExtends.java:8:14: compiler.err.concrete.supertype.for.inline.class: CheckExtends, java.lang.Object
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
@@ -1,3 +1,3 @@
-IllegalByValueTest2.java:19:56: compiler.err.value.may.not.extend
 IllegalByValueTest2.java:19:27: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
+IllegalByValueTest2.java:19:56: compiler.err.inline.type.must.not.implement.identity.object: compiler.misc.anonymous.class: java.lang.InlineObject
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Check inlineness via __inline__ annotation
  * @bug 8222745
- * @compile/fail/ref=InlineAnnotationTest.out -XDrawDiagnostics InlineAnnotationTest.java
+ * @compile/fail/ref=InlineAnnotationTest.out -XDallowEmptyValues -XDrawDiagnostics InlineAnnotationTest.java
  */
 
 @__inline__

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
@@ -1,5 +1,4 @@
 InlineAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
-InlineAnnotationTest.java:9:1: compiler.err.value.may.not.extend
-InlineAnnotationTest.java:13:1: compiler.err.empty.value.not.yet
+InlineAnnotationTest.java:9:1: compiler.err.concrete.supertype.for.inline.class: InlineAnnotationTest01, java.lang.Object
 InlineAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
-4 errors
+3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
@@ -26,9 +26,9 @@
 public class SuperclassCollections {
 
     public static class BadSuper {}
-    
+
     public interface GoodSuperInterface {}
-    public static abstract class GoodSuper extends Object {} 
+    public static abstract class GoodSuper extends Object {}
     public static abstract class Integer extends Number {
         public double doubleValue() { return 0; }
         public float floatValue() { return 0; }

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class SuperclassCollections {
+
+    public static class BadSuper {}
+    
+    public interface GoodSuperInterface {}
+    public static abstract class GoodSuper extends Object {} 
+    public static abstract class Integer extends Number {
+        public double doubleValue() { return 0; }
+        public float floatValue() { return 0; }
+        public long longValue() { return 0; }
+        public int intValue() { return 0; }
+    }
+    public static abstract class SuperWithInstanceField {
+        int x;
+    }
+    public static abstract class SuperWithInstanceField_01 extends SuperWithInstanceField {}
+
+    public static abstract class SuperWithStaticField {
+        static int x;
+    }
+    public static abstract class SuperWithEmptyNoArgCtor {
+        SuperWithEmptyNoArgCtor() {
+            // Programmer supplied ctor but injected super call
+        }
+    }
+    public static abstract class SuperWithEmptyNoArgCtor_01 extends SuperWithEmptyNoArgCtor {
+        SuperWithEmptyNoArgCtor_01() {
+            super();  // programmer coded chaining no-arg constructor
+        }
+    }
+    public static abstract class SuperWithEmptyNoArgCtor_02 extends SuperWithEmptyNoArgCtor_01 {
+        // Synthesized chaining no-arg constructor
+    }
+
+    public static abstract class SuperWithNonEmptyNoArgCtor {
+        SuperWithNonEmptyNoArgCtor() {
+            System.out.println("Non-Empty");
+        }
+    }
+    public static abstract class SuperWithNonEmptyNoArgCtor_01 extends SuperWithNonEmptyNoArgCtor {}
+
+    public static abstract class SuperWithArgedCtor {
+        SuperWithArgedCtor() {}
+        SuperWithArgedCtor(String s) {
+        }
+    }
+    public static abstract class SuperWithArgedCtor_01 extends SuperWithArgedCtor {}
+
+    public static abstract class SuperWithInstanceInit {
+        {
+            System.out.println("Disqualified from being super");
+        }
+    }
+    public static abstract class SuperWithInstanceInit_01 extends SuperWithInstanceInit {
+        {
+            // Not disqualified since it is a meaningless empty block.
+        }
+    }
+
+    public static abstract class SuperWithSynchronizedMethod {
+        synchronized void foo() {}
+    }
+    public static abstract class SuperWithSynchronizedMethod_1 extends SuperWithSynchronizedMethod {
+    }
+
+    public abstract class InnerSuper {}
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
@@ -14,10 +14,10 @@ public class SuperclassConstraints {
     inline class I0 extends BadSuper {} // ERROR: concrete super class
     inline class I1 extends Object {}   // ERROR: concrete jlO cannot be express-superclass
     inline class I2 {} // OK
-    
+
     // Test that abstract class is allowed to be super including when extending jlO
     interface GoodSuperInterface {}
-    static abstract class GoodSuper extends Object {} 
+    static abstract class GoodSuper extends Object {}
     inline class I3 extends GoodSuper implements GoodSuperInterface {} // jlO can be indirect super class
     static abstract class Integer extends Number {
         public double doubleValue() { return 0; }
@@ -50,7 +50,7 @@ public class SuperclassConstraints {
     inline class I7 extends SuperWithStaticField {} // OK.
 
     // -------------------------------------------------------------
-    
+
     // Test that no-arg constructor must be empty
     static abstract class SuperWithEmptyNoArgCtor {
         SuperWithEmptyNoArgCtor() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
@@ -1,0 +1,111 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8242900
+ * @summary Verify various constraints for an inline class's super types.
+ * @compile/fail/ref=SuperclassConstraints.out -XDallowEmptyValues -XDrawDiagnostics -XDdev SuperclassConstraints.java
+ */
+
+public class SuperclassConstraints {
+
+    // -------------------------------------------------------------
+
+    // Test that super class cannot be concrete, including express jlO
+    static class BadSuper {}
+    inline class I0 extends BadSuper {} // ERROR: concrete super class
+    inline class I1 extends Object {}   // ERROR: concrete jlO cannot be express-superclass
+    inline class I2 {} // OK
+    
+    // Test that abstract class is allowed to be super including when extending jlO
+    interface GoodSuperInterface {}
+    static abstract class GoodSuper extends Object {} 
+    inline class I3 extends GoodSuper implements GoodSuperInterface {} // jlO can be indirect super class
+    static abstract class Integer extends Number {
+        public double doubleValue() { return 0; }
+        public float floatValue() { return 0; }
+        public long longValue() { return 0; }
+        public int intValue() { return 0; }
+    }
+    inline class I4 extends Integer {}
+    inline class I5 extends Number {
+        public double doubleValue() { return 0; }
+        public float floatValue() { return 0; }
+        public long longValue() { return 0; }
+        public int intValue() { return 0; }
+    }
+
+    // -------------------------------------------------------------
+
+    // Test that super class cannot define instance fields.
+    static abstract class SuperWithInstanceField {
+        int x;
+    }
+    static abstract class SuperWithInstanceField_01 extends SuperWithInstanceField {}
+
+    inline class I6 extends SuperWithInstanceField_01 {} // ERROR:
+
+    // Test that super class can define static fields.
+    static abstract class SuperWithStaticField {
+        static int x;
+    }
+    inline class I7 extends SuperWithStaticField {} // OK.
+
+    // -------------------------------------------------------------
+    
+    // Test that no-arg constructor must be empty
+    static abstract class SuperWithEmptyNoArgCtor {
+        SuperWithEmptyNoArgCtor() {
+            // Programmer supplied ctor but injected super call
+        }
+    }
+    static abstract class SuperWithEmptyNoArgCtor_01 extends SuperWithEmptyNoArgCtor {
+        SuperWithEmptyNoArgCtor_01() {
+            super();  // programmer coded chaining no-arg constructor
+        }
+    }
+    static abstract class SuperWithEmptyNoArgCtor_02 extends SuperWithEmptyNoArgCtor_01 {
+        // Synthesized chaining no-arg constructor
+    }
+    inline class I8 extends SuperWithEmptyNoArgCtor_02 {}
+
+    static abstract class SuperWithNonEmptyNoArgCtor {
+        SuperWithNonEmptyNoArgCtor() {
+            System.out.println("Non-Empty");
+        }
+    }
+    static abstract class SuperWithNonEmptyNoArgCtor_01 extends SuperWithNonEmptyNoArgCtor {}
+    inline class I9 extends SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
+
+    // Test that there can be no other constructors.
+    static abstract class SuperWithArgedCtor {
+        SuperWithArgedCtor() {}
+        SuperWithArgedCtor(String s) {
+        }
+    }
+    static abstract class SuperWithArgedCtor_01 extends SuperWithArgedCtor {}
+    inline class I10 extends SuperWithArgedCtor_01 {} // ERROR:
+
+    // Test that instance initializers are not allowed in supers
+    static abstract class SuperWithInstanceInit {
+        {
+            System.out.println("Disqualified from being super");
+        }
+    }
+    static abstract class SuperWithInstanceInit_01 extends SuperWithInstanceInit {
+        {
+            // Not disqualified since it is a meaningless empty block.
+        }
+    }
+    inline class I11 extends SuperWithInstanceInit_01 {} // ERROR:
+
+    // Test that synchronized methods are not allowed in supers.
+    static abstract class SuperWithSynchronizedMethod {
+        synchronized void foo() {}
+    }
+    static abstract class SuperWithSynchronizedMethod_1 extends SuperWithSynchronizedMethod {
+    }
+    inline class I12 extends SuperWithSynchronizedMethod_1 {} // ERROR:
+
+    // No instance fields and no arged constructor also means inner classes cannot be supers
+    abstract class InnerSuper {}
+    inline class I13 extends InnerSuper {}
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,0 +1,9 @@
+SuperclassConstraints.java:14:12: compiler.err.inline.type.must.not.implement.identity.object: SuperclassConstraints.I0
+SuperclassConstraints.java:15:12: compiler.err.concrete.supertype.for.inline.class: SuperclassConstraints.I1, java.lang.Object
+SuperclassConstraints.java:44:12: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
+SuperclassConstraints.java:76:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
+SuperclassConstraints.java:85:12: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor
+SuperclassConstraints.java:98:12: compiler.err.super.class.declares.init.block: SuperclassConstraints.I11, SuperclassConstraints.SuperWithInstanceInit
+SuperclassConstraints.java:106:12: compiler.err.super.method.cannot.be.synchronized: foo(), SuperclassConstraints.I12, SuperclassConstraints.SuperWithSynchronizedMethod
+SuperclassConstraints.java:110:12: compiler.err.super.class.cannot.be.inner: SuperclassConstraints.I13, SuperclassConstraints.InnerSuper
+8 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
@@ -1,5 +1,5 @@
 ValueAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
-ValueAnnotationTest.java:9:1: compiler.err.value.may.not.extend
+ValueAnnotationTest.java:9:1: compiler.err.empty.value.not.yet
 ValueAnnotationTest.java:13:1: compiler.err.empty.value.not.yet
 ValueAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
 4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -2,6 +2,6 @@ ValueModifierTest.java:11:28: compiler.err.empty.value.not.yet
 ValueModifierTest.java:14:16: compiler.err.empty.value.not.yet
 ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: value
 ValueModifierTest.java:15:21: compiler.err.empty.value.not.yet
-ValueModifierTest.java:16:28: compiler.err.value.may.not.extend
 ValueModifierTest.java:16:20: compiler.err.cant.inherit.from.final: value
+ValueModifierTest.java:16:28: compiler.err.override.meth: (compiler.misc.cant.override: hashCode(), compiler.misc.anonymous.class: ValueModifierTest$3, hashCode(), value), final
 6 errors

--- a/test/langtools/tools/javac/varargs/6806876/T6806876.out
+++ b/test/langtools/tools/javac/varargs/6806876/T6806876.out
@@ -1,4 +1,4 @@
-T6806876.java:11:32: compiler.warn.unchecked.generic.array.creation: java.lang.Number&java.lang.Comparable<? extends java.lang.Number&java.lang.Comparable<?>&java.lang.constant.Constable&java.lang.constant.ConstantDesc>&java.lang.constant.Constable&java.lang.constant.ConstantDesc[]
+T6806876.java:11:32: compiler.warn.unchecked.generic.array.creation: java.lang.Number&java.lang.IdentityObject&java.lang.Comparable<? extends java.lang.Number&java.lang.IdentityObject&java.lang.Comparable<?>&java.lang.constant.Constable&java.lang.constant.ConstantDesc>&java.lang.constant.Constable&java.lang.constant.ConstantDesc[]
 T6806876.java:14:19: compiler.warn.unchecked.varargs.non.reifiable.type: T
 - compiler.err.warnings.and.werror
 1 error

--- a/test/langtools/tools/javap/AnnoTest.java
+++ b/test/langtools/tools/javap/AnnoTest.java
@@ -49,50 +49,50 @@ public class AnnoTest {
 
         expect(out,
                 "RuntimeVisibleAnnotations:\n" +
-                "  0: #23(#24=B#25)\n" +
+                "  0: #21(#22=B#23)\n" +
                 "    AnnoTest$ByteAnno(\n" +
                 "      value=(byte) 42\n" +
                 "    )\n" +
-                "  1: #26(#24=S#27)\n" +
+                "  1: #24(#22=S#25)\n" +
                 "    AnnoTest$ShortAnno(\n" +
                 "      value=(short) 3\n" +
                 "    )");
         expect(out,
                 "RuntimeInvisibleAnnotations:\n" +
-                "  0: #29(#24=[J#30,J#32,J#34,J#36,J#38])\n" +
+                "  0: #27(#22=[J#28,J#30,J#32,J#34,J#36])\n" +
                 "    AnnoTest$ArrayAnno(\n" +
                 "      value=[1l,2l,3l,4l,5l]\n" +
                 "    )\n" +
-                "  1: #40(#24=Z#41)\n" +
+                "  1: #38(#22=Z#39)\n" +
                 "    AnnoTest$BooleanAnno(\n" +
                 "      value=false\n" +
                 "    )\n" +
-                "  2: #42(#43=c#44)\n" +
+                "  2: #40(#41=c#42)\n" +
                 "    AnnoTest$ClassAnno(\n" +
                 "      type=class Ljava/lang/Object;\n" +
                 "    )\n" +
-                "  3: #45(#46=e#47.#48)\n" +
+                "  3: #43(#44=e#45.#46)\n" +
                 "    AnnoTest$EnumAnno(\n" +
                 "      kind=Ljavax/lang/model/element/ElementKind;.PACKAGE\n" +
                 "    )\n" +
-                "  4: #49(#24=I#50)\n" +
+                "  4: #47(#22=I#48)\n" +
                 "    AnnoTest$IntAnno(\n" +
                 "      value=2\n" +
                 "    )\n" +
-                "  5: #51()\n" +
+                "  5: #49()\n" +
                 "    AnnoTest$IntDefaultAnno\n" +
-                "  6: #52(#53=s#54)\n" +
+                "  6: #50(#51=s#52)\n" +
                 "    AnnoTest$NameAnno(\n" +
                 "      name=\"NAME\"\n" +
                 "    )\n" +
-                "  7: #55(#56=D#57,#59=F#60)\n" +
+                "  7: #53(#54=D#55,#57=F#58)\n" +
                 "    AnnoTest$MultiAnno(\n" +
                 "      d=3.14159d\n" +
                 "      f=2.71828f\n" +
                 "    )\n" +
-                "  8: #61()\n" +
+                "  8: #59()\n" +
                 "    AnnoTest$SimpleAnno\n" +
-                "  9: #62(#24=@#49(#24=I#63))\n" +
+                "  9: #60(#22=@#47(#22=I#61))\n" +
                 "    AnnoTest$AnnoAnno(\n" +
                 "      value=@AnnoTest$IntAnno(\n" +
                 "        value=5\n" +
@@ -100,7 +100,7 @@ public class AnnoTest {
                 "    )");
         expect(out,
                 "RuntimeInvisibleTypeAnnotations:\n" +
-                "  0: #65(): CLASS_EXTENDS, type_index=0\n" +
+                "  0: #63(): CLASS_EXTENDS, type_index=0\n" +
                 "    AnnoTest$TypeAnno");
 
         if (errors > 0)


### PR DESCRIPTION
Here is a change set that implements the changes for

     https://bugs.openjdk.java.net/browse/JDK-8242900 ([lworld] Allow an inline type to declare a superclass that meets specified restrictions)
and its prerequisite blocker:
    https://bugs.openjdk.java.net/browse/JDK-8242912 (Abstract classes should not implement IdentityObject)

Here is a roadmap that would make it easier for you to review:

    - Go over to the JBS tickets above and read up the description of the tasks
    - Start with the new tests to understand what is being implemented and tested:
       
            test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
            test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
            test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
            test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
            test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out

     - Review of source files is best taken up in this order:
            Flags.java: defines two new flags to decorate classes with initializer blocks and empty no-arg constructor as being such.
            Attr.java:    During attribution flag classes that have initializer blocks and constructors that are empty no-arg constructors.
                              Arrange to check for constraints of a super class of an inline class.
            Check.java: Check the superclass's constraints when asked by the attributor.
            ClassReader.java: When reading class files, flags constructors that are empty no-arg constructors (save for chaining to super's no-arg ctor)
            compiler.properties: new errors.
            TransValues.java: In earlier versions, Inline types implicitly extended jlO, so any super() chaining call must be jlO's ctor. This is no longer the case. So remove the assertion.
            TreeInfo.java: Tweak to a utility method to make it more general and suitable for our present needs.
            TypeEnter.java: Earlier specs forbid an inline type declaration to have an extends clause. This is no longer illegal. So we don't error anymore. Abstract types should not implement the new top interface (IdentityObject)

    - These changes are simply rolling back prior changes made at the time of injection of new top interfaces. Because we don't inject them anymore for abstract classes, we should not encode them in "golden" files:
            test/jdk/java/lang/annotation/TypeAnnotationReflection.java
            test/jdk/java/lang/reflect/Generics/TestC1.java
            test/jdk/java/lang/reflect/Generics/TestC2.java
            test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_2.out
            test/langtools/tools/javac/processing/rounds/OverwriteBetweenCompilations_3.out
            test/langtools/tools/javap/AnnoTest.java

    - To shut up CheckExamples.java from spuriously failing, for the time being add the new compiler message keys to the white list:
            test/langtools/tools/javac/diags/examples.not-yet.txt

    - Other minorly modified tests that you may want to eyeball: (The diagnostics change a little bit since "extends" clause is no longer illegal. I have added -XDallowEmptyValues in some cases to exercise different code paths and elicit different diagnostics)

            test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
            test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
            test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
            test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
            test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
            test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
            test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out

    - This one is an odd man out: (Earlier Number implemented IdentityObject, but not anymore since it is abstract, so it is injected deeper now and surfaces - but this whole express injection is a temporary thing and will go away with JDK-8242612
        test/langtools/tools/javac/varargs/6806876/T6806876.out
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8242900](https://bugs.openjdk.java.net/browse/JDK-8242900): [lworld] Allow an inline type to declare a superclass that meets specified restrictions


### Reviewers
 * JimLaskey (no known github.com user name / role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/23/head:pull/23`
`$ git checkout pull/23`
