### PR TITLE
8244796: [lworld] Javac does not compile test/hotspot/jtreg/runtime/valhalla/valuetypes/UnsafeTest.java anymore

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -52,6 +52,7 @@ import com.sun.tools.javac.code.Type.JCPrimitiveType;
 import com.sun.tools.javac.code.Type.JCVoidType;
 import com.sun.tools.javac.code.Type.MethodType;
 import com.sun.tools.javac.code.Type.UnknownType;
+import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.Types.UniqueType;
 import com.sun.tools.javac.comp.Modules;
 import com.sun.tools.javac.jvm.Target;
@@ -268,8 +269,17 @@ public class Symtab {
         return classFields.computeIfAbsent(
             new UniqueType(type, types), k -> {
                 Type arg = null;
-                if (type.getTag() == ARRAY || type.getTag() == CLASS)
-                    arg = types.erasure(type);
+                if (type.getTag() == ARRAY || type.getTag() == CLASS) {
+                    /* Temporary treatment for inline class: Given an inline class V that implements
+                       I1, I2, ... In, V.class is typed to be Class<? extends Object & I1 & I2 .. & In>
+                    */
+                    if (type.isValue()) {
+                        Type it = types.makeIntersectionType(((ClassType)type).interfaces_field, true);
+                        arg = new WildcardType(it, BoundKind.EXTENDS, boundClass);
+                    } else {
+                        arg = types.erasure(type);
+                    }
+                }
                 else if (type.isPrimitiveOrVoid())
                     arg = types.boxedClass(type).type;
                 else

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2518,8 +2518,13 @@ public class Attr extends JCTree.Visitor {
                     methodName == names.getClass &&
                     argtypes.isEmpty()) {
                 // as a special case, x.getClass() has type Class<? extends |X|>
+                // Temporary treatment for inline class: Given an inline class V that implements
+                // I1, I2, ... In, v.getClass() is typed to be Class<? extends Object & I1 & I2 .. & In>
+                Type wcb = qualifierType.isValue()
+                              ? types.makeIntersectionType(((ClassType) qualifierType).interfaces_field, true)
+                              : types.erasure(qualifierType);
                 return new ClassType(restype.getEnclosingType(),
-                        List.of(new WildcardType(types.erasure(qualifierType),
+                        List.of(new WildcardType(wcb,
                                 BoundKind.EXTENDS,
                                 syms.boundClass)),
                         restype.tsym,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -898,9 +898,7 @@ public class Check {
     }
 
     void checkParameterizationWithValues(DiagnosticPosition pos, Type t) {
-        if (t.tsym != syms.classType.tsym) { // tolerate Value.class.
-            valueParameterizationChecker.visit(t, pos);
-        }
+        valueParameterizationChecker.visit(t, pos);
     }
 
     /** valueParameterizationChecker: A type visitor that descends down the given type looking for instances of value types

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8244796
+ * @bug 8244796 8244799
  * @summary Value class literal tests
  * @compile/fail/ref=ClassLiteralNegativeTest.out -XDrawDiagnostics ClassLiteralNegativeTest.java
  */

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
@@ -1,0 +1,12 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8244796
+ * @summary Value class literal tests
+ * @compile/fail/ref=ClassLiteralNegativeTest.out -XDrawDiagnostics ClassLiteralNegativeTest.java
+ */
+
+final inline class ClassLiteralNegativeTest {
+    Class<ClassLiteralNegativeTest> c1 = null; // error
+    Class<? extends ClassLiteralNegativeTest> c2 = null; // error
+    Class<? super ClassLiteralNegativeTest> c3 = null; // error
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.out
@@ -1,0 +1,4 @@
+ClassLiteralNegativeTest.java:9:11: compiler.err.type.found.req: ClassLiteralNegativeTest, (compiler.misc.type.req.ref)
+ClassLiteralNegativeTest.java:10:11: compiler.err.type.found.req: ClassLiteralNegativeTest, (compiler.misc.type.req.ref)
+ClassLiteralNegativeTest.java:11:11: compiler.err.type.found.req: ClassLiteralNegativeTest, (compiler.misc.type.req.ref)
+3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8244796
+ * @summary Temporary typing of inline class literals.
+ */
+
+/* Given an inline class V that implements I1, I2, ... In,
+   V.class and v.getClass() are typed to be Class<? extends Object & I1 & I2 .. & In>
+*/
+public class ClassLiteralTypingTest {
+
+    interface I {}
+
+    public static <T> long size(Class<T> c) {
+        return 0;
+    }
+
+    public static long foo(Class<? extends I> p) {
+        return 1;
+    }
+
+    static inline class V implements I {
+        int x = 42;
+    }
+
+    public static void main(String[] args) {
+        if (size(V.class) != 0 || size(new V().getClass()) != 0 ||
+             foo(V.class) != 1 ||  foo(new V().getClass()) != 1)
+            throw new AssertionError("Unexpected behavior");
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8244796
+ * @bug 8244796 8244799
  * @summary Temporary typing of inline class literals.
  */
 


### PR DESCRIPTION
Summary: Implement temporary typing rules for value class literals, these being:

    o Given a value class V that implements an interface I
        - Class<V>, Class<? extends V>, Class<? super V> are all malformed for the time being.
        - V.class and v.getClass() are to be typed temporarily as Class<? extends Object & I>
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244796](https://bugs.openjdk.java.net/browse/JDK-8244796): [lworld] Javac does not compile test/hotspot/jtreg/runtime/valhalla/valuetypes/UnsafeTest.java anymore


### Reviewers
 * Jim Laskey ([jlaskey](@JimLaskey) - no project role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/46/head:pull/46`
`$ git checkout pull/46`
