### PR TITLE
[lworld] Incorrect renaming of ValueFieldMaxFlat size in compiler tests

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
@@ -259,7 +259,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
@@ -267,7 +267,7 @@ public abstract class ValueTypeTest {
                 "-XX:-UseCompressedOops",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
@@ -275,7 +275,7 @@ public abstract class ValueTypeTest {
                 "-XX:-UseCompressedOops",
                 "-XX:InlineArrayElemMaxFlatOops=0",
                 "-XX:InlineArrayElemMaxFlatSize=0",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields",
                 "-XX:+StressInlineTypeReturnedAsFields"};
@@ -285,7 +285,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=0",
                 "-XX:InlineArrayElemMaxFlatSize=0",
-                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
@@ -293,7 +293,7 @@ public abstract class ValueTypeTest {
                 "-DVerifyIR=false",
                 "-XX:InlineArrayElemMaxFlatOops=-1",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields",
                 "-XX:-ReduceInitialCardMarks"};
@@ -302,7 +302,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         }


### PR DESCRIPTION
Renamed to InlineFieldMaxFlatSize.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/72/head:pull/72`
`$ git checkout pull/72`
