### PR TITLE
8243623: [lworld] Syntax and other mechanical changes in langtools tests for JDK-8237072

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8222634
-     * @summary Check array creation with V and V.ref
+ * @summary Check array creation with V and V.ref
  * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
  * @compile ArrayCreationWithQuestion.java
  * @run main/othervm -Xverify:none ArrayCreationWithQuestion

--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8222634
- * @summary Check array creation with V and V?
+     * @summary Check array creation with V and V.ref
  * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
  * @compile ArrayCreationWithQuestion.java
  * @run main/othervm -Xverify:none ArrayCreationWithQuestion
@@ -38,8 +38,8 @@ import java.nio.file.Paths;
 public class ArrayCreationWithQuestion {
 
     static inline class VT {
-        VT?[] a1 = new VT?[42];
-        VT?[] a2 = new VT?[42];
+        VT.ref[] a1 = new VT.ref[42];
+        VT.ref[] a2 = new VT.ref[42];
         VT[] a3 = new VT[42];
         VT[] a4 = new VT[42];
     }
@@ -53,10 +53,10 @@ public class ArrayCreationWithQuestion {
                                             Paths.get(System.getProperty("test.classes"),
                                                 "ArrayCreationWithQuestion$VT.class").toString() };
         runCheck(params, new String [] {
-        "         6: anewarray     #3                  // class ArrayCreationWithQuestion$VT",
-        "        17: anewarray     #3                  // class ArrayCreationWithQuestion$VT",
-        "        28: anewarray     #11                 // class \"QArrayCreationWithQuestion$VT;\"",
-        "        39: anewarray     #11                 // class \"QArrayCreationWithQuestion$VT;\"",
+        "         6: anewarray     #3                  // class ArrayCreationWithQuestion$VT$ref",
+        "        17: anewarray     #3                  // class ArrayCreationWithQuestion$VT$ref",
+        "        28: anewarray     #12                 // class \"QArrayCreationWithQuestion$VT;\"",
+        "        39: anewarray     #12                 // class \"QArrayCreationWithQuestion$VT;\"",
          });
 
      }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayRelationsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayRelationsTest.java
