### PR TITLE
8244934: [lworld] Copyright header format

### DIFF
--- a/src/hotspot/share/oops/valueArrayOop.cpp
+++ b/src/hotspot/share/oops/valueArrayOop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/IdentityObject.java
+++ b/src/java.base/share/classes/java/lang/IdentityObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/InlineObject.java
+++ b/src/java.base/share/classes/java/lang/InlineObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/__inline__.java
+++ b/src/java.base/share/classes/java/lang/__inline__.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/vm/jni/SubElementSelector.java
+++ b/src/java.base/share/classes/jdk/internal/vm/jni/SubElementSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/EmptyValueTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/EmptyValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.lang.reflect.Field;
  * @library /test/lib
  * @compile -XDallowEmptyValues EmptyValueTest.java
  * @run main/othervm -XX:+EnableValhalla runtime.valhalla.valuetypes.EmptyValueTest
- 
+
  */
 
 public class EmptyValueTest {
@@ -54,7 +54,7 @@ public class EmptyValueTest {
     static class WithInt {
 	int i;
     }
-    
+
     static class WithEmptyField extends WithInt  {
 	// With current layout strategy for reference classs, the empty
 	// value field would be placed between the int and the Object
@@ -62,7 +62,7 @@ public class EmptyValueTest {
 	Object o;
 	EmptyValue empty;
     }
-    
+
     public static void main(String[] args) {
 	// Create an empty value
 	EmptyValue empty = new EmptyValue();
@@ -81,7 +81,7 @@ public class EmptyValueTest {
 	w.empty = new EmptyValue();
 	Asserts.assertEquals(w.empty.getClass(), EmptyValue.class);
 	Asserts.assertTrue(w.empty.isEmpty());
-	
+
 	// Create an array of empty values
 	EmptyValue[] emptyArray = new EmptyValue[100];
 	for(EmptyValue element : emptyArray) {
@@ -109,7 +109,7 @@ public class EmptyValueTest {
 	    Asserts.assertEquals(element.getClass(), EmptyValue.class);
 	    Asserts.assertTrue(element.isEmpty());
 	}
-	
+
 	// Passing an empty value in argument
 	assert isEmpty(empty);
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/libTestJNIArrays.c
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/libTestJNIArrays.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ Java_TestJNIArrays_initializeIntIntArrayBuffer(JNIEnv* env, jobject receiver, ja
   *(int*)(buffer + i1_offset) = i1;
   void* base = (void*)(*env)->GetFlattenedArrayElements(env, array, NULL);
   for (int i = 0; i < len; i++) {
-    memcpy((char*)base + i * elm_sz, buffer, elm_sz); 
+    memcpy((char*)base + i * elm_sz, buffer, elm_sz);
   }
   (*env)->ReleaseFlattenedArrayElements(env, array, base, 0);
   free(buffer);
@@ -148,7 +148,7 @@ static int compare_IntInt(void* offsets, const void* x, const void* y)  {
 #endif // __APPLE__
 #ifdef __linux__
 static int compare_IntInt(const void* x, const void* y, void* offsets)  {
-#endif // __linux__  
+#endif // __linux__
   int i0_offset = ((struct IntInt_offsets*)offsets)->i0_offset;
   int x_i0 = *(int*)((char*)x + i0_offset);
   int y_i0 = *(int*)((char*)y + i0_offset);

--- a/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class BoxValCastTest {
         runCheck(params, new String [] {
 
         "checkcast     #7                  // class \"QBoxValCastTest$VT;\""
-           
+
          });
 
      }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CastNoNullCheckTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CastNoNullCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/valhalla/lworld-values/CastNullCheckTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CastNullCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSuperCompileOnly.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSuperCompileOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/valhalla/lworld-values/DefaultNonInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DefaultNonInlines.java
@@ -1,17 +1,13 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without eve
- *
- * n the implied warranty of MERCHANTABILITY or
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/valhalla/lworld-values/Point.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Point.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/valhalla/baseline/fields/Set8.java
+++ b/test/micro/org/openjdk/bench/valhalla/baseline/fields/Set8.java
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 8016, 8018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 8 only, as
+ * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 8 for more details (a copy is included in the LICENSE file that
+ * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
  * You should have received a copy of the GNU General Public License version
- * 8 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 08110-1301 USA.
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any

--- a/test/micro/org/openjdk/bench/valhalla/corelibs/mapprotos/HashMapBench.java
+++ b/test/micro/org/openjdk/bench/valhalla/corelibs/mapprotos/HashMapBench.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as


### PR DESCRIPTION
Some badly formatted files adjusted
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244934](https://bugs.openjdk.java.net/browse/JDK-8244934): [lworld] Copyright header format


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/47/head:pull/47`
`$ git checkout pull/47`
