### PR TITLE
8243317: jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java fails multiple tests

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -430,7 +430,8 @@ public class TestRecordTypes extends JavadocTester {
                 "<pre>public record <span class=\"type-name-label\">R</span>("
                         + rcAnno
                         + "int&nbsp;i)\n" +
-                        "extends java.lang.Record</pre>",
+                        "extends java.lang.Record\n" +
+                        "implements java.lang.IdentityObject</pre>",
                 "<div class=\"member-signature\">"
                         + fAnno
                         + "<span class=\"modifiers\">private final</span>&nbsp;<span class=\"return-type\">int</span>"


### PR DESCRIPTION
Jim, Could you please review this test only fix to address a test failure ?

Basically, this javadoc test is surprised by the "implements IdentityObject" detail
in the output as it is not prepared for it.

(Note however that this is a temporary measure. As a part of the upcoming work for
https://bugs.openjdk.java.net/browse/JDK-8242612, we will also be ensuring that
the new super top types stay implicit and don't get to surface in javadoc outputs)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243317](https://bugs.openjdk.java.net/browse/JDK-8243317): jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java fails multiple tests


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/45/head:pull/45`
`$ git checkout pull/45`
