### PR TITLE
8247309: [lworld] C1 crashes when compiling _defaultvalue referencing unresolved inline type

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2414,8 +2414,8 @@ void GraphBuilder::new_instance(int klass_index) {
 
 void GraphBuilder::default_value(int klass_index) {
   bool will_link;
-  ciValueKlass* vk = stream()->get_klass(will_link)->as_value_klass();
   if (!stream()->is_unresolved_klass()) {
+    ciValueKlass* vk = stream()->get_klass(will_link)->as_value_klass();
     apush(append(new Constant(new InstanceConstant(vk->default_value_instance()))));
   } else {
     ValueStack* state_before = copy_state_before();

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnresolvedDefault.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnresolvedDefault.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8247309
+ * @summary Test correct handling of defaultvalue bytecode with unresolved inline class.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestUnresolvedDefault::test TestUnresolvedDefault
+ */
+
+public class TestUnresolvedDefault {
+
+    static inline class UnresolvedInline {
+        int x = 42;
+    }
+
+    static int test() {
+        return UnresolvedInline.default.x;
+    }
+
+    static public void main(String[] args) {
+        test();
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
@@ -259,7 +259,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
@@ -267,7 +267,7 @@ public abstract class ValueTypeTest {
                 "-XX:-UseCompressedOops",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
@@ -275,7 +275,7 @@ public abstract class ValueTypeTest {
                 "-XX:-UseCompressedOops",
                 "-XX:InlineArrayElemMaxFlatOops=0",
                 "-XX:InlineArrayElemMaxFlatSize=0",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields",
                 "-XX:+StressInlineTypeReturnedAsFields"};
@@ -285,7 +285,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=0",
                 "-XX:InlineArrayElemMaxFlatSize=0",
-                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
@@ -293,7 +293,7 @@ public abstract class ValueTypeTest {
                 "-DVerifyIR=false",
                 "-XX:InlineArrayElemMaxFlatOops=-1",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=0",
+                "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields",
                 "-XX:-ReduceInitialCardMarks"};
@@ -302,7 +302,7 @@ public abstract class ValueTypeTest {
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:InlineArrayElemMaxFlatOops=5",
                 "-XX:InlineArrayElemMaxFlatSize=-1",
-                "-XX:InlineFiledMaxFlatSize=-1",
+                "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         }


### PR DESCRIPTION
Should only cast to value klass after we've checked for unresolved klass.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247309](https://bugs.openjdk.java.net/browse/JDK-8247309): [lworld] C1 crashes when compiling _defaultvalue referencing unresolved inline type


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/73/head:pull/73`
`$ git checkout pull/73`
