### PR TITLE
8244519: [lworld] C2 compilation fails with 'monitors must always exist for synchronized methods'

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -690,7 +690,7 @@ bool ciInstanceKlass::can_be_value_klass(bool is_exact) {
       Method* m = methods->at(i);
       if ((m->is_synchronized() && !m->is_static()) ||
           (m->is_object_constructor() &&
-           (!m->signature()->is_void_method_signature() ||
+           (m->signature() != vmSymbols::void_method_signature() ||
             !m->is_vanilla_constructor()))) {
         return false;
       }

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -70,8 +70,6 @@ private:
 
   int                    _has_injected_fields; // any non static injected fields? lazily initialized.
 
-  ciInstanceKlass*       _vcc_klass; // points to the value-capable class corresponding to the current derived value type class.
-
   // The possible values of the _implementor fall into following three cases:
   //   NULL: no implementor.
   //   A ciInstanceKlass that's not itself: one implementor.
@@ -251,7 +249,6 @@ public:
 
   bool is_leaf_type();
   ciInstanceKlass* implementor();
-  ciInstanceKlass* vcc_klass();
 
   ciInstanceKlass* unique_implementor() {
     assert(is_loaded(), "must be loaded");
@@ -259,9 +256,7 @@ public:
     return (impl != this ? impl : NULL);
   }
 
-  virtual bool can_be_value_klass(bool is_exact = false) {
-    return EnableValhalla && (!is_loaded() || is_valuetype() || ((is_java_lang_Object() || is_interface() || (is_abstract() && !has_nonstatic_fields())) && !is_exact));
-  }
+  virtual bool can_be_value_klass(bool is_exact = false);
 
   // Is the defining class loader of this class the default loader?
   bool uses_default_loader() const;

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -653,7 +653,8 @@ bool Method::is_vanilla_constructor() const {
   if (size == 0 || size % 5 != 0) return false;
   address cb = code_base();
   int last = size - 1;
-  if (cb[0] != Bytecodes::_aload_0 || cb[1] != Bytecodes::_invokespecial || cb[last] != Bytecodes::_return) {
+  if ((cb[0] != Bytecodes::_aload_0 && cb[0] != Bytecodes::_fast_aload_0 && cb[0] != Bytecodes::_nofast_aload_0) ||
+       cb[1] != Bytecodes::_invokespecial || cb[last] != Bytecodes::_return) {
     // Does not call superclass default constructor
     return false;
   }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1290,6 +1290,7 @@ void Parse::do_method_entry() {
       lock_obj = makecon(t_lock);
     } else {                  // Else pass the "this" pointer,
       lock_obj = local(0);    // which is Parm0 from StartNode
+      assert(!_gvn.type(lock_obj)->make_oopptr()->can_be_value_type(), "can't be an inline type");
     }
     // Clear out dead values from the debug info.
     kill_dead_locals();


### PR DESCRIPTION
C2 incorrectly assumes that the receiver of a synchronized method of an abstract class can be an inline type and therefore adds a runtime check to the locking code (see 'can_be_value_type' check in PhaseMacroExpand::expand_lock_node). While processing the JVMState of an uncommon trap emitted for that runtime check, we assert because there is no monitor (yet) although the method is synchronized. 

I've modified ciInstanceKlass::can_be_value_klass accordingly and added an to catch similar problems earlier. I've also removed some dead code.

This fix includes the is_vanilla_constructor() fix from JDK-8243204.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244519](https://bugs.openjdk.java.net/browse/JDK-8244519): [lworld] C2 compilation fails with "monitors must always exist for synchronized methods"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/36/head:pull/36`
`$ git checkout pull/36`
