### PR TITLE
8244092: [lworld] TestC2CCalls segfaults in frame::sender_for_compiled_frame with ZGC

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -715,7 +715,7 @@ intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr)
     // and does not account for the return address.
     intptr_t* real_frame_size_addr = (intptr_t*) (saved_fp_addr - 1);
     int real_frame_size = ((*real_frame_size_addr) + wordSize) / wordSize;
-    assert(real_frame_size >= _cb->frame_size(), "invalid frame size");
+    assert(real_frame_size >= _cb->frame_size() && real_frame_size <= 1000000, "invalid frame size");
     sender_sp = unextended_sp() + real_frame_size;
   }
   return sender_sp;

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -33,6 +33,7 @@ class CompiledEntrySignature;
 class C1_MacroAssembler: public MacroAssembler {
  private:
   int scalarized_entry(const CompiledEntrySignature *ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_value_entry_label, bool is_value_ro_entry);
+  void build_frame_helper(int frame_size_in_bytes, int sp_inc, bool needs_stack_repair);
  public:
   // creation
   C1_MacroAssembler(CodeBuffer* code) : MacroAssembler(code) { pd_init(); }


### PR DESCRIPTION
Stack slot containing real_frame_size is trashed by ZCG barrier code in scalarized entry of C1 compiled code. As a result, we crash during stack walking. We should re-set it before jumping to the verified entry. Also refactored the related code and added an assert to catch this.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244092](https://bugs.openjdk.java.net/browse/JDK-8244092): [lworld] TestC2CCalls segfaults in frame::sender_for_compiled_frame with ZGC


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/31/head:pull/31`
`$ git checkout pull/31`
