### PR TITLE
8245216: [lworld] The JVM should inject the IdentityObject interface to types which need it

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -131,6 +131,7 @@ class ClassFileParser {
   Array<u2>* _nest_members;
   u2 _nest_host;
   Array<RecordComponent*>* _record_components;
+  GrowableArray<InstanceKlass*>* _temp_local_interfaces;
   Array<InstanceKlass*>* _local_interfaces;
   Array<InstanceKlass*>* _transitive_interfaces;
   Annotations* _combined_annotations;
@@ -199,11 +200,14 @@ class ClassFileParser {
   bool _has_contended_fields;
 
   bool _has_flattenable_fields;
+  bool _has_nonstatic_fields;
   bool _is_empty_value;
   bool _is_naturally_atomic;
   bool _is_declared_atomic;
   bool _invalid_inline_super;   // if true, invalid super type for an inline type.
   bool _invalid_identity_super; // if true, invalid super type for an identity type.
+  bool _implements_identityObject;
+  bool _has_injected_identityObject;
 
   // precomputed flags
   bool _has_finalizer;
@@ -594,6 +598,7 @@ class ClassFileParser {
   void set_invalid_inline_super() { _invalid_inline_super = true; }
   bool invalid_identity_super() const { return _invalid_identity_super; }
   void set_invalid_identity_super() { _invalid_identity_super = true; }
+  bool is_invalid_super_for_inline_type();
 
   u2 java_fields_count() const { return _java_fields_count; }
 

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -64,7 +64,8 @@ bool VerificationType::resolve_and_check_assignability(InstanceKlass* klass, Sym
     // Otherwise, we treat interfaces as java.lang.Object.
     return !from_is_array ||
       this_class == SystemDictionary::Cloneable_klass() ||
-      this_class == SystemDictionary::Serializable_klass();
+      this_class == SystemDictionary::Serializable_klass() ||
+      this_class == SystemDictionary::IdentityObject_klass();
   } else if (from_is_object) {
     Klass* from_class = SystemDictionary::resolve_or_fail(
         from_name, Handle(THREAD, klass->class_loader()),

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -60,7 +60,8 @@ bool VerificationType::resolve_and_check_assignability(InstanceKlass* klass, Sym
       from_name != vmSymbols::java_lang_Object())) {
     // If we are not trying to access a protected field or method in
     // java.lang.Object then, for arrays, we only allow assignability
-    // to interfaces java.lang.Cloneable and java.io.Serializable.
+    // to interfaces java.lang.Cloneable, java.io.Serializable,
+    // and java.lang.IdentityObject.
     // Otherwise, we treat interfaces as java.lang.Object.
     return !from_is_array ||
       this_class == SystemDictionary::Cloneable_klass() ||

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -315,7 +315,7 @@ void Universe::genesis(TRAPS) {
 
         ClassLoaderData* null_cld = ClassLoaderData::the_null_class_loader_data();
 
-        _the_array_interfaces_array     = MetadataFactory::new_array<Klass*>(null_cld, 2, NULL, CHECK);
+        _the_array_interfaces_array     = MetadataFactory::new_array<Klass*>(null_cld, 3, NULL, CHECK);
         _the_empty_int_array            = MetadataFactory::new_array<int>(null_cld, 0, CHECK);
         _the_empty_short_array          = MetadataFactory::new_array<u2>(null_cld, 0, CHECK);
         _the_empty_method_array         = MetadataFactory::new_array<Method*>(null_cld, 0, CHECK);
@@ -340,12 +340,16 @@ void Universe::genesis(TRAPS) {
              SystemDictionary::Cloneable_klass(), "u3");
       assert(_the_array_interfaces_array->at(1) ==
              SystemDictionary::Serializable_klass(), "u3");
+      assert(_the_array_interfaces_array->at(2) ==
+                   SystemDictionary::IdentityObject_klass(), "u3");
+
     } else
 #endif
     {
       // Set up shared interfaces array.  (Do this before supers are set up.)
       _the_array_interfaces_array->at_put(0, SystemDictionary::Cloneable_klass());
       _the_array_interfaces_array->at_put(1, SystemDictionary::Serializable_klass());
+      _the_array_interfaces_array->at_put(2, SystemDictionary::IdentityObject_klass());
     }
 
     initialize_basic_type_klass(boolArrayKlassObj(), CHECK);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -296,7 +296,8 @@ class InstanceKlass: public Klass {
     _misc_is_naturally_atomic                 = 1 << 21, // loaded/stored in one instruction
     _misc_is_declared_atomic                  = 1 << 22, // implements jl.NonTearable
     _misc_invalid_inline_super                = 1 << 23, // invalid super type for an inline type
-    _misc_invalid_identity_super              = 1 << 24  // invalid super type for an identity type
+    _misc_invalid_identity_super              = 1 << 24, // invalid super type for an identity type
+    _misc_has_injected_identityObject         = 1 << 25  // IdentityObject has been injected by the JVM
   };
   u2 shared_loader_type_bits() const {
     return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
@@ -479,6 +480,14 @@ class InstanceKlass: public Klass {
   // Initialized in the class file parser, not changed later.
   void set_invalid_identity_super() {
     _misc_flags |= _misc_invalid_identity_super;
+  }
+
+  bool has_injected_identityObject() const {
+    return (_misc_flags & _misc_has_injected_identityObject);
+  }
+
+  void set_has_injected_identityObject() {
+    _misc_flags |= _misc_has_injected_identityObject;
   }
 
   // field sizes

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -383,9 +383,10 @@ GrowableArray<Klass*>* ObjArrayKlass::compute_secondary_supers(int num_extra_slo
     set_secondary_supers(Universe::the_array_interfaces_array());
     return NULL;
   } else {
-    GrowableArray<Klass*>* secondaries = new GrowableArray<Klass*>(num_elem_supers+2);
+    GrowableArray<Klass*>* secondaries = new GrowableArray<Klass*>(num_elem_supers+3);
     secondaries->push(SystemDictionary::Cloneable_klass());
     secondaries->push(SystemDictionary::Serializable_klass());
+    secondaries->push(SystemDictionary::IdentityObject_klass());
     for (int i = 0; i < num_elem_supers; i++) {
       Klass* elem_super = elem_supers->at(i);
       Klass* array_super = elem_super->array_klass_or_null();

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -399,9 +399,10 @@ GrowableArray<Klass*>* ValueArrayKlass::compute_secondary_supers(int num_extra_s
     set_secondary_supers(Universe::the_array_interfaces_array());
     return NULL;
   } else {
-    GrowableArray<Klass*>* secondaries = new GrowableArray<Klass*>(num_elem_supers+2);
+    GrowableArray<Klass*>* secondaries = new GrowableArray<Klass*>(num_elem_supers+3);
     secondaries->push(SystemDictionary::Cloneable_klass());
     secondaries->push(SystemDictionary::Serializable_klass());
+    secondaries->push(SystemDictionary::IdentityObject_klass());
     for (int i = 0; i < num_elem_supers; i++) {
       Klass* elem_super = (Klass*) elem_supers->at(i);
       Klass* array_super = elem_super->array_klass_or_null();

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1120,10 +1120,14 @@ JVM_ENTRY(jobjectArray, JVM_GetClassInterfaces(JNIEnv *env, jclass cls))
   // Figure size of result array
   int size;
   if (klass->is_instance_klass()) {
-    size = InstanceKlass::cast(klass)->local_interfaces()->length();
+    InstanceKlass* ik = InstanceKlass::cast(klass);
+    size = ik->local_interfaces()->length();
+    if (ik->has_injected_identityObject()) {
+      size--;
+    }
   } else {
     assert(klass->is_objArray_klass() || klass->is_typeArray_klass(), "Illegal mirror klass");
-    size = 2;
+    size = 3;
   }
 
   // Allocate result array
@@ -1133,13 +1137,17 @@ JVM_ENTRY(jobjectArray, JVM_GetClassInterfaces(JNIEnv *env, jclass cls))
   if (klass->is_instance_klass()) {
     // Regular instance klass, fill in all local interfaces
     for (int index = 0; index < size; index++) {
-      Klass* k = InstanceKlass::cast(klass)->local_interfaces()->at(index);
-      result->obj_at_put(index, k->java_mirror());
+      InstanceKlass* ik = InstanceKlass::cast(klass);
+      Klass* k = ik->local_interfaces()->at(index);
+      if (!ik->has_injected_identityObject() || k != SystemDictionary::IdentityObject_klass()) {
+        result->obj_at_put(index, k->java_mirror());
+      }
     }
   } else {
-    // All arrays implement java.lang.Cloneable and java.io.Serializable
+    // All arrays implement java.lang.Cloneable, java.io.Serializable and java.lang.IdentityObject
     result->obj_at_put(0, SystemDictionary::Cloneable_klass()->java_mirror());
     result->obj_at_put(1, SystemDictionary::Serializable_klass()->java_mirror());
+    result->obj_at_put(2, SystemDictionary::IdentityObject_klass()->java_mirror());
   }
   return (jobjectArray) JNIHandles::make_local(env, result());
 JVM_END

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1136,11 +1136,12 @@ JVM_ENTRY(jobjectArray, JVM_GetClassInterfaces(JNIEnv *env, jclass cls))
   // Fill in result
   if (klass->is_instance_klass()) {
     // Regular instance klass, fill in all local interfaces
+    int cursor = 0;
     for (int index = 0; index < size; index++) {
       InstanceKlass* ik = InstanceKlass::cast(klass);
       Klass* k = ik->local_interfaces()->at(index);
       if (!ik->has_injected_identityObject() || k != SystemDictionary::IdentityObject_klass()) {
-        result->obj_at_put(index, k->java_mirror());
+        result->obj_at_put(cursor++, k->java_mirror());
       }
     }
   } else {

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -869,11 +869,13 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   // JVMSpec|           u2 interfaces[interfaces_count];
   Array<InstanceKlass*>* interfaces =  ik()->local_interfaces();
   int num_interfaces = interfaces->length();
-  write_u2(num_interfaces);
+  write_u2(num_interfaces - (ik()->has_injected_identityObject() ? 1 : 0) );
   for (int index = 0; index < num_interfaces; index++) {
     HandleMark hm(thread());
     InstanceKlass* iik = interfaces->at(index);
-    write_u2(class_symbol_to_cpool_index(iik->name()));
+    if (!ik()->has_injected_identityObject() || iik != SystemDictionary::IdentityObject_klass()) {
+      write_u2(class_symbol_to_cpool_index(iik->name()));
+    }
   }
 
   // JVMSpec|           u2 fields_count;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -83,6 +83,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
     private HotSpotResolvedObjectTypeImpl serializableType;
     private HotSpotResolvedObjectTypeImpl cloneableType;
     private HotSpotResolvedObjectTypeImpl enumType;
+    private HotSpotResolvedObjectTypeImpl identityObjectType;
 
     HotSpotResolvedObjectTypeImpl getJavaLangObject() {
         if (javaLangObject == null) {
@@ -117,6 +118,13 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
             serializableType = (HotSpotResolvedObjectTypeImpl) fromClass(Serializable.class);
         }
         return serializableType;
+    }
+
+    HotSpotResolvedObjectTypeImpl getJavaLangIdentityObject() {
+        if (identityObjectType == null) {
+            identityObjectType = (HotSpotResolvedObjectTypeImpl) fromClass(IdentityObject.class);
+        }
+        return identityObjectType;
     }
 
     HotSpotResolvedObjectTypeImpl getJavaLangThrowable() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -277,9 +277,10 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
     public HotSpotResolvedObjectTypeImpl[] getInterfaces() {
         if (interfaces == null) {
             if (isArray()) {
-                HotSpotResolvedObjectTypeImpl[] types = new HotSpotResolvedObjectTypeImpl[2];
+                HotSpotResolvedObjectTypeImpl[] types = new HotSpotResolvedObjectTypeImpl[3];
                 types[0] = runtime().getJavaLangCloneable();
                 types[1] = runtime().getJavaLangSerializable();
+                types[2] = runtime().getJavaLangIdentityObject();
                 this.interfaces = types;
             } else {
                 interfaces = runtime().compilerToVm.getInterfaces(this);

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -259,7 +259,9 @@ public class TestResolvedJavaType extends TypeUniverse {
             ResolvedJavaType type = metaAccess.lookupJavaType(c);
             Class<?>[] expected = c.getInterfaces();
             ResolvedJavaType[] actual = type.getInterfaces();
-            assertEquals(expected.length, actual.length);
+            // With injection of the IdentityObject interface by the JVM, the number of
+            // interfaces visible through reflection and through JVMCI could differ by one
+            assertTrue(expected.length == actual.length || (actual.length - expected.length) == 1);
             for (int i = 0; i < expected.length; i++) {
                 assertTrue(actual[i].equals(metaAccess.lookupJavaType(expected[i])));
             }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeImplementingIdentityObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeImplementingIdentityObject.java
@@ -1,0 +1,3 @@
+public abstract class AbstractTypeImplementingIdentityObject implements IdentityObject {
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithNonstaticFields.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithNonstaticFields.java
@@ -1,0 +1,3 @@
+public abstract class AbstractTypeWithNonstaticFields {
+    int i;
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithStaticFields.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithStaticFields.java
@@ -1,0 +1,3 @@
+public abstract class AbstractTypeWithStaticFields {
+    static int i;
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedNonstaticMethod.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedNonstaticMethod.java
@@ -1,5 +1,5 @@
 public abstract class AbstractTypeWithSynchronizedNonstaticMethod {
     synchronized int getInt() {
-	return 42;
+        return 42;
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedNonstaticMethod.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedNonstaticMethod.java
@@ -1,0 +1,5 @@
+public abstract class AbstractTypeWithSynchronizedNonstaticMethod {
+    synchronized int getInt() {
+	return 42;
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedStaticMethod.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedStaticMethod.java
@@ -1,0 +1,5 @@
+public abstract class AbstractTypeWithSynchronizedStaticMethod {
+    static synchronized int getInt() {
+	return 42;
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedStaticMethod.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/AbstractTypeWithSynchronizedStaticMethod.java
@@ -1,5 +1,5 @@
 public abstract class AbstractTypeWithSynchronizedStaticMethod {
     static synchronized int getInt() {
-	return 42;
+        return 42;
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/IdentityType.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/IdentityType.jcod
@@ -1,0 +1,62 @@
+class IdentityType {
+  0xCAFEBABE;
+  0; // minor version
+  59; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "java/lang/Object"; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "()V"; // #6
+    class #8; // #7
+    Utf8 "IdentityType"; // #8
+    Utf8 "Code"; // #9
+    Utf8 "LineNumberTable"; // #10
+    Utf8 "SourceFile"; // #11
+    Utf8 "IdentityType.java"; // #12
+  } // Constant Pool
+
+  0x0021; // access
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#9) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#10) { // LineNumberTable
+              [] { // line_number_table
+                0  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#11) { // SourceFile
+      #12;
+    } // end SourceFile
+  } // Attributes
+} // end class IdentityType

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/IdentityTypeImplementingIdentityObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/IdentityTypeImplementingIdentityObject.java
@@ -1,0 +1,3 @@
+public class IdentityTypeImplementingIdentityObject implements IdentityObject{
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/InlineType.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/InlineType.java
@@ -1,0 +1,3 @@
+public inline class InlineType {
+    int i = 0;
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/Interface.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/Interface.java
@@ -1,0 +1,3 @@
+public interface Interface {
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/InterfaceExtendingIdentityObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/InterfaceExtendingIdentityObject.java
@@ -1,0 +1,3 @@
+public interface InterfaceExtendingIdentityObject extends IdentityObject {
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/TestIdentityObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/TestIdentityObject.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @summary test that IdentityObject interface is injected correctly
+ * @compile IdentityType.jcod
+ * @compile Interface.java InterfaceExtendingIdentityObject.java 
+ * @compile AbstractTypeImplementingIdentityObject.java
+ * @compile AbstractTypeWithNonstaticFields.java AbstractTypeWithStaticFields.java
+ * @compile AbstractTypeWithSynchronizedNonstaticMethod.java AbstractTypeWithSynchronizedStaticMethod.java
+ * @compile InlineType.java IdentityTypeImplementingIdentityObject.java
+ * @compile TestIdentityObject.java 
+ * @run main/othervm -verify TestIdentityObject
+ */
+
+public class TestIdentityObject {
+    static void checkIdentityObject(Class c, boolean subtype, boolean visible) {
+	boolean s;
+	try {
+	    c.asSubclass(IdentityObject.class);
+	    s = true;
+	} catch(ClassCastException e) {
+	    s = false;
+	}
+	if (subtype != s) {
+	    if (subtype) {
+		throw new RuntimeException("Type " + c.getName() + " is missing IdentityObject");
+	    } else {
+		throw new RuntimeException("Type " + c.getName() + " should not implements IdentityObject");
+	    }
+	}
+	boolean found = false;
+	Class[] interfaces = c.getInterfaces();
+	for(Class i : interfaces) {
+	    if (i == IdentityObject.class) found = true;
+	}
+	if (found != visible) {
+	    if (visible) {
+		throw new RuntimeException("Type " + c.getName() + "  should have IdentityObject visible, but it hasn't");
+	    } else {
+		throw new RuntimeException("Type " + c.getName() + "  should not have IdentityObject visible, but it has");
+	    }
+	}
+    }
+
+    public static void main(String[] args) {
+	checkIdentityObject(InlineType.class, false, false);
+	checkIdentityObject(IdentityType.class, true, false);
+	checkIdentityObject(IdentityTypeImplementingIdentityObject.class, true, true);
+	checkIdentityObject(Interface.class, false, false);
+	checkIdentityObject(InterfaceExtendingIdentityObject.class, true, true);
+	checkIdentityObject(AbstractTypeImplementingIdentityObject.class, true, true);
+	checkIdentityObject(AbstractTypeWithNonstaticFields.class, true, false);
+	checkIdentityObject(AbstractTypeWithStaticFields.class, false, false);
+	checkIdentityObject(AbstractTypeWithSynchronizedNonstaticMethod.class, true, false);
+	checkIdentityObject(AbstractTypeWithSynchronizedStaticMethod.class, false, false);
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/TestIdentityObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/identityObject/TestIdentityObject.java
@@ -25,55 +25,55 @@
  * @test
  * @summary test that IdentityObject interface is injected correctly
  * @compile IdentityType.jcod
- * @compile Interface.java InterfaceExtendingIdentityObject.java 
+ * @compile Interface.java InterfaceExtendingIdentityObject.java
  * @compile AbstractTypeImplementingIdentityObject.java
  * @compile AbstractTypeWithNonstaticFields.java AbstractTypeWithStaticFields.java
  * @compile AbstractTypeWithSynchronizedNonstaticMethod.java AbstractTypeWithSynchronizedStaticMethod.java
  * @compile InlineType.java IdentityTypeImplementingIdentityObject.java
- * @compile TestIdentityObject.java 
+ * @compile TestIdentityObject.java
  * @run main/othervm -verify TestIdentityObject
  */
 
 public class TestIdentityObject {
     static void checkIdentityObject(Class c, boolean subtype, boolean visible) {
-	boolean s;
-	try {
-	    c.asSubclass(IdentityObject.class);
-	    s = true;
-	} catch(ClassCastException e) {
-	    s = false;
-	}
-	if (subtype != s) {
-	    if (subtype) {
-		throw new RuntimeException("Type " + c.getName() + " is missing IdentityObject");
-	    } else {
-		throw new RuntimeException("Type " + c.getName() + " should not implements IdentityObject");
-	    }
-	}
-	boolean found = false;
-	Class[] interfaces = c.getInterfaces();
-	for(Class i : interfaces) {
-	    if (i == IdentityObject.class) found = true;
-	}
-	if (found != visible) {
-	    if (visible) {
-		throw new RuntimeException("Type " + c.getName() + "  should have IdentityObject visible, but it hasn't");
-	    } else {
-		throw new RuntimeException("Type " + c.getName() + "  should not have IdentityObject visible, but it has");
-	    }
-	}
+        boolean s;
+        try {
+            c.asSubclass(IdentityObject.class);
+            s = true;
+        } catch(ClassCastException e) {
+            s = false;
+        }
+        if (subtype != s) {
+            if (subtype) {
+                throw new RuntimeException("Type " + c.getName() + " is missing IdentityObject");
+            } else {
+                throw new RuntimeException("Type " + c.getName() + " should not implements IdentityObject");
+            }
+        }
+        boolean found = false;
+        Class[] interfaces = c.getInterfaces();
+        for(Class i : interfaces) {
+            if (i == IdentityObject.class) found = true;
+        }
+        if (found != visible) {
+            if (visible) {
+                throw new RuntimeException("Type " + c.getName() + "  should have IdentityObject visible, but it hasn't");
+            } else {
+                throw new RuntimeException("Type " + c.getName() + "  should not have IdentityObject visible, but it has");
+            }
+        }
     }
 
     public static void main(String[] args) {
-	checkIdentityObject(InlineType.class, false, false);
-	checkIdentityObject(IdentityType.class, true, false);
-	checkIdentityObject(IdentityTypeImplementingIdentityObject.class, true, true);
-	checkIdentityObject(Interface.class, false, false);
-	checkIdentityObject(InterfaceExtendingIdentityObject.class, true, true);
-	checkIdentityObject(AbstractTypeImplementingIdentityObject.class, true, true);
-	checkIdentityObject(AbstractTypeWithNonstaticFields.class, true, false);
-	checkIdentityObject(AbstractTypeWithStaticFields.class, false, false);
-	checkIdentityObject(AbstractTypeWithSynchronizedNonstaticMethod.class, true, false);
-	checkIdentityObject(AbstractTypeWithSynchronizedStaticMethod.class, false, false);
+        checkIdentityObject(InlineType.class, false, false);
+        checkIdentityObject(IdentityType.class, true, false);
+        checkIdentityObject(IdentityTypeImplementingIdentityObject.class, true, true);
+        checkIdentityObject(Interface.class, false, false);
+        checkIdentityObject(InterfaceExtendingIdentityObject.class, true, true);
+        checkIdentityObject(AbstractTypeImplementingIdentityObject.class, true, true);
+        checkIdentityObject(AbstractTypeWithNonstaticFields.class, true, false);
+        checkIdentityObject(AbstractTypeWithStaticFields.class, false, false);
+        checkIdentityObject(AbstractTypeWithSynchronizedNonstaticMethod.class, true, false);
+        checkIdentityObject(AbstractTypeWithSynchronizedStaticMethod.class, false, false);
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/testSupers/InlineClassWithBadSupers.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/testSupers/InlineClassWithBadSupers.jcod
@@ -66,7 +66,7 @@ class SuperNotAbstract {
     class #23; // #22     at 0xE8
     Utf8 "NotAbstract"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -98,8 +98,7 @@ class SuperNotAbstract {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -327,7 +326,7 @@ class SuperHasNonStaticFields {
     class #23; // #22     at 0xE8
     Utf8 "HasNonStaticFields"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -359,8 +358,7 @@ class SuperHasNonStaticFields {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -588,7 +586,7 @@ class SuperHasSynchMethod {
     class #23; // #22     at 0xE8
     Utf8 "ValidSuper"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -620,8 +618,7 @@ class SuperHasSynchMethod {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -848,7 +845,7 @@ class SuperCtorHasArgs {
     class #23; // #22     at 0xE8
     Utf8 "CtorHasArgs"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -880,8 +877,7 @@ class SuperCtorHasArgs {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -1110,7 +1106,7 @@ class SuperCtorIsNotEmpty {
     class #23; // #22     at 0xE8
     Utf8 "CtorIsNotEmpty"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -1142,8 +1138,7 @@ class SuperCtorIsNotEmpty {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -1373,7 +1368,7 @@ class InlineImplementsIdentityObject {
     class #25; // #24     at 0x011E
     Utf8 "java/lang/IdentityObject"; // #25     at 0x0121
     class #27; // #26     at 0x0126
-    Utf8 "java/lang/InlineObject"; // #27     at 0x0129
+    Utf8 "Unused"; // #27     at 0x0129
     Utf8 "getX"; // #28     at 0x0142
     Utf8 "()I"; // #29     at 0x0149
     Utf8 "Code"; // #30     at 0x014F
@@ -1405,9 +1400,8 @@ class InlineImplementsIdentityObject {
   #1;// this_cpx
   #22;// super_cpx
 
-  [2] { // Interfaces
+  [1] { // Interfaces
     #24;
-    #26;
   } // Interfaces
 
   [2] { // fields
@@ -1636,7 +1630,7 @@ class SuperImplementsIdentityObject {
     class #23; // #22     at 0xE8
     Utf8 "ImplementsIdentityObject"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -1668,8 +1662,7 @@ class SuperImplementsIdentityObject {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields
@@ -1897,7 +1890,7 @@ class SuperIntfImplementsIdentityObject {
     class #23; // #22     at 0xE8
     Utf8 "IntfImplementsIdentityObject"; // #23     at 0xEB
     class #25; // #24     at 0xF9
-    Utf8 "java/lang/InlineObject"; // #25     at 0xFC
+    Utf8 "Unused"; // #25     at 0xFC
     Utf8 "getX"; // #26     at 0x0115
     Utf8 "()I"; // #27     at 0x011C
     Utf8 "Code"; // #28     at 0x0122
@@ -1929,8 +1922,7 @@ class SuperIntfImplementsIdentityObject {
   #1;// this_cpx
   #22;// super_cpx
 
-  [1] { // Interfaces
-    #24;
+  [0] { // Interfaces
   } // Interfaces
 
   [2] { // fields

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
@@ -67,10 +67,12 @@ public class ClassHierarchyTest {
     // java.lang.Object/null
     // |--DcmdBaseClass/0xa4abcd48
     // |  implements Intf2/0xa4abcd48 (declared intf)
+    // |  implements java.lang.IdentityObject/null (declared intf)
     // |  implements Intf1/0xa4abcd48 (inherited intf)
     // |  |--DcmdTestClass/0xa4abcd48
     // |  |  implements Intf1/0xa4abcd48 (inherited intf)
     // |  |  implements Intf2/0xa4abcd48 (inherited intf)
+    // |  |  implements java.lang.IdentityObject/null (inherited intf)
 
     static Pattern expected_lambda_line =
         Pattern.compile("\\|--DcmdTestClass\\$\\$Lambda.*");

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,10 +79,12 @@ public class ClassHierarchyTest {
         Pattern.compile("java.lang.Object/null"),
         Pattern.compile("\\|--DcmdBaseClass/0x(\\p{XDigit}*)"),
         Pattern.compile("\\|  implements Intf2/0x(\\p{XDigit}*) \\(declared intf\\)"),
+        Pattern.compile("\\|  implements java.lang.IdentityObject/null \\(declared intf\\)"),
         Pattern.compile("\\|  implements Intf1/0x(\\p{XDigit}*) \\(inherited intf\\)"),
         Pattern.compile("\\|  \\|--DcmdTestClass/0x(\\p{XDigit}*)"),
         Pattern.compile("\\|  \\|  implements Intf1/0x(\\p{XDigit}*) \\(inherited intf\\)"),
-        Pattern.compile("\\|  \\|  implements Intf2/0x(\\p{XDigit}*) \\(inherited intf\\)")
+        Pattern.compile("\\|  \\|  implements Intf2/0x(\\p{XDigit}*) \\(inherited intf\\)"),
+        Pattern.compile("\\|  \\|  implements java.lang.IdentityObject/null \\(inherited intf\\)")
     };
 
     public void run(CommandExecutor executor) throws ClassNotFoundException {
@@ -140,7 +142,7 @@ public class ClassHierarchyTest {
                 Assert.fail("Failed to match line #" + i + ": " + line);
             }
             // "implements" lines should not be in this output.
-            if (i == 2 || i == 4) i += 2;
+            if (i == 2 || i == 6) i += 3;
         }
         if (lines.hasNext()) {
             String line = lines.next();
@@ -164,7 +166,7 @@ public class ClassHierarchyTest {
                 // subsequent lines.
                 classLoaderAddr = m.group(1);
                 System.out.println(classLoaderAddr);
-            } else if (i > 2) {
+            } else if (i > 2 && i != 4 && i != 9) {
                 if (!classLoaderAddr.equals(m.group(1))) {
                     Assert.fail("Classloader address didn't match on line #"
                                         + i + ": " + line);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ public class interfaces001 {
                 };
     static final int DECLARED_INTERFACES = class_interfaces.length;
     static final long interfaceIDs[] = new long[DECLARED_INTERFACES];
+    static long identityObjectID;
 
     public static void main (String argv[]) {
         System.exit(run(argv,System.out) + JCK_STATUS_BASE);
@@ -98,6 +99,7 @@ public class interfaces001 {
                         log.display("Getting ReferenceTypeID for interface signature: " + class_interfaces[i][1]);
                         interfaceIDs[i] = debugee.getReferenceTypeID(class_interfaces[i][1]);
                     }
+                    identityObjectID = debugee.getReferenceTypeID("Ljava/lang/IdentityObject;");
 
                     // begin test of JDWP command
 
@@ -124,7 +126,8 @@ public class interfaces001 {
                     int interfaces = reply.getInt();
                     log.display("  interfaces: " + interfaces);
 
-                    if (interfaces != DECLARED_INTERFACES) {
+                    // Adding one to the number of interfaces because of the injection of IdentityObject by the VM
+                    if (interfaces != DECLARED_INTERFACES + 1) {
                         log.complain("Unexpected number of declared interfaces in the reply packet:" + interfaces
                                     + " (expected: " + DECLARED_INTERFACES + ")");
                         success = false;
@@ -137,12 +140,19 @@ public class interfaces001 {
                         long interfaceID = reply.getReferenceTypeID();
                         log.display("    interfaceID: " + interfaceID);
 
-                        if (interfaceID != interfaceIDs[i]) {
-                            log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
-                                        + " (expected: " + interfaceIDs[i] + ")");
-                            success = false;
+                        if (i < DECLARED_INTERFACES) {
+                            if (interfaceID != interfaceIDs[i]) {
+                                log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
+                                             + " (expected: " + interfaceIDs[i] + ")");
+                                success = false;
+                            }
+                        } else {
+                            if (interfaceID != identityObjectID) {
+                                log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
+                                             + " (expected identityObjectID: " + identityObjectID + ")");
+                                success = false;
+                            }
                         }
-
                     }
 
                     if (! reply.isParsed()) {

--- a/test/jdk/java/lang/Class/ArrayMethods.java
+++ b/test/jdk/java/lang/Class/ArrayMethods.java
@@ -90,7 +90,7 @@ public class ArrayMethods {
         Class<?>[] is = new Integer[0].getClass().getInterfaces();
         boolean thisFailed = false;
 
-        if (is.length != 2)
+        if (is.length != 3)
             thisFailed = true;
 
         if (!is[0].getCanonicalName().equals("java.lang.Cloneable"))
@@ -99,10 +99,13 @@ public class ArrayMethods {
         if (!is[1].getCanonicalName().equals("java.io.Serializable"))
             thisFailed = true;
 
+        if (!is[2].getCanonicalName().equals("java.lang.IdentityObject"))
+            thisFailed = true;
+
         if (thisFailed) {
             failed++;
             System.out.println(Arrays.asList(is));
-            System.out.println("Should contain exactly Cloneable, Serializable in that order.");
+            System.out.println("Should contain exactly Cloneable, Serializable and IdentityObject in that order.");
         }
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
@@ -60,7 +60,7 @@ public class InstanceOfTopTypeTest {
             throw new AssertionError("Broken");
         if (oa[0] instanceof InlineObject)
             points++;
-        if (points != 4) // Change to != 6 after JDK-8237958 is fixed
+        if (points != 6)
             throw new AssertionError("Broken top type set up" + points);
     }
 }


### PR DESCRIPTION
Please review these changes for JDK-8245216.

This code makes the JVM to inject the IdentityObject interface when needed.
The details are in the CR:
https://bugs.openjdk.java.net/browse/JDK-8245216

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8245216](https://bugs.openjdk.java.net/browse/JDK-8245216): [lworld] The JVM should inject the IdentityObject interface to types which need it ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer) ⚠️ Review applies to 00cfcb6c42c94186f3786a3b807cfe0daac67f87

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/51/head:pull/51`
`$ git checkout pull/51`
