### PR TITLE
8244414: [lworld] Migrate Valhalla micro benchmarks suite to not use V? syntax

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4000,6 +4000,22 @@ public class Types {
 
         int[] kinds = new int[ts.length];
 
+        boolean haveValues = false;
+        boolean haveRefs = false;
+        for (int i = 0 ; i < ts.length ; i++) {
+            if (ts[i].isValue())
+                haveValues = true;
+            else
+                haveRefs = true;
+        }
+        if (haveRefs && haveValues) {
+            System.arraycopy(ts, 0, ts = new Type[ts.length], 0, ts.length);
+            for (int i = 0; i < ts.length; i++) {
+                if (ts[i].isValue())
+                    ts[i] = ts[i].referenceProjection();
+            }
+        }
+
         int boundkind = UNKNOWN_BOUND;
         for (int i = 0 ; i < ts.length ; i++) {
             Type t = ts[i];

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -471,6 +471,10 @@ public class Enter extends JCTree.Visitor {
         c.flags_field = chk.checkFlags(tree.pos(), tree.mods.flags, c, tree);
         c.sourcefile = env.toplevel.sourcefile;
         c.members_field = WriteableScope.create(c);
+        if (c.projection != null) {
+            // Do not carry around symbols from prior round.
+            c.projection.members_field = WriteableScope.create(c.projection);
+        }
         c.clearAnnotationMetadata();
 
         ClassType ct = (ClassType)c.type;
@@ -492,6 +496,12 @@ public class Enter extends JCTree.Visitor {
         // Enter type parameters.
         ct.typarams_field = classEnter(tree.typarams, localEnv);
         ct.allparams_field = null;
+        if (ct.isValue()) {
+            if (ct.projection != null) {
+                ct.projection.typarams_field = ct.typarams_field;
+                ct.projection.allparams_field = ct.allparams_field;
+            }
+        }
 
         // install further completer for this type.
         c.completer = typeEnter;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2949,6 +2949,13 @@ public class Resolve {
                             return sym;
                         }
                     };
+                    ClassSymbol refProjection = newConstr.owner.isValue() ?
+                                                     (ClassSymbol) newConstr.owner.referenceProjection() : null;
+                    if (refProjection != null) {
+                        MethodSymbol clone = newConstr.clone(refProjection);
+                        clone.projection = newConstr;
+                        newConstr.projection = clone;
+                    }
                     bestSoFar = selectBest(env, site, argtypes, typeargtypes,
                             newConstr,
                             bestSoFar,

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244458 8244414
+ * @summary Diamond inference does not work with value classes
+ * @run main InlineDiamondTest
+ */
+
+public class InlineDiamondTest<E> {
+
+    interface I<T> {
+    }
+
+    public I<E> get() {
+        return new Y<>();
+    }
+
+    private inline class Y<U> implements I<U> {
+        int x = 42;
+    }
+    
+    public static void main(String [] args) {
+        InlineDiamondTest<String> idt = new InlineDiamondTest<>();
+        I<String> is = idt.get();
+        String toString = is.toString();
+        if (!toString.equals("[InlineDiamondTest$Y x=42]"))
+            throw new AssertionError("Expected: " + toString);
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
@@ -42,7 +42,7 @@ public class InlineDiamondTest<E> {
     private inline class Y<U> implements I<U> {
         int x = 42;
     }
-    
+
     public static void main(String [] args) {
         InlineDiamondTest<String> idt = new InlineDiamondTest<>();
         I<String> is = idt.get();

--- a/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
@@ -26,28 +26,24 @@
 /*
  * @test
  * @bug 8244458 8244414
- * @summary Diamond inference does not work with value classes
- * @run main InlineDiamondTest
+ * @summary Check that javac does not crash while computing LUB involving values.
+ * @run main LubWithInlines
  */
 
-public class InlineDiamondTest<E> {
-
-    interface I<T> {
+public class LubWithInlines {
+    interface I {}
+    static class Node implements I {
     }
-
-    public I<E> get() {
-        return new Y<>();
+    static I foo(Node e) {
+        var ret = (e == null) ? new XNodeWrapper() : e;
+        return ret;
     }
-
-    private inline class Y<U> implements I<U> {
-        int x = 42;
+    static inline class XNodeWrapper implements I {
+        int i = 42;
     }
-
     public static void main(String [] args) {
-        InlineDiamondTest<String> idt = new InlineDiamondTest<>();
-        I<String> is = idt.get();
-        String toString = is.toString();
-        if (!toString.equals("[InlineDiamondTest$Y x=42]"))
-            throw new AssertionError("Expected: " + toString);
+        I i = foo(null);
+        if (!i.toString().equals("[LubWithInlines$XNodeWrapper i=42]"))
+            throw new AssertionError("Unexpected: " + i);
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244458 8244414
+ * @summary Diamond inference does not work with value classes
+ * @run main InlineDiamondTest
+ */
+
+public class InlineDiamondTest<E> {
+
+    interface I<T> {
+    }
+
+    public I<E> get() {
+        return new Y<>();
+    }
+
+    private inline class Y<U> implements I<U> {
+        int x = 42;
+    }
+    
+    public static void main(String [] args) {
+        InlineDiamondTest<String> idt = new InlineDiamondTest<>();
+        I<String> is = idt.get();
+        String toString = is.toString();
+        if (!toString.equals("[InlineDiamondTest$Y x=42]"))
+            throw new AssertionError("Expected: " + toString);
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
@@ -42,7 +42,7 @@ public class InlineDiamondTest<E> {
     private inline class Y<U> implements I<U> {
         int x = 42;
     }
-    
+
     public static void main(String [] args) {
         InlineDiamondTest<String> idt = new InlineDiamondTest<>();
         I<String> is = idt.get();

--- a/test/micro/org/openjdk/bench/valhalla/corelibs/mapprotos/XHashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/corelibs/mapprotos/XHashMap.java
@@ -309,9 +309,9 @@ public class XHashMap<K,V> extends XAbstractMap<K,V>
         final int hash;
         final K key;
         V value;
-        Node?<K,V> next;
+        Node<K,V> next;
 
-        XNode(int hash, K key, V value, Node?<K,V> next) {
+        XNode(int hash, K key, V value, Node<K,V> next) {
             this.hash = hash;
             this.key = key;
             this.value = value;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch1.java
@@ -62,11 +62,11 @@ public class IsCmpBranch1 extends ACmpBase {
     Val1[] value1_75, value2_75;
     Val1[] value1_100, value2_100;
 
-    Val1?[] boxed1_00, boxed2_00;
-    Val1?[] boxed1_25, boxed2_25;
-    Val1?[] boxed1_50, boxed2_50;
-    Val1?[] boxed1_75, boxed2_75;
-    Val1?[] boxed1_100, boxed2_100;
+    Val1.ref[] boxed1_00, boxed2_00;
+    Val1.ref[] boxed1_25, boxed2_25;
+    Val1.ref[] boxed1_50, boxed2_50;
+    Val1.ref[] boxed1_75, boxed2_75;
+    Val1.ref[] boxed1_100, boxed2_100;
 
     Vector[] covariance1_00, covariance2_00;
     Vector[] covariance1_25, covariance2_25;
@@ -87,16 +87,16 @@ public class IsCmpBranch1 extends ACmpBase {
         value2_75 = populateValues2(value1_75, 75);
         value1_100 = populateValues1();
         value2_100 = populateValues2(value1_100, 100);
-        boxed1_00 = new Val1?[SIZE];
-        boxed2_00 = new Val1?[SIZE];
-        boxed1_25 = new Val1?[SIZE];
-        boxed2_25 = new Val1?[SIZE];
-        boxed1_50 = new Val1?[SIZE];
-        boxed2_50 = new Val1?[SIZE];
-        boxed1_75 = new Val1?[SIZE];
-        boxed2_75 = new Val1?[SIZE];
-        boxed1_100 = new Val1?[SIZE];
-        boxed2_100 = new Val1?[SIZE];
+        boxed1_00 = new Val1.ref[SIZE];
+        boxed2_00 = new Val1.ref[SIZE];
+        boxed1_25 = new Val1.ref[SIZE];
+        boxed2_25 = new Val1.ref[SIZE];
+        boxed1_50 = new Val1.ref[SIZE];
+        boxed2_50 = new Val1.ref[SIZE];
+        boxed1_75 = new Val1.ref[SIZE];
+        boxed2_75 = new Val1.ref[SIZE];
+        boxed1_100 = new Val1.ref[SIZE];
+        boxed2_100 = new Val1.ref[SIZE];
         for(int i = 0; i< SIZE; i++) {
             boxed1_00[i] = value1_00[i];
             boxed2_00[i] = value2_00[i];
@@ -201,7 +201,7 @@ public class IsCmpBranch1 extends ACmpBase {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int boxed_comparison(Val1?[] objects1, Val1?[] objects2) {
+    private static int boxed_comparison(Val1.ref[] objects1, Val1.ref[] objects2) {
         int s = 0;
         for (int i = 0; i < SIZE; i++) {
             if (objects1[i] == objects2[i]) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch2.java
@@ -61,11 +61,11 @@ public class IsCmpBranch2 extends ACmpBase {
     Val2[] value1_75, value2_75;
     Val2[] value1_100, value2_100;
 
-    Val2?[] boxed1_00, boxed2_00;
-    Val2?[] boxed1_25, boxed2_25;
-    Val2?[] boxed1_50, boxed2_50;
-    Val2?[] boxed1_75, boxed2_75;
-    Val2?[] boxed1_100, boxed2_100;
+    Val2.ref[] boxed1_00, boxed2_00;
+    Val2.ref[] boxed1_25, boxed2_25;
+    Val2.ref[] boxed1_50, boxed2_50;
+    Val2.ref[] boxed1_75, boxed2_75;
+    Val2.ref[] boxed1_100, boxed2_100;
 
     Vector[] covariance1_00, covariance2_00;
     Vector[] covariance1_25, covariance2_25;
@@ -86,16 +86,16 @@ public class IsCmpBranch2 extends ACmpBase {
         value2_75 = populateValues2(value1_75, 75);
         value1_100 = populateValues1();
         value2_100 = populateValues2(value1_100, 100);
-        boxed1_00 = new Val2?[SIZE];
-        boxed2_00 = new Val2?[SIZE];
-        boxed1_25 = new Val2?[SIZE];
-        boxed2_25 = new Val2?[SIZE];
-        boxed1_50 = new Val2?[SIZE];
-        boxed2_50 = new Val2?[SIZE];
-        boxed1_75 = new Val2?[SIZE];
-        boxed2_75 = new Val2?[SIZE];
-        boxed1_100 = new Val2?[SIZE];
-        boxed2_100 = new Val2?[SIZE];
+        boxed1_00 = new Val2.ref[SIZE];
+        boxed2_00 = new Val2.ref[SIZE];
+        boxed1_25 = new Val2.ref[SIZE];
+        boxed2_25 = new Val2.ref[SIZE];
+        boxed1_50 = new Val2.ref[SIZE];
+        boxed2_50 = new Val2.ref[SIZE];
+        boxed1_75 = new Val2.ref[SIZE];
+        boxed2_75 = new Val2.ref[SIZE];
+        boxed1_100 = new Val2.ref[SIZE];
+        boxed2_100 = new Val2.ref[SIZE];
         for(int i = 0; i< SIZE; i++) {
             boxed1_00[i] = value1_00[i];
             boxed2_00[i] = value2_00[i];
@@ -200,7 +200,7 @@ public class IsCmpBranch2 extends ACmpBase {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int boxed_comparison(Val2?[] objects1, Val2?[] objects2) {
+    private static int boxed_comparison(Val2.ref[] objects1, Val2.ref[] objects2) {
         int s = 0;
         for (int i = 0; i < SIZE; i++) {
             if (objects1[i] == objects2[i]) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/acmp/IsCmpBranch8.java
@@ -61,11 +61,11 @@ public class IsCmpBranch8 extends ACmpBase {
     Val8[] value1_75, value2_75;
     Val8[] value1_100, value2_100;
 
-    Val8?[] boxed1_00, boxed2_00;
-    Val8?[] boxed1_25, boxed2_25;
-    Val8?[] boxed1_50, boxed2_50;
-    Val8?[] boxed1_75, boxed2_75;
-    Val8?[] boxed1_100, boxed2_100;
+    Val8.ref[] boxed1_00, boxed2_00;
+    Val8.ref[] boxed1_25, boxed2_25;
+    Val8.ref[] boxed1_50, boxed2_50;
+    Val8.ref[] boxed1_75, boxed2_75;
+    Val8.ref[] boxed1_100, boxed2_100;
 
     Vector[] covariance1_00, covariance2_00;
     Vector[] covariance1_25, covariance2_25;
@@ -86,16 +86,16 @@ public class IsCmpBranch8 extends ACmpBase {
         value2_75 = populateValues2(value1_75, 75);
         value1_100 = populateValues1();
         value2_100 = populateValues2(value1_100, 100);
-        boxed1_00 = new Val8?[SIZE];
-        boxed2_00 = new Val8?[SIZE];
-        boxed1_25 = new Val8?[SIZE];
-        boxed2_25 = new Val8?[SIZE];
-        boxed1_50 = new Val8?[SIZE];
-        boxed2_50 = new Val8?[SIZE];
-        boxed1_75 = new Val8?[SIZE];
-        boxed2_75 = new Val8?[SIZE];
-        boxed1_100 = new Val8?[SIZE];
-        boxed2_100 = new Val8?[SIZE];
+        boxed1_00 = new Val8.ref[SIZE];
+        boxed2_00 = new Val8.ref[SIZE];
+        boxed1_25 = new Val8.ref[SIZE];
+        boxed2_25 = new Val8.ref[SIZE];
+        boxed1_50 = new Val8.ref[SIZE];
+        boxed2_50 = new Val8.ref[SIZE];
+        boxed1_75 = new Val8.ref[SIZE];
+        boxed2_75 = new Val8.ref[SIZE];
+        boxed1_100 = new Val8.ref[SIZE];
+        boxed2_100 = new Val8.ref[SIZE];
         for(int i = 0; i< SIZE; i++) {
             boxed1_00[i] = value1_00[i];
             boxed2_00[i] = value2_00[i];
@@ -200,7 +200,7 @@ public class IsCmpBranch8 extends ACmpBase {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int boxed_comparison(Val8?[] objects1, Val8?[] objects2) {
+    private static int boxed_comparison(Val8.ref[] objects1, Val8.ref[] objects2) {
         int s = 0;
         for (int i = 0; i < SIZE; i++) {
             if (objects1[i] == objects2[i]) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy1.java
@@ -15,8 +15,8 @@ public class Arraycopy1 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val1?[] srcBoxed;
-    Val1?[] dstBoxed;
+    Val1.ref[] srcBoxed;
+    Val1.ref[] dstBoxed;
 
     @Setup
     public void setup() {
@@ -24,8 +24,8 @@ public class Arraycopy1 extends SizedBase {
         dstValue = new Val1[size];
         srcCovariance = Utils.fillV(new Val1[size]);
         dstCovariance = new Val1[size];
-        srcBoxed = Utils.fillB(new Val1?[size]);
-        dstBoxed = new Val1?[size];
+        srcBoxed = Utils.fillB(new Val1.ref[size]);
+        dstBoxed = new Val1.ref[size];
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy2.java
@@ -15,8 +15,8 @@ public class Arraycopy2 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val2?[] srcBoxed;
-    Val2?[] dstBoxed;
+    Val2.ref[] srcBoxed;
+    Val2.ref[] dstBoxed;
 
     @Setup
     public void setup() {
@@ -24,8 +24,8 @@ public class Arraycopy2 extends SizedBase {
         dstValue = new Val2[size];
         srcCovariance = Utils.fillV(new Val2[size]);
         dstCovariance = new Val2[size];
-        srcBoxed = Utils.fillB(new Val2?[size]);
-        dstBoxed = new Val2?[size];
+        srcBoxed = Utils.fillB(new Val2.ref[size]);
+        dstBoxed = new Val2.ref[size];
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Arraycopy8.java
@@ -15,8 +15,8 @@ public class Arraycopy8 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val8?[] srcBoxed;
-    Val8?[] dstBoxed;
+    Val8.ref[] srcBoxed;
+    Val8.ref[] dstBoxed;
 
     @Setup
     public void setup() {
@@ -24,8 +24,8 @@ public class Arraycopy8 extends SizedBase {
         dstValue = new Val8[size];
         srcCovariance = Utils.fillV(new Val8[size]);
         dstCovariance = new Val8[size];
-        srcBoxed = Utils.fillB(new Val8?[size]);
-        dstBoxed = new Val8?[size];
+        srcBoxed = Utils.fillB(new Val8.ref[size]);
+        dstBoxed = new Val8.ref[size];
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy1.java
@@ -15,8 +15,8 @@ public class Copy1 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val1?[] srcBoxed;
-    Val1?[] dstBoxed;
+    Val1.ref[] srcBoxed;
+    Val1.ref[] dstBoxed;
 
 
 
@@ -26,8 +26,8 @@ public class Copy1 extends SizedBase {
         dstValue = new Val1[size];
         srcCovariance = Utils.fillV(new Val1[size]);
         dstCovariance = new Val1[size];
-        srcBoxed = Utils.fillB(new Val1?[size]);
-        dstBoxed = new Val1?[size];
+        srcBoxed = Utils.fillB(new Val1.ref[size]);
+        dstBoxed = new Val1.ref[size];
     }
 
     @Benchmark
@@ -50,8 +50,8 @@ public class Copy1 extends SizedBase {
 
     @Benchmark
     public void boxed() {
-        Val1?[] s = srcBoxed;
-        Val1?[] d = dstBoxed;
+        Val1.ref[] s = srcBoxed;
+        Val1.ref[] d = dstBoxed;
         for (int i = 0; i < size; i++) {
             d[i] = s[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy2.java
@@ -15,8 +15,8 @@ public class Copy2 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val2?[] srcBoxed;
-    Val2?[] dstBoxed;
+    Val2.ref[] srcBoxed;
+    Val2.ref[] dstBoxed;
 
     @Setup
     public void setup() {
@@ -24,8 +24,8 @@ public class Copy2 extends SizedBase {
         dstValue = new Val2[size];
         srcCovariance = Utils.fillV(new Val2[size]);
         dstCovariance = new Val2[size];
-        srcBoxed = Utils.fillB(new Val2?[size]);
-        dstBoxed = new Val2?[size];
+        srcBoxed = Utils.fillB(new Val2.ref[size]);
+        dstBoxed = new Val2.ref[size];
     }
 
     @Benchmark
@@ -48,8 +48,8 @@ public class Copy2 extends SizedBase {
 
     @Benchmark
     public void boxed() {
-        Val2?[] s = srcBoxed;
-        Val2?[] d = dstBoxed;
+        Val2.ref[] s = srcBoxed;
+        Val2.ref[] d = dstBoxed;
         for (int i = 0; i < size; i++) {
             d[i] = s[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Copy8.java
@@ -15,8 +15,8 @@ public class Copy8 extends SizedBase {
     Vector[] srcCovariance;
     Vector[] dstCovariance;
 
-    Val8?[] srcBoxed;
-    Val8?[] dstBoxed;
+    Val8.ref[] srcBoxed;
+    Val8.ref[] dstBoxed;
 
     @Setup
     public void setup() {
@@ -24,8 +24,8 @@ public class Copy8 extends SizedBase {
         dstValue = new Val8[size];
         srcCovariance = Utils.fillV(new Val8[size]);
         dstCovariance = new Val8[size];
-        srcBoxed = Utils.fillB(new Val8?[size]);
-        dstBoxed = new Val8?[size];
+        srcBoxed = Utils.fillB(new Val8.ref[size]);
+        dstBoxed = new Val8.ref[size];
     }
 
     @Benchmark
@@ -48,8 +48,8 @@ public class Copy8 extends SizedBase {
 
     @Benchmark
     public void boxed() {
-        Val8?[] s = srcBoxed;
-        Val8?[] d = dstBoxed;
+        Val8.ref[] s = srcBoxed;
+        Val8.ref[] d = dstBoxed;
         for (int i = 0; i < size; i++) {
             d[i] = s[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set1.java
@@ -9,20 +9,20 @@ import org.openjdk.bench.valhalla.types.Vector;
 public class Set1 extends SizedBase {
 
     Val1[] values;
-    Val1?[] boxed;
+    Val1.ref[] boxed;
     Vector[] covariance;
 
     @Setup
     public void setup() {
         values = new Val1[size];
-        boxed = new Val1?[size];
+        boxed = new Val1.ref[size];
         covariance = new Val1[size];
     }
 
 
     @Benchmark
     public Object boxed() {
-        Val1?[] values = boxed;
+        Val1.ref[] values = boxed;
         for (int i = 0; i < size; i++) {
             values[i] = new Val1(i);
         }
@@ -52,7 +52,7 @@ public class Set1 extends SizedBase {
      */
     @Benchmark
     public Object newBoxed() {
-        Val1?[] values = new Val1?[size];
+        Val1.ref[] values = new Val1.ref[size];
         for (int i = 0; i < size; i++) {
             values[i] = new Val1(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set2.java
@@ -9,20 +9,20 @@ import org.openjdk.bench.valhalla.types.Vector;
 public class Set2 extends SizedBase {
 
     Val2[] values;
-    Val2?[] boxed;
+    Val2.ref[] boxed;
     Vector[] covariance;
 
     @Setup
     public void setup() {
         values = new Val2[size];
-        boxed = new Val2?[size];
+        boxed = new Val2.ref[size];
         covariance = new Val2[size];
     }
 
 
     @Benchmark
     public Object boxed() {
-        Val2?[] values = boxed;
+        Val2.ref[] values = boxed;
         for (int i = 0, k = 0; i < size; i++, k += 2) {
             values[i] = new Val2(k, k + 1);
         }
@@ -52,7 +52,7 @@ public class Set2 extends SizedBase {
      */
     @Benchmark
     public Object newBoxed() {
-        Val2?[] values = new Val2?[size];
+        Val2.ref[] values = new Val2.ref[size];
         for (int i = 0, k = 0; i < size; i++, k += 2) {
             values[i] = new Val2(k, k + 1);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Set8.java
@@ -9,20 +9,20 @@ import org.openjdk.bench.valhalla.types.Vector;
 public class Set8 extends SizedBase {
 
     Val8[] values;
-    Val8?[] boxed;
+    Val8.ref[] boxed;
     Vector[] covariance;
 
     @Setup
     public void setup() {
         values = new Val8[size];
-        boxed = new Val8?[size];
+        boxed = new Val8.ref[size];
         covariance = new Val8[size];
     }
 
 
     @Benchmark
     public Object boxed() {
-        Val8?[] values = boxed;
+        Val8.ref[] values = boxed;
         for (int i = 0, k = 0; i < size; i++, k += 8) {
             values[i] = new Val8(k, k + 1, k + 2, k + 3, k + 4, k + 5, k + 6, k + 7);
         }
@@ -52,7 +52,7 @@ public class Set8 extends SizedBase {
      */
     @Benchmark
     public Object newBoxed() {
-        Val8?[] values = new Val8?[size];
+        Val8.ref[] values = new Val8.ref[size];
         for (int i = 0, k = 0; i < size; i++, k += 8) {
             values[i] = new Val8(k, k + 1, k + 2, k + 3, k + 4, k + 5, k + 6, k + 7);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum1.java
@@ -9,12 +9,12 @@ import org.openjdk.bench.valhalla.lworld.types.Val1;
 public class Sum1 extends SizedBase {
 
     Val1[] values;
-    Val1?[] boxed;
+    Val1.ref[] boxed;
 
     @Setup
     public void setup() {
         values = Utils.fillV(new Val1[size]);
-        boxed = Utils.fillB(new Val1?[size]);
+        boxed = Utils.fillB(new Val1.ref[size]);
     }
 
     @Benchmark
@@ -39,8 +39,8 @@ public class Sum1 extends SizedBase {
 
     @Benchmark
     public int boxed() {
-        Val1?[] v = this.boxed;
-        Val1? sum = new Val1(0);
+        Val1.ref[] v = this.boxed;
+        Val1.ref sum = new Val1(0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val1)v[i]);
         }
@@ -49,7 +49,7 @@ public class Sum1 extends SizedBase {
 
     @Benchmark
     public int boxScalarized() {
-        Val1?[] v = this.boxed;
+        Val1.ref[] v = this.boxed;
         int sum = 0;
         for (int i = 0; i < size; i++) {
             sum += v[i].f0;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum2.java
@@ -9,12 +9,12 @@ import org.openjdk.bench.valhalla.lworld.types.Val2;
 public class Sum2 extends SizedBase {
 
     Val2[] values;
-    Val2?[] boxed;
+    Val2.ref[] boxed;
 
     @Setup
     public void setup() {
         values = Utils.fillV(new Val2[size]);
-        boxed = Utils.fillB(new Val2?[size]);
+        boxed = Utils.fillB(new Val2.ref[size]);
     }
 
     @Benchmark
@@ -41,8 +41,8 @@ public class Sum2 extends SizedBase {
 
     @Benchmark
     public int boxed() {
-        Val2?[] v = this.boxed;
-        Val2? sum = new Val2(0, 0);
+        Val2.ref[] v = this.boxed;
+        Val2.ref sum = new Val2(0, 0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val2)v[i]);
         }
@@ -51,7 +51,7 @@ public class Sum2 extends SizedBase {
 
     @Benchmark
     public int boxScalarized() {
-        Val2?[] v = this.boxed;
+        Val2.ref[] v = this.boxed;
         int f0 = 0;
         int f1 = 0;
         for (int i = 0; i < size; i++) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/arrays/Sum8.java
@@ -9,12 +9,12 @@ import org.openjdk.bench.valhalla.lworld.types.Val8;
 public class Sum8 extends SizedBase {
 
     Val8[] values;
-    Val8?[] boxed;
+    Val8.ref[] boxed;
 
     @Setup
     public void setup() {
         values = Utils.fillV(new Val8[size]);
-        boxed = Utils.fillB(new Val8?[size]);
+        boxed = Utils.fillB(new Val8.ref[size]);
     }
 
     @Benchmark
@@ -53,8 +53,8 @@ public class Sum8 extends SizedBase {
 
     @Benchmark
     public int boxed() {
-        Val8?[] v = this.boxed;
-        Val8? sum = new Val8(0,0,0,0,0,0,0,0);
+        Val8.ref[] v = this.boxed;
+        Val8.ref sum = new Val8(0,0,0,0,0,0,0,0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val8)v[i]);
         }
@@ -63,7 +63,7 @@ public class Sum8 extends SizedBase {
 
     @Benchmark
     public int boxScalarized() {
-        Val8?[] v = this.boxed;
+        Val8.ref[] v = this.boxed;
         int f0 = 0;
         int f1 = 0;
         int f2 = 0;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann1.java
@@ -45,7 +45,7 @@ public class Ackermann1 extends AckermannBase {
                ack_value(new Val1(X3), new Val1(Y3)).reduce();
     }
 
-    private static Val1? ack_boxed(Val1? x, Val1? y) {
+    private static Val1.ref ack_boxed(Val1.ref x, Val1.ref y) {
         return x.reduce() == 0 ?
                 y.inc() :
                 (y.reduce() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann2.java
@@ -45,7 +45,7 @@ public class Ackermann2 extends AckermannBase {
                ack_value(new Val2(0, X3), new Val2(0, Y3)).reduce();
     }
 
-    private static Val2? ack_boxed(Val2? x, Val2? y) {
+    private static Val2.ref ack_boxed(Val2.ref x, Val2.ref y) {
         return x.reduce() == 0 ?
                 y.inc() :
                 (y.reduce() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/callconv/Ackermann8.java
@@ -45,7 +45,7 @@ public class Ackermann8 extends AckermannBase {
                ack_value(new Val8(0, 0, 0, 0, 0, 0, 0, X3), new Val8(0, 0, 0, 0, 0, 0, 0, Y3)).reduce();
     }
 
-    private static Val8? ack_boxed(Val8? x, Val8? y) {
+    private static Val8.ref ack_boxed(Val8.ref x, Val8.ref y) {
         return x.reduce() == 0 ?
                 y.inc() :
                 (y.reduce() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/lworld/callconv/CallConv1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/callconv/CallConv1.java
@@ -20,10 +20,10 @@ public class CallConv1 extends CallBase {
 
     abstract static class InvocationLogic {
 
-        public abstract Val? computeBox(Val? v1);
-        public abstract Val? computeBox(Val? v1, Val? v2);
-        public abstract Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4);
-        public abstract Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4, Val? v5, Val? v6, Val? v7, Val? v8);
+        public abstract Val.ref computeBox(Val.ref v1);
+        public abstract Val.ref computeBox(Val.ref v1, Val.ref v2);
+        public abstract Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4);
+        public abstract Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4, Val.ref v5, Val.ref v6, Val.ref v7, Val.ref v8);
 
         public abstract Val compute(Val v1);
         public abstract Val compute(Val v1, Val v2);
@@ -35,22 +35,22 @@ public class CallConv1 extends CallBase {
     static class InvokeImpl1 extends InvocationLogic {
 
         @Override
-        public Val? computeBox(Val? v1) {
+        public Val.ref computeBox(Val.ref v1) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4, Val? v5, Val? v6, Val? v7, Val? v8) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4, Val.ref v5, Val.ref v6, Val.ref v7, Val.ref v8) {
             return v1;
         }
 
@@ -79,22 +79,22 @@ public class CallConv1 extends CallBase {
     static class InvokeImpl2 extends InvocationLogic {
 
         @Override
-        public Val? computeBox(Val? v1) {
+        public Val.ref computeBox(Val.ref v1) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4, Val? v5, Val? v6, Val? v7, Val? v8) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4, Val.ref v5, Val.ref v6, Val.ref v7, Val.ref v8) {
             return v1;
         }
 
@@ -123,22 +123,22 @@ public class CallConv1 extends CallBase {
     static class InvokeImpl3 extends InvocationLogic {
 
         @Override
-        public Val? computeBox(Val? v1) {
+        public Val.ref computeBox(Val.ref v1) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4) {
             return v1;
         }
 
         @Override
-        public Val? computeBox(Val? v1, Val? v2, Val? v3, Val? v4, Val? v5, Val? v6, Val? v7, Val? v8) {
+        public Val.ref computeBox(Val.ref v1, Val.ref v2, Val.ref v3, Val.ref v4, Val.ref v5, Val.ref v6, Val.ref v7, Val.ref v8) {
             return v1;
         }
 
@@ -203,14 +203,14 @@ public class CallConv1 extends CallBase {
         return logic;
     }
 
-    Val? b1 = new Val(42);
-    Val? b2 = new Val(43);
-    Val? b3 = new Val(44);
-    Val? b4 = new Val(45);
-    Val? b5 = new Val(46);
-    Val? b6 = new Val(47);
-    Val? b7 = new Val(48);
-    Val? b8 = new Val(49);
+    Val.ref b1 = new Val(42);
+    Val.ref b2 = new Val(43);
+    Val.ref b3 = new Val(44);
+    Val.ref b4 = new Val(45);
+    Val.ref b5 = new Val(46);
+    Val.ref b6 = new Val(47);
+    Val.ref b7 = new Val(48);
+    Val.ref b8 = new Val(49);
 
     @CompilerControl(CompilerControl.Mode.INLINE)
     public int boxed1(InvocationLogic[] logic) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox1.java
@@ -3,7 +3,7 @@ package org.openjdk.bench.valhalla.lworld.fields;
 import org.openjdk.bench.valhalla.lworld.types.Val1;
 
 public class NodeBox1 {
-    public Val1? f;
+    public Val1.ref f;
 
     public static NodeBox1[] set(NodeBox1[] a) {
         for (int i = 0; i < a.length; i++) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox2.java
@@ -3,7 +3,7 @@ package org.openjdk.bench.valhalla.lworld.fields;
 import org.openjdk.bench.valhalla.lworld.types.Val2;
 
 public class NodeBox2 {
-    public Val2? f;
+    public Val2.ref f;
 
     public static NodeBox2[] set(NodeBox2[] a) {
         for (int i = 0; i < a.length; i++) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/NodeBox8.java
@@ -3,7 +3,7 @@ package org.openjdk.bench.valhalla.lworld.fields;
 import org.openjdk.bench.valhalla.lworld.types.Val8;
 
 public class NodeBox8 {
-    public Val8? f;
+    public Val8.ref f;
 
     public static NodeBox8[] set(NodeBox8[] a) {
         for (int i = 0; i < a.length; i++) {

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum1.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum1.java
@@ -39,7 +39,7 @@ public class Sum1 extends SizedBase {
     @Benchmark
     public int boxed() {
         NodeBox1[] v = this.boxed;
-        Val1? sum = new Val1(0);
+        Val1.ref sum = new Val1(0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val1)v[i].f);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum2.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum2.java
@@ -42,7 +42,7 @@ public class Sum2 extends SizedBase {
     @Benchmark
     public int boxed() {
         NodeBox2[] v = this.boxed;
-        Val2? sum = new Val2(0, 0);
+        Val2.ref sum = new Val2(0, 0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val2)v[i].f);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum8.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/fields/Sum8.java
@@ -54,7 +54,7 @@ public class Sum8 extends SizedBase {
     @Benchmark
     public int boxed() {
         NodeBox8[] v = this.boxed;
-        Val8? sum = new Val8(0,0,0,0,0,0,0,0);
+        Val8.ref sum = new Val8(0,0,0,0,0,0,0,0);
         for (int i = 0; i < size; i++) {
             sum = sum.add((Val8)v[i].f);
         }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/invoke/ObjectHashCodeExplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/invoke/ObjectHashCodeExplicit.java
@@ -45,9 +45,9 @@ public class ObjectHashCodeExplicit extends CallBase {
     Val1[] values1;
     Val2[] values2;
     Val3[] values3;
-    Val1?[] boxed1;
-    Val2?[] boxed2;
-    Val3?[] boxed3;
+    Val1.ref[] boxed1;
+    Val2.ref[] boxed2;
+    Val3.ref[] boxed3;
 
     @Setup
     public void setup() {
@@ -63,15 +63,15 @@ public class ObjectHashCodeExplicit extends CallBase {
         for (int i = 0; i < SIZE; i++) {
             values3[i] = new Val3(42);
         }
-        boxed1 = new Val1?[SIZE];
+        boxed1 = new Val1.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed1[i] = new Val1(42);
         }
-        boxed2 = new Val2?[SIZE];
+        boxed2 = new Val2.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed2[i] = new Val2(42);
         }
-        boxed3 = new Val3?[SIZE];
+        boxed3 = new Val3.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed3[i] = new Val3(42);
         }
@@ -97,9 +97,9 @@ public class ObjectHashCodeExplicit extends CallBase {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int hashExactBoxed(Val1?[] arr) {
+    public int hashExactBoxed(Val1.ref[] arr) {
         int r = 0;
-        for(Val1? o : arr) {
+        for(Val1.ref o : arr) {
             r += o.hashCode();
         }
         return r;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/invoke/ObjectHashCodeImplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/invoke/ObjectHashCodeImplicit.java
@@ -33,9 +33,9 @@ public class ObjectHashCodeImplicit extends CallBase {
     Val1[] values1;
     Val2[] values2;
     Val3[] values3;
-    Val1?[] boxed1;
-    Val2?[] boxed2;
-    Val3?[] boxed3;
+    Val1.ref[] boxed1;
+    Val2.ref[] boxed2;
+    Val3.ref[] boxed3;
 
     @Setup
     public void setup() {
@@ -51,15 +51,15 @@ public class ObjectHashCodeImplicit extends CallBase {
         for (int i = 0; i < SIZE; i++) {
             values3[i] = new Val3(42);
         }
-        boxed1 = new Val1?[SIZE];
+        boxed1 = new Val1.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed1[i] = new Val1(42);
         }
-        boxed2 = new Val2?[SIZE];
+        boxed2 = new Val2.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed2[i] = new Val2(42);
         }
-        boxed3 = new Val3?[SIZE];
+        boxed3 = new Val3.ref[SIZE];
         for (int i = 0; i < SIZE; i++) {
             boxed3[i] = new Val3(42);
         }
@@ -85,9 +85,9 @@ public class ObjectHashCodeImplicit extends CallBase {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int hashExactBoxed(Val1?[] arr) {
+    public int hashExactBoxed(Val1.ref[] arr) {
         int r = 0;
-        for(Val1? o : arr) {
+        for(Val1.ref o : arr) {
             r += o.hashCode();
         }
         return r;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/matrix/Boxed.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/matrix/Boxed.java
@@ -11,16 +11,16 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class Boxed extends MatrixBase {
 
-    Complex?[][] A;
-    Complex?[][] B;
+    Complex.ref[][] A;
+    Complex.ref[][] B;
 
     @Setup
     public void setup() {
-        A = populate(new Complex?[size][size]);
-        B = populate(new Complex?[size][size]);
+        A = populate(new Complex.ref[size][size]);
+        B = populate(new Complex.ref[size][size]);
     }
 
-    private Complex?[][] populate(Complex?[][] m) {
+    private Complex.ref[][] populate(Complex.ref[][] m) {
         int size = m.length;
         for (int i = 0; i < size; i++) {
             for (int j = 0; j < size; j++) {
@@ -31,9 +31,9 @@ public class Boxed extends MatrixBase {
     }
 
     @Benchmark
-    public Complex?[][] multiply() {
+    public Complex.ref[][] multiply() {
         int size = A.length;
-        Complex?[][] R = new Complex?[size][size];
+        Complex.ref[][] R = new Complex.ref[size][size];
         for (int i = 0; i < size; i++) {
             for (int j = 0; j < size; j++) {
                 Complex s = Complex.H.ZERO;
@@ -47,15 +47,15 @@ public class Boxed extends MatrixBase {
     }
 
     @Benchmark
-    public Complex?[][] multiplyCacheFriendly() {
+    public Complex.ref[][] multiplyCacheFriendly() {
         int size = A.length;
-        Complex?[][] R = new Complex?[size][size];
+        Complex.ref[][] R = new Complex.ref[size][size];
         for (int i = 0; i < size; i++) {
             Arrays.fill(R[i], Complex.H.ZERO);
         }
         for (int i = 0; i < size; i++) {
             for (int k = 0; k < size; k++) {
-                Complex? aik = A[i][k];
+                Complex.ref aik = A[i][k];
                 for (int j = 0; j < size; j++) {
                     R[i][j] = R[i][j].add(aik.mul((Complex)B[k][j]));
                 }
@@ -65,9 +65,9 @@ public class Boxed extends MatrixBase {
     }
 
     @Benchmark
-    public Complex?[][] multiplyCacheFriendly1() {
+    public Complex.ref[][] multiplyCacheFriendly1() {
         int size = A.length;
-        Complex?[][] R = new Complex?[size][size];
+        Complex.ref[][] R = new Complex.ref[size][size];
         for (int i = 0; i < size; i++) {
             for (int j = 0; j < size; j++) {
                 R[i][j] = Complex.H.ZERO;
@@ -75,7 +75,7 @@ public class Boxed extends MatrixBase {
         }
         for (int i = 0; i < size; i++) {
             for (int k = 0; k < size; k++) {
-                Complex? aik = A[i][k];
+                Complex.ref aik = A[i][k];
                 for (int j = 0; j < size; j++) {
                     R[i][j] = R[i][j].add(aik.mul((Complex)B[k][j]));
                 }

--- a/test/micro/org/openjdk/bench/valhalla/lworld/traversal/Boxed.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/traversal/Boxed.java
@@ -9,17 +9,17 @@ import org.openjdk.bench.valhalla.lworld.types.Val1;
 
 public abstract class Boxed extends TraversalBase {
 
-    Val1?[] values;
+    Val1.ref[] values;
 
     public void setup(int[] a) {
-        values = new Val1?[a.length];
+        values = new Val1.ref[a.length];
         for (int i = 0; i < a.length; i++) {
             values[i] = new Val1(a[i]);
         }
     }
 
     @CompilerControl(CompilerControl.Mode.INLINE)
-    public static int walk(Val1?[] a) {
+    public static int walk(Val1.ref[] a) {
         int steps = 0;
         for(int i = a[0].reduce(); i!=0; i=a[i].reduce()) steps++;
         return steps;

--- a/test/micro/org/openjdk/bench/valhalla/lworld/types/Utils.java
+++ b/test/micro/org/openjdk/bench/valhalla/lworld/types/Utils.java
@@ -10,7 +10,7 @@ public class Utils {
         return a;
     }
 
-    public static Val1?[] fillB(Val1?[] a) {
+    public static Val1.ref[] fillB(Val1.ref[] a) {
         for (int i = 0; i < a.length; i++) {
             a[i] = new Val1(i);
         }
@@ -24,7 +24,7 @@ public class Utils {
         return a;
     }
 
-    public static Val2?[] fillB(Val2?[] a) {
+    public static Val2.ref[] fillB(Val2.ref[] a) {
         for (int i = 0, k = 0; i < a.length; i++, k += 2) {
             a[i] = new Val2(k, k + 1);
         }
@@ -38,7 +38,7 @@ public class Utils {
         return a;
     }
 
-    public static Val8?[] fillB(Val8?[] a) {
+    public static Val8.ref[] fillB(Val8.ref[] a) {
         for (int i = 0, k = 0; i < a.length; i++, k += 8) {
             a[i] = new Val8(k, k + 1, k + 2, k + 3, k + 4, k + 5, k + 6, k + 7);
         }


### PR DESCRIPTION
Description of changes:

Hi Maruizio,

    Could you please review these assorted changes that block the build of Valhalla micro
benchmarks ? This is a culumative fix for JDK-8244414 and JDK-8244458

    You could skip a review of the benchmark source files themselves - these have only mechanical changes from V? to V.ref except for one case where there was a usage of Node?<K,V> with Node actually being an identity class. We don't support the transformed Node.ref<K,V> for identity classes, so I had to drop the '?'

Problems fixed:

    (i) Resolve.java: Diamond inference did not work for inline type constructors: Basically, the (static factory method equivalent) constructors synthesized during diamond inference did not have their reference projection counterparts and had to be paired up with them.

    (ii) Types.java: LUB computation in the presence of mixed values and non-values should first apply widening conversion.

    (iii) Enter.java: When we recompile files due to annotation processing rounds, discard
any prior state carried on by the reference projection so as to keep it in sync with its peer.
(A separate test will be added separately - for now building microbenchmarks is the test for this)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244414](https://bugs.openjdk.java.net/browse/JDK-8244414): [lworld] Migrate Valhalla micro benchmarks suite to not use V? syntax


### Reviewers
 * Maurizio Cimadamore ([mcimadamore](@mcimadamore) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/35/head:pull/35`
`$ git checkout pull/35`
