### PR TITLE
8247567: [lworld] java.lang.AssertionError: Invalid pool entry

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/StaticSelectedThroughProjection.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/StaticSelectedThroughProjection.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8247567
+ * @summary Javac chokes on static member selection via the reference projection.
+ * @run main StaticSelectedThroughProjection
+ */
+
+public class StaticSelectedThroughProjection {
+    static inline class MyValue {
+        int x = 42;
+        static String test() {
+            return "OK";
+        };
+    }
+    public static void main(String[] args) {
+        if (!MyValue.ref.test().equals("OK"))
+            throw new AssertionError("Broken");
+    }
+}


### PR DESCRIPTION
This patch fixes problems in static member access via reference projection type,
by rewriting V.ref.staticMethod() to be V.staticMethod()
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247567](https://bugs.openjdk.java.net/browse/JDK-8247567): [lworld] java.lang.AssertionError: Invalid pool entry


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/81/head:pull/81`
`$ git checkout pull/81`
