### PR TITLE
8230082: [lworld] Volatile field declaration in inline class fails with ClassFormatError

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1453,7 +1453,7 @@ public class Check {
                                PRIVATE,
                                PUBLIC | PROTECTED)
                  &&
-                 checkDisjoint(pos, flags,
+                 checkDisjoint(pos, (flags | implicit), // complain against volatile & implcitly final entities too.
                                FINAL,
                                VOLATILE)
                  &&

--- a/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.java
@@ -1,0 +1,18 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8230082
+ * @summary Javac should not allow inline type's fields to be volatile (as they are final)
+ * @compile/fail/ref=NoVolatileFields.out -XDrawDiagnostics NoVolatileFields.java
+ */
+
+public class NoVolatileFields {
+
+    static class Foo {
+        volatile final int i = 0; // Error
+    }
+
+    static inline class Bar {
+        volatile int i = 0; // Error
+    }
+}
+

--- a/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.out
@@ -1,0 +1,3 @@
+NoVolatileFields.java:11:28: compiler.err.illegal.combination.of.modifiers: final, volatile
+NoVolatileFields.java:15:22: compiler.err.illegal.combination.of.modifiers: final, volatile
+2 errors


### PR DESCRIPTION
Jim, could you please review this small fix ?

Basically while checking that both FINAL and VOLATILE are not simultaneously
on, we should also check implicitly computed flags.

(Perhaps all calls to disjoint should consider implicit flags - but after
spending some time, I couldn't construct other problematic scenarios, so
decided to mind my business and limit it to the case at hand)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8230082](https://bugs.openjdk.java.net/browse/JDK-8230082): [lworld] Volatile field declaration in inline class fails with ClassFormatError


### Reviewers
 * JimLaskey (no known github.com user name / role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/43/head:pull/43`
`$ git checkout pull/43`
