### PR TITLE
8244563: [lworld] Javac does not allow jlO to be express superclass of inline types.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -743,11 +743,10 @@ public class Check {
         }
 
     void checkConstraintsOfInlineSuper(DiagnosticPosition pos, ClassSymbol c) {
-        boolean indirectSuper = false;
-        for(Type st = types.supertype(c.type); st != Type.noType; indirectSuper = true, st = types.supertype(st)) {
+        for(Type st = types.supertype(c.type); st != Type.noType; st = types.supertype(st)) {
             if (st == null || st.tsym == null || st.tsym.kind == ERR)
                 return;
-            if  (indirectSuper && st.tsym == syms.objectType.tsym)
+            if  (st.tsym == syms.objectType.tsym)
                 return;
             if (!st.tsym.isAbstract()) {
                 log.error(pos, Errors.ConcreteSupertypeForInlineClass(c, st));

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
@@ -1,8 +1,8 @@
 /*
  * @test /nodynamiccopyright/
- * @summary Values may not extend
+ * @summary Values may not extend a concrete type other than jlO
  *
- * @compile/fail/ref=CheckExtends.out -XDallowEmptyValues -XDrawDiagnostics CheckExtends.java
+ * @compile/fail/ref=CheckExtends.out -XDrawDiagnostics CheckExtends.java
  */
 
 final inline class CheckExtends extends Object {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:8:14: compiler.err.concrete.supertype.for.inline.class: CheckExtends, java.lang.Object
+CheckExtends.java:8:14: compiler.err.empty.value.not.yet
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
@@ -1,4 +1,3 @@
 InlineAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
-InlineAnnotationTest.java:9:1: compiler.err.concrete.supertype.for.inline.class: InlineAnnotationTest01, java.lang.Object
 InlineAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
-3 errors
+2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
@@ -12,7 +12,7 @@ public class SuperclassConstraints {
     // Test that super class cannot be concrete, including express jlO
     static class BadSuper {}
     inline class I0 extends BadSuper {} // ERROR: concrete super class
-    inline class I1 extends Object {}   // ERROR: concrete jlO cannot be express-superclass
+    inline class I1 extends Object {}   // OK: concrete jlO can be express-superclass
     inline class I2 {} // OK
 
     // Test that abstract class is allowed to be super including when extending jlO

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,9 +1,8 @@
 SuperclassConstraints.java:14:12: compiler.err.inline.type.must.not.implement.identity.object: SuperclassConstraints.I0
-SuperclassConstraints.java:15:12: compiler.err.concrete.supertype.for.inline.class: SuperclassConstraints.I1, java.lang.Object
 SuperclassConstraints.java:44:12: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
 SuperclassConstraints.java:76:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
 SuperclassConstraints.java:85:12: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor
 SuperclassConstraints.java:98:12: compiler.err.super.class.declares.init.block: SuperclassConstraints.I11, SuperclassConstraints.SuperWithInstanceInit
 SuperclassConstraints.java:106:12: compiler.err.super.method.cannot.be.synchronized: foo(), SuperclassConstraints.I12, SuperclassConstraints.SuperWithSynchronizedMethod
 SuperclassConstraints.java:110:12: compiler.err.super.class.cannot.be.inner: SuperclassConstraints.I13, SuperclassConstraints.InnerSuper
-8 errors
+7 errors


### PR DESCRIPTION
Tolerate jlO as an express supertype of an inline class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244563](https://bugs.openjdk.java.net/browse/JDK-8244563): [lworld] Javac does not allow jlO to be express superclass of inline types.


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/49/head:pull/49`
`$ git checkout pull/49`
