### PR TITLE
8244559: [lworld] Lambda and parameterized ref of an inline type doesn't work well

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1621,10 +1621,13 @@ public class Check {
 
         public void visitSelectInternal(JCFieldAccess tree) {
             if (tree.type.tsym.isStatic() &&
-                tree.selected.type.isParameterized()) {
+                tree.selected.type.isParameterized() &&
+                    (tree.name != names.ref || !tree.type.isReferenceProjection())) {
                 // The enclosing type is not a class, so we are
                 // looking at a static member type.  However, the
                 // qualifying expression is parameterized.
+                // Tolerate the pseudo-select V.ref: V<T>.ref will be static if V<T> is and
+                // should not be confused as selecting a static member of a parameterized type.
                 log.error(tree.pos(), Errors.CantSelectStaticClassFromParamType);
             } else {
                 // otherwise validate the rest of the expression

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProperTypeApplySelectTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProperTypeApplySelectTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244559
+ * @summary Check that javac transforms Types to AST nodes properly.
+ * @run main ProperTypeApplySelectTest
+ */
+
+import java.util.List;
+
+public class ProperTypeApplySelectTest {
+
+  static String out = "";
+
+  inline static class Foo<V> {
+    int x;
+    Foo(int x) { this.x = x; }
+  }
+
+  static void m(Foo foo) {
+    out += "inline";
+  }
+  static void m(Foo.ref foo) {
+    out += "ref";
+  }
+
+  public static void main(String[] args) {
+    List<Foo.ref<Integer>> list = List.of(new Foo<Integer>(3));
+    list.stream().forEach(e -> m(e));
+    if (!out.equals("ref"))
+        throw new AssertionError("Unexpected: " + out);
+  }
+}


### PR DESCRIPTION
Jim, Could you please review this patch which fixes two problems? TIA.

(1) Basically, the code to create AST nodes from a Type is not handling reference
projection types properly. Given a type V.ref\<T\>, it ends up creating AST that
look like V\<T\>.ref rather than V.ref\<T\>

(2) When V\<T\> is a nested static class, the construct V.ref\<T\> _appears_ to 
access a static member type of the parameterized type V which is usually an
error. But ref is not really a member and so this should be tolerated.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244559](https://bugs.openjdk.java.net/browse/JDK-8244559): [lworld] Lambda and parameterized ref of an inline type doesn't work well


### Reviewers
 * JimLaskey (no known github.com user name / role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/39/head:pull/39`
`$ git checkout pull/39`
