### PR TITLE
8244810: [lworld] Decommission arrayStorageProperties from Klass:array_klass() et el

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1094,7 +1094,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_i
         { Bytecode_anewarray anew(caller_method(), caller_method->bcp_from(bci));
           Klass* ek = caller_method->constants()->klass_at(anew.index(), CHECK);
           if (ek->is_value() && caller_method->constants()->klass_at_noresolve(anew.index())->is_Q_signature()) {
-            k = ek->array_klass(ArrayStorageProperties::flattened_and_null_free, 1, CHECK);
+            k = ek->array_klass(1, CHECK);
             assert(ArrayKlass::cast(k)->storage_properties().is_null_free(), "Expect a null-free array class here");
           } else {
             k = ek->array_klass(CHECK);

--- a/src/hotspot/share/ci/ciObjArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.cpp
@@ -138,10 +138,8 @@ ciObjArrayKlass* ciObjArrayKlass::make_impl(ciKlass* element_klass, bool never_n
   if (element_klass->is_loaded()) {
     EXCEPTION_CONTEXT;
     // The element klass is loaded
-    ArrayStorageProperties props = never_null ? ArrayStorageProperties::flattened_and_null_free : ArrayStorageProperties::empty;
-    Klass* array = element_klass->get_Klass()->array_klass(props, THREAD);
+    Klass* array = element_klass->get_Klass()->array_klass(THREAD);
     if (element_klass->is_valuetype()) {
-      assert(!ObjArrayKlass::cast(array)->storage_properties().is_flattened(), "should not be flattened");
       assert(ObjArrayKlass::cast(array)->storage_properties().is_null_free() == never_null, "wrong nullability storage property");
     }
     if (HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/ci/ciValueArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciValueArrayKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,8 +133,7 @@ ciValueArrayKlass* ciValueArrayKlass::make_impl(ciKlass* element_klass) {
   {
     EXCEPTION_CONTEXT;
     // The element klass is loaded
-    Klass* array = element_klass->get_Klass()->array_klass(ArrayStorageProperties::flattened_and_null_free, 1, THREAD);
-    assert(ValueArrayKlass::cast(array)->storage_properties().is_flattened(), "should be flattened");
+    Klass* array = element_klass->get_Klass()->array_klass(1, THREAD);
     assert(ValueArrayKlass::cast(array)->storage_properties().is_null_free(), "should be null free");
     if (HAS_PENDING_EXCEPTION) {
       CLEAR_PENDING_EXCEPTION;

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -289,11 +289,11 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
                                                          protection_domain,
                                                          CHECK_NULL);
     if (k != NULL) {
-      k = k->array_klass(ArrayStorageProperties::for_signature(class_name), ndims, CHECK_NULL);
+      k = k->array_klass(ndims, CHECK_NULL);
     }
   } else {
     k = Universe::typeArrayKlassObj(t);
-    k = TypeArrayKlass::cast(k)->array_klass(ArrayStorageProperties::empty, ndims, CHECK_NULL);
+    k = TypeArrayKlass::cast(k)->array_klass(ndims, CHECK_NULL);
   }
   return k;
 }
@@ -1019,7 +1019,7 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
       k = SystemDictionary::find(ss.as_symbol(), class_loader, protection_domain, THREAD);
     }
     if (k != NULL) {
-      k = k->array_klass_or_null(ArrayStorageProperties::for_signature(class_name), ndims);
+      k = k->array_klass_or_null(ndims);
     }
   } else {
     k = find(class_name, class_loader, protection_domain, THREAD);
@@ -2283,7 +2283,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     }
     // If element class already loaded, allocate array klass
     if (klass != NULL) {
-      klass = klass->array_klass_or_null(ArrayStorageProperties::for_signature(class_name), ndims);
+      klass = klass->array_klass_or_null(ndims);
     }
   } else {
     MutexLocker mu(THREAD, SystemDictionary_lock);

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ objArrayOop oopFactory::new_objArray(Klass* klass, int length, TRAPS) {
 arrayOop oopFactory::new_valueArray(Klass* klass, int length, TRAPS) {
   assert(klass->is_value(), "Klass must be value type");
   // Request flattened, but we might not actually get it...either way "null-free" are the aaload/aastore semantics
-  Klass* array_klass = klass->array_klass(ArrayStorageProperties::flattened_and_null_free, 1, CHECK_NULL);
+  Klass* array_klass = klass->array_klass(1, CHECK_NULL);
   assert(ArrayKlass::cast(array_klass)->storage_properties().is_null_free(), "Expect a null-free array class here");
 
   arrayOop oop;
@@ -152,7 +152,7 @@ arrayOop oopFactory::new_valueArray(Klass* klass, int length, TRAPS) {
 objArrayHandle oopFactory::copy_valueArray_to_objArray(valueArrayHandle array, TRAPS) {
   int len = array->length();
   ValueArrayKlass* vak = ValueArrayKlass::cast(array->klass());
-  objArrayHandle oarray = new_objArray_handle(vak->element_klass(),
+  objArrayHandle oarray = new_objArray_handle(vak->element_klass()->super(),
                                               array->length(), CHECK_(objArrayHandle()));
   vak->copy_array(array(), 0, oarray(), 0, len, CHECK_(objArrayHandle()));
   return oarray;

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -152,10 +152,10 @@ arrayOop oopFactory::new_valueArray(Klass* klass, int length, TRAPS) {
 objArrayHandle oopFactory::copy_valueArray_to_objArray(valueArrayHandle array, TRAPS) {
   int len = array->length();
   ValueArrayKlass* vak = ValueArrayKlass::cast(array->klass());
-  objArrayHandle oarray = new_objArray_handle(vak->element_klass()->super(),
-                                              array->length(), CHECK_(objArrayHandle()));
-  vak->copy_array(array(), 0, oarray(), 0, len, CHECK_(objArrayHandle()));
-  return oarray;
+  objArrayOop oarray = new_objectArray(array->length(), CHECK_(objArrayHandle()));
+  objArrayHandle oarrayh(THREAD, oarray);
+  vak->copy_array(array(), 0, oarrayh(), 0, len, CHECK_(objArrayHandle()));
+  return oarrayh;
 }
 
 objArrayHandle  oopFactory::ensure_objArray(oop array, TRAPS) {

--- a/src/hotspot/share/memory/oopFactory.hpp
+++ b/src/hotspot/share/memory/oopFactory.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,10 @@ class oopFactory: AllStatic {
   // Value arrays...
   // LWorld:
   //    - Q-type signature allocation should use this path.
-  //    - L-type signature allocation should use new_objArray (even with value type elements)
+  //    - L-type signature allocation should use new_objArray
   //
-  // Method specifically creates ArrayStorageProperties::null_free and possibly flattened if possible
-  // i.e. valueArrayOop if flattening can be done, else objArrayOop with "null free" storage properties
+  // Method specifically null free and possibly flattened if possible
+  // i.e. valueArrayOop if flattening can be done, else "null free" objArrayOop
   static arrayOop        new_valueArray(Klass* klass, int length, TRAPS);
 
   // Helper conversions from value to obj array...

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -26,6 +26,7 @@
 #define SHARE_OOPS_ARRAYKLASS_HPP
 
 #include "oops/klass.hpp"
+#include "oops/arrayStorageProperties.hpp"
 
 class fieldDescriptor;
 class klassVtable;
@@ -55,8 +56,8 @@ class ArrayKlass: public Klass {
   ArrayKlass(Symbol* name, KlassID id);
   ArrayKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
-  // Create array_name for element klass, creates a permanent symbol, returns result
-  static Symbol* create_element_klass_array_name(bool is_qtype, Klass* element_klass, TRAPS);
+  // Create array_name for element klass
+  static Symbol* create_element_klass_array_name(Klass* element_klass, TRAPS);
 
  public:
   // Instance variables

--- a/src/hotspot/share/oops/arrayStorageProperties.cpp
+++ b/src/hotspot/share/oops/arrayStorageProperties.cpp
@@ -30,7 +30,6 @@
 STATIC_ASSERT((int)ArrayStorageProperties::nof_oop_properties <= (int)oopDesc::storage_props_nof_bits);
 
 const ArrayStorageProperties ArrayStorageProperties::empty     = ArrayStorageProperties(empty_value);
-const ArrayStorageProperties ArrayStorageProperties::flattened = ArrayStorageProperties(flattened_value);
 const ArrayStorageProperties ArrayStorageProperties::null_free = ArrayStorageProperties(null_free_value);
 const ArrayStorageProperties ArrayStorageProperties::flattened_and_null_free =
         ArrayStorageProperties(flattened_value | null_free_value);

--- a/src/hotspot/share/oops/arrayStorageProperties.hpp
+++ b/src/hotspot/share/oops/arrayStorageProperties.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/arrayStorageProperties.hpp
+++ b/src/hotspot/share/oops/arrayStorageProperties.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/arrayStorageProperties.hpp
+++ b/src/hotspot/share/oops/arrayStorageProperties.hpp
@@ -51,27 +51,18 @@ class ArrayStorageProperties {
 
   bool is_empty() const { return _flags == empty_value; }
 
-  void clear_flattened()    { clear_flags_bits(flattened_value); }
-
   bool is_flattened() const { return test_flags_bit(flattened_bit); }
-  void set_flattened()      { set_flags_bits(flattened_value); }
 
   bool is_null_free() const { return test_flags_bit(null_free_bit); }
-  void set_null_free()      { set_flags_bits(null_free_value); }
 
   uint8_t value() const { return _flags; }
   template <typename T> T encode(int shift) const { return static_cast<T>(_flags) << shift; }
 
   // Well-known constants...
   static const ArrayStorageProperties empty;
-  static const ArrayStorageProperties flattened;
   static const ArrayStorageProperties null_free;
   static const ArrayStorageProperties flattened_and_null_free;
 
-  static ArrayStorageProperties for_signature(Symbol* sig) {
-    return (sig->is_Q_array_signature() || sig->is_Q_signature()) ?
-      ArrayStorageProperties::flattened_and_null_free : ArrayStorageProperties::empty;
-  }
 };
 
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1449,8 +1449,7 @@ void InstanceKlass::check_valid_for_instantiation(bool throwError, TRAPS) {
   }
 }
 
-Klass* InstanceKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS) {
-  assert(storage_props.is_empty(), "Unexpected");
+Klass* InstanceKlass::array_klass_impl(bool or_null, int n, TRAPS) {
   // Need load-acquire for lock-free read
   if (array_klasses_acquire() == NULL) {
     if (or_null) return NULL;
@@ -1463,7 +1462,7 @@ Klass* InstanceKlass::array_klass_impl(ArrayStorageProperties storage_props, boo
 
       // Check if update has already taken place
       if (array_klasses() == NULL) {
-        Klass*    k = ObjArrayKlass::allocate_objArray_klass(storage_props, 1, this, CHECK_NULL);
+        Klass*    k = ObjArrayKlass::allocate_objArray_klass(1, this, CHECK_NULL);
         // use 'release' to pair with lock-free load
         release_set_array_klasses(k);
       }
@@ -1472,13 +1471,13 @@ Klass* InstanceKlass::array_klass_impl(ArrayStorageProperties storage_props, boo
   // _this will always be set at this point
   ObjArrayKlass* oak = (ObjArrayKlass*)array_klasses();
   if (or_null) {
-    return oak->array_klass_or_null(storage_props, n);
+    return oak->array_klass_or_null(n);
   }
-  return oak->array_klass(storage_props, n, THREAD);
+  return oak->array_klass(n, THREAD);
 }
 
-Klass* InstanceKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS) {
-  return array_klass_impl(storage_props, or_null, 1, THREAD);
+Klass* InstanceKlass::array_klass_impl(bool or_null, TRAPS) {
+  return array_klass_impl(or_null, 1, THREAD);
 }
 
 static int call_class_initializer_counter = 0;   // for debugging

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1454,10 +1454,10 @@ private:
   JNIid* jni_id_for_impl                         (int offset);
 protected:
   // Returns the array class for the n'th dimension
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, int n, TRAPS);
 
   // Returns the array class with this class as element type
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, TRAPS);
 
 private:
 

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -631,29 +631,29 @@ void Klass::set_archived_java_mirror_raw(oop m) {
 }
 #endif // INCLUDE_CDS_JAVA_HEAP
 
-Klass* Klass::array_klass_or_null(ArrayStorageProperties storage_props, int rank) {
+Klass* Klass::array_klass_or_null(int rank) {
   EXCEPTION_MARK;
   // No exception can be thrown by array_klass_impl when called with or_null == true.
   // (In anycase, the execption mark will fail if it do so)
-  return array_klass_impl(storage_props, true, rank, THREAD);
+  return array_klass_impl(true, rank, THREAD);
 }
 
 
-Klass* Klass::array_klass_or_null(ArrayStorageProperties storage_props) {
+Klass* Klass::array_klass_or_null() {
   EXCEPTION_MARK;
   // No exception can be thrown by array_klass_impl when called with or_null == true.
   // (In anycase, the execption mark will fail if it do so)
-  return array_klass_impl(storage_props, true, THREAD);
+  return array_klass_impl(true, THREAD);
 }
 
 
-Klass* Klass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int rank, TRAPS) {
+Klass* Klass::array_klass_impl(bool or_null, int rank, TRAPS) {
   fatal("array_klass should be dispatched to InstanceKlass, ObjArrayKlass or TypeArrayKlass");
   return NULL;
 }
 
 
-Klass* Klass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS) {
+Klass* Klass::array_klass_impl(bool or_null, TRAPS) {
   fatal("array_klass should be dispatched to InstanceKlass, ObjArrayKlass or TypeArrayKlass");
   return NULL;
 }
@@ -743,16 +743,6 @@ void Klass::oop_print_on(oop obj, outputStream* st) {
      st->cr();
      st->print(BULLET"prototype_header: " INTPTR_FORMAT, _prototype_header.value());
      st->cr();
-     ArrayStorageProperties props = obj->array_storage_properties();
-     if (props.value() != 0) {
-       st->print(" - array storage properties: ");
-       if (props.is_flattened()) {
-         st->print(" flat");
-       }
-       if (props.is_null_free()) {
-         st->print(" non nullable");
-       }
-     }
   }
 
   // print class

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -28,7 +28,6 @@
 #include "classfile/classLoaderData.hpp"
 #include "memory/iterator.hpp"
 #include "memory/memRegion.hpp"
-#include "oops/arrayStorageProperties.hpp"
 #include "oops/markWord.hpp"
 #include "oops/metadata.hpp"
 #include "oops/oop.hpp"
@@ -480,27 +479,15 @@ protected:
   }
 
   // array class with specific rank
-  Klass* array_klass(int rank, TRAPS) {
-    return array_klass_impl(ArrayStorageProperties::empty, false, rank, THREAD);
-  }
-
-  Klass* array_klass(ArrayStorageProperties storage_props, int rank, TRAPS) {
-    return array_klass_impl(storage_props, false, rank, THREAD);
-  }
+  Klass* array_klass(int rank, TRAPS)         {  return array_klass_impl(false, rank, THREAD); }
 
   // array class with this klass as element type
-  Klass* array_klass(TRAPS) {
-    return array_klass_impl(ArrayStorageProperties::empty, false, THREAD);
-  }
-
-  Klass* array_klass(ArrayStorageProperties storage_props, TRAPS) {
-    return array_klass_impl(storage_props, false, THREAD);
-  }
+   Klass* array_klass(TRAPS)                   {  return array_klass_impl(false, THREAD); }
 
   // These will return NULL instead of allocating on the heap:
   // NB: these can block for a mutex, like other functions with TRAPS arg.
-  Klass* array_klass_or_null(ArrayStorageProperties storage_props, int rank);
-  Klass* array_klass_or_null(ArrayStorageProperties storage_props);
+  Klass* array_klass_or_null(int rank);
+  Klass* array_klass_or_null();
 
   virtual oop protection_domain() const = 0;
 
@@ -513,8 +500,8 @@ protected:
   oop klass_holder() const { return class_loader_data()->holder_phantom(); }
 
  protected:
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int rank, TRAPS);
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, int rank, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, TRAPS);
 
   // Error handling when length > max_length or length < 0
   static void check_array_allocation_length(int length, int max_length, TRAPS);

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,8 +69,7 @@ class ObjArrayKlass : public ArrayKlass {
   int oop_size(oop obj) const;
 
   // Allocation
-  static Klass* allocate_objArray_klass(ArrayStorageProperties storage_props,
-                                          int n, Klass* element_klass, TRAPS);
+  static Klass* allocate_objArray_klass(int n, Klass* element_klass, TRAPS);
 
   objArrayOop allocate(int length, TRAPS);
   oop multi_allocate(int rank, jint* sizes, TRAPS);
@@ -91,10 +90,10 @@ class ObjArrayKlass : public ArrayKlass {
                int length, TRAPS);
  protected:
   // Returns the ObjArrayKlass for n'th dimension.
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, int n, TRAPS);
 
   // Returns the array class with this class as element type.
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, TRAPS);
 
  public:
 

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -171,8 +171,7 @@ void TypeArrayKlass::copy_array(arrayOop s, int src_pos, arrayOop d, int dst_pos
 }
 
 // create a klass of array holding typeArrays
-Klass* TypeArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS) {
-  assert(storage_props.is_empty(), "Didn't expect storage properties");
+Klass* TypeArrayKlass::array_klass_impl(bool or_null, int n, TRAPS) {
   int dim = dimension();
   assert(dim <= n, "check order of chain");
     if (dim == n)
@@ -188,8 +187,7 @@ Klass* TypeArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bo
       MutexLocker mu(THREAD, MultiArray_lock);
 
       if (higher_dimension() == NULL) {
-        Klass* oak = ObjArrayKlass::allocate_objArray_klass(
-              ArrayStorageProperties::empty, dim + 1, this, CHECK_NULL);
+        Klass* oak = ObjArrayKlass::allocate_objArray_klass(dim + 1, this, CHECK_NULL);
         ObjArrayKlass* h_ak = ObjArrayKlass::cast(oak);
         h_ak->set_lower_dimension(this);
         // use 'release' to pair with lock-free load
@@ -201,14 +199,14 @@ Klass* TypeArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bo
 
   ObjArrayKlass* h_ak = ObjArrayKlass::cast(higher_dimension());
   if (or_null) {
-    return h_ak->array_klass_or_null(storage_props, n);
+    return h_ak->array_klass_or_null(n);
   }
   THREAD->check_possible_safepoint();
-  return h_ak->array_klass(storage_props, n, THREAD);
+  return h_ak->array_klass(n, THREAD);
 }
 
-Klass* TypeArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS) {
-  return array_klass_impl(storage_props, or_null, dimension() +  1, THREAD);
+Klass* TypeArrayKlass::array_klass_impl(bool or_null, TRAPS) {
+  return array_klass_impl(or_null, dimension() +  1, THREAD);
 }
 
 int TypeArrayKlass::oop_size(oop obj) const {

--- a/src/hotspot/share/oops/typeArrayKlass.hpp
+++ b/src/hotspot/share/oops/typeArrayKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,10 +94,10 @@ class TypeArrayKlass : public ArrayKlass {
 
  protected:
   // Find n'th dimensional array
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, int n, TRAPS);
 
   // Returns the array class with this class as element type
-  virtual Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  virtual Klass* array_klass_impl(bool or_null, TRAPS);
 
  public:
   static TypeArrayKlass* cast(Klass* k) {

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -82,6 +82,7 @@ void ValueArrayKlass::set_element_klass(Klass* k) {
 }
 
 ValueArrayKlass* ValueArrayKlass::allocate_klass(Klass* element_klass, TRAPS) {
+  guarantee((!Universe::is_bootstrapping() || SystemDictionary::Object_klass_loaded()), "Really ?!");
   assert(ValueArrayFlatten, "Flatten array required");
   assert(ValueKlass::cast(element_klass)->is_naturally_atomic() || (!ValueArrayAtomicAccess), "Atomic by-default");
 
@@ -89,34 +90,54 @@ ValueArrayKlass* ValueArrayKlass::allocate_klass(Klass* element_klass, TRAPS) {
    *  MVT->LWorld, now need to allocate secondaries array types, just like objArrayKlass...
    *  ...so now we are trying out covariant array types, just copy objArrayKlass
    *  TODO refactor any remaining commonality
+   *
    */
-
-  // Eagerly allocate the direct array supertype, which would be "[L<vt>;" for this "[Q<vt>;"
-  Klass* super_klass = element_klass->array_klass_or_null(ArrayStorageProperties::empty);
-  if (super_klass == NULL) {
-    MutexUnlocker mu(MultiArray_lock);
-    // allocate super...need to drop the lock
-    element_klass->array_klass(ArrayStorageProperties::empty, 1, CHECK_NULL);
-    // retry, start from the beginning since lock dropped...
-    Klass* ak = element_klass->array_klass(ArrayStorageProperties::flattened_and_null_free, 1, CHECK_NULL);
-    return ValueArrayKlass::cast(ak);
+  // Eagerly allocate the direct array supertype.
+  Klass* super_klass = NULL;
+  Klass* element_super = element_klass->super();
+  if (element_super != NULL) {
+    // The element type has a direct super.  E.g., String[] has direct super of Object[].
+    super_klass = element_super->array_klass_or_null();
+    bool supers_exist = super_klass != NULL;
+    // Also, see if the element has secondary supertypes.
+    // We need an array type for each.
+    const Array<Klass*>* element_supers = element_klass->secondary_supers();
+    for( int i = element_supers->length()-1; i >= 0; i-- ) {
+      Klass* elem_super = element_supers->at(i);
+      if (elem_super->array_klass_or_null() == NULL) {
+        supers_exist = false;
+        break;
+      }
+    }
+    if (!supers_exist) {
+      // Oops.  Not allocated yet.  Back out, allocate it, and retry.
+      Klass* ek = NULL;
+      {
+        MutexUnlocker mu(MultiArray_lock);
+        super_klass = element_super->array_klass(CHECK_NULL);
+        for( int i = element_supers->length()-1; i >= 0; i-- ) {
+          Klass* elem_super = element_supers->at(i);
+          elem_super->array_klass(CHECK_NULL);
+        }
+        // Now retry from the beginning
+        ek = element_klass->array_klass(CHECK_NULL);
+      }  // re-lock
+      return ValueArrayKlass::cast(ek);
+    }
   }
 
-  Symbol* name = ArrayKlass::create_element_klass_array_name(true, element_klass, CHECK_NULL);
+  Symbol* name = ArrayKlass::create_element_klass_array_name(element_klass, CHECK_NULL);
   ClassLoaderData* loader_data = element_klass->class_loader_data();
   int size = ArrayKlass::static_size(ValueArrayKlass::header_size());
   ValueArrayKlass* vak = new (loader_data, size, THREAD) ValueArrayKlass(element_klass, name);
-  loader_data->add_class(vak);
 
   ModuleEntry* module = vak->module();
   assert(module != NULL, "No module entry for array");
   complete_create_array_klass(vak, super_klass, module, CHECK_NULL);
-  return vak;
-}
 
-ValueArrayKlass* ValueArrayKlass::allocate_klass(ArrayStorageProperties storage_props, Klass* element_klass, TRAPS) {
-  assert(storage_props.is_flattened(), "Expected flat storage");
-  return allocate_klass(element_klass, THREAD);
+  loader_data->add_class(vak);
+
+  return vak;
 }
 
 void ValueArrayKlass::initialize(TRAPS) {
@@ -310,8 +331,7 @@ void ValueArrayKlass::copy_array(arrayOop s, int src_pos,
 }
 
 
-Klass* ValueArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS) {
-  assert(storage_props.is_flattened() || n > 1, "Expected flat storage");
+Klass* ValueArrayKlass::array_klass_impl(bool or_null, int n, TRAPS) {
   assert(dimension() <= n, "check order of chain");
   int dim = dimension();
   if (dim == n) return this;
@@ -329,7 +349,7 @@ Klass* ValueArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, b
 
         // Create multi-dim klass object and link them together
         Klass* k =
-          ObjArrayKlass::allocate_objArray_klass(storage_props, dim + 1, this, CHECK_NULL);
+          ObjArrayKlass::allocate_objArray_klass(dim + 1, this, CHECK_NULL);
         ObjArrayKlass* ak = ObjArrayKlass::cast(k);
         ak->set_lower_dimension(this);
         OrderAccess::storestore();
@@ -343,13 +363,13 @@ Klass* ValueArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, b
 
   ObjArrayKlass *ak = ObjArrayKlass::cast(higher_dimension());
   if (or_null) {
-    return ak->array_klass_or_null(storage_props, n);
+    return ak->array_klass_or_null(n);
   }
-  return ak->array_klass(storage_props, n, THREAD);
+  return ak->array_klass(n, THREAD);
 }
 
-Klass* ValueArrayKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS) {
-  return array_klass_impl(storage_props, or_null, dimension() +  1, THREAD);
+Klass* ValueArrayKlass::array_klass_impl(bool or_null, TRAPS) {
+  return array_klass_impl(or_null, dimension() +  1, THREAD);
 }
 
 ModuleEntry* ValueArrayKlass::module() const {
@@ -384,7 +404,7 @@ GrowableArray<Klass*>* ValueArrayKlass::compute_secondary_supers(int num_extra_s
     secondaries->push(SystemDictionary::Serializable_klass());
     for (int i = 0; i < num_elem_supers; i++) {
       Klass* elem_super = (Klass*) elem_supers->at(i);
-      Klass* array_super = elem_super->array_klass_or_null(ArrayStorageProperties::empty);
+      Klass* array_super = elem_super->array_klass_or_null();
       assert(array_super != NULL, "must already have been created");
       secondaries->push(array_super);
     }

--- a/src/hotspot/share/oops/valueArrayKlass.hpp
+++ b/src/hotspot/share/oops/valueArrayKlass.hpp
@@ -43,13 +43,12 @@ class ValueArrayKlass : public ArrayKlass {
   // Constructor
   ValueArrayKlass(Klass* element_klass, Symbol* name);
 
-  static ValueArrayKlass* allocate_klass(Klass* element_klass, TRAPS);
  protected:
   // Returns the ArrayKlass for n'th dimension.
-  Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS);
+  Klass* array_klass_impl(bool or_null, int n, TRAPS);
 
   // Returns the array class with this class as element type.
-  Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  Klass* array_klass_impl(bool or_null, TRAPS);
 
  public:
 
@@ -68,7 +67,7 @@ class ValueArrayKlass : public ArrayKlass {
   }
 
   // klass allocation
-  static ValueArrayKlass* allocate_klass(ArrayStorageProperties storage_props, Klass* element_klass, TRAPS);
+  static ValueArrayKlass* allocate_klass(Klass* element_klass, TRAPS);
 
   void initialize(TRAPS);
 

--- a/src/hotspot/share/oops/valueKlass.cpp
+++ b/src/hotspot/share/oops/valueKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,9 +180,8 @@ bool ValueKlass::flatten_array() {
   if (!ValueArrayFlatten) {
     return false;
   }
-
-  int elem_bytes = raw_value_byte_size();
   // Too big
+  int elem_bytes = raw_value_byte_size();
   if ((ValueArrayElemMaxFlatSize >= 0) && (elem_bytes > ValueArrayElemMaxFlatSize)) {
     return false;
   }
@@ -190,12 +189,14 @@ bool ValueKlass::flatten_array() {
   if ((ValueArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > ValueArrayElemMaxFlatOops)) {
     return false;
   }
-
   // Declared atomic but not naturally atomic.
   if (is_declared_atomic() && !is_naturally_atomic()) {
     return false;
   }
-
+  // VM enforcing ValueArrayAtomicAccess only...
+  if (ValueArrayAtomicAccess && (!is_naturally_atomic())) {
+    return false;
+  }
   return true;
 }
 
@@ -218,19 +219,19 @@ void ValueKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle p
 }
 
 
-Klass* ValueKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS) {
-  if (storage_props.is_null_free()) {
-    return value_array_klass(storage_props, or_null, n, THREAD);
+Klass* ValueKlass::array_klass_impl(bool or_null, int n, TRAPS) {
+  if (flatten_array()) {
+    return value_array_klass(or_null, n, THREAD);
   } else {
-    return InstanceKlass::array_klass_impl(storage_props, or_null, n, THREAD);
+    return InstanceKlass::array_klass_impl(or_null, n, THREAD);
   }
 }
 
-Klass* ValueKlass::array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS) {
-  return array_klass_impl(storage_props, or_null, 1, THREAD);
+Klass* ValueKlass::array_klass_impl(bool or_null, TRAPS) {
+  return array_klass_impl(or_null, 1, THREAD);
 }
 
-Klass* ValueKlass::value_array_klass(ArrayStorageProperties storage_props, bool or_null, int rank, TRAPS) {
+Klass* ValueKlass::value_array_klass(bool or_null, int rank, TRAPS) {
   Klass* vak = acquire_value_array_klass();
   if (vak == NULL) {
     if (or_null) return NULL;
@@ -244,20 +245,17 @@ Klass* ValueKlass::value_array_klass(ArrayStorageProperties storage_props, bool 
       }
     }
   }
-  if (!vak->is_valueArray_klass()) {
-    storage_props.clear_flattened();
-  }
   if (or_null) {
-    return vak->array_klass_or_null(storage_props, rank);
+    return vak->array_klass_or_null(rank);
   }
-  return vak->array_klass(storage_props, rank, THREAD);
+  return vak->array_klass(rank, THREAD);
 }
 
 Klass* ValueKlass::allocate_value_array_klass(TRAPS) {
-  if (flatten_array() && (is_naturally_atomic() || (!ValueArrayAtomicAccess))) {
-    return ValueArrayKlass::allocate_klass(ArrayStorageProperties::flattened_and_null_free, this, THREAD);
+  if (flatten_array()) {
+    return ValueArrayKlass::allocate_klass(this, THREAD);
   }
-  return ObjArrayKlass::allocate_objArray_klass(ArrayStorageProperties::null_free, 1, this, THREAD);
+  return ObjArrayKlass::allocate_objArray_klass(1, this, THREAD);
 }
 
 void ValueKlass::array_klasses_do(void f(Klass* k)) {

--- a/src/hotspot/share/oops/valueKlass.hpp
+++ b/src/hotspot/share/oops/valueKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,13 +171,13 @@ class ValueKlass: public InstanceKlass {
 
  protected:
   // Returns the array class for the n'th dimension
-  Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, int n, TRAPS);
+  Klass* array_klass_impl(bool or_null, int n, TRAPS);
 
   // Returns the array class with this class as element type
-  Klass* array_klass_impl(ArrayStorageProperties storage_props, bool or_null, TRAPS);
+  Klass* array_klass_impl(bool or_null, TRAPS);
 
   // Specifically flat array klass
-  Klass* value_array_klass(ArrayStorageProperties storage_props, bool or_null, int rank, TRAPS);
+  Klass* value_array_klass(bool or_null, int rank, TRAPS);
 
  public:
   // Type testing

--- a/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
@@ -75,7 +75,7 @@ public:
     if (_dictionary_walk) {
       // Collect array classes this way when walking the dictionary (because array classes are
       // not in the dictionary).
-      for (Klass* l = k->array_klass_or_null(ArrayStorageProperties::empty); l != NULL; l = l->array_klass_or_null(ArrayStorageProperties::empty)) {
+      for (Klass* l = k->array_klass_or_null(); l != NULL; l = l->array_klass_or_null()) {
         _classStack.push((jclass) _env->jni_reference(Handle(_cur_thread, l->java_mirror())));
       }
       // CMH flat arrays (ValueKlass)

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -393,8 +393,7 @@ arrayOop Reflection::reflect_new_multi_array(oop element_mirror, typeArrayOop di
       dim += k_dim;
     }
   }
-  ArrayStorageProperties storage_props = ArrayStorageProperties::for_signature(klass->name());
-  klass = klass->array_klass(storage_props, dim, CHECK_NULL);
+  klass = klass->array_klass(dim, CHECK_NULL);
   oop obj = ArrayKlass::cast(klass)->multi_allocate(len, dimensions, CHECK_NULL);
   assert(obj->is_array(), "just checking");
   return arrayOop(obj);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1075,7 +1075,7 @@ void DumperSupport::dump_class_and_array_classes(DumpWriter* writer, Klass* k) {
   writer->end_sub_record();
 
   // array classes
-  k = k->array_klass_or_null(ArrayStorageProperties::empty);
+  k = k->array_klass_or_null();
   while (k != NULL) {
     assert(k->is_objArray_klass(), "not an ObjArrayKlass");
 
@@ -1103,7 +1103,7 @@ void DumperSupport::dump_class_and_array_classes(DumpWriter* writer, Klass* k) {
     writer->end_sub_record();
 
     // get the array class for the next rank
-    k = k->array_klass_or_null(ArrayStorageProperties::empty);
+    k = k->array_klass_or_null();
   }
 }
 
@@ -1138,7 +1138,7 @@ void DumperSupport::dump_basic_type_array_class(DumpWriter* writer, Klass* k) {
     writer->end_sub_record();
 
     // get the array class for the next rank
-    k = klass->array_klass_or_null(ArrayStorageProperties::empty);
+    k = klass->array_klass_or_null();
   }
 }
 
@@ -1637,7 +1637,7 @@ void VM_HeapDumper::do_load_class(Klass* k) {
     writer()->write_symbolID(name);
 
     // write a LOAD_CLASS record for the array type (if it exists)
-    k = klass->array_klass_or_null(ArrayStorageProperties::empty);
+    k = klass->array_klass_or_null();
   } while (k != NULL);
 }
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -65,15 +65,12 @@ public class ValueTypeArray {
     }
 
     void testClassForName() {
-        String arrayClsName = "[Lruntime.valhalla.valuetypes.Point;";
+        String arrayClsName = "[Lruntime.valhalla.valuetypes.Point$ref;";
         String qarrayClsName = "[Qruntime.valhalla.valuetypes.Point;";
         try {
             // L-type..
             Class<?> arrayCls = Class.forName(arrayClsName);
             assertTrue(arrayCls.isArray(), "Expected an array class");
-
-            assertTrue(arrayCls.getComponentType() == Point.class.asIndirectType(),
-                       "Expected component type of Point.class got: " + arrayCls.getComponentType());
 
             arrayClsName = "[" + arrayClsName;
             Class<?> mulArrayCls = Class.forName(arrayClsName);


### PR DESCRIPTION
First part of LW2 to LW3 arrays
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244810](https://bugs.openjdk.java.net/browse/JDK-8244810): [lworld] Decommission arrayStorageProperties from Klass:array_klass() et el


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/44/head:pull/44`
`$ git checkout pull/44`
