### PR TITLE
8247590: [lworld] JVM_ACC_FIELD_INLINED clashes with ENUM

### DIFF
--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -86,7 +86,7 @@ enum {
   JVM_ACC_FIELD_STABLE                    = 0x00000020, // @Stable field, same as JVM_ACC_SYNCHRONIZED and JVM_ACC_SUPER
   JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE  = 0x00000200, // (static) final field updated outside (class) initializer, same as JVM_ACC_NATIVE
   JVM_ACC_FIELD_HAS_GENERIC_SIGNATURE     = 0x00000800, // field has generic signature
-  JVM_ACC_FIELD_INLINED                   = 0x00004000, // field is inlined
+  JVM_ACC_FIELD_INLINED                   = 0x00008000, // field is inlined
 
   JVM_ACC_FIELD_INTERNAL_FLAGS       = JVM_ACC_FIELD_ACCESS_WATCHED |
                                        JVM_ACC_FIELD_MODIFICATION_WATCHED |

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -458,7 +458,7 @@ final class MemberName implements Member, Cloneable {
     static final int SYNTHETIC   = 0x00001000;
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
-    static final int FLATTENED   = 0x00004000;
+    static final int FLATTENED   = 0x00008000;
 
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isBridge() {

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -332,7 +332,7 @@ public class Modifier {
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
     static final int MANDATED    = 0x00008000;
-    static final int FLATTENED   = 0x00004000;      // HotSpot-specific bit
+    static final int FLATTENED   = 0x00008000;      // HotSpot-specific bit
     static boolean isSynthetic(int mod) {
       return (mod & SYNTHETIC) != 0;
     }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -177,7 +177,7 @@ public final class Unsafe {
     @HotSpotIntrinsicCandidate
     public native void putInt(Object o, long offset, int x);
 
-    private static final int JVM_ACC_FIELD_INLINED = 0x00004000; // HotSpot-specific bit
+    private static final int JVM_ACC_FIELD_INLINED = 0x00008000; // HotSpot-specific bit
 
     /**
      * Returns true if the given field is flattened.


### PR DESCRIPTION
Went back to 0x8000 as previous
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247590](https://bugs.openjdk.java.net/browse/JDK-8247590): [lworld] JVM_ACC_FIELD_INLINED clashes with ENUM


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/82/head:pull/82`
`$ git checkout pull/82`
