### PR TITLE
8244982: [lworld] Javac does not compile test/jdk/valhalla/valuetypes/StreamTest.java anymore

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
@@ -341,7 +341,7 @@ public class TransValues extends TreeTranslator {
                         fieldAccess.selected =
                                 make.TypeCast(types.erasure(selectedType.valueProjection().type), fieldAccess.selected);
                         if (sym.owner.isReferenceProjection()) // is an empty class file.
-                            sym = sym.valueProjection();
+                            TreeInfo.setSymbol(fieldAccess, sym.valueProjection());
                         break;
                     case TYP:
                         fieldAccess.selected = make.Type(types.erasure(selectedType.valueProjection().type));

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -54,12 +54,12 @@ public class StreamTest {
     @Test
     public void testInlineType() {
         Arrays.stream(values)
-                .map(Value::point)
+                .map(Value.ref::point)
                 .filter(p -> p.x >= 5)
                 .forEach(System.out::println);
 
         Arrays.stream(values)
-                .map(Value::nullablePoint)
+                .map(Value.ref::nullablePoint)
                 .filter(p -> p != null)
                 .forEach(System.out::println);
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/StreamsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/StreamsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8244982
+ * @summary Javac has trouble compiling method references
+ * @run main StreamsTest
+ */
+
+import java.util.Arrays;
+
+public class StreamsTest {
+
+    public static inline class X {
+
+        String data;
+
+        X(String data) {
+            this.data = data;
+        }
+
+        String data() { return data; }
+
+        static String accumulate = "";
+
+        static void accumulate(String s) {
+            accumulate += s;
+        }
+
+        static String streamedData() {
+
+            X [] xs = new X[] {
+                                 new X("Streams "),
+                                 new X("test "),
+                                 new X("passed OK!")
+                      };
+
+            Arrays.stream(xs)
+                        .map(X.ref::data)
+                        .filter(p -> p != null)
+                        .forEach(X::accumulate);
+
+            return accumulate;
+        }
+    }
+
+    public static void main(String [] args) {
+        if (!X.streamedData().equals("Streams test passed OK!"))
+            throw new AssertionError("Unexpected data in stream");
+    }
+}


### PR DESCRIPTION
Jim, could you please review this fix ? Here is some background:

ATM, we infer (by design) Arrays.stream(X[]) to be a Stream<X.ref> (and not as
Stream\<X\> as the latter is malformed as of now) and so the method reference X::data
ends up with a receiver type of X.ref instead of X.

Until such time JLS 15.13.1 (Compile-Time Declaration of a Method Reference) is
amended to account for inline widening/narrowing conversions, this is ilegal
code (as there is no subtyping relationship between X.ref and X) and to make it
work the test has to be changed to use X.ref::data instead of X::data

With this change, the test code would compile, but in order to be able to run it
we need a further tweak in LambdaToMethod. Since in the present code generation
scheme, X$ref.class files are completely empty, lambda meta factory would go looking
for a method data() in X$ref during bootstrap and this would result in a 
NoSuchMethodError. To workaround that, we use a tried and tested trick in javac
land where we fold the method reference into a lambda and in the lambda body apply
suitable inline conversions.

So the method reference X.ref::data gets transformed into an equivalent lambda
       (Object rec$)->((X.ref)rec$).data() 
in com.sun.tools.javac.comp.LambdaToMethod.MemberReferenceToLambda#lambda

This also has the "wrong" receiver, but we already have code in 
com.sun.tools.javac.jvm.TransValues#visitSelect to sharpen the receiver and 
make it ((X)(X.ref)rec$).data()

Finally, there also a change in TransValues that is not essential to this fix,
but is related. We were inadvertantly changing a local variable (only) without
really changing the AST (as we should). This is corrected now.

(If you are wondering how despite this things were working, that is because
com.sun.tools.javac.jvm.Gen#binaryQualifier was covering for us. It is not
incorrect to let com.sun.tools.javac.jvm.Gen#binaryQualifier handle it, but
is a waste of resource in that it creates an additional clone, while we
already have a clone handy)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244982](https://bugs.openjdk.java.net/browse/JDK-8244982): [lworld] Javac does not compile test/jdk/valhalla/valuetypes/StreamTest.java anymore ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Jim Laskey ([jlaskey](@JimLaskey) - no project role)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/48/head:pull/48`
`$ git checkout pull/48`
