### PR TITLE
Rename value type -XX options to inline...

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -498,7 +498,7 @@ void LIR_Assembler::return_op(LIR_Opr result) {
 
   ciMethod* method = compilation()->method();
 
-  if (ValueTypeReturnedAsFields && method->signature()->returns_never_null()) {
+  if (InlineTypeReturnedAsFields && method->signature()->returns_never_null()) {
     ciType* return_type = method->return_type();
     if (return_type->is_valuetype()) {
       ciValueKlass* vk = return_type->as_value_klass();
@@ -1586,7 +1586,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
   // This is called when we use aastore into a an array declared as "[LVT;",
-  // where we know VT is not flattenable (due to ValueArrayElemMaxFlatOops, etc).
+  // where we know VT is not flattenable (due to InlineArrayElemMaxFlatSize, etc).
   // However, we need to do a NULL check if the actual array is a "[QVT;".
 
   __ load_storage_props(op->tmp()->as_register(), op->array()->as_register());

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -377,7 +377,7 @@ void C1_MacroAssembler::verified_value_entry() {
 }
 
 int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature *ces, int frame_size_in_bytes, int bang_size_in_bytes, Label& verified_value_entry_label, bool is_value_ro_entry) {
-  // This function required to support for ValueTypePassFieldsAsArgs
+  // This function required to support for InlineTypePassFieldsAsArgs
   if (C1Breakpoint || VerifyFPU || !UseStackBanging) {
     // Verified Entry first instruction should be 5 bytes long for correct
     // patching by patch_verified_entry().
@@ -392,7 +392,7 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature *ces, int f
   nop();
   // verify_FPU(0, "method_entry");
 
-  assert(ValueTypePassFieldsAsArgs, "sanity");
+  assert(InlineTypePassFieldsAsArgs, "sanity");
 
   GrowableArray<SigEntry>* sig   = &ces->sig();
   GrowableArray<SigEntry>* sig_cc = is_value_ro_entry ? &ces->sig_cc_ro() : &ces->sig_cc();

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -64,8 +64,8 @@ define_pd_global(bool, RewriteFrequentPairs, true);
 
 define_pd_global(bool, PreserveFramePointer, false);
 
-define_pd_global(bool, ValueTypePassFieldsAsArgs, false);
-define_pd_global(bool, ValueTypeReturnedAsFields, false);
+define_pd_global(bool, InlineTypePassFieldsAsArgs, false);
+define_pd_global(bool, InlineTypeReturnedAsFields, false);
 
 define_pd_global(uintx, TypeProfileLevel, 111);
 

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -687,7 +687,7 @@ void InterpreterMacroAssembler::remove_activation(
   }
 
 
-  if (state == atos && ValueTypeReturnedAsFields) {
+  if (state == atos && InlineTypeReturnedAsFields) {
     Label skip;
     // Test if the return type is a value type
     ldr(rscratch1, Address(rfp, frame::interpreter_frame_method_offset * wordSize));

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -444,7 +444,7 @@ static void patch_callers_callsite(MacroAssembler *masm) {
 // calling convention the interpreter expects).
 static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_extended) {
   int total_args_passed = 0;
-  if (ValueTypePassFieldsAsArgs) {
+  if (InlineTypePassFieldsAsArgs) {
      for (int i = 0; i < sig_extended->length(); i++) {
        BasicType bt = sig_extended->at(i)._bt;
        if (SigEntry::is_reserved_entry(sig_extended, i)) {
@@ -487,7 +487,7 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
 
 static void gen_c2i_adapter_helper(MacroAssembler* masm, BasicType bt, const VMRegPair& reg_pair, int extraspace, const Address& to) {
 
-    assert(bt != T_VALUETYPE || !ValueTypePassFieldsAsArgs, "no value type here");
+    assert(bt != T_VALUETYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
 
     // Say 4 args:
     // i   st_off
@@ -560,8 +560,8 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   bool has_value_argument = false;
 
-  if (ValueTypePassFieldsAsArgs) {
-      // Is there a value type argument?
+  if (InlineTypePassFieldsAsArgs) {
+      // Is there an inline type argument?
      for (int i = 0; i < sig_extended->length() && !has_value_argument; i++) {
        has_value_argument = (sig_extended->at(i)._bt == T_VALUETYPE);
      }
@@ -630,7 +630,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // offset to start parameters
     int st_off   = (total_args_passed - next_arg_int - 1) * Interpreter::stackElementSize;
 
-    if (!ValueTypePassFieldsAsArgs || bt != T_VALUETYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_VALUETYPE) {
 
             if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
                continue; // Ignore reserved entry

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -369,7 +369,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // handle return types different from T_INT
     __ BIND(is_value);
-    if (ValueTypeReturnedAsFields) {
+    if (InlineTypeReturnedAsFields) {
       // Check for flattened return value
       __ cbz(r0, is_long);
       // Initialize pre-allocated buffer

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -437,7 +437,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   // and NULL it as marker that esp is now tos until next java call
   __ str(zr, Address(rfp, frame::interpreter_frame_last_sp_offset * wordSize));
 
-  if (state == atos && ValueTypeReturnedAsFields) {
+  if (state == atos && InlineTypeReturnedAsFields) {
     __ store_value_type_fields_to_buf(NULL, true);
   }
 

--- a/src/hotspot/cpu/ppc/globals_ppc.hpp
+++ b/src/hotspot/cpu/ppc/globals_ppc.hpp
@@ -67,8 +67,8 @@ define_pd_global(bool, RewriteFrequentPairs,  true);
 
 define_pd_global(bool, PreserveFramePointer,  false);
 
-define_pd_global(bool, ValueTypePassFieldsAsArgs, false);
-define_pd_global(bool, ValueTypeReturnedAsFields, false);
+define_pd_global(bool, InlineTypePassFieldsAsArgs, false);
+define_pd_global(bool, InlineTypeReturnedAsFields, false);
 
 define_pd_global(uintx, TypeProfileLevel, 111);
 

--- a/src/hotspot/cpu/sparc/globals_sparc.hpp
+++ b/src/hotspot/cpu/sparc/globals_sparc.hpp
@@ -74,8 +74,8 @@ define_pd_global(bool, RewriteFrequentPairs, true);
 
 define_pd_global(bool, PreserveFramePointer, false);
 
-define_pd_global(bool, ValueTypePassFieldsAsArgs, false);
-define_pd_global(bool, ValueTypeReturnedAsFields, false);
+define_pd_global(bool, InlineTypePassFieldsAsArgs, false);
+define_pd_global(bool, InlineTypeReturnedAsFields, false);
 
 define_pd_global(uintx, TypeProfileLevel, 111);
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -528,7 +528,7 @@ void LIR_Assembler::return_op(LIR_Opr result) {
   }
 
   ciMethod* method = compilation()->method();
-  if (ValueTypeReturnedAsFields && method->signature()->returns_never_null()) {
+  if (InlineTypeReturnedAsFields && method->signature()->returns_never_null()) {
     ciType* return_type = method->return_type();
     if (return_type->is_valuetype()) {
       ciValueKlass* vk = return_type->as_value_klass();

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -382,7 +382,7 @@ void C1_MacroAssembler::verified_entry() {
 }
 
 int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature *ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_value_entry_label, bool is_value_ro_entry) {
-  assert(ValueTypePassFieldsAsArgs, "sanity");
+  assert(InlineTypePassFieldsAsArgs, "sanity");
   // Make sure there is enough stack space for this method's activation.
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   generate_stack_overflow_check(bang_size_in_bytes);

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1159,7 +1159,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
             // new "[QVT;"
             __ cmpl(t0, Klass::_lh_array_tag_vt_value);  // the array can be flattened.
             __ jcc(Assembler::equal, ok);
-            __ cmpl(t0, Klass::_lh_array_tag_obj_value); // the array cannot be flattened (due to ValueArrayElemMaxFlatSize, etc)
+            __ cmpl(t0, Klass::_lh_array_tag_obj_value); // the array cannot be flattened (due to InlineArrayElementMaxFlatSize, etc)
             __ jcc(Assembler::equal, ok);
             __ stop("assert(is an object or value array klass)");
             break;

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -89,8 +89,8 @@ define_pd_global(bool, PreserveFramePointer, false);
 
 define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
 
-define_pd_global(bool, ValueTypePassFieldsAsArgs, LP64_ONLY(true) NOT_LP64(false));
-define_pd_global(bool, ValueTypeReturnedAsFields, LP64_ONLY(true) NOT_LP64(false));
+define_pd_global(bool, InlineTypePassFieldsAsArgs, LP64_ONLY(true) NOT_LP64(false));
+define_pd_global(bool, InlineTypeReturnedAsFields, LP64_ONLY(true) NOT_LP64(false));
 
 #define ARCH_FLAGS(develop, \
                    product, \

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1153,9 +1153,9 @@ void InterpreterMacroAssembler::remove_activation(
   movptr(rbx,
          Address(rbp, frame::interpreter_frame_sender_sp_offset * wordSize));
 
-  if (state == atos && ValueTypeReturnedAsFields) {
+  if (state == atos && InlineTypeReturnedAsFields) {
     Label skip;
-    // Test if the return type is a value type
+    // Test if the return type is an inline type
     movptr(rdi, Address(rbp, frame::interpreter_frame_method_offset * wordSize));
     movptr(rdi, Address(rdi, Method::const_offset()));
     load_unsigned_byte(rdi, Address(rdi, ConstMethod::result_type_offset()));

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -658,7 +658,7 @@ static void patch_callers_callsite(MacroAssembler *masm) {
 // calling convention the interpreter expects).
 static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_extended) {
   int total_args_passed = 0;
-  if (ValueTypePassFieldsAsArgs) {
+  if (InlineTypePassFieldsAsArgs) {
     for (int i = 0; i < sig_extended->length(); i++) {
       BasicType bt = sig_extended->at(i)._bt;
       if (SigEntry::is_reserved_entry(sig_extended, i)) {
@@ -706,7 +706,7 @@ static void gen_c2i_adapter_helper(MacroAssembler* masm,
                                    const Address& to,
                                    int extraspace,
                                    bool is_oop) {
-  assert(bt != T_VALUETYPE || !ValueTypePassFieldsAsArgs, "no value type here");
+  assert(bt != T_VALUETYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
   if (bt == T_VOID) {
     assert(prev_bt == T_LONG || prev_bt == T_DOUBLE, "missing half");
     return;
@@ -779,8 +779,8 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   __ bind(skip_fixup);
 
-  if (ValueTypePassFieldsAsArgs) {
-    // Is there a value type argument?
+  if (InlineTypePassFieldsAsArgs) {
+    // Is there an inline type argument?
     bool has_value_argument = false;
     for (int i = 0; i < sig_extended->length() && !has_value_argument; i++) {
       has_value_argument = (sig_extended->at(i)._bt == T_VALUETYPE);
@@ -860,7 +860,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     assert(next_arg_int <= total_args_passed, "more arguments for the interpreter than expected?");
     BasicType bt = sig_extended->at(next_arg_comp)._bt;
     int st_off = (total_args_passed - next_arg_int) * Interpreter::stackElementSize;
-    if (!ValueTypePassFieldsAsArgs || bt != T_VALUETYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_VALUETYPE) {
       if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
         continue; // Ignore reserved entry
       }
@@ -4422,7 +4422,7 @@ BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const
   }
   assert(j == regs->length(), "missed a field?");
 
-  if (StressValueTypeReturnedAsFields) {
+  if (StressInlineTypeReturnedAsFields) {
     __ load_klass(rax, rax);
     __ orptr(rax, 1);
   }

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -415,7 +415,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // handle return types different from T_INT
     __ BIND(is_value);
-    if (ValueTypeReturnedAsFields) {
+    if (InlineTypeReturnedAsFields) {
       // Check for flattened return value
       __ testptr(rax, 1);
       __ jcc(Assembler::zero, is_long);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,7 +206,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   // and NULL it as marker that esp is now tos until next java call
   __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), (int32_t)NULL_WORD);
 
-  if (state == atos && ValueTypeReturnedAsFields) {
+  if (state == atos && InlineTypeReturnedAsFields) {
     __ store_value_type_fields_to_buf(NULL);
   }
 

--- a/src/hotspot/cpu/zero/globals_zero.hpp
+++ b/src/hotspot/cpu/zero/globals_zero.hpp
@@ -70,8 +70,8 @@ define_pd_global(uintx, TypeProfileLevel, 0);
 
 define_pd_global(bool, PreserveFramePointer, false);
 
-define_pd_global(bool, ValueTypePassFieldsAsArgs, false);
-define_pd_global(bool, ValueTypeReturnedAsFields, false);
+define_pd_global(bool, InlineTypePassFieldsAsArgs, false);
+define_pd_global(bool, InlineTypeReturnedAsFields, false);
 
 // No performance work done here yet.
 define_pd_global(bool, CompactStrings, false);

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1044,7 +1044,7 @@ void LIR_OpJavaCall::emit_code(LIR_Assembler* masm) {
 }
 
 bool LIR_OpJavaCall::maybe_return_as_fields(ciValueKlass** vk_ret) const {
-  if (ValueTypeReturnedAsFields) {
+  if (InlineTypeReturnedAsFields) {
     if (method()->signature()->maybe_returns_never_null()) {
       ciType* return_type = method()->return_type();
       if (return_type->is_valuetype()) {

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -651,7 +651,7 @@ void LIR_Assembler::emit_std_entries() {
   _masm->align(CodeEntryAlignment);
   const CompiledEntrySignature* ces = compilation()->compiled_entry_signature();
   if (ces->has_scalarized_args()) {
-    assert(ValueTypePassFieldsAsArgs && method()->get_Method()->has_scalarized_args(), "must be");
+    assert(InlineTypePassFieldsAsArgs && method()->get_Method()->has_scalarized_args(), "must be");
     CodeOffsets::Entries ro_entry_type = ces->c1_value_ro_entry_type();
 
     // UEP: check icache and fall-through

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4419,8 +4419,8 @@ void ClassFileParser::layout_fields(ConstantPool* cp,
       }
       ValueKlass* vk = ValueKlass::cast(klass);
       // Conditions to apply flattening or not should be defined in a single place
-      bool too_big_to_flatten = (ValueFieldMaxFlatSize >= 0 &&
-                                 (vk->size_helper() * HeapWordSize) > ValueFieldMaxFlatSize);
+      bool too_big_to_flatten = (InlineFieldMaxFlatSize >= 0 &&
+                                 (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
       bool too_atomic_to_flatten = vk->is_declared_atomic();
       bool too_volatile_to_flatten = fs.access_flags().is_volatile();
       if (vk->is_naturally_atomic()) {
@@ -4875,7 +4875,7 @@ void ClassFileParser::layout_fields(ConstantPool* cp,
 
 #ifndef PRODUCT
   if ((PrintFieldLayout && !is_inline_type()) ||
-      (PrintValueLayout && (is_inline_type() || has_nonstatic_value_fields))) {
+      (PrintInlineLayout && (is_inline_type() || has_nonstatic_value_fields))) {
     print_field_layout(_class_name,
           _fields,
           cp,

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -630,8 +630,8 @@ void FieldLayoutBuilder::regular_field_sorting() {
                                                                 _protection_domain, true, THREAD);
         assert(klass != NULL, "Sanity check");
         ValueKlass* vk = ValueKlass::cast(klass);
-        bool too_big_to_flatten = (ValueFieldMaxFlatSize >= 0 &&
-                                   (vk->size_helper() * HeapWordSize) > ValueFieldMaxFlatSize);
+        bool too_big_to_flatten = (InlineFieldMaxFlatSize >= 0 &&
+                                   (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
         bool too_atomic_to_flatten = vk->is_declared_atomic();
         bool too_volatile_to_flatten = fs.access_flags().is_volatile();
         if (vk->is_naturally_atomic()) {
@@ -730,8 +730,8 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
                 _protection_domain, true, CHECK);
         assert(klass != NULL, "Sanity check");
         ValueKlass* vk = ValueKlass::cast(klass);
-        bool too_big_to_flatten = (ValueFieldMaxFlatSize >= 0 &&
-                                   (vk->size_helper() * HeapWordSize) > ValueFieldMaxFlatSize);
+        bool too_big_to_flatten = (InlineFieldMaxFlatSize >= 0 &&
+                                   (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
         bool too_atomic_to_flatten = vk->is_declared_atomic();
         bool too_volatile_to_flatten = fs.access_flags().is_volatile();
         if (vk->is_naturally_atomic()) {

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ ValueArrayKlass::ValueArrayKlass(Klass* element_klass, Symbol* name) : ArrayKlas
 
   CMH("tweak name symbol refcnt ?")
 #ifndef PRODUCT
-  if (PrintValueArrayLayout) {
+  if (PrintInlineArrayLayout) {
     print();
   }
 #endif
@@ -84,7 +84,7 @@ void ValueArrayKlass::set_element_klass(Klass* k) {
 ValueArrayKlass* ValueArrayKlass::allocate_klass(Klass* element_klass, TRAPS) {
   guarantee((!Universe::is_bootstrapping() || SystemDictionary::Object_klass_loaded()), "Really ?!");
   assert(ValueArrayFlatten, "Flatten array required");
-  assert(ValueKlass::cast(element_klass)->is_naturally_atomic() || (!ValueArrayAtomicAccess), "Atomic by-default");
+  assert(ValueKlass::cast(element_klass)->is_naturally_atomic() || (!InlineArrayAtomicAccess), "Atomic by-default");
 
   /*
    *  MVT->LWorld, now need to allocate secondaries array types, just like objArrayKlass...

--- a/src/hotspot/share/oops/valueKlass.cpp
+++ b/src/hotspot/share/oops/valueKlass.cpp
@@ -182,19 +182,19 @@ bool ValueKlass::flatten_array() {
   }
   // Too big
   int elem_bytes = raw_value_byte_size();
-  if ((ValueArrayElemMaxFlatSize >= 0) && (elem_bytes > ValueArrayElemMaxFlatSize)) {
+  if ((InlineArrayElemMaxFlatSize >= 0) && (elem_bytes > InlineArrayElemMaxFlatSize)) {
     return false;
   }
   // Too many embedded oops
-  if ((ValueArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > ValueArrayElemMaxFlatOops)) {
+  if ((InlineArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > InlineArrayElemMaxFlatOops)) {
     return false;
   }
   // Declared atomic but not naturally atomic.
   if (is_declared_atomic() && !is_naturally_atomic()) {
     return false;
   }
-  // VM enforcing ValueArrayAtomicAccess only...
-  if (ValueArrayAtomicAccess && (!is_naturally_atomic())) {
+  // VM enforcing InlineArrayAtomicAccess only...
+  if (InlineArrayAtomicAccess && (!is_naturally_atomic())) {
     return false;
   }
   return true;
@@ -316,7 +316,7 @@ void ValueKlass::initialize_calling_convention(TRAPS) {
   // Because the pack and unpack handler addresses need to be loadable from generated code,
   // they are stored at a fixed offset in the klass metadata. Since value type klasses do
   // not have a vtable, the vtable offset is used to store these addresses.
-  if (is_scalarizable() && (ValueTypeReturnedAsFields || ValueTypePassFieldsAsArgs)) {
+  if (is_scalarizable() && (InlineTypeReturnedAsFields || InlineTypePassFieldsAsArgs)) {
     ResourceMark rm;
     GrowableArray<SigEntry> sig_vk;
     int nb_fields = collect_fields(&sig_vk);
@@ -326,7 +326,7 @@ void ValueKlass::initialize_calling_convention(TRAPS) {
       extended_sig->at_put(i, sig_vk.at(i));
     }
 
-    if (ValueTypeReturnedAsFields) {
+    if (InlineTypeReturnedAsFields) {
       nb_fields++;
       BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, nb_fields);
       sig_bt[0] = T_METADATA;
@@ -377,9 +377,9 @@ void ValueKlass::cleanup_blobs() {
   }
 }
 
-// Can this value type be scalarized?
+// Can this inline type be scalarized?
 bool ValueKlass::is_scalarizable() const {
-  return ScalarizeValueTypes;
+  return ScalarizeInlineTypes;
 }
 
 // Can this value type be returned as multiple values?
@@ -419,7 +419,7 @@ void ValueKlass::save_oop_fields(const RegisterMap& reg_map, GrowableArray<Handl
 
 // Update oop fields in registers from handles after a safepoint
 void ValueKlass::restore_oop_results(RegisterMap& reg_map, GrowableArray<Handle>& handles) const {
-  assert(ValueTypeReturnedAsFields, "inconsistent");
+  assert(InlineTypeReturnedAsFields, "inconsistent");
   const Array<SigEntry>* sig_vk = extended_sig();
   const Array<VMRegPair>* regs = return_regs();
   assert(regs != NULL, "inconsistent");

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,7 @@ class DirectCallGenerator : public CallGenerator {
       _call_node(NULL),
       _separate_io_proj(separate_io_proj)
   {
-    if (ValueTypeReturnedAsFields && method->is_method_handle_intrinsic()) {
+    if (InlineTypeReturnedAsFields && method->is_method_handle_intrinsic()) {
       // If that call has not been optimized by the time optimizations are over,
       // we'll need to add a call to create a value type instance from the klass
       // returned by the call (see PhaseMacroExpand::expand_mh_intrinsic_return).

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -734,7 +734,7 @@ Node *CallNode::match(const ProjNode *proj, const Matcher *match, const RegMask*
     } else {
       // The Call may return multiple values (value type fields): we
       // create one projection per returned values.
-      assert(con <= TypeFunc::Parms+1 || ValueTypeReturnedAsFields, "only for multi value return");
+      assert(con <= TypeFunc::Parms+1 || InlineTypeReturnedAsFields, "only for multi value return");
       uint ideal_reg = range_cc->field_at(con)->ideal_reg();
       return new MachProjNode(this, con, mask[con-TypeFunc::Parms], ideal_reg);
     }

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -660,7 +660,7 @@ public:
   bool is_call_to_arraycopystub() const;
 
   virtual void copy_call_debug_info(PhaseIterGVN* phase, CallNode *oldcall) {}
-  
+
 #ifndef PRODUCT
   virtual void        dump_req(outputStream *st = tty) const;
   virtual void        dump_spec(outputStream *st) const;
@@ -733,7 +733,7 @@ public:
       C->add_macro_node(this);
     }
     const TypeTuple *r = tf->range_sig();
-    if (ValueTypeReturnedAsFields &&
+    if (InlineTypeReturnedAsFields &&
         method != NULL &&
         method->is_method_handle_intrinsic() &&
         r->cnt() > TypeFunc::Parms &&

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,7 +181,7 @@ RegMask* Matcher::return_values_mask(const TypeTuple *range) {
   }
   RegMask* mask = NEW_RESOURCE_ARRAY(RegMask, cnt);
 
-  if (!ValueTypeReturnedAsFields) {
+  if (!InlineTypeReturnedAsFields) {
     // Get ideal-register return type
     uint ireg = range->field_at(TypeFunc::Parms)->ideal_reg();
     // Get machine return register

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -933,7 +933,7 @@ void Compile::return_values(JVMState* jvms) {
       assert(res->is_ValueType(), "what else supports multi value return?");
       ValueTypeNode* vt = res->as_ValueType();
       ret->add_req_batch(NULL, tf()->range_cc()->cnt() - TypeFunc::Parms);
-      if (vt->is_allocated(&kit.gvn()) && !StressValueTypeReturnedAsFields) {
+      if (vt->is_allocated(&kit.gvn()) && !StressInlineTypeReturnedAsFields) {
         ret->init_req(TypeFunc::Parms, vt->get_oop());
       } else {
         ret->init_req(TypeFunc::Parms, vt->tagged_klass(kit.gvn()));

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2124,14 +2124,14 @@ bool Arguments::check_vm_args_consistency() {
 
   status = status && GCArguments::check_args_consistency();
 
-  if (AMD64_ONLY(false &&) !FLAG_IS_DEFAULT(ValueTypePassFieldsAsArgs)) {
-    FLAG_SET_CMDLINE(ValueTypePassFieldsAsArgs, false);
-    warning("ValueTypePassFieldsAsArgs is not supported on this platform");
+  if (AMD64_ONLY(false &&) !FLAG_IS_DEFAULT(InlineTypePassFieldsAsArgs)) {
+    FLAG_SET_CMDLINE(InlineTypePassFieldsAsArgs, false);
+    warning("InlineTypePassFieldsAsArgs is not supported on this platform");
   }
 
-  if (AMD64_ONLY(false &&) !FLAG_IS_DEFAULT(ValueTypeReturnedAsFields)) {
-    FLAG_SET_CMDLINE(ValueTypeReturnedAsFields, false);
-    warning("ValueTypeReturnedAsFields is not supported on this platform");
+  if (AMD64_ONLY(false &&) !FLAG_IS_DEFAULT(InlineTypeReturnedAsFields)) {
+    FLAG_SET_CMDLINE(InlineTypeReturnedAsFields, false);
+    warning("InlineTypeReturnedAsFields is not supported on this platform");
   }
 
   return status;
@@ -4139,8 +4139,8 @@ jint Arguments::apply_ergo() {
   }
   if (!EnableValhalla || (is_interpreter_only() && !is_dumping_archive())) {
     // Disable calling convention optimizations if value types are not supported
-    ValueTypePassFieldsAsArgs = false;
-    ValueTypeReturnedAsFields = false;
+    InlineTypePassFieldsAsArgs = false;
+    InlineTypeReturnedAsFields = false;
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -765,23 +765,23 @@ const size_t minimumSymbolTableSize = 1024;
   notproduct(bool, PrintFieldLayout, false,                                 \
           "Print field layout for each class")                              \
                                                                             \
-  notproduct(bool, PrintValueLayout, false,                                 \
-          "Print field layout for each value type")                         \
+  notproduct(bool, PrintInlineLayout, false,                                \
+          "Print field layout for each inline type")                        \
                                                                             \
-  notproduct(bool, PrintValueArrayLayout, false,                            \
-          "Print array layout for each value type array")                   \
+  notproduct(bool, PrintInlineArrayLayout, false,                           \
+          "Print array layout for each inline type array")                  \
                                                                             \
-  product(intx, ValueArrayElemMaxFlatSize, -1,                              \
-          "Max size for flattening value array elements, <0 no limit")      \
+  product(intx, InlineArrayElemMaxFlatSize, -1,                             \
+          "Max size for flattening inline array elements, <0 no limit")     \
                                                                             \
-  product(intx, ValueFieldMaxFlatSize, 128,                                 \
-          "Max size for flattening value type fields, <0 no limit")         \
+  product(intx, InlineFieldMaxFlatSize, 128,                                \
+          "Max size for flattening inline type fields, <0 no limit")        \
                                                                             \
-  product(intx, ValueArrayElemMaxFlatOops, 4,                               \
-          "Max nof embedded object references in a value type to flatten, <0 no limit")  \
+  product(intx, InlineArrayElemMaxFlatOops, 4,                              \
+          "Max nof embedded object references in an inline type to flatten, <0 no limit")  \
                                                                             \
-  product(bool, ValueArrayAtomicAccess, false,                              \
-          "Atomic value array accesses by-default, for all value arrays")   \
+  product(bool, InlineArrayAtomicAccess, false,                             \
+          "Atomic inline array accesses by-default, for all inline arrays") \
                                                                             \
   /* Need to limit the extent of the padding to reasonable size.          */\
   /* 8K is well beyond the reasonable HW cache line size, even with       */\
@@ -2498,17 +2498,17 @@ const size_t minimumSymbolTableSize = 1024;
   product(bool, EnableValhalla, true,                                       \
           "Enable experimental Valhalla features")                          \
                                                                             \
-  product_pd(bool, ValueTypePassFieldsAsArgs,                               \
-          "Pass each value type field as an argument at calls")             \
+  product_pd(bool, InlineTypePassFieldsAsArgs,                              \
+          "Pass each inline type field as an argument at calls")            \
                                                                             \
-  product_pd(bool, ValueTypeReturnedAsFields,                               \
-          "Return fields instead of a value type reference")                \
+  product_pd(bool, InlineTypeReturnedAsFields,                              \
+          "Return fields instead of an inline type reference")              \
                                                                             \
-  develop(bool, StressValueTypeReturnedAsFields, false,                     \
-          "Stress return of fields instead of a value type reference")      \
+  develop(bool, StressInlineTypeReturnedAsFields, false,                    \
+          "Stress return of fields instead of an inline type reference")    \
                                                                             \
-  develop(bool, ScalarizeValueTypes, true,                                  \
-          "Scalarize value types in compiled code")                         \
+  develop(bool, ScalarizeInlineTypes, true,                                 \
+          "Scalarize inline types in compiled code")                        \
                                                                             \
   diagnostic(ccstrlist, ForceNonTearable, "",                               \
           "List of inline classes which are forced to be atomic "           \

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -442,7 +442,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
 #endif
 
   jobject value_buffer = NULL;
-  if (ValueTypeReturnedAsFields && result->get_type() == T_VALUETYPE) {
+  if (InlineTypeReturnedAsFields && result->get_type() == T_VALUETYPE) {
     // Pre allocate buffered value in case the result is returned
     // flattened by compiled code
     ValueKlass* vk = method->returned_value_type(thread);

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -1044,7 +1044,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
     GrowableArray<Handle> return_values;
     ValueKlass* vk = NULL;
 
-    if (return_oop && ValueTypeReturnedAsFields) {
+    if (return_oop && InlineTypeReturnedAsFields) {
       SignatureStream ss(method->signature());
       while (!ss.at_return_type()) {
         ss.next();

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1220,9 +1220,9 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
 
 // TEMP!!!!
 // This should be removed after LW2 arrays are implemented (JDK-8220790).
-// It's an alias to (EnableValhalla && (ValueArrayElemMaxFlatSize != 0)),
+// It's an alias to (EnableValhalla && (InlineArrayElemMaxFlatSize != 0)),
 // which is actually not 100% correct, but works for the current set of C1/C2
 // implementation and test cases.
-#define ValueArrayFlatten (EnableValhalla && (ValueArrayElemMaxFlatSize != 0))
+#define ValueArrayFlatten (EnableValhalla && (InlineArrayElemMaxFlatSize != 0))
 
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
@@ -61,7 +61,7 @@ public class TestArrays extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:ValueArrayElemMaxFlatSize=-1", "-XX:-UncommonNullCast"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:InlineArrayElemMaxFlatSize=-1", "-XX:-UncommonNullCast"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast"};
         case 5: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
         }
@@ -1916,8 +1916,8 @@ public class TestArrays extends ValueTypeTest {
     }
 
     // Verify that writing an object of a non-flattenable inline type to an array marks the array as not-flat
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = ALLOCA_G + LOAD_UNKNOWN_VALUE + STORE_UNKNOWN_VALUE)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, failOn = ALLOC_G + ALLOCA_G + LOAD_UNKNOWN_VALUE + STORE_UNKNOWN_VALUE)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = ALLOCA_G + LOAD_UNKNOWN_VALUE + STORE_UNKNOWN_VALUE)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = ALLOC_G + ALLOCA_G + LOAD_UNKNOWN_VALUE + STORE_UNKNOWN_VALUE)
     public Object test82(Object[] array, NotFlattenable vt, Object o, int i) {
         array[0] = vt;
         array[1] = array[0];

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class TestBasicFunctionality extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-DVerifyIR=false"};
-        case 3: return new String[] {"-XX:ValueArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
         }
         return null;
     }
@@ -90,8 +90,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     }
 
     // Return incoming value type without accessing fields
-    @Test(valid = ValueTypePassFieldsAsArgsOn, match = {ALLOC, STORE}, matchCount = {1, 14}, failOn = LOAD + TRAP)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, failOn = ALLOC + LOAD + STORE + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, match = {ALLOC, STORE}, matchCount = {1, 14}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = ALLOC + LOAD + STORE + TRAP)
     public MyValue1 test3(MyValue1 v) {
         return v;
     }
@@ -139,8 +139,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
 
     // Create a value type in compiled code and pass it to
     // the interpreter via a call.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = LOAD + TRAP + ALLOC)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = LOAD + TRAP + ALLOC)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
     public long test6() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         // Pass to interpreter
@@ -185,8 +185,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     }
 
     // Merge value types created from two branches
-    @Test(valid = ValueTypePassFieldsAsArgsOn, match = {LOAD}, matchCount = {12}, failOn = TRAP + ALLOC + STORE)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, match = {ALLOC, STORE}, matchCount = {1, 12}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, match = {LOAD}, matchCount = {12}, failOn = TRAP + ALLOC + STORE)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC, STORE}, matchCount = {1, 12}, failOn = LOAD + TRAP)
     public MyValue1 test9(boolean b, int localrI, long localrL) {
         MyValue1 v;
         if (b) {
@@ -314,8 +314,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
 
     // Create a value type in a non-inlined method and then call a
     // non-inlined method on that value type.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = (ALLOC + STORE + TRAP), match = {LOAD}, matchCount = {12})
-    @Test(valid = ValueTypePassFieldsAsArgsOff, failOn = (ALLOC + LOAD + STORE + TRAP))
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = (ALLOC + STORE + TRAP), match = {LOAD}, matchCount = {12})
+    @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = (ALLOC + LOAD + STORE + TRAP))
     public long test14() {
         MyValue1 v = MyValue1.createWithFieldsDontInline(rI, rL);
         return v.hashInterpreted();
@@ -329,8 +329,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
 
     // Create a value type in an inlined method and then call a
     // non-inlined method on that value type.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = (LOAD + TRAP + ALLOC))
-    @Test(valid = ValueTypePassFieldsAsArgsOff, failOn = (LOAD + TRAP), match = {ALLOC}, matchCount = {1})
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = (LOAD + TRAP + ALLOC))
+    @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = (LOAD + TRAP), match = {ALLOC}, matchCount = {1})
     public long test15() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         return v.hashInterpreted();
@@ -373,8 +373,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     // Create a value type in compiled code and pass it to the
     // interpreter via a call. The value is live at the first call so
     // debug info should include a reference to all its fields.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = ALLOC + LOAD + TRAP)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = ALLOC + LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
     public long test18() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         v.hashInterpreted();
@@ -390,8 +390,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     // Create a value type in compiled code and pass it to the
     // interpreter via a call. The value type is passed twice but
     // should only be allocated once.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = ALLOC + LOAD + TRAP)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = ALLOC + LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD + TRAP)
     public long test19() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         return sumValue(v, v);
@@ -412,8 +412,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     // interpreter via a call. The value type is live at the uncommon
     // trap: verify that deoptimization causes the value type to be
     // correctly allocated.
-    @Test(valid = ValueTypePassFieldsAsArgsOn, failOn = LOAD + ALLOC + STORE)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = LOAD + ALLOC + STORE)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC}, matchCount = {1}, failOn = LOAD)
     public long test20(boolean deopt) {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         MyValue2[] va = new MyValue2[3];
@@ -631,8 +631,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     }
 
     // Verify that C2 recognizes value type loads and re-uses the oop to avoid allocations
-    @Test(valid = ValueTypeReturnedAsFieldsOn)
-    @Test(valid = ValueTypeReturnedAsFieldsOff, failOn = ALLOC + ALLOCA + STORE)
+    @Test(valid = InlineTypeReturnedAsFieldsOn)
+    @Test(valid = InlineTypeReturnedAsFieldsOff, failOn = ALLOC + ALLOCA + STORE)
     public MyValue3 test31(MyValue3[] va) {
         // C2 can re-use the oop returned by createDontInline()
         // because the corresponding value type is equal to 'copy'.
@@ -652,8 +652,8 @@ public class TestBasicFunctionality extends ValueTypeTest {
     }
 
     // Verify that C2 recognizes value type loads and re-uses the oop to avoid allocations
-    @Test(valid = ValueTypePassFieldsAsArgsOn)
-    @Test(valid = ValueTypePassFieldsAsArgsOff, failOn = ALLOC + ALLOCA + STORE)
+    @Test(valid = InlineTypePassFieldsAsArgsOn)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = ALLOC + ALLOCA + STORE)
     public MyValue3 test32(MyValue3 vt, MyValue3[] va) {
         // C2 can re-use the oop of vt because vt is equal to 'copy'.
         MyValue3 copy = MyValue3.copy(vt);

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
@@ -35,18 +35,18 @@ import jdk.internal.misc.Unsafe;
  * @summary Detect tearing on value type buffer writes due to missing barriers.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -XX:ValueFieldMaxFlatSize=0 -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:ValueFieldMaxFlatSize=0 -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:ValueFieldMaxFlatSize=0 -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:ValueFieldMaxFlatSize=0 -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
@@ -47,7 +47,7 @@ public class TestCallingConvention extends ValueTypeTest {
         switch (scenario) {
         case 0: return new String[] {"-Dsun.reflect.inflationThreshold=10000"}; // Don't generate bytecodes but call through runtime for reflective calls
         case 1: return new String[] {"-Dsun.reflect.inflationThreshold=10000"};
-        case 3: return new String[] {"-XX:ValueArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
         }
         return null;
     }
@@ -309,8 +309,8 @@ public class TestCallingConvention extends ValueTypeTest {
     }
 
     MyValue3 test15_vt2;
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + LOAD + TRAP)
-    @Test(valid = ValueTypeReturnedAsFieldsOff)
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + LOAD + TRAP)
+    @Test(valid = InlineTypeReturnedAsFieldsOff)
     public void test15() {
         test15_vt2 = test15_interp();
     }
@@ -323,8 +323,8 @@ public class TestCallingConvention extends ValueTypeTest {
 
     // Return value types in registers from compiled -> interpreter
     final MyValue3 test16_vt = MyValue3.create();
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + STORE + TRAP)
-    @Test(valid = ValueTypeReturnedAsFieldsOff)
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + STORE + TRAP)
+    @Test(valid = InlineTypeReturnedAsFieldsOff)
     public MyValue3 test16() {
         return test16_vt;
     }
@@ -343,8 +343,8 @@ public class TestCallingConvention extends ValueTypeTest {
     }
 
     MyValue3 test17_vt2;
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + LOAD + TRAP)
-    @Test(valid = ValueTypeReturnedAsFieldsOff)
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + LOAD + TRAP)
+    @Test(valid = InlineTypeReturnedAsFieldsOff)
     public void test17() {
         test17_vt2 = test17_comp();
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConventionC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConventionC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
                 "-XX:CICompilerCount=2",
                 "-XX:TieredStopAtLevel=4",
                 "-XX:+TieredCompilation",
-                "-XX:+StressValueTypeReturnedAsFields"
+                "-XX:+StressInlineTypeReturnedAsFields"
             };
         case 2: return new String[] {
                 // Same as above, but flip all the compLevel=C1 and compLevel=C2, so we test
@@ -439,7 +439,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
     static RefPoint refPointField2 = new RefPoint(56789, 0x12345678);
 
     // This inline class has too many fields to fit in registers on x64 for
-    // ValueTypeReturnedAsFields.
+    // InlineTypeReturnedAsFields.
     static inline class TooBigToReturnAsFields {
         int a0 = 0;
         int a1 = 1;
@@ -1586,9 +1586,9 @@ public class TestCallingConventionC1 extends ValueTypeTest {
     }
 
     //-------------------------------------------------------------------------------
-    // Tests for how C1 handles ValueTypeReturnedAsFields in both calls and returns
+    // Tests for how C1 handles InlineTypeReturnedAsFields in both calls and returns
     //-------------------------------------------------------------------------------
-    // C2->C1 invokestatic with ValueTypeReturnedAsFields (Point)
+    // C2->C1 invokestatic with InlineTypeReturnedAsFields (Point)
     @Test(compLevel = C2)
     public int test78(Point p) {
         Point np = test78_helper(p);
@@ -1608,7 +1608,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, n);
     }
 
-    // C2->C1 invokestatic with ValueTypeReturnedAsFields (RefPoint)
+    // C2->C1 invokestatic with InlineTypeReturnedAsFields (RefPoint)
     @Test(compLevel = C2)
     public int test79(RefPoint p) {
         RefPoint np = test79_helper(p);
@@ -1628,7 +1628,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, n);
     }
 
-    // C1->C2 invokestatic with ValueTypeReturnedAsFields (RefPoint)
+    // C1->C2 invokestatic with InlineTypeReturnedAsFields (RefPoint)
     @Test(compLevel = C1)
     public int test80(RefPoint p) {
         RefPoint np = test80_helper(p);
@@ -1648,7 +1648,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, n);
     }
 
-    // Interpreter->C1 invokestatic with ValueTypeReturnedAsFields (Point)
+    // Interpreter->C1 invokestatic with InlineTypeReturnedAsFields (Point)
     @Test(compLevel = C1)
     public Point test81(Point p) {
         return p;
@@ -1664,7 +1664,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(p.y, pointField2.y);
     }
 
-    // C1->Interpreter invokestatic with ValueTypeReturnedAsFields (RefPoint)
+    // C1->Interpreter invokestatic with InlineTypeReturnedAsFields (RefPoint)
     @Test(compLevel = C1)
     public int test82(RefPoint p) {
         RefPoint np = test82_helper(p);
@@ -1684,10 +1684,10 @@ public class TestCallingConventionC1 extends ValueTypeTest {
     }
 
     //-------------------------------------------------------------------------------
-    // Tests for ValueTypeReturnedAsFields vs the inline class TooBigToReturnAsFields
+    // Tests for InlineTypeReturnedAsFields vs the inline class TooBigToReturnAsFields
     //-------------------------------------------------------------------------------
 
-    // C2->C1 invokestatic with ValueTypeReturnedAsFields (TooBigToReturnAsFields)
+    // C2->C1 invokestatic with InlineTypeReturnedAsFields (TooBigToReturnAsFields)
     @Test(compLevel = C2)
     public int test83(TooBigToReturnAsFields p) {
         TooBigToReturnAsFields np = test83_helper(p);
@@ -1707,7 +1707,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, n);
     }
 
-    // C1->C2 invokestatic with ValueTypeReturnedAsFields (TooBigToReturnAsFields)
+    // C1->C2 invokestatic with InlineTypeReturnedAsFields (TooBigToReturnAsFields)
     @Test(compLevel = C1)
     public int test84(TooBigToReturnAsFields p) {
         TooBigToReturnAsFields np = test84_helper(p);
@@ -1727,7 +1727,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, n);
     }
 
-    // Interpreter->C1 invokestatic with ValueTypeReturnedAsFields (TooBigToReturnAsFields)
+    // Interpreter->C1 invokestatic with InlineTypeReturnedAsFields (TooBigToReturnAsFields)
     @Test(compLevel = C1)
     public TooBigToReturnAsFields test85(TooBigToReturnAsFields p) {
         return p;
@@ -1740,7 +1740,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(p.a2, tooBig.a2);
     }
 
-    // C1->Interpreter invokestatic with ValueTypeReturnedAsFields (TooBigToReturnAsFields)
+    // C1->Interpreter invokestatic with InlineTypeReturnedAsFields (TooBigToReturnAsFields)
     @Test(compLevel = C1)
     public int test86(TooBigToReturnAsFields p) {
         TooBigToReturnAsFields np = test86_helper(p);
@@ -1760,10 +1760,10 @@ public class TestCallingConventionC1 extends ValueTypeTest {
     }
 
     //-------------------------------------------------------------------------------
-    // Tests for how C1 handles ValueTypeReturnedAsFields in both calls and returns (RefPoint?)
+    // Tests for how C1 handles InlineTypeReturnedAsFields in both calls and returns (RefPoint?)
     //-------------------------------------------------------------------------------
 
-    // C2->C1 invokestatic with ValueTypeReturnedAsFields (RefPoint.ref)
+    // C2->C1 invokestatic with InlineTypeReturnedAsFields (RefPoint.ref)
     @Test(compLevel = C2)
     public RefPoint.ref test87(RefPoint.ref p) {
         return test87_helper(p);
@@ -1781,7 +1781,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, null);
     }
 
-    // C2->C1 invokestatic with ValueTypeReturnedAsFields (RefPoint.ref with constant null)
+    // C2->C1 invokestatic with InlineTypeReturnedAsFields (RefPoint.ref with constant null)
     @Test(compLevel = C2)
     public RefPoint.ref test88() {
         return test88_helper();
@@ -1799,7 +1799,7 @@ public class TestCallingConventionC1 extends ValueTypeTest {
         Asserts.assertEQ(result, null);
     }
 
-    // C1->C2 invokestatic with ValueTypeReturnedAsFields (RefPoint.ref)
+    // C1->C2 invokestatic with InlineTypeReturnedAsFields (RefPoint.ref)
     @Test(compLevel = C1)
     public RefPoint.ref test89(RefPoint.ref p) {
         return test89_helper(p);

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
@@ -44,32 +44,32 @@ import sun.hotspot.WhiteBox;
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:-ValueTypePassFieldsAsArgs -XX:-ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:-ValueTypePassFieldsAsArgs -XX:-ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+ValueTypePassFieldsAsArgs -XX:+ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+ValueTypePassFieldsAsArgs -XX:+ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+ValueTypePassFieldsAsArgs -XX:+ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=-1 -XX:ValueFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+ValueTypePassFieldsAsArgs -XX:+ValueTypeReturnedAsFields -XX:ValueArrayElemMaxFlatSize=-1 -XX:ValueFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  */

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @summary Test accessing value type arrays that exceed the flattening threshold.
  * @library /test/lib
  * @run main/othervm -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:ValueArrayElemMaxFlatOops=1 -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:ValueArrayElemMaxFlatSize=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:InlineArrayElemMaxFlatOops=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:InlineArrayElemMaxFlatSize=1 -Xbatch TestFlatArrayThreshold
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
@@ -49,7 +49,7 @@ public class TestIntrinsics extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:ValueArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:InlineArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
@@ -50,7 +50,7 @@ public class TestLWorld extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-DVerifyIR=false", "-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:ValueArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:InlineArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestMethodHandles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,8 +146,8 @@ public class TestMethodHandles extends ValueTypeTest {
 
     static final MethodHandle test1_mh;
 
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + STORE + CALL)
-    @Test(valid = ValueTypeReturnedAsFieldsOff, match = { ALLOC, STORE }, matchCount = { 1, 14 })
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + STORE + CALL)
+    @Test(valid = InlineTypeReturnedAsFieldsOff, match = { ALLOC, STORE }, matchCount = { 1, 14 })
     public MyValue3 test1() throws Throwable {
         return (MyValue3)test1_mh.invokeExact(this);
     }
@@ -274,8 +274,8 @@ public class TestMethodHandles extends ValueTypeTest {
 
     static final MethodHandle test6_mh;
 
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + ALLOCA + STORE + STOREVALUETYPEFIELDS)
-    @Test(valid = ValueTypeReturnedAsFieldsOff)
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + ALLOCA + STORE + STOREVALUETYPEFIELDS)
+    @Test(valid = InlineTypeReturnedAsFieldsOff)
     public MyValue3 test6() throws Throwable {
         return (MyValue3)test6_mh.invokeExact(this);
     }
@@ -387,8 +387,8 @@ public class TestMethodHandles extends ValueTypeTest {
 
     static final MethodHandle test9_mh;
 
-    @Test(valid = ValueTypeReturnedAsFieldsOn, failOn = ALLOC + ALLOCA + STORE + STOREVALUETYPEFIELDS)
-    @Test(valid = ValueTypeReturnedAsFieldsOff)
+    @Test(valid = InlineTypeReturnedAsFieldsOn, failOn = ALLOC + ALLOCA + STORE + STOREVALUETYPEFIELDS)
+    @Test(valid = InlineTypeReturnedAsFieldsOff)
     public MyValue3 test9() throws Throwable {
         return (MyValue3)test9_mh.invokeExact(this);
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
@@ -47,7 +47,7 @@ public class TestNullableValueTypes extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:ValueArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:InlineArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
@@ -43,7 +43,7 @@ public class TestOnStackReplacement extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:ValueArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
@@ -29,22 +29,22 @@
  * @run main/othervm -Xcomp
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:InlineArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:ValueArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:InlineArrayElemMaxFlatSize=0
  *                   TestUnloadedValueTypeArray
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class TestUnloadedValueTypeField extends compiler.valhalla.valuetypes.Val
 
     static final String[][] scenarios = {
         {},
-        {"-XX:ValueFieldMaxFlatSize=0"}
+        {"-XX:InlineFieldMaxFlatSize=0"}
     };
 
     @Override

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnresolvedValueClass.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnresolvedValueClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class TestUnresolvedValueClass {
             }
 
             // Run test in new VM instance
-            String[] arg = {"-XX:+ValueTypePassFieldsAsArgs", "TestUnresolvedValueClass", "run"};
+            String[] arg = {"-XX:+InlineTypePassFieldsAsArgs", "TestUnresolvedValueClass", "run"};
             OutputAnalyzer oa = ProcessTools.executeTestJvm(arg);
 
             // Adapter creation for TestUnresolvedValueClass::test1 should fail with a

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
@@ -163,12 +163,12 @@ public abstract class ValueTypeTest {
         "-XX:+VerifyOops", "-XX:+VerifyStack", "-XX:+VerifyLastFrame", "-XX:+VerifyBeforeGC", "-XX:+VerifyAfterGC",
         "-XX:+VerifyDuringGC", "-XX:+VerifyAdapterSharing"};
 
-    protected static final int ValueTypePassFieldsAsArgsOn = 0x1;
-    protected static final int ValueTypePassFieldsAsArgsOff = 0x2;
+    protected static final int InlineTypePassFieldsAsArgsOn = 0x1;
+    protected static final int InlineTypePassFieldsAsArgsOff = 0x2;
     protected static final int ValueTypeArrayFlattenOn = 0x4;
     protected static final int ValueTypeArrayFlattenOff = 0x8;
-    protected static final int ValueTypeReturnedAsFieldsOn = 0x10;
-    protected static final int ValueTypeReturnedAsFieldsOff = 0x20;
+    protected static final int InlineTypeReturnedAsFieldsOn = 0x10;
+    protected static final int InlineTypeReturnedAsFieldsOff = 0x20;
     protected static final int AlwaysIncrementalInlineOn = 0x40;
     protected static final int AlwaysIncrementalInlineOff = 0x80;
     protected static final int G1GCOn = 0x100;
@@ -179,9 +179,9 @@ public abstract class ValueTypeTest {
     protected static final int ArrayLoadStoreProfileOff = 0x2000;
     protected static final int TypeProfileOn = 0x4000;
     protected static final int TypeProfileOff = 0x8000;
-    protected static final boolean ValueTypePassFieldsAsArgs = (Boolean)WHITE_BOX.getVMFlag("ValueTypePassFieldsAsArgs");
-    protected static final boolean ValueTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("ValueArrayElemMaxFlatSize") == -1); // FIXME - fix this if default of ValueArrayElemMaxFlatSize is changed
-    protected static final boolean ValueTypeReturnedAsFields = (Boolean)WHITE_BOX.getVMFlag("ValueTypeReturnedAsFields");
+    protected static final boolean InlineTypePassFieldsAsArgs = (Boolean)WHITE_BOX.getVMFlag("InlineTypePassFieldsAsArgs");
+    protected static final boolean ValueTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("InlineArrayElemMaxFlatSize") == -1); // FIXME - fix this if default of InlineArrayElemMaxFlatSize is changed
+    protected static final boolean InlineTypeReturnedAsFields = (Boolean)WHITE_BOX.getVMFlag("InlineTypeReturnedAsFields");
     protected static final boolean AlwaysIncrementalInline = (Boolean)WHITE_BOX.getVMFlag("AlwaysIncrementalInline");
     protected static final boolean G1GC = (Boolean)WHITE_BOX.getVMFlag("UseG1GC");
     protected static final boolean ZGC = (Boolean)WHITE_BOX.getVMFlag("UseZGC");
@@ -257,54 +257,54 @@ public abstract class ValueTypeTest {
         case 0: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:ValueArrayElemMaxFlatOops=5",
-                "-XX:ValueArrayElemMaxFlatSize=-1",
-                "-XX:ValueFieldMaxFlatSize=-1",
-                "-XX:+ValueTypePassFieldsAsArgs",
-                "-XX:+ValueTypeReturnedAsFields"};
+                "-XX:InlineArrayElemMaxFlatOops=5",
+                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:+InlineTypePassFieldsAsArgs",
+                "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:ValueArrayElemMaxFlatOops=5",
-                "-XX:ValueArrayElemMaxFlatSize=-1",
-                "-XX:ValueFieldMaxFlatSize=-1",
-                "-XX:-ValueTypePassFieldsAsArgs",
-                "-XX:-ValueTypeReturnedAsFields"};
+                "-XX:InlineArrayElemMaxFlatOops=5",
+                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:-InlineTypePassFieldsAsArgs",
+                "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:ValueArrayElemMaxFlatOops=0",
-                "-XX:ValueArrayElemMaxFlatSize=0",
-                "-XX:ValueFieldMaxFlatSize=-1",
-                "-XX:+ValueTypePassFieldsAsArgs",
-                "-XX:+ValueTypeReturnedAsFields",
-                "-XX:+StressValueTypeReturnedAsFields"};
+                "-XX:InlineArrayElemMaxFlatOops=0",
+                "-XX:InlineArrayElemMaxFlatSize=0",
+                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:+InlineTypePassFieldsAsArgs",
+                "-XX:+InlineTypeReturnedAsFields",
+                "-XX:+StressInlineTypeReturnedAsFields"};
         case 3: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:ValueArrayElemMaxFlatOops=0",
-                "-XX:ValueArrayElemMaxFlatSize=0",
-                "-XX:ValueFieldMaxFlatSize=0",
-                "-XX:+ValueTypePassFieldsAsArgs",
-                "-XX:+ValueTypeReturnedAsFields"};
+                "-XX:InlineArrayElemMaxFlatOops=0",
+                "-XX:InlineArrayElemMaxFlatSize=0",
+                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:+InlineTypePassFieldsAsArgs",
+                "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
-                "-XX:ValueArrayElemMaxFlatOops=-1",
-                "-XX:ValueArrayElemMaxFlatSize=-1",
-                "-XX:ValueFieldMaxFlatSize=0",
-                "-XX:+ValueTypePassFieldsAsArgs",
-                "-XX:-ValueTypeReturnedAsFields",
+                "-XX:InlineArrayElemMaxFlatOops=-1",
+                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:+InlineTypePassFieldsAsArgs",
+                "-XX:-InlineTypeReturnedAsFields",
                 "-XX:-ReduceInitialCardMarks"};
         case 5: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:ValueArrayElemMaxFlatOops=5",
-                "-XX:ValueArrayElemMaxFlatSize=-1",
-                "-XX:ValueFieldMaxFlatSize=-1",
-                "-XX:-ValueTypePassFieldsAsArgs",
-                "-XX:-ValueTypeReturnedAsFields"};
+                "-XX:InlineArrayElemMaxFlatOops=5",
+                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:-InlineTypePassFieldsAsArgs",
+                "-XX:-InlineTypeReturnedAsFields"};
         }
         return null;
     }
@@ -473,12 +473,12 @@ public abstract class ValueTypeTest {
         private final BooleanSupplier predicate;
 
         private static final TestAnnotation testAnnotations[] = {
-            new TestAnnotation(ValueTypePassFieldsAsArgsOn, () -> ValueTypePassFieldsAsArgs),
-            new TestAnnotation(ValueTypePassFieldsAsArgsOff, () -> !ValueTypePassFieldsAsArgs),
+            new TestAnnotation(InlineTypePassFieldsAsArgsOn, () -> InlineTypePassFieldsAsArgs),
+            new TestAnnotation(InlineTypePassFieldsAsArgsOff, () -> !InlineTypePassFieldsAsArgs),
             new TestAnnotation(ValueTypeArrayFlattenOn, () -> ValueTypeArrayFlatten),
             new TestAnnotation(ValueTypeArrayFlattenOff, () -> !ValueTypeArrayFlatten),
-            new TestAnnotation(ValueTypeReturnedAsFieldsOn, () -> ValueTypeReturnedAsFields),
-            new TestAnnotation(ValueTypeReturnedAsFieldsOff, () -> !ValueTypeReturnedAsFields),
+            new TestAnnotation(InlineTypeReturnedAsFieldsOn, () -> InlineTypeReturnedAsFields),
+            new TestAnnotation(InlineTypeReturnedAsFieldsOff, () -> !InlineTypeReturnedAsFields),
             new TestAnnotation(AlwaysIncrementalInlineOn, () -> AlwaysIncrementalInline),
             new TestAnnotation(AlwaysIncrementalInlineOff, () -> !AlwaysIncrementalInline),
             new TestAnnotation(G1GCOn, () -> G1GC),

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/FlattenableSemanticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,11 +36,11 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator Point.java JumboValue.java
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator FlattenableSemanticTest.java
- * @run main/othervm -Xint -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
+ * @run main/othervm -Xint -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
  * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.FlattenableSemanticTest
- * @run main/othervm -Xcomp -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
+ * @run main/othervm -Xcomp -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.valuetypes.FlattenableSemanticTest
  * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.FlattenableSemanticTest
- * // debug: -XX:+PrintValueLayout -XX:-ShowMessageBoxOnError
+ * // debug: -XX:+PrintInlineLayout -XX:-ShowMessageBoxOnError
  */
 public class FlattenableSemanticTest {
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestFieldNullability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestFieldNullability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test TestFieldNullability
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator TestFieldNullability.java
- * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError -XX:ValueFieldMaxFlatSize=32
+ * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError -XX:InlineFieldMaxFlatSize=32
  *                   runtime.valhalla.valuetypes.TestFieldNullability
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
@@ -40,8 +40,8 @@ import jdk.internal.vm.jni.SubElementSelector;
  * @requires (os.simpleArch == "x64")
  * @requires (os.family == "linux" | os.family == "mac")
  * @compile -XDallowWithFieldOperator TestJNIArrays.java
- * @run main/othervm/native/timeout=3000 -XX:ValueArrayElemMaxFlatSize=128 -XX:+PrintFlattenableLayouts -XX:+UseCompressedOops TestJNIArrays
- * @run main/othervm/native/timeout=3000 -XX:ValueArrayElemMaxFlatSize=128 -XX:+PrintFlattenableLayouts -XX:-UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:InlineArrayElemMaxFlatSize=128 -XX:+PrintFlattenableLayouts -XX:+UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:InlineArrayElemMaxFlatSize=128 -XX:+PrintFlattenableLayouts -XX:-UseCompressedOops TestJNIArrays
  */
 public class TestJNIArrays {
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/UninitializedValueFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/UninitializedValueFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,8 @@ import jdk.test.lib.Asserts;
  * @summary Uninitialized inline fields test
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator -XDallowFlattenabilityModifiers Point.java JumboValue.java UninitializedValueFieldsTest.java
- * @run main/othervm -Xint -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.UninitializedValueFieldsTest
- * @run main/othervm -Xcomp -XX:ValueFieldMaxFlatSize=64 runtime.valhalla.valuetypes.UninitializedValueFieldsTest
+ * @run main/othervm -Xint -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.valuetypes.UninitializedValueFieldsTest
+ * @run main/othervm -Xcomp -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.valuetypes.UninitializedValueFieldsTest
  */
 public class UninitializedValueFieldsTest {
     static Point.ref nonFlattenableStaticPoint;

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -35,10 +35,10 @@ import static jdk.test.lib.Asserts.*;
  * @summary Plain array test for Inline Types
  * @library /test/lib
  * @compile ValueTypeArray.java Point.java Long8Value.java Person.java
- * @run main/othervm -Xint  -XX:ValueArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xint  -XX:ValueArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:InlineArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:InlineArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.ValueTypeArray
  */
 public class ValueTypeArray {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
@@ -33,10 +33,10 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator ValueTypeDensity.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xint -XX:ValueArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xint -XX:InlineArrayElemMaxFlatSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI ValueTypeDensity
- * @run main/othervm -Xcomp -XX:ValueArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI ValueTypeDensity
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions
@@ -49,8 +49,8 @@ public class ValueTypeDensity {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     public ValueTypeDensity() {
-        if (WHITE_BOX.getIntxVMFlag("ValueArrayElemMaxFlatSize") != -1) {
-            throw new IllegalStateException("ValueArrayElemMaxFlatSize should be -1");
+        if (WHITE_BOX.getIntxVMFlag("InlineArrayElemMaxFlatSize") != -1) {
+            throw new IllegalStateException("InlineArrayElemMaxFlatSize should be -1");
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -25,8 +25,8 @@
 /*
  * @test
  * @summary test VarHandle on inline class array
- * @run testng/othervm -XX:ValueArrayElemMaxFlatSize=-1 ArrayElementVarHandleTest
- * @run testng/othervm -XX:ValueArrayElemMaxFlatSize=0  ArrayElementVarHandleTest
+ * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=-1 ArrayElementVarHandleTest
+ * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=0  ArrayElementVarHandleTest
  */
 
 import java.lang.invoke.*;

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary test Object methods on inline types
  * @run testng/othervm -Xint -Dvalue.bsm.salt=1 ObjectMethods
  * @run testng/othervm -Xcomp -Dvalue.bsm.salt=1 ObjectMethods
- * @run testng/othervm -Dvalue.bsm.salt=1 -XX:ValueFieldMaxFlatSize=0 ObjectMethods
+ * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
  */
 
 import java.lang.reflect.Modifier;

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
- * @run testng/othervm -XX:ValueArrayElemMaxFlatSize=-1 ValueArray
- * @run testng/othervm -XX:ValueArrayElemMaxFlatSize=0  ValueArray
+ * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=-1 ValueArray
+ * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=0  ValueArray
  */
 
 import java.lang.reflect.Array;


### PR DESCRIPTION
Rename hotspot -XX value type related options to have 'inline type' in their names instead of 'value type'.  Also, changed associated comments.
The changes were tested with mach5 tiers 1-3.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/64/head:pull/64`
`$ git checkout pull/64`
