### PR TITLE
8244235: java.lang.NoSuchFieldError: this when initializing an inner class inside an inline type

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/ThisIsNotAnInstanceField.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ThisIsNotAnInstanceField.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244235
+ * @summary Javac mistakenly treats references to _this_ as a reference to an instance field
+ * @run main ThisIsNotAnInstanceField
+ */
+
+public inline class ThisIsNotAnInstanceField {
+
+    int i = 513;
+
+    Inner.ref i2 = new Inner();
+
+    inline class Inner {
+        int c = 511;
+    }
+
+    static public void main(String[] args) {
+        ThisIsNotAnInstanceField t1 = new ThisIsNotAnInstanceField();
+        if (t1.i + t1.i2.c != 1024)
+            throw new AssertionError("Unexpected: " + Integer.valueOf(t1.i + t1.i2.c));
+    }
+}


### PR DESCRIPTION
Jim, Thanks for reviewing this small fix.

Basically, javac mistakenly treats references to 'this' as an instance field.
Fix is to handle this particular case specially and return the value factory
product which is the proxy for 'this' in the inline factory.

I renamed a method suitably for better clarity. Of the three call sites only
one needed change. It is implausible in the other two sites that the symbol
involved is 'this' (since 'this' cannot be assigned to and qualified this would
have been lowered already)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244235](https://bugs.openjdk.java.net/browse/JDK-8244235): java.lang.NoSuchFieldError: this when initializing an inner class inside an inline type


### Reviewers
 * JimLaskey (no known github.com user name / role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/42/head:pull/42`
`$ git checkout pull/42`
