### PR TITLE
8244931: [lworld] Decommission arrayStorageProperties from runtime null free and flat array tests

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2626,7 +2626,7 @@ void MacroAssembler::test_klass_is_empty_value(Register klass, Register temp_reg
   {
     Label done_check;
     test_klass_is_value(klass, temp_reg, done_check);
-    stop("test_klass_is_empty_value with none value klass");
+    stop("test_klass_is_empty_value with non value klass");
     bind(done_check);
   }
 #endif
@@ -2661,29 +2661,49 @@ void MacroAssembler::test_field_is_flattened(Register flags, Register temp_reg, 
 
 void MacroAssembler::test_flattened_array_oop(Register oop, Register temp_reg,
                                               Label&is_flattened_array) {
-  load_storage_props(temp_reg, oop);
-  testb(temp_reg, ArrayStorageProperties::flattened_value);
-  jcc(Assembler::notZero, is_flattened_array);
+  load_klass(temp_reg, oop);
+  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
+  test_flattened_array_layout(temp_reg, is_flattened_array);
 }
 
 void MacroAssembler::test_non_flattened_array_oop(Register oop, Register temp_reg,
                                                   Label&is_non_flattened_array) {
-  load_storage_props(temp_reg, oop);
-  testb(temp_reg, ArrayStorageProperties::flattened_value);
-  jcc(Assembler::zero, is_non_flattened_array);
+  load_klass(temp_reg, oop);
+  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
+  test_non_flattened_array_layout(temp_reg, is_non_flattened_array);
 }
 
 void MacroAssembler::test_null_free_array_oop(Register oop, Register temp_reg, Label&is_null_free_array) {
-  load_storage_props(temp_reg, oop);
-  testb(temp_reg, ArrayStorageProperties::null_free_value);
-  jcc(Assembler::notZero, is_null_free_array);
+  load_klass(temp_reg, oop);
+  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
+  test_null_free_array_layout(temp_reg, is_null_free_array);
 }
 
 void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_reg, Label&is_non_null_free_array) {
-  load_storage_props(temp_reg, oop);
-  testb(temp_reg, ArrayStorageProperties::null_free_value);
+  load_klass(temp_reg, oop);
+  movl(temp_reg, Address(temp_reg, Klass::layout_helper_offset()));
+  test_non_null_free_array_layout(temp_reg, is_non_null_free_array);
+}
+
+void MacroAssembler::test_flattened_array_layout(Register lh, Label& is_flattened_array) {
+  testl(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  jcc(Assembler::notZero, is_flattened_array);
+}
+void MacroAssembler::test_non_flattened_array_layout(Register lh, Label& is_non_flattened_array) {
+  testl(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  jcc(Assembler::zero, is_non_flattened_array);
+}
+
+void MacroAssembler::test_null_free_array_layout(Register lh, Label& is_null_free_array) {
+  testl(lh, Klass::_lh_null_free_bit_inplace);
+  jcc(Assembler::notZero, is_null_free_array);
+}
+
+void MacroAssembler::test_non_null_free_array_layout(Register lh, Label& is_non_null_free_array) {
+  testl(lh, Klass::_lh_null_free_bit_inplace);
   jcc(Assembler::zero, is_non_null_free_array);
 }
+
 
 void MacroAssembler::os_breakpoint() {
   // instead of directly emitting a breakpoint, call os:breakpoint for better debugability

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -121,6 +121,12 @@ class MacroAssembler: public Assembler {
   void test_null_free_array_oop(Register oop, Register temp_reg, Label&is_null_free_array);
   void test_non_null_free_array_oop(Register oop, Register temp_reg, Label&is_non_null_free_array);
 
+  // Check array klass layout helper for flatten or null-free arrays...
+  void test_flattened_array_layout(Register lh, Label& is_flattened_array);
+  void test_non_flattened_array_layout(Register lh, Label& is_non_flattened_array);
+  void test_null_free_array_layout(Register lh, Label& is_null_free_array);
+  void test_non_null_free_array_layout(Register lh, Label& is_non_null_free_array);
+
   // Required platform-specific helpers for Label::patch_instructions.
   // They _shadow_ the declarations in AbstractAssembler, which are undefined.
   void pd_patch_instruction(address branch, address target, const char* file, int line) {

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -1156,7 +1156,8 @@ void TemplateTable::aastore() {
   // Move array class to rdi
   __ load_klass(rdi, rdx);
   if (ValueArrayFlatten) {
-    __ test_flattened_array_oop(rdx, rbx, is_flat_array);
+    __ movl(rbx, Address(rdi, Klass::layout_helper_offset()));
+    __ test_flattened_array_layout(rbx, is_flat_array);
   }
 
   // Move subklass into rbx

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -461,7 +461,7 @@ static void profile_flat_array(JavaThread* thread) {
 }
 
 JRT_ENTRY(void, Runtime1::load_flattened_array(JavaThread* thread, valueArrayOopDesc* array, int index))
-  assert(ArrayKlass::cast(array->klass())->storage_properties().is_flattened(), "should not be called");
+  assert(array->klass()->is_valueArray_klass(), "should not be called");
   profile_flat_array(thread);
 
   NOT_PRODUCT(_load_flattened_array_slowcase_cnt++;)
@@ -473,16 +473,16 @@ JRT_END
 
 
 JRT_ENTRY(void, Runtime1::store_flattened_array(JavaThread* thread, valueArrayOopDesc* array, int index, oopDesc* value))
-  if (ArrayKlass::cast(array->klass())->storage_properties().is_flattened()) {
+  if (array->klass()->is_valueArray_klass()) {
     profile_flat_array(thread);
   }
 
   NOT_PRODUCT(_store_flattened_array_slowcase_cnt++;)
   if (value == NULL) {
-    assert(ArrayKlass::cast(array->klass())->storage_properties().is_flattened() || ArrayKlass::cast(array->klass())->storage_properties().is_null_free(), "should not be called");
+    assert(array->klass()->is_valueArray_klass() || array->klass()->is_null_free_array_klass(), "should not be called");
     SharedRuntime::throw_and_post_jvmti_exception(thread, vmSymbols::java_lang_NullPointerException());
   } else {
-    assert(ArrayKlass::cast(array->klass())->storage_properties().is_flattened(), "should not be called");
+    assert(array->klass()->is_valueArray_klass(), "should not be called");
     array->value_copy_to_index(value, index);
   }
 JRT_END
@@ -1095,7 +1095,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* thread, Runtime1::StubID stub_i
           Klass* ek = caller_method->constants()->klass_at(anew.index(), CHECK);
           if (ek->is_value() && caller_method->constants()->klass_at_noresolve(anew.index())->is_Q_signature()) {
             k = ek->array_klass(1, CHECK);
-            assert(ArrayKlass::cast(k)->storage_properties().is_null_free(), "Expect a null-free array class here");
+            assert(k->is_null_free_array_klass(), "Expect a null-free array class here");
           } else {
             k = ek->array_klass(CHECK);
           }

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -137,7 +137,7 @@ arrayOop oopFactory::new_valueArray(Klass* klass, int length, TRAPS) {
   assert(klass->is_value(), "Klass must be value type");
   // Request flattened, but we might not actually get it...either way "null-free" are the aaload/aastore semantics
   Klass* array_klass = klass->array_klass(1, CHECK_NULL);
-  assert(ArrayKlass::cast(array_klass)->storage_properties().is_null_free(), "Expect a null-free array class here");
+  assert(array_klass->is_null_free_array_klass(), "Expect a null-free array class here");
 
   arrayOop oop;
   if (array_klass->is_valueArray_klass()) {

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -205,7 +205,7 @@ jint Klass::array_layout_helper(BasicType etype) {
   int  esize = type2aelembytes(etype);
   bool isobj = (etype == T_OBJECT);
   int  tag   =  isobj ? _lh_array_tag_obj_value : _lh_array_tag_type_value;
-  int lh = array_layout_helper(tag, hsize, etype, exact_log2(esize));
+  int lh = array_layout_helper(tag, false, hsize, etype, exact_log2(esize));
 
   assert(lh < (int)_lh_neutral_value, "must look like an array layout");
   assert(layout_helper_is_array(lh), "correct kind");

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -161,20 +161,17 @@ oop ValueArrayKlass::multi_allocate(int rank, jint* last_size, TRAPS) {
 
 jint ValueArrayKlass::array_layout_helper(ValueKlass* vk) {
   BasicType etype = T_VALUETYPE;
-  int atag  = _lh_array_tag_vt_value;
   int esize = upper_log2(vk->raw_value_byte_size());
   int hsize = arrayOopDesc::base_offset_in_bytes(etype);
 
-  int lh = (atag       << _lh_array_tag_shift)
-    |      (hsize      << _lh_header_size_shift)
-    |      ((int)etype << _lh_element_type_shift)
-    |      ((esize)    << _lh_log2_element_size_shift);
+  int lh = Klass::array_layout_helper(_lh_array_tag_vt_value, true, hsize, etype, esize);
 
   assert(lh < (int)_lh_neutral_value, "must look like an array layout");
   assert(layout_helper_is_array(lh), "correct kind");
   assert(layout_helper_is_valueArray(lh), "correct kind");
   assert(!layout_helper_is_typeArray(lh), "correct kind");
   assert(!layout_helper_is_objArray(lh), "correct kind");
+  assert(layout_helper_is_null_free(lh), "correct kind");
   assert(layout_helper_header_size(lh) == hsize, "correct decode");
   assert(layout_helper_element_type(lh) == etype, "correct decode");
   assert(layout_helper_log2_element_size(lh) == esize, "correct decode");


### PR DESCRIPTION
Moved runtime and interpreter flat & null free tests to klass layout helper
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244931](https://bugs.openjdk.java.net/browse/JDK-8244931): [lworld] Decommission arrayStorageProperties from runtime null free and flat array tests


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/54/head:pull/54`
`$ git checkout pull/54`
