### PR TITLE
8243627: [lworld] Co-evolve jdk-valhalla tests along with JDK-8237072

### DIFF
--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -156,7 +156,7 @@ public class ArrayElementVarHandleTest {
             Point.makePoint(100, 200)
     };
 
-    private static final Point?[] NULLABLE_POINTS = new Point?[]{
+    private static final Point.ref[] NULLABLE_POINTS = new Point.ref[]{
         Point.makePoint(11, 22),
                 Point.makePoint(110, 220),
                 null
@@ -181,13 +181,13 @@ public class ArrayElementVarHandleTest {
     @Test
     public static void testObjectArrayVarHandle() throws Throwable {
         ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Object[].class);
-        // Point[] <: Point?[] <: Object
+        // Point[] <: Point.ref[] <: Object
         Object[] array1 = test.newArray(POINTS.length);
         test.setElements(array1, POINTS);
         test.setElements(array1, NULLABLE_POINTS);
         test.setElements(array1, new Object[] { "abc", Point.makePoint(1, 2) });
 
-        Point ?[]array2 = new Point ?[NULLABLE_POINTS.length];
+        Point.ref []array2 = new Point.ref [NULLABLE_POINTS.length];
         test.setElements(array2, POINTS);
         test.setElements(array2, NULLABLE_POINTS);
 
@@ -196,20 +196,20 @@ public class ArrayElementVarHandleTest {
     }
 
     /*
-     * VarHandle of Point?[].class
+     * VarHandle of Point.ref[].class
      */
     @Test
     public static void testIndirectPointVarHandle() throws Throwable {
-        Object o = new Point?[0];
+        Object o = new Point.ref[0];
         ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(o.getClass());
         assertTrue(test.componentType.isIndirectType());
 
-        // Point[] <: Point?[] <: Object
-        Point?[] array1 = (Point?[])test.newArray(POINTS.length);
+        // Point[] <: Point.ref[] <: Object
+        Point.ref[] array1 = (Point.ref[])test.newArray(POINTS.length);
         test.setElements(array1, POINTS);
         test.setElements(array1, NULLABLE_POINTS);
 
-        Point?[] array2 = new Point?[NULLABLE_POINTS.length];
+        Point.ref[] array2 = new Point.ref[NULLABLE_POINTS.length];
         test.setElements(array2, POINTS);
         test.setElements(array2, NULLABLE_POINTS);
 
@@ -225,7 +225,7 @@ public class ArrayElementVarHandleTest {
         ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Point[].class);
         assertFalse(test.componentType.isIndirectType());
 
-        // Point[] <: Point?[] <: Object
+        // Point[] <: Point.ref[] <: Object
         Point[] array1 = (Point[]) test.newArray(POINTS.length);
         test.setElements(array1, POINTS);
 
@@ -234,20 +234,20 @@ public class ArrayElementVarHandleTest {
     }
 
     /*
-     * VarHandle of Line?[].class
+     * VarHandle of Line.ref[].class
      */
     @Test
     public static void testIndirectLineVarHandle() throws Throwable {
-        Line?[] nullableLines = new Line?[] { null, null };
+        Line.ref[] nullableLines = new Line.ref[] { null, null };
         ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(nullableLines.getClass());
         assertTrue(test.componentType.isIndirectType());
 
-        // Line[] <: Line?[]
-        Line?[] array1 = (Line?[])test.newArray(LINES.length);
+        // Line[] <: Line.ref[]
+        Line.ref[] array1 = (Line.ref[])test.newArray(LINES.length);
         test.setElements(array1, LINES);
         test.setElements(array1, nullableLines);
 
-        Line?[] array2 = new Line?[LINES.length];
+        Line.ref[] array2 = new Line.ref[LINES.length];
         test.setElements(array2, LINES);
         test.setElements(array2, nullableLines);
 

--- a/test/jdk/valhalla/valuetypes/InlineReferenceTest.java
+++ b/test/jdk/valhalla/valuetypes/InlineReferenceTest.java
@@ -39,14 +39,14 @@ public class InlineReferenceTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     static void test1() {
-        Point? p = new Point(10,20);
-        WeakReference<Point?> r = new WeakReference<>(p);
+        Point.ref p = new Point(10,20);
+        WeakReference<Point.ref> r = new WeakReference<>(p);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     static void test2() {
         ReferenceQueue<Object> q = new ReferenceQueue<>();
-        Point? p = new Point(1,2);
-        WeakReference<Point?> r = new WeakReference<>(p, q);
+        Point.ref p = new Point(1,2);
+        WeakReference<Point.ref> r = new WeakReference<>(p, q);
     }
 }

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -133,9 +133,9 @@ public class MethodHandleTest {
 
     @Test
     public static void testNullableArray() throws Throwable {
-        Class<?> arrayClass = (new Point?[0]).getClass();
+        Class<?> arrayClass = (new Point.ref[0]).getClass();
         Class<?> elementType = arrayClass.getComponentType();
-        assertTrue(elementType == Point.class.asIndirectType(), arrayClass.getComponentType().toString());
+        assertTrue(elementType == Point.ref.class, arrayClass.getComponentType().toString());
 
         MethodHandle setter = MethodHandles.arrayElementSetter(arrayClass);
         MethodHandle getter = MethodHandles.arrayElementGetter(arrayClass);
@@ -195,7 +195,8 @@ public class MethodHandleTest {
     void setValueField(String name, Object obj, Object value) throws Throwable {
         Field f = c.getDeclaredField(name);
         boolean isStatic = Modifier.isStatic(f.getModifiers());
-        assertTrue(f.getType().isInlineClass());
+        assertTrue(f.getType().isInlineClass() ||
+                   f.getType().getCanonicalName().endsWith("$ref"));
         assertTrue((isStatic && obj == null) || (!isStatic && obj != null));
         Object v = f.get(obj);
 

--- a/test/jdk/valhalla/valuetypes/MixedValues.java
+++ b/test/jdk/valhalla/valuetypes/MixedValues.java
@@ -25,12 +25,12 @@ import java.util.List;
 
 public class MixedValues {
     static Point staticPoint = Point.makePoint(10, 10);
-    static Line? staticLine;   // null static field of non-flattened type
+    static Line.ref staticLine;   // null static field of non-flattened type
     Point p;
     Line l;
     MutablePath mutablePath;
     List<String> list;
-    Point? nfp;
+    Point.ref nfp;
 
     public MixedValues(Point p, Line l, MutablePath path, String... names) {
         this.p = p;

--- a/test/jdk/valhalla/valuetypes/NonFlattenValue.java
+++ b/test/jdk/valhalla/valuetypes/NonFlattenValue.java
@@ -22,7 +22,7 @@
  */
 
 public inline class NonFlattenValue {
-    Point? nfp;
+    Point.ref nfp;
 
     NonFlattenValue() {
         this.nfp = Point.makePoint(0,0);
@@ -30,13 +30,13 @@ public inline class NonFlattenValue {
     NonFlattenValue(Point p) {
         this.nfp = p;
     }
-    public Point? point() {
+    public Point.ref point() {
         return nfp;
     }
     public Point pointValue() {
         return (Point) nfp;
     }
-    public boolean has(Point p1, Point? p2) {
+    public boolean has(Point p1, Point.ref p2) {
         return nfp.equals(p1) || nfp.equals(p2);
     }
 

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -208,9 +208,9 @@ public class ObjectMethods {
 
     static inline class MyValue1 {
         private Point p;
-        private Point? np;
+        private Point.ref np;
 
-        MyValue1(int x, int y, Point? np) {
+        MyValue1(int x, int y, Point.ref np) {
             this.p = Point.makePoint(x, y);
             this.np = np;
         }

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -125,9 +125,9 @@ public class QTypeDescriptorTest {
 
     @DataProvider
     static Object[][] descriptors() {
-        Class<?> pointLType = Point.class.asIndirectType();
+        Class<?> pointLType = Point.ref.class;
         Class<?> pointQType = Point.class;
-        Class<?> nonFlattenValueLType = NonFlattenValue.class.asIndirectType();
+        Class<?> nonFlattenValueLType = NonFlattenValue.ref.class;
         Class<?> nonFlattenValueQType = NonFlattenValue.class;
         return new Object[][]{
             { QTypeDescriptorTest.class, "toLine", new Class<?>[] {pointQType, nonFlattenValueQType}, true},
@@ -152,7 +152,7 @@ public class QTypeDescriptorTest {
 
     @DataProvider
     static Object[][] methodTypes() {
-        Class<?> pointLType = Point.class.asIndirectType();
+        Class<?> pointLType = Point.ref.class;
         Class<?> pointQType = Point.class;
         ClassLoader loader = QTypeDescriptorTest.class.getClassLoader();
         return new Object[][]{
@@ -162,12 +162,12 @@ public class QTypeDescriptorTest {
             { "point",      MethodType.methodType(pointQType),                            false },
             { "pointValue", MethodType.methodType(pointLType),                            false },
             { "has",        MethodType.methodType(boolean.class, pointLType, pointQType), false },
-            { "point",      MethodType.fromMethodDescriptorString("()LPoint;", loader),         true },
+            { "point",      MethodType.fromMethodDescriptorString("()LPoint$ref;", loader),         true },
             { "point",      MethodType.fromMethodDescriptorString("()QPoint;", loader),         false },
             { "pointValue", MethodType.fromMethodDescriptorString("()QPoint;", loader),         true },
             { "pointValue", MethodType.fromMethodDescriptorString("()LPoint;", loader),         false },
-            { "has",        MethodType.fromMethodDescriptorString("(QPoint;LPoint;)Z", loader), true },
-            { "has",        MethodType.fromMethodDescriptorString("(LPoint;LPoint;)Z", loader), false },
+            { "has",        MethodType.fromMethodDescriptorString("(QPoint;LPoint$ref;)Z", loader), true },
+            { "has",        MethodType.fromMethodDescriptorString("(LPoint$ref;LPoint$ref;)Z", loader), false },
         };
     }
 

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -64,10 +64,10 @@ public class Reflection {
     static void testNonFlattenValue() throws Exception {
         NonFlattenValue nfv = NonFlattenValue.make(10, 20);
         Reflection test = new Reflection(NonFlattenValue.class, "NonFlattenValue", nfv);
-        test.checkField("final Point? NonFlattenValue.nfp", "nfp", Point.class.asIndirectType());
+        test.checkField("final Point$ref NonFlattenValue.nfp", "nfp", Point.ref.class);
         test.checkMethod("public Point NonFlattenValue.pointValue()", "pointValue", Point.class);
-        test.checkMethod("public Point? NonFlattenValue.point()", "point", Point.class.asIndirectType());
-        test.checkMethod("public boolean NonFlattenValue.has(Point,Point?)", "has", boolean.class, Point.class, Point.class.asIndirectType());
+        test.checkMethod("public Point$ref NonFlattenValue.point()", "point", Point.ref.class);
+        test.checkMethod("public boolean NonFlattenValue.has(Point,Point$ref)", "has", boolean.class, Point.class, Point.ref.class);
     }
 
     /*
@@ -75,15 +75,15 @@ public class Reflection {
      */
     static void testMirrors() throws Exception {
         Class<?> primary = Point.class;
-        Class<?> indirect = Point.class.asIndirectType();
+        Class<?> indirect = Point.ref.class;
 
         assertEquals(primary, Point.class);
-        assertEquals(indirect, Point.class.asNullableType());
+        assertEquals(indirect, Point.ref.class);
         assertTrue(primary.isInlineClass());
         assertFalse(primary.isIndirectType());
         assertFalse(primary.isNullableType());
 
-        assertTrue(indirect.isInlineClass());
+        assertTrue(!indirect.isInlineClass());
         assertTrue(indirect.isIndirectType());
         assertTrue(indirect.isNullableType());
 
@@ -116,7 +116,7 @@ public class Reflection {
         assertEquals(Point.class.asNullableType().getName(), "Point");
         assertEquals(Line.class.getName(), "Line");
         assertEquals((new Point[0]).getClass().getName(), "[QPoint;");
-        assertEquals((new Point?[0][0]).getClass().getName(), "[[LPoint;");
+        assertEquals((new Point.ref[0][0]).getClass().getName(), "[[LPoint$ref;");
     }
 
     private final Class<?> c;

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -67,8 +67,8 @@ public class StreamTest {
     static inline class Value {
         int i;
         Point p;
-        Point? nullable;
-        Value(int i, Point p, Point? np) {
+        Point.ref nullable;
+        Value(int i, Point p, Point.ref np) {
             this.i = i;
             this.p = p;
             this.nullable = np;
@@ -78,7 +78,7 @@ public class StreamTest {
             return p;
         }
 
-        Point? nullablePoint() {
+        Point.ref nullablePoint() {
             return nullable;
         }
     }

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -39,8 +39,8 @@ public class SubstitutabilityTest {
     Object[][] substitutableCases() {
         Point p1 = Point.makePoint(10, 10);
         Point p2 = Point.makePoint(20, 20);
-        Point? box1 = p1;
-        Point? box2 = p2;
+        Point.ref box1 = p1;
+        Point.ref box2 = p2;
         Line l1 = Line.makeLine(p1, p2);
         var mpath = MutablePath.makePath(10, 20, 30, 40);
         var mixedValues = new MixedValues(p1, l1, mpath, "value");

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -49,7 +49,7 @@ public class ValueArray {
     }
 
     private static Class<?> nullablePointArrayClass() {
-        Object a = new Point?[0];
+        Object a = new Point.ref[0];
         return a.getClass();
     }
 
@@ -153,7 +153,7 @@ public class ValueArray {
                            new Point[][] { new Point[] { Point.makePoint(1, 2),
                                                          Point.makePoint(10, 20)}}},
             new Object[] { nullablePointArrayClass(),
-                           new Point?[] { Point.makePoint(11, 22),
+                           new Point.ref[] { Point.makePoint(11, 22),
                                           Point.makePoint(110, 220),
                                           null }},
             new Object[] { NonFlattenValue[].class,
@@ -201,16 +201,16 @@ public class ValueArray {
     @Test
     static void testPointArray() {
         Point[] qArray = new Point[0];
-        Point?[] lArray = new Point?[0];
+        Point.ref[] lArray = new Point.ref[0];
 
         ValueArray test = new ValueArray(Point[].class, qArray);
         test.run();
 
-        ValueArray test1 = new ValueArray(Point?[].class, lArray);
+        ValueArray test1 = new ValueArray(Point.ref[].class, lArray);
         test.run();
 
         // language instanceof
         assertTrue(qArray instanceof Point[]);
-        assertTrue(lArray instanceof Point?[]);
+        assertTrue(lArray instanceof Point.ref[]);
     }
 }


### PR DESCRIPTION
Mandy,

May I request you to review these changes to jdk-valhalla tests ? 

JDK-8237072 adds supports for the new syntax notation of V.ref and V.val to 
refer to the reference projection of a value type V and its value projection.
The old syntax of V? is withdrawn. This change also has class file implications
where the descriptor/signature encodings will now start mentioning $ref in the
class pool entries. Also every inline type results in two class files now
one for each projection - with the reference projection class being the superclass
of the inline class.

I'll push them after your review and *after* JDK-8237072 itself is pushed.
Thanks in advance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243627](https://bugs.openjdk.java.net/browse/JDK-8243627): [lworld] Co-evolve jdk-valhalla tests along with JDK-8237072


### Reviewers
 * Mandy Chung ([mchung](@mlchung) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/27/head:pull/27`
`$ git checkout pull/27`
