### PR TITLE
8245646: [lworld] LW3 Reduce impact of IdentityObject on metaspace

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5057,6 +5057,11 @@ static Array<InstanceKlass*>* compute_transitive_interfaces(const InstanceKlass*
     // length will be less than the max_transitive_size if duplicates were removed
     const int length = result->length();
     assert(length <= max_transitive_size, "just checking");
+
+    if (length == 1 && result->at(0) == SystemDictionary::IdentityObject_klass()) {
+      return Universe::the_single_IdentityObject_klass_array();
+    }
+
     Array<InstanceKlass*>* const new_result =
       MetadataFactory::new_array<InstanceKlass*>(loader_data, length, CHECK_NULL);
     for (int i = 0; i < length; i++) {
@@ -6396,6 +6401,10 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik, bool changed_by_loa
   // it's official
   set_klass(ik);
 
+  if (ik->name() == vmSymbols::java_lang_IdentityObject()) {
+    Universe::initialize_the_single_IdentityObject_klass_array(ik, CHECK);
+  }
+
   debug_only(ik->verify();)
 }
 
@@ -7047,6 +7056,8 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
   int itfs_len = _temp_local_interfaces->length();
   if (itfs_len == 0) {
     _local_interfaces = Universe::the_empty_instance_klass_array();
+  } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == SystemDictionary::IdentityObject_klass()) {
+    _local_interfaces = Universe::the_single_IdentityObject_klass_array();
   } else {
     _local_interfaces = MetadataFactory::new_array<InstanceKlass*>(_loader_data, itfs_len, NULL, CHECK);
     for (int i = 0; i < itfs_len; i++) {

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -136,6 +136,7 @@ class Universe: AllStatic {
   static Array<u2>*             _the_empty_short_array;          // Canonicalized short array
   static Array<Klass*>*         _the_empty_klass_array;          // Canonicalized klass array
   static Array<InstanceKlass*>* _the_empty_instance_klass_array; // Canonicalized instance klass array
+  static Array<InstanceKlass*>* _the_single_IdentityObject_klass_array;
   static Array<Method*>*        _the_empty_method_array;         // Canonicalized method array
 
   static Array<Klass*>*  _the_array_interfaces_array;
@@ -312,6 +313,12 @@ class Universe: AllStatic {
   static Array<Method*>*         the_empty_method_array() { return _the_empty_method_array; }
   static Array<Klass*>*          the_empty_klass_array()  { return _the_empty_klass_array; }
   static Array<InstanceKlass*>*  the_empty_instance_klass_array() { return _the_empty_instance_klass_array; }
+  static Array<InstanceKlass*>*  the_single_IdentityObject_klass_array() {
+    assert(_the_single_IdentityObject_klass_array != NULL, "Must be initialized before use");
+    assert(_the_single_IdentityObject_klass_array->length() == 1, "Sanity check");
+    return _the_single_IdentityObject_klass_array;
+  }
+  static void initialize_the_single_IdentityObject_klass_array(InstanceKlass* ik, TRAPS);
 
   // OutOfMemoryError support. Returns an error with the required message. The returned error
   // may or may not have a backtrace. If error has a backtrace then the stack trace is already

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -537,14 +537,16 @@ void InstanceKlass::deallocate_interfaces(ClassLoaderData* loader_data,
     // check that the interfaces don't come from super class
     Array<InstanceKlass*>* sti = (super_klass == NULL) ? NULL :
                     InstanceKlass::cast(super_klass)->transitive_interfaces();
-    if (ti != sti && ti != NULL && !ti->is_shared()) {
+    if (ti != sti && ti != NULL && !ti->is_shared() &&
+        ti != Universe::the_single_IdentityObject_klass_array()) {
       MetadataFactory::free_array<InstanceKlass*>(loader_data, ti);
     }
   }
 
   // local interfaces can be empty
   if (local_interfaces != Universe::the_empty_instance_klass_array() &&
-      local_interfaces != NULL && !local_interfaces->is_shared()) {
+      local_interfaces != NULL && !local_interfaces->is_shared() &&
+      local_interfaces != Universe::the_single_IdentityObject_klass_array()) {
     MetadataFactory::free_array<InstanceKlass*>(loader_data, local_interfaces);
   }
 }


### PR DESCRIPTION
Please review these changes for JDK-8245646.

This is not a new feature, just an optimization to reduce the number klass arrays containing only `IdentityObject` begin allocated in metaspaces.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8245646](https://bugs.openjdk.java.net/browse/JDK-8245646): [lworld] LW3 Reduce impact of IdentityObject on metaspace 


### Reviewers
 * David Simms ([dsimms](@MrSimms) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/57/head:pull/57`
`$ git checkout pull/57`
