### PR TITLE
8247578: [lworld] New inlined JVM internal field access constant in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -458,7 +458,7 @@ final class MemberName implements Member, Cloneable {
     static final int SYNTHETIC   = 0x00001000;
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
-    static final int FLATTENED   = 0x00008000;
+    static final int FLATTENED   = 0x00004000;
 
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isBridge() {

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -332,7 +332,7 @@ public class Modifier {
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
     static final int MANDATED    = 0x00008000;
-    static final int FLATTENED   = 0x00008000;      // HotSpot-specific bit
+    static final int FLATTENED   = 0x00004000;      // HotSpot-specific bit
     static boolean isSynthetic(int mod) {
       return (mod & SYNTHETIC) != 0;
     }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -177,13 +177,13 @@ public final class Unsafe {
     @HotSpotIntrinsicCandidate
     public native void putInt(Object o, long offset, int x);
 
-    private static final int JVM_ACC_FLATTENED = 0x00008000; // HotSpot-specific bit
+    private static final int JVM_ACC_FIELD_INLINED = 0x00004000; // HotSpot-specific bit
 
     /**
      * Returns true if the given field is flattened.
      */
     public boolean isFlattened(Field f) {
-        return (f.getModifiers() & JVM_ACC_FLATTENED) == JVM_ACC_FLATTENED;
+        return (f.getModifiers() & JVM_ACC_FIELD_INLINED) == JVM_ACC_FIELD_INLINED;
     }
 
     /**


### PR DESCRIPTION
Changed the flattened field access constant to JVM_ACC_FIELD_INLINED
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247578](https://bugs.openjdk.java.net/browse/JDK-8247578): [lworld] New inlined JVM internal field access constant in java.base


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/80/head:pull/80`
`$ git checkout pull/80`
