### PR TITLE
allow inline classes to have abstract supers

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6927,11 +6927,14 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
       return;
     }
 
-    // For a value class, only java/lang/Object is an acceptable super class
+    // For an inline class, only java/lang/Object or special abstract classes
+    // are acceptable super classes.
     if (_access_flags.get_flags() & JVM_ACC_VALUE) {
-      guarantee_property(_super_klass->name() == vmSymbols::java_lang_Object(),
-        "Inline type must have java.lang.Object as superclass in class file %s",
-        CHECK);
+      if (_super_klass->name() != vmSymbols::java_lang_Object()) {
+        guarantee_property(_super_klass->is_abstract(),
+          "Inline type must have java.lang.Object or an abstract class as its superclass, class file %s",
+          CHECK);
+      }
     }
 
     // Make sure super class is not final

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/classfileparser/BadValueTypes.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/classfileparser/BadValueTypes.java
@@ -60,7 +60,8 @@ public class BadValueTypes {
         runTest("ValueMethodSynch",
                 "Method getInt in class ValueMethodSynch (an inline class) has illegal modifiers");
 
-        runTest("ValueSuperClass", "Inline type must have java.lang.Object as superclass");
+        runTest("ValueSuperClass",
+                "Inline type must have java.lang.Object or an abstract class as its superclass");
 
         // Test that ClassCircularityError gets detected for instance fields.
         System.out.println("Testing ClassCircularityError for instance fields");


### PR DESCRIPTION
Plesae review this change to allow inline classes to have super classes that are abstract classes.  This fix does not test that the abstract classes are 'special'.  That will be done in a future release.

Also, fix verification issue with assigning an inline type to an object of one of its super classes.

Tests will be added once javac support for inline types having abstract classes is merged in.

Thanks, Harold
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/24/head:pull/24`
`$ git checkout pull/24`
