### PR TITLE
8244561: [lworld] Javac should not allow instantiation of V.ref or V.val

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2721,6 +2721,14 @@ public class Attr extends JCTree.Visitor {
             boolean isSpeculativeDiamondInferenceRound = TreeInfo.isDiamond(tree) &&
                     resultInfo.checkContext.deferredAttrContext().mode == DeferredAttr.AttrMode.SPECULATIVE;
             boolean skipNonDiamondPath = false;
+            // Check that it is an instantiation of a class and not a projection type
+            if (clazz.hasTag(SELECT)) {
+                JCFieldAccess fieldAccess = (JCFieldAccess) clazz;
+                if (fieldAccess.selected.type.isValue() &&
+                        (fieldAccess.name == names.ref || fieldAccess.name == names.val)) {
+                    log.error(tree.pos(), Errors.ProjectionCantBeInstantiated);
+                }
+            }
             // Check that class is not abstract
             if (cdef == null && !isSpeculativeDiamondInferenceRound && // class body may be nulled out in speculative tree copy
                 (clazztype.tsym.flags() & (ABSTRACT | INTERFACE)) != 0) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3795,5 +3795,6 @@ compiler.err.super.class.declares.init.block=\
 compiler.err.super.class.cannot.be.inner=\
     The super class {1} of the inline class {0} is an inner class. This is disallowed.
 
-
+compiler.err.projection.cant.be.instantiated=\
+    Illegal attempt to instantiate a projection type
 

--- a/test/langtools/tools/javac/diags/examples/ProjectionCantBeInstantiated.java
+++ b/test/langtools/tools/javac/diags/examples/ProjectionCantBeInstantiated.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.projection.cant.be.instantiated
+
+public inline class ProjectionCantBeInstantiated {
+    int x = 42;
+    public static void main(String[] args) {
+        new ProjectionCantBeInstantiated();
+        new ProjectionCantBeInstantiated.ref();
+        new ProjectionCantBeInstantiated.val();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
@@ -1,0 +1,15 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8244561
+ * @summary Javac should not allow instantiation of V.ref or V.val
+ * @compile/fail/ref=ProjectionInstantiationTest.out -XDrawDiagnostics ProjectionInstantiationTest.java
+ */
+
+final inline class ProjectionInstantiationTest {
+    int x = 42;
+    public static void main(String[] args) {
+        new ProjectionInstantiationTest();
+        new ProjectionInstantiationTest.ref();
+        new ProjectionInstantiationTest.val();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.out
@@ -1,0 +1,3 @@
+ProjectionInstantiationTest.java:12:9: compiler.err.projection.cant.be.instantiated
+ProjectionInstantiationTest.java:13:9: compiler.err.projection.cant.be.instantiated
+2 errors


### PR DESCRIPTION
Instantiation semantics requires a class and projections are types and so are
disallowed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244561](https://bugs.openjdk.java.net/browse/JDK-8244561): [lworld] Javac should not allow instantiation of V.ref or V.val


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/85/head:pull/85`
`$ git checkout pull/85`
