### PR TITLE
8247664: [lworld] Bogus error message: incompatible types while using separate compilation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -303,8 +303,27 @@ public class ClassReader {
     private void enterMember(ClassSymbol c, Symbol sym) {
         // Synthetic members are not entered -- reason lost to history (optimization?).
         // Lambda methods must be entered because they may have inner classes (which reference them)
-        if ((sym.flags_field & (SYNTHETIC|BRIDGE)) != SYNTHETIC || sym.name.startsWith(names.lambda))
+        ClassSymbol refProjection =  c.isValue() ? c.referenceProjection() : null;
+        if ((sym.flags_field & (SYNTHETIC|BRIDGE)) != SYNTHETIC || sym.name.startsWith(names.lambda)) {
             c.members_field.enter(sym);
+            if (refProjection != null) {
+                Symbol clone = null;
+                if (sym.kind == MTH) {
+                    MethodSymbol valMethod = (MethodSymbol)sym;
+                    MethodSymbol refMethod = valMethod.clone(refProjection);
+                    valMethod.projection = refMethod;
+                    refMethod.projection = valMethod;
+                    clone = refMethod;
+                } else if (sym.kind == VAR) {
+                    VarSymbol valVar = (VarSymbol)sym;
+                    VarSymbol refVar = valVar.clone(refProjection);
+                    valVar.projection = refVar;
+                    refVar.projection = valVar;
+                    clone = refVar;
+                }
+                refProjection.members_field.enter(clone);
+            }
+        }
     }
 
 /************************************************************************
@@ -2466,6 +2485,10 @@ public class ClassReader {
     }
 
     protected ClassSymbol enterClass(Name name) {
+        if (allowInlineTypes && name.toString().endsWith("$ref")) {
+            ClassSymbol v = syms.enterClass(currentModule, name.subName(0, name.length() - 4));
+            return v.referenceProjection();
+        }
         return syms.enterClass(currentModule, name);
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8247664
+ * @summary Bogus error message: incompatible types while using separate compilation.
+ * @compile SeparateCompileTest01.java
+ * @run main SeparateCompileTest
+ */
+
+public class SeparateCompileTest {
+    public static void main(String[] args) {
+        Pointer<Point.ref> p_ref = Point.TYPE.allocate();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest01.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest01.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @bug 8247664
+ * @summary Bogus error message: incompatible types while using separate compilation.
+ */
+
+class Pointer<X> {
+    final long addr;
+
+    public Pointer(long addr) {
+        this.addr = addr;
+    }
+}
+
+class ForeignType<X> {
+    public Pointer<X> allocate() { return null; }
+}
+
+inline class Point {
+    final int x;
+    final int y;
+
+    public Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public static ForeignType<Point.ref> TYPE = new ForeignType<>() { };
+}


### PR DESCRIPTION
Add support for reference projection materailization from binary artifacts.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247664](https://bugs.openjdk.java.net/browse/JDK-8247664): [lworld] Bogus error message: incompatible types while using separate compilation


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/84/head:pull/84`
`$ git checkout pull/84`
