### PR TITLE
8245019: [lworld] SIGSEGV in BufferBlob::buffered value type due to instruction memory corruption

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -242,8 +242,8 @@ BufferBlob* BufferBlob::create(const char* name, int buffer_size) {
 }
 
 
-BufferBlob::BufferBlob(const char* name, int size, CodeBuffer* cb)
-  : RuntimeBlob(name, cb, sizeof(BufferBlob), size, CodeOffsets::frame_never_safe, 0, NULL)
+BufferBlob::BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb)
+  : RuntimeBlob(name, cb, header_size, size, CodeOffsets::frame_never_safe, 0, NULL)
 {}
 
 BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
@@ -254,7 +254,7 @@ BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   assert(name != NULL, "must provide a name");
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) BufferBlob(name, size, cb);
+    blob = new (size) BufferBlob(name, sizeof(BufferBlob), size, cb);
   }
   // Track memory usage statistic after releasing CodeCache_lock
   MemoryService::track_code_cache_memory_usage();
@@ -356,7 +356,7 @@ MethodHandlesAdapterBlob* MethodHandlesAdapterBlob::create(int buffer_size) {
 //----------------------------------------------------------------------------------------------------
 // Implementation of BufferedValueTypeBlob
 BufferedValueTypeBlob::BufferedValueTypeBlob(int size, CodeBuffer* cb, int pack_fields_off, int pack_fields_jobject_off, int unpack_fields_off) :
-  BufferBlob("buffered value type", size, cb),
+  BufferBlob("buffered value type", sizeof(BufferedValueTypeBlob), size, cb),
   _pack_fields_off(pack_fields_off),
   _pack_fields_jobject_off(pack_fields_jobject_off),
   _unpack_fields_off(unpack_fields_off) {

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -402,7 +402,7 @@ class BufferBlob: public RuntimeBlob {
  private:
   // Creation support
   BufferBlob(const char* name, int size);
-  BufferBlob(const char* name, int size, CodeBuffer* cb);
+  BufferBlob(const char* name, int header_size, int size, CodeBuffer* cb);
   BufferBlob(const char* name, int size, CodeBuffer* cb, int frame_complete, int frame_size, OopMapSet* oop_maps, bool caller_must_gc_arguments = false);
 
   // This ordinary operator delete is needed even though not used, so the


### PR DESCRIPTION
The layout of BufferedValueTypeBlob is incorrectly computed (sizeof(BufferBlob) instead of sizeof(BufferedValueTypeBlob)) and as a result, the instructions at the start of the blob are overwritten by the C++ object header. This only happens with a product build, I assume with a debug build there is some additional padding.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8245019](https://bugs.openjdk.java.net/browse/JDK-8245019): [lworld] SIGSEGV in BufferBlob::buffered value type due to instruction memory corruption ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/52/head:pull/52`
`$ git checkout pull/52`
