### PR TITLE
8247238: [lworld] JIT should trust final fields in inline type buffers

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1814,7 +1814,12 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         if (!const_oop->is_null_object() && const_oop->is_loaded()) {
           ciConstant field_value = field->constant_value_of(const_oop);
           if (field_value.is_valid()) {
-            constant = make_constant(field_value, field);
+            if (field->is_flattenable() && field_value.is_null_or_zero()) {
+              // Non-flattened but flattenable inline type field. Replace null by the default value.
+              constant = new Constant(new InstanceConstant(field->type()->as_value_klass()->default_value_instance()));
+            } else {
+              constant = make_constant(field_value, field);
+            }
             // For CallSite objects add a dependency for invalidation of the optimization.
             if (field->is_call_site_target()) {
               ciCallSite* call_site = const_oop->as_call_site();

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -229,7 +229,8 @@ ciField::ciField(ciField* field, ciInstanceKlass* holder, int offset, bool is_fi
   _name = field->_name;
   _signature = field->_signature;
   _type = field->_type;
-  _is_constant = field->_is_constant;
+  // Trust final flattened fields
+  _is_constant = is_final;
   _known_to_link_with_put = field->_known_to_link_with_put;
   _known_to_link_with_get = field->_known_to_link_with_get;
   _constant_value = field->_constant_value;
@@ -253,6 +254,9 @@ static bool trust_final_non_static_fields(ciInstanceKlass* holder) {
   // Lookup.defineHiddenClass or the private jdk.internal.misc.Unsafe API and
   // can't be serialized, so there is no hacking of finals going on with them.
   if (holder->is_hidden() || holder->is_unsafe_anonymous())
+    return true;
+  // Trust final fields in inline type buffers
+  if (holder->is_valuetype())
     return true;
   // Trust final fields in all boxed classes
   if (holder->is_box_klass())

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4581,7 +4581,8 @@ Node* GraphKit::make_constant_from_field(ciField* field, Node* obj) {
                                                         /*is_unsigned_load=*/false);
   if (con_type != NULL) {
     Node* con = makecon(con_type);
-    if (field->layout_type() == T_VALUETYPE && field->type()->as_value_klass()->is_scalarizable() && !con_type->maybe_null()) {
+    assert(!field->is_flattenable() || (field->is_static() && !con_type->is_zero_type()), "sanity");
+    if (field->layout_type() == T_VALUETYPE && field->type()->as_value_klass()->is_scalarizable()) {
       // Load value type from constant oop
       con = ValueTypeNode::make_from_oop(this, con, field->type()->as_value_klass());
     }


### PR DESCRIPTION
Constant fold field loads from inline type buffers (only affects/helps C1 since C2 aggressively scalarizes anyway).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247238](https://bugs.openjdk.java.net/browse/JDK-8247238): [lworld] JIT should trust final fields in inline type buffers


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/75/head:pull/75`
`$ git checkout pull/75`