@@ -35,7 +35,7 @@ public inline class ArrayRelationsTest {
     int x = 42;
 
     public static void main(String [] args) {
-        ArrayRelationsTest? [] la = new ArrayRelationsTest?[10];
+        ArrayRelationsTest.ref [] la = new ArrayRelationsTest.ref[10];
         ArrayRelationsTest [] qa = new ArrayRelationsTest[10];
         boolean cce = false;
         try {
@@ -47,7 +47,7 @@ public inline class ArrayRelationsTest {
             throw new AssertionError("Missing CCE");
         }
         la = qa;
-        ArrayRelationsTest?[] la2 = qa;
+        ArrayRelationsTest.ref[] la2 = qa;
         ArrayRelationsTest [] qa2 = (ArrayRelationsTest []) la2;
         boolean npe = false;
         try {
@@ -71,7 +71,7 @@ public inline class ArrayRelationsTest {
 
         // round trip;
         Object o = oa = la = qa;
-        qa = (ArrayRelationsTest[]) (la = (ArrayRelationsTest? []) (oa = (Object []) o));
+        qa = (ArrayRelationsTest[]) (la = (ArrayRelationsTest.ref []) (oa = (Object []) o));
         qa [0] = new ArrayRelationsTest();
 
         npe = false;
@@ -84,7 +84,7 @@ public inline class ArrayRelationsTest {
             throw new AssertionError("Missing NPE");
         }
 
-        la = new ArrayRelationsTest? [10];
+        la = new ArrayRelationsTest.ref [10];
 
         cce = false;
         try {

--- a/test/langtools/tools/javac/valhalla/lworld-values/AssortedTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AssortedTests.java
@@ -38,7 +38,7 @@ class X {
     static final MyValue1 vField = new MyValue1();
 
     inline class MyValue2 {
-        final MyValue1? vBoxField;
+        final MyValue1.ref vBoxField;
 
         public MyValue2() {
             vBoxField = new MyValue1();
@@ -56,7 +56,7 @@ inline class MyValue3 {
 class Y {
 
     inline class MyValue4 {
-        final MyValue3? vBoxField = null;
+        final MyValue3.ref vBoxField = null;
 
         public int test() {
             return vBoxField.hash();
@@ -67,12 +67,12 @@ class Y {
 }
 
 interface MyInterface {
-    public void test(MyValue5? vt);
+    public void test(MyValue5.ref vt);
 }
 
 inline class MyValue5 implements MyInterface {
     final int x = 0;
 
     @Override
-    public void test(MyValue5? vt) { }
+    public void test(MyValue5.ref vt) { }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/BogusIncompatibility.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BogusIncompatibility.java
@@ -30,6 +30,6 @@
  */
 
 public class BogusIncompatibility {
-  MyValue? field = MyValue.create();
-  MyValue? field2 = MyValue.create();
+  MyValue.ref field = MyValue.create();
+  MyValue.ref field2 = MyValue.create();
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
@@ -39,13 +39,13 @@ public class BoxValCastTest {
 
     static inline class VT {
         int f = 0;
-        static final VT? vtbox = (VT?) new VT(); // no binary cast
+        static final VT.ref vtbox = (VT.ref) new VT(); // no binary cast
         static VT vt = (VT) vtbox; // binary cast
-        static VT? box = vt; // no binary cast
-        static VT? box2 = (VT) box; // no binary cast
-        static VT? box3 = id(new VT()); // no binary cast + binary cast
+        static VT.ref box = vt; // no binary cast
+        static VT.ref box2 = (VT) box; // binary cast
+        static VT.ref box3 = id(new VT()); // no binary cast + no binary cast
 
-        static VT id(VT? vtb) {
+        static VT id(VT.ref vtb) {
             return (VT) vtb; // binary
         }
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFieldDescriptors.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFieldDescriptors.java
@@ -50,19 +50,19 @@ public inline class CheckFieldDescriptors {
                     throw new Exception("Bad descriptor for field1");
             } else if (fld.getName(cls.constant_pool).equals("f2")) {
                 fCount++;
-                if (!fld.descriptor.getValue(cls.constant_pool).equals("LCheckFieldDescriptors;"))
+                if (!fld.descriptor.getValue(cls.constant_pool).equals("LCheckFieldDescriptors$ref;"))
                     throw new Exception("Bad descriptor for field2");
             } else if (fld.getName(cls.constant_pool).equals("f3")) {
                 fCount++;
-                if (!fld.descriptor.getValue(cls.constant_pool).equals("LCheckFieldDescriptors;"))
+                if (!fld.descriptor.getValue(cls.constant_pool).equals("LCheckFieldDescriptors$ref;"))
                     throw new Exception("Bad descriptor for field3");
             } else if (fld.getName(cls.constant_pool).equals("a1")) {
                 fCount++;
-                if (!fld.descriptor.getValue(cls.constant_pool).equals("[LCheckFieldDescriptors;"))
+                if (!fld.descriptor.getValue(cls.constant_pool).equals("[LCheckFieldDescriptors$ref;"))
                     throw new Exception("Bad descriptor for field4");
             } else if (fld.getName(cls.constant_pool).equals("a2")) {
                 fCount++;
-                if (!fld.descriptor.getValue(cls.constant_pool).equals("[LCheckFieldDescriptors;"))
+                if (!fld.descriptor.getValue(cls.constant_pool).equals("[LCheckFieldDescriptors$ref;"))
                     throw new Exception("Bad descriptor for field5");
             } else if (fld.getName(cls.constant_pool).equals("a3")) {
                 fCount++;
@@ -83,11 +83,11 @@ public inline class CheckFieldDescriptors {
 class CheckFieldDescriptorsAuxilliary {
 
     CheckFieldDescriptors f1;
-    CheckFieldDescriptors? f2;
-    CheckFieldDescriptors? f3;
+    CheckFieldDescriptors.ref f2;
+    CheckFieldDescriptors.ref f3;
 
-    CheckFieldDescriptors?[] a1 = new CheckFieldDescriptors?[42];
-    CheckFieldDescriptors?[] a2 = new CheckFieldDescriptors?[42];
+    CheckFieldDescriptors.ref[] a1 = new CheckFieldDescriptors.ref[42];
+    CheckFieldDescriptors.ref[] a2 = new CheckFieldDescriptors.ref[42];
     CheckFieldDescriptors[] a3 = new CheckFieldDescriptors[42];
     CheckFieldDescriptors[] a4 = new CheckFieldDescriptors[42];
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckNullWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckNullWithQuestion.java
@@ -26,23 +26,23 @@
 /*
  * @test
  * @bug 8222634
- * @summary Check null assignment/comparisons against VT?
+ * @summary Check null assignment/comparisons against VT.ref
  * @compile CheckNullWithQuestion.java
  */
 
 inline class CheckNullWithQuestion {
     final int x = 0;
     void foo(boolean flag) {
-        CheckNullWithQuestion? vBox = null;
+        CheckNullWithQuestion.ref vBox = null;
         if (vBox != null) {}
-        CheckNullWithQuestion? val = flag ? vBox : null;
+        CheckNullWithQuestion.ref val = flag ? vBox : null;
     }
 }
 
 class X {
     void foo(boolean flag) {
-        CheckNullWithQuestion? vBox = null;
+        CheckNullWithQuestion.ref vBox = null;
         if (vBox != null) {}
-        CheckNullWithQuestion? val = flag ? vBox : null;
+        CheckNullWithQuestion.ref val = flag ? vBox : null;
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
@@ -9,6 +9,6 @@
 import java.util.List;
 
 inline class X {
-    List<X?> ls = new Object();    
-    X?[] xa = new Object?[10];
+    List<X.ref> ls = new Object();
+    X.ref[] xa = new Object[10];
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 inline class X {
     List<X.ref> ls = new Object();
-    X.ref[] xa = new Object[10];
+    X.ref[] xa = new Object[10];  // no support for Object.ref yet, but they are the same.
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.out
@@ -1,3 +1,3 @@
-CheckQuestionInMessages.java:12:19: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Object, java.util.List<X?>)
-CheckQuestionInMessages.java:13:15: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Object[], X?[])
+CheckQuestionInMessages.java:12:22: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Object, java.util.List<X$ref>)
+CheckQuestionInMessages.java:13:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Object[], X$ref[])
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CompilerNoBogusAssert.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CompilerNoBogusAssert.java
@@ -43,7 +43,7 @@ public class CompilerNoBogusAssert {
     }
 
 
-    static void testCastingFromBoxToVal(Point? p) {
+    static void testCastingFromBoxToVal(Point.ref p) {
         boolean npe = false;
         try {
             Point pv = (Point) p;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CompilesJustFine.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CompilesJustFine.java
@@ -32,7 +32,7 @@
 
 class CompilesFine {
 
-    static Point? nfspQm;
+    static Point.ref nfspQm;
 
     public static void main(String[] args) {
         nfspQm = null;
@@ -51,7 +51,7 @@ inline final class Point {
 class CompilesJustFine {
 
     static final inline class Value {
-        final PointBug2? nfpQm;
+        final PointBug2.ref nfpQm;
 
         private Value() {
             nfpQm = PointBug2.createPoint(0, 0);

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes.java
@@ -75,7 +75,7 @@ inline class OptionalInt {
 public final class ExplicitLambdaWithNullableTypes {
 
    public static void main(String[] args) {
-       List<OptionalInt?> opts = new ArrayList<>();
+       List<OptionalInt.ref> opts = new ArrayList<>();
        for (int i=0; i < 5; i++) {
            opts.add(OptionalInt.of(i));
            opts.add(OptionalInt.empty());
@@ -83,7 +83,7 @@ public final class ExplicitLambdaWithNullableTypes {
        }
 
        Integer total = opts.stream()
-           .map((OptionalInt? o) -> {
+           .map((OptionalInt.ref o) -> {
                if (o == null)
                    return 0;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes2.java
@@ -76,15 +76,15 @@ inline class OptionalInt {
 public final class ExplicitLambdaWithNullableTypes2 {
 
    public static void main(String[] args) {
-       List<OptionalInt?> opts = new ArrayList<>();
+       List<OptionalInt.ref> opts = new ArrayList<>();
        for (int i=0; i < 5; i++) {
            opts.add(OptionalInt.of(i));
            opts.add(OptionalInt.empty());
            opts.add(null);
        }
 
-       Stream<OptionalInt?> soi = opts.stream();
-       ToIntFunction<OptionalInt?> f = (OptionalInt? o) -> {
+       Stream<OptionalInt.ref> soi = opts.stream();
+       ToIntFunction<OptionalInt.ref> f = (OptionalInt.ref o) -> {
             if (o == null) return 0;
             OptionalInt op = (OptionalInt)o;
             return op.orElse(0);

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes3.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes3.java
@@ -76,15 +76,15 @@ inline class OptionalInt {
 public final class ExplicitLambdaWithNullableTypes3 {
 
    public static void main(String[] args) {
-       List<OptionalInt?> opts = new ArrayList<>();
+       List<OptionalInt.ref> opts = new ArrayList<>();
        for (int i=0; i < 5; i++) {
            opts.add(OptionalInt.of(i));
            opts.add(OptionalInt.empty());
            opts.add(null);
        }
 
-       Stream<OptionalInt?> soi = opts.stream();
-       ToIntFunction<OptionalInt?> f = o -> {
+       Stream<OptionalInt.ref> soi = opts.stream();
+       ToIntFunction<OptionalInt.ref> f = o -> {
             if (o == null) return 0;
             OptionalInt op = (OptionalInt)o;
             return op.orElse(0);

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues4.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues4.java
@@ -34,7 +34,7 @@ inline class InlineType<E> {
 
     interface Sample<K extends Comparable<? super K>, V> {
         void doesCompile(InlineType<? extends K> argument);
-        void doesNotCompile(java.util.Map.Entry<InlineType<? extends K>?, ? extends V> arg);
+        void doesNotCompile(java.util.Map.Entry<InlineType.ref<? extends K>, ? extends V> arg);
     }
 
     private E element;

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues5.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues5.java
@@ -87,16 +87,16 @@ public final class GenericsAndValues5 {
 
    public static void main(String[] args) {
 
-       List<Optional<Integer>?> opts = new ArrayList<>();
+       List<Optional.ref<Integer>> opts = new ArrayList<>();
        for (int i=0; i < 6; i++) {
            Optional<Integer> oi = Optional.of(i);
-           opts.add((Optional<Integer>?)oi);
+           opts.add((Optional.ref<Integer>)oi);
            Optional<Integer> oe = Optional.empty();
-           opts.add((Optional<Integer>?)oe);
+           opts.add((Optional.ref<Integer>)oe);
        }
 
        Integer total = opts.stream()
-           .map((Optional<Integer>? o) -> {
+           .map((Optional.ref<Integer> o) -> {
                Optional<Integer> op = (Optional<Integer>)o;
                return op.orElse(0);
            })

--- a/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
@@ -43,8 +43,8 @@ public class InnerClassAttributeValuenessTest {
         }
 
         // Uncomment the next line, and Inner ceases to be a value type
-        public static final Inner? ZERO = Inner.create(0);
-        public static final Inner? ZERO2 = Inner.create(0);
+        public static final Inner.ref ZERO = Inner.create(0);
+        public static final Inner.ref ZERO2 = Inner.create(0);
     }
 
     public static void main(String[] args) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/InstanceofProjectionArray.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InstanceofProjectionArray.java
@@ -26,7 +26,7 @@
 /*
  * @test
  * @bug 8222974
- * @summary javac doesn't like "?" syntax in instanceof type expression
+ * @summary javac doesn't like "?" syntax in instanceof type expression (syntax is dead)
  * @compile InstanceofProjectionArray.java
  */
 
@@ -37,11 +37,11 @@ public inline class InstanceofProjectionArray {
     public InstanceofProjectionArray() { this.value = 0; }
 
     public static void main(String[] args) throws Throwable {
-        InstanceofProjectionArray?[] foos = new InstanceofProjectionArray?[1];
-        if (!(foos instanceof InstanceofProjectionArray?[])) {
+        InstanceofProjectionArray.ref[] foos = new InstanceofProjectionArray.ref[1];
+        if (!(foos instanceof InstanceofProjectionArray.ref[])) {
             throw new RuntimeException("Thought that should work");
         }
-        InstanceofProjectionArray?[][] xx = null;
-        if (xx instanceof InstanceofProjectionArray?[][]) {}
+        InstanceofProjectionArray.ref[][] xx = null;
+        if (xx instanceof InstanceofProjectionArray.ref[][]) {}
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest.java
@@ -55,7 +55,7 @@ public inline class IntercastTest {
             return new Tuple(index, array[index]);
         }
 
-        Cursor? next() {
+        Cursor.ref next() {
             if (index + 1 == array.length) {
                 return null;
             }
@@ -63,7 +63,7 @@ public inline class IntercastTest {
         }
     }
 
-    private static Cursor? indexedElements(int[] array) {
+    private static Cursor.ref indexedElements(int[] array) {
         if (array.length == 0) {
             return null;
         }
@@ -72,7 +72,7 @@ public inline class IntercastTest {
 
     public int sum() {
         int sum = 0;
-        for (Cursor? cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
+        for (Cursor.ref cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
             Tuple tuple = cursor.current();
             sum += tuple.index + tuple.element;
         }
@@ -84,7 +84,7 @@ public inline class IntercastTest {
         if (x.sum() != 63 || x.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }
-        IntercastTest? xbox = (IntercastTest?) x;
+        IntercastTest.ref xbox = (IntercastTest.ref) x;
         if (xbox.sum() != 63 || xbox.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest2.java
@@ -55,7 +55,7 @@ public inline class IntercastTest2 {
             return new Tuple(index, array[index]);
         }
 
-        Cursor? next() {
+        Cursor.ref next() {
             if (index + 1 == array.length) {
                 return null;
             }
@@ -63,7 +63,7 @@ public inline class IntercastTest2 {
         }
     }
 
-    private static Cursor? indexedElements(int[] array) {
+    private static Cursor.ref indexedElements(int[] array) {
         if (array.length == 0) {
             return null;
         }
@@ -72,7 +72,7 @@ public inline class IntercastTest2 {
 
     public int sum() {
         int sum = 0;
-        for (Cursor? cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
+        for (Cursor.ref cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
             Tuple tuple = cursor.current();
             sum += tuple.index + tuple.element;
         }
@@ -84,7 +84,7 @@ public inline class IntercastTest2 {
         if (x.sum() != 63 || x.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }
-        IntercastTest2? xbox = (IntercastTest2?) x;
+        IntercastTest2.ref xbox = (IntercastTest2.ref) x;
         if (xbox.sum() != 63 || xbox.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest.java
@@ -55,7 +55,7 @@ public inline class LookupOnLoxTest {
             return new Tuple(index, array[index]);
         }
 
-        Cursor? next() {
+        Cursor.ref next() {
             if (index + 1 == array.length) {
                 return null;
             }
@@ -63,7 +63,7 @@ public inline class LookupOnLoxTest {
         }
     }
 
-    private static Cursor? indexedElements(int[] array) {
+    private static Cursor.ref indexedElements(int[] array) {
         if (array.length == 0) {
             return null;
         }
@@ -72,7 +72,7 @@ public inline class LookupOnLoxTest {
 
     public int sum() {
         int sum = 0;
-        for (Cursor? cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
+        for (Cursor.ref cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
             Tuple tuple = cursor.current();
             sum += tuple.index + tuple.element;
         }
@@ -84,7 +84,7 @@ public inline class LookupOnLoxTest {
         if (x.sum() != 63 || x.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }
-        LookupOnLoxTest? xbox = x;
+        LookupOnLoxTest.ref xbox = x;
         if (xbox.sum() != 63 || xbox.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest2.java
@@ -55,7 +55,7 @@ public inline class LookupOnLoxTest2 {
             return new Tuple(index, array[index]);
         }
 
-        Cursor? next() {
+        Cursor.ref next() {
             if (index + 1 == array.length) {
                 return null;
             }
@@ -63,7 +63,7 @@ public inline class LookupOnLoxTest2 {
         }
     }
 
-    private static Cursor? indexedElements(int[] array) {
+    private static Cursor.ref indexedElements(int[] array) {
         if (array.length == 0) {
             return null;
         }
@@ -72,7 +72,7 @@ public inline class LookupOnLoxTest2 {
 
     public int sum() {
         int sum = 0;
-        for (Cursor? cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
+        for (Cursor.ref cursor = indexedElements(ARRAY); cursor != null; cursor = cursor.next()) {
             Tuple tuple = cursor.current();
             sum += tuple.index + tuple.element;
         }
@@ -84,7 +84,7 @@ public inline class LookupOnLoxTest2 {
         if (x.sum() != 63 || x.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }
-        LookupOnLoxTest2? xbox = x;
+        LookupOnLoxTest2.ref xbox = x;
         if (xbox.sum() != 63 || xbox.ARRAY.length != 3) {
             throw new AssertionError("Broken");
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/Point.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Point.java
@@ -31,8 +31,8 @@
  */
 
 inline class Point {
-    static final Point? origin = makePoint(10, 20);
-    static final Point? origin2 = makePoint(10, 20);
+    static final Point.ref origin = makePoint(10, 20);
+    static final Point.ref origin2 = makePoint(10, 20);
     int x;
     int y;
     Point () {

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectedArrayDotClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectedArrayDotClass.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8222722
- * @summary  Javac fails to compile V?[].class
+ * @summary  Javac fails to compile V?[].class (syntax dead)
  * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
  * @compile ProjectedArrayDotClass.java
  * @run main/othervm -Xverify:none ProjectedArrayDotClass
@@ -40,9 +40,9 @@ public class ProjectedArrayDotClass {
     static inline class VT {
         int x = 42;
         public static void main(String[] args) {
-            System.out.println(VT?[].class);
+            System.out.println(VT.ref[].class);
             System.out.println(VT[].class);
-            System.out.println(ProjectedArrayDotClass.VT?[].class);
+            System.out.println(ProjectedArrayDotClass.VT.ref[].class);
             System.out.println(ProjectedArrayDotClass.VT[].class);
         }
     }
@@ -56,9 +56,9 @@ public class ProjectedArrayDotClass {
                                             Paths.get(System.getProperty("test.classes"),
                                                 "ProjectedArrayDotClass$VT.class").toString() };
         runCheck(params, new String [] {
-        "         3: ldc           #13                 // class \"[LProjectedArrayDotClass$VT;\"",
+        "         3: ldc           #13                 // class \"[LProjectedArrayDotClass$VT$ref;\"",
         "        11: ldc           #21                 // class \"[QProjectedArrayDotClass$VT;\"",
-        "        19: ldc           #13                 // class \"[LProjectedArrayDotClass$VT;\"",
+        "        19: ldc           #13                 // class \"[LProjectedArrayDotClass$VT$ref;\"",
         "        27: ldc           #21                 // class \"[QProjectedArrayDotClass$VT;\"",
          });
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
@@ -42,7 +42,7 @@ public inline class ValueConstructorRef {
     }
     
     public static void main(String [] args) {   
-    	Supplier<ValueConstructorRef?> sx = ValueConstructorRef::new;
+       Supplier<ValueConstructorRef.ref> sx = ValueConstructorRef::new;
     	ValueConstructorRef x = (ValueConstructorRef) sx.get();
         if (!x.toString().equals("[ValueConstructorRef x=1234 y=5678]"))
             throw new AssertionError(x);

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 
 public final inline class ValuesAsRefs {
 
-    final ArrayList<? extends ValuesAsRefs?> ao = null; // values can be wildcard bounds.
+    final ArrayList<? extends ValuesAsRefs.ref> ao = null; // values can be wildcard bounds.
 
     final inline class I implements java.io.Serializable {
         final int y = 42;
@@ -40,15 +40,15 @@ public final inline class ValuesAsRefs {
     void foo() {
         I i = this.new I();  // values can be enclosing instances.
         i = ValuesAsRefs.I.default;
-        Object o = (I? & java.io.Serializable) i; // values can be used in intersection casts
+        Object o = (I.ref & java.io.Serializable) i; // values can be used in intersection casts
     }
     <T> void goo() {
-        this.<ValuesAsRefs?>goo(); // values can be type arguments to generic method calls
+        this.<ValuesAsRefs.ref>goo(); // values can be type arguments to generic method calls
     }
 
     public static void main(String [] args) {
         Object o = null;
-        ArrayList<ValuesAsRefs.I?> aloi = new ArrayList<>(); // values can be type arguments.
+        ArrayList<ValuesAsRefs.I.ref> aloi = new ArrayList<>(); // values can be type arguments.
         boolean OK = false;
         try {
             aloi.add((ValuesAsRefs.I) o);


### PR DESCRIPTION
Jim,

May I request you to review these changes to langtools tests that anticipate and
align with JDK-8237072 ? These changes are mechanical in nature and I decided it
is best to separate them from the RFR for JDK-8237072 itself to help create sharper
focus on the important pieces there. (Non-mechanical meaningful test changes with
be included in that RFR itself)

JDK-8237072 adds supports for the new syntax notation of V.ref and V.val to
refer to the reference projection of a value type V and its value projection.
The old syntax of V? is withdrawn. This change also has class file implications
where the descriptor/signature encodings will now start mentioning $ref in the
class pool entries. Also every inline type results in two class files now
one for each projection - with the reference projection class being the superclass
of the inline class.

I'll push them after your review and after JDK-8237072 itself is pushed.
Thanks in advance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243623](https://bugs.openjdk.java.net/browse/JDK-8243623): [lworld] Syntax and other mechanical changes in langtools tests for JDK-8237072


### Reviewers
 * JimLaskey (no known github.com user name / role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/29/head:pull/29`
`$ git checkout pull/29`
