### PR TITLE
8243626: [lworld] Co-evolve hotspot-runtime tests along with JDK-8237072

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/CheckcastTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/CheckcastTest.java
@@ -65,14 +65,14 @@ public class CheckcastTest {
     static void testCastingFromValToBox(Point p) {
         boolean npe = false;
         try {
-            Point? pb = p;
+            Point.ref pb = p;
         } catch(NullPointerException e) {
             npe = true;
         }
         Asserts.assertFalse(npe, "Casting from val to box should not throw an NPE");
     }
 
-    static void testCastingFromBoxToVal(Point? p) {
+    static void testCastingFromBoxToVal(Point.ref p) {
         boolean npe = false;
         try {
             Point pv = (Point) p;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
@@ -44,16 +44,16 @@ import jdk.test.lib.Asserts;
  */
 public class FlattenableSemanticTest {
 
-    static Point? nfsp;
+    static Point.ref nfsp;
     static Point fsp;
 
-    Point? nfip;
+    Point.ref nfip;
     Point fip;
 
-    static JumboValue? nfsj;
+    static JumboValue.ref nfsj;
     static JumboValue fsj;
 
-    JumboValue? nfij;
+    JumboValue.ref nfij;
     JumboValue fij;
 
     static Object getNull() {
@@ -82,7 +82,7 @@ public class FlattenableSemanticTest {
         // Assigning null must be allowed for non flattenable inline fields
         boolean exception = true;
         try {
-            nfsp = (Point?)getNull();
+            nfsp = (Point.ref)getNull();
             nfsp = null;
             exception = false;
         } catch (NullPointerException e) {
@@ -91,7 +91,7 @@ public class FlattenableSemanticTest {
         Asserts.assertFalse(exception, "Invalid NPE when assigning null to a non flattenable field");
 
         try {
-            nfsj = (JumboValue?)getNull();
+            nfsj = (JumboValue.ref)getNull();
             nfsj = null;
             exception = false;
         } catch (NullPointerException e) {
@@ -100,7 +100,7 @@ public class FlattenableSemanticTest {
         Asserts.assertFalse(exception, "Invalid NPE when assigning null to a non flattenable field");
 
         try {
-            test.nfip = (Point?)getNull();
+            test.nfip = (Point.ref)getNull();
             test.nfip = null;
             exception = false;
         } catch (NullPointerException e) {
@@ -109,7 +109,7 @@ public class FlattenableSemanticTest {
         Asserts.assertFalse(exception, "Invalid NPE when assigning null to a non flattenable field");
 
         try {
-            test.nfij = (JumboValue?)getNull();
+            test.nfij = (JumboValue.ref)getNull();
             test.nfij = null;
             exception = false;
         } catch (NullPointerException e) {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/QuickeningTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/QuickeningTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Asserts;
 public class QuickeningTest {
 
     static class Parent {
-    Point? nfp;       /* Not flattenable inline field */
+    Point.ref nfp;       /* Not flattenable inline field */
     Point fp;         /* Flattenable and flattened inline field */
     JumboValue fj;    /* Flattenable not flattened inline field */
 
@@ -48,7 +48,7 @@ public class QuickeningTest {
 
     static class Child extends Parent {
         // This class inherited fields from the Parent class
-        Point? nfp2;      /* Not flattenable inline field */
+        Point.ref nfp2;      /* Not flattenable inline field */
         Point fp2;        /* Flattenable and flattened inline field */
         JumboValue fj2;   /* Flattenable not flattened inline field */
 
@@ -58,7 +58,7 @@ public class QuickeningTest {
     }
 
     static final inline class Value {
-        final Point? nfp;       /* Not flattenable inline field */
+        final Point.ref nfp;       /* Not flattenable inline field */
         final Point fp;         /* Flattenable and flattened inline field */
         final JumboValue fj;    /* Flattenable not flattened inline field */
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestFieldNullability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestFieldNullability.java
@@ -53,11 +53,11 @@ public class TestFieldNullability {
     }
 
     static inline class TestValue {
-        final MyValue? nullableField;
+        final MyValue.ref nullableField;
         final MyValue nullfreeField;        // flattened
-        final MyValue? nullField;           // src of null
+        final MyValue.ref nullField;           // src of null
         final MyBigValue nullfreeBigField;  // not flattened
-        final MyBigValue? nullBigField;     // src of null
+        final MyBigValue.ref nullBigField;     // src of null
 
         public void test() {
             Asserts.assertNull(nullField, "Invalid non null value for uninitialized non flattenable field");
@@ -94,11 +94,11 @@ public class TestFieldNullability {
     }
 
     static class TestClass {
-        MyValue? nullableField;
+        MyValue.ref nullableField;
         MyValue nullfreeField;       // flattened
-        MyValue? nullField;
+        MyValue.ref nullField;
         MyBigValue nullfreeBigField; // not flattened
-        MyBigValue? nullBigField;
+        MyBigValue.ref nullBigField;
 
         public void test() {
             Asserts.assertNull(nullField, "Invalid non null value for uninitialized non flattenable field");

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue1.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue1.java
@@ -23,14 +23,14 @@
 package runtime.valhalla.valuetypes;
 
 final class ContainerValue1 {
-    static TestValue1? staticValueField;
+    static TestValue1.ref staticValueField;
     TestValue1 nonStaticValueField;
     TestValue1[] inlineArray;
 }
 
 public inline final class TestValue1 {
 
-    static TestValue1? staticValue = getInstance();
+    static TestValue1.ref staticValue = getInstance();
 
     final int i;
     final String name;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue2.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue2.java
@@ -23,13 +23,13 @@
 package runtime.valhalla.valuetypes;
 
 final class ContainerValue2 {
-    static TestValue2? staticValueField;
+    static TestValue2.ref staticValueField;
     TestValue2 nonStaticValueField;
     TestValue2[] valueArray;
 }
 
 public inline final class TestValue2 {
-    static TestValue2? staticValue = getInstance();
+    static TestValue2.ref staticValue = getInstance();
 
     final long l;
     final double d;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue3.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue3.java
@@ -23,14 +23,14 @@
 package runtime.valhalla.valuetypes;
 
 final class ContainerValue3 {
-    static TestValue3? staticValueField;
+    static TestValue3.ref staticValueField;
     TestValue3 nonStaticValueField;
     TestValue3[] valueArray;
 }
 
 public inline final class TestValue3 {
 
-    static TestValue3? staticValue = getInstance();
+    static TestValue3.ref staticValue = getInstance();
 
     final byte b;
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue4.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestValue4.java
@@ -25,14 +25,14 @@ package runtime.valhalla.valuetypes;
 import java.nio.ByteBuffer;
 
 final class ContainerValue4 {
-    static TestValue4? staticValueField;
+    static TestValue4.ref staticValueField;
     TestValue4 nonStaticValueField;
     TestValue4[] valueArray;
 }
 
 public inline final class TestValue4 {
 
-    static TestValue4? staticValue = getInstance();
+    static TestValue4.ref staticValue = getInstance();
 
     final byte b1;
     final byte b2;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/UninitializedValueFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/UninitializedValueFieldsTest.java
@@ -33,15 +33,15 @@ import jdk.test.lib.Asserts;
  * @run main/othervm -Xcomp -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.UninitializedValueFieldsTest
  */
 public class UninitializedValueFieldsTest {
-    static Point? nonFlattenableStaticPoint;
+    static Point.ref nonFlattenableStaticPoint;
     static Point staticPoint;
 
     Point instancePoint;
 
-    static JumboValue? sj1;
+    static JumboValue.ref sj1;
     static JumboValue sj2;
 
-    JumboValue? j1;
+    JumboValue.ref j1;
     JumboValue j2;
 
     static Object getNull() {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -223,23 +223,23 @@ public class ValueTypeArray {
 
         // Now create ObjArrays of ValueArray...
         cls = (Class<?>) Point.class.asIndirectType();
-        Point?[][] barray = (Point?[][]) Array.newInstance(cls, 1, 2);
+        Point.ref[][] barray = (Point.ref[][]) Array.newInstance(cls, 1, 2);
         assertEquals(barray.length, 1, "Incorrect length");
         assertEquals(barray[0].length, 2, "Incorrect length");
         barray[0][1] = Point.createPoint(1, 2);
-        Point? pb = barray[0][1];
+        Point.ref pb = barray[0][1];
         int x = pb.getX();
         assertEquals(x, 1, "Bad Point Value");
     }
 
-    static final inline class MyInt implements Comparable<MyInt?> {
+    static final inline class MyInt implements Comparable<MyInt.ref> {
         final int value;
 
         private MyInt() { this(0); }
         private MyInt(int v) { value = v; }
         public int getValue() { return value; }
         public String toString() { return "MyInt: " + getValue(); }
-        public int compareTo(MyInt? that) { return Integer.compare(this.getValue(), that.getValue()); }
+        public int compareTo(MyInt.ref that) { return Integer.compare(this.getValue(), that.getValue()); }
         public boolean equals(Object o) {
             if (o instanceof MyInt) {
                 return this.getValue() == ((MyInt) o).getValue();
@@ -252,9 +252,9 @@ public class ValueTypeArray {
         }
 
         // Null-able fields here are a temp hack to avoid ClassCircularityError
-        public static final MyInt? MIN = MyInt.create(Integer.MIN_VALUE);
-        public static final MyInt? ZERO = MyInt.create(0);
-        public static final MyInt? MAX = MyInt.create(Integer.MAX_VALUE);
+        public static final MyInt.ref MIN = MyInt.create(Integer.MIN_VALUE);
+        public static final MyInt.ref ZERO = MyInt.create(0);
+        public static final MyInt.ref MAX = MyInt.create(Integer.MAX_VALUE);
     }
 
     static MyInt staticMyInt = MyInt.create(-1);
@@ -274,7 +274,7 @@ public class ValueTypeArray {
         MyInt[] myInts = new MyInt[1];
         assertTrue(myInts instanceof Object[]);
         assertTrue(myInts instanceof Comparable[]);
-        assertTrue(myInts instanceof MyInt?[]);
+        assertTrue(myInts instanceof MyInt.ref[]);
 
         Class<?> cls = MyInt.class;
         assertTrue(cls.isInlineClass());
@@ -293,26 +293,26 @@ public class ValueTypeArray {
         MyOtherInt[][] matrix = new MyOtherInt[1][1];
         assertTrue(matrix[0] instanceof MyOtherInt[]);
         assertTrue(matrix[0] instanceof SomeSecondaryType[]);
-        assertTrue(matrix[0] instanceof MyOtherInt?[]);
+        assertTrue(matrix[0] instanceof MyOtherInt.ref[]);
 
         // Box types vs Inline...
-        MyInt?[] myValueRefs = new MyInt?[1];
-        assertTrue(myValueRefs instanceof MyInt?[]);
+        MyInt.ref[] myValueRefs = new MyInt.ref[1];
+        assertTrue(myValueRefs instanceof MyInt.ref[]);
         assertTrue(myValueRefs instanceof Object[]);
         assertTrue(myValueRefs instanceof Comparable[]);
         assertFalse(myValueRefs instanceof MyInt[]);
 
-        MyInt?[][] myMdValueRefs = new MyInt?[1][1];
-        assertTrue(myMdValueRefs[0] instanceof MyInt?[]);
+        MyInt.ref[][] myMdValueRefs = new MyInt.ref[1][1];
+        assertTrue(myMdValueRefs[0] instanceof MyInt.ref[]);
         assertTrue(myMdValueRefs[0] instanceof Object[]);
         assertTrue(myMdValueRefs[0] instanceof Comparable[]);
         assertFalse(myMdValueRefs[0] instanceof MyInt[]);
 
         // Did we break checkcast...
-        MyInt?[]     va1 = (MyInt?[])null;
-        MyInt?[]     va2 = null;
-        MyInt?[][]   va3 = (MyInt?[][])null;
-        MyInt?[][][] va4 = (MyInt?[][][])null;
+        MyInt.ref[]     va1 = (MyInt.ref[])null;
+        MyInt.ref[]     va2 = null;
+        MyInt.ref[][]   va3 = (MyInt.ref[][])null;
+        MyInt.ref[][][] va4 = (MyInt.ref[][][])null;
         MyInt[]      va5 = null;
         MyInt[]      va6 = (MyInt[])null;
         MyInt[][]    va7 = (MyInt[][])null;
@@ -323,7 +323,7 @@ public class ValueTypeArray {
     void testUtilArrays() {
         // Sanity check j.u.Arrays
 
-        // cast to q-type temp effect of avoiding circularity error (decl static MyInt?)
+        // cast to q-type temp effect of avoiding circularity error (decl static MyInt.ref)
         MyInt[] myInts = new MyInt[] { (MyInt) MyInt.MAX, (MyInt) MyInt.MIN };
         // Sanity sort another copy
         MyInt[] copyMyInts = Arrays.copyOf(myInts, myInts.length + 1);
@@ -385,12 +385,12 @@ public class ValueTypeArray {
         comparables[1] = null;
         assertTrue(comparables[0] == null && comparables[1] == null, "Not null ?");
 
-        MyInt?[] myIntRefArray = new MyInt?[1];
+        MyInt.ref[] myIntRefArray = new MyInt.ref[1];
         assertTrue(myIntRefArray[0] == null, "Got: " + myIntRefArray[0]);
         myIntRefArray[0] = null;
 
-        MyInt?[] srcNulls = new MyInt?[2];
-        MyInt?[] dstNulls = new MyInt?[2];
+        MyInt.ref[] srcNulls = new MyInt.ref[2];
+        MyInt.ref[] dstNulls = new MyInt.ref[2];
         System.arraycopy(srcNulls, 0, dstNulls, 0, 2);
         checkArrayElementsEqual(srcNulls, dstNulls);
         srcNulls[1] = MyInt.create(1);
@@ -432,7 +432,7 @@ public class ValueTypeArray {
             throw new RuntimeException("Expected ArrayStoreException");
         } catch (ArrayStoreException ase) {}
 
-        MyInt?[] myIntRefArray = new MyInt?[3];
+        MyInt.ref[] myIntRefArray = new MyInt.ref[3];
         System.arraycopy(valArray, 0, myIntRefArray, 0, 3);
         checkArrayElementsEqual(valArray, myIntRefArray);
 
@@ -465,7 +465,7 @@ public class ValueTypeArray {
         static MyPoint create(int x, int y) {
             return new MyPoint(x, y);
         }
-        static final MyPoint? ORIGIN = create(0);
+        static final MyPoint.ref ORIGIN = create(0);
     }
 
     void testComposition() {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeCreation.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeCreation.java
@@ -75,7 +75,7 @@ public class ValueTypeCreation {
 
     static final inline class StaticSelf {
 
-        static final StaticSelf? DEFAULT = create(0);
+        static final StaticSelf.ref DEFAULT = create(0);
         final int f1;
 
         private StaticSelf() { f1 = 0; }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypesTest.java
@@ -146,7 +146,7 @@ public class ValueTypesTest {
         String sig = "()Q" + inlineClass.getName() + ";";
         final String methodSignature = sig.replace('.', '/');
         final String fieldQSignature = "Q" + inlineClass.getName().replace('.', '/') + ";";
-        final String fieldLSignature = "L" + inlineClass.getName().replace('.', '/') + ";";
+        final String fieldLSignature = "L" + inlineClass.getName().replace('.', '/') + "$ref;";
         System.out.println(methodSignature);
         MethodHandle fromExecStackToFields = MethodHandleBuilder.loadCode(
                 LOOKUP,
@@ -187,6 +187,7 @@ public class ValueTypesTest {
                     .putstatic(containerClass, "staticValueField", fieldLSignature)
                     .invokestatic(System.class, "gc", "()V", false)
                     .getstatic(containerClass, "staticValueField", fieldLSignature)
+                    .checkcast(inlineClass)
                     .invokevirtual(inlineClass, "verify", "()Z", false)
                     .iconst_1()
                     .ifcmp(TypeTag.I, CondKind.NE, "failed")
@@ -194,6 +195,7 @@ public class ValueTypesTest {
                     .putstatic(containerClass, "staticValueField", fieldLSignature)
                     .invokestatic(System.class, "gc", "()V", false)
                     .getstatic(containerClass, "staticValueField", fieldLSignature)
+                    .checkcast(inlineClass)
                     .invokevirtual(inlineClass, "verify", "()Z", false)
                     .iconst_1()
                     .ifcmp(TypeTag.I, CondKind.NE, "failed")


### PR DESCRIPTION
Frederic,

May I request you to review these changes to hotspot runtime tests ?

JDK-8237072 adds supports for the new syntax notation of V.ref and V.val to
refer to the reference projection of a value type V and its value projection.
The old syntax of V? is withdrawn. This change also has class file implications
where the descriptor/signature encodings will now start mentioning $ref in the
class pool entries. Also every inline type results in two class files now
one for each projection - with the reference projection class being the superclass
of the inline class.

I'll push them after your review and after JDK-8237072 itself is pushed.
Thanks in advance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243626](https://bugs.openjdk.java.net/browse/JDK-8243626): [lworld] Co-evolve hotspot-runtime tests along with JDK-8237072


### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/28/head:pull/28`
`$ git checkout pull/28`
