### PR TITLE
8244708: [lworld] CDS tests that bundle inline classes should also bundle reference projection classes.

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -30,7 +30,7 @@
  * @bug 8231610
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloRelocation
- * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point
+ * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
  * @run driver ArchiveRelocationTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
- * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point
+ * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
  * @run driver HelloInlineClassTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -31,7 +31,7 @@
  * @bug 8231610
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloRelocation
- * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point
+ * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
  * @run driver DynamicArchiveRelocationTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
- * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point
+ * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
  * @run driver HelloDynamicInlineClass
  */
 


### PR DESCRIPTION
Patch to also jar up the $ref.class files.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244708](https://bugs.openjdk.java.net/browse/JDK-8244708): [lworld] CDS tests that bundle inline classes should also bundle reference projection classes.


### Reviewers
 * David Simms ([dsimms](@MrSimms) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/40/head:pull/40`
`$ git checkout pull/40`
