### PR TITLE
8247686: [lworld] C2 compilation fails with assert(!is_default(*igvn)) failed: default value type allocation

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4672,7 +4672,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
       if (!stopped()) {
         Node* obj_length = load_array_length(obj);
         Node* obj_size  = NULL;
-        Node* alloc_obj = new_array(obj_klass, obj_length, 0, &obj_size, true);  // no arguments to push
+        Node* alloc_obj = new_array(obj_klass, obj_length, 0, &obj_size, /*deoptimize_on_exception=*/true);
 
         BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
         if (bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, BarrierSetC2::Parsing)) {
@@ -4688,7 +4688,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
             ac->set_clone_oop_array();
             Node* n = _gvn.transform(ac);
             assert(n == ac, "cannot disappear");
-            ac->connect_outputs(this);
+            ac->connect_outputs(this, /*deoptimize_on_exception=*/true);
 
             result_reg->init_req(_objArray_path, control());
             result_val->init_req(_objArray_path, alloc_obj);


### PR DESCRIPTION
We need to handle dead (default) inline type allocations in ValueTypeNode::Ideal and remove membars in PhaseMacroExpand::process_users_of_allocation.

I've also fixed a failed merge of JDK-8246453 (see library_call.cpp changes):
https://hg.openjdk.java.net/jdk/jdk/rev/6a4bdf4655ce
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247686](https://bugs.openjdk.java.net/browse/JDK-8247686): [lworld] C2 compilation fails with assert(!is_default(*igvn)) failed: default value type allocation


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/86/head:pull/86`
`$ git checkout pull/86`
