### PR TITLE
8247746: [lworld] TestNullableArray::test78 fails with ZGC due to incorrect result

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -94,7 +94,6 @@ void Parse::array_load(BasicType bt) {
     // Cannot statically determine if array is flattened, emit runtime check
     assert(ValueArrayFlatten && is_reference_type(bt) && elemptr->can_be_value_type() && !ary_t->klass_is_exact() && !ary_t->is_not_null_free() &&
            (!elemptr->is_valuetypeptr() || elemptr->value_klass()->flatten_array()), "array can't be flattened");
-    Node* ctl = control();
     IdealKit ideal(this);
     IdealVariable res(ideal);
     ideal.declarations_done();
@@ -104,7 +103,7 @@ void Parse::array_load(BasicType bt) {
       sync_kit(ideal);
       const TypeAryPtr* adr_type = TypeAryPtr::get_array_body_type(bt);
       Node* ld = access_load_at(ary, adr, adr_type, elemptr, bt,
-                                IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD, ctl);
+                                IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD);
       ideal.sync_kit(this);
       ideal.set(res, ld);
     } ideal.else_(); {


### PR DESCRIPTION
A missing control dependency between an oop load from an array and the corresponding "is-not-flat" check led to re-ordering of the load to before the check. Although the result is only used in the "not-flat" case, ZGC load barriers are still executed on that "oop" that is actually a non-oop field of the flattened inline type array element. In rare cases, the following barrier code screws up the contents of that field:

#0  0x00007fa990daf32e in Atomic::PlatformCmpxchg<8ul>::operator()<unsigned long> (this=<optimized out>, exchange_value=<optimized out>, compare_value=<optimized out>, 
    dest=0x100000f17350) at /oracle/valhalla_int/open/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp:126
#1  Atomic::CmpxchgImpl<unsigned long, unsigned long, unsigned long, void>::operator() (this=<optimized out>, order=memory_order_conservative, exchange_value=21990232555242, 
    compare_value=<optimized out>, dest=0x100000f17350) at /oracle/valhalla_int/open/src/hotspot/share/runtime/atomic.hpp:745
#2  Atomic::cmpxchg<unsigned long, unsigned long, unsigned long> (order=memory_order_conservative, exchange_value=21990232555242, compare_value=<optimized out>, dest=0x100000f17350)
    at /oracle/valhalla_int/open/src/hotspot/share/runtime/atomic.hpp:721
#3  ZBarrier::self_heal<&ZBarrier::is_good_or_null_fast_path> (heal_addr=<optimized out>, addr=<optimized out>, p=0x100000f17350)
    at /oracle/valhalla_int/open/src/hotspot/share/gc/z/zBarrier.inline.hpp:120
#4  ZBarrier::self_heal<&ZBarrier::is_good_or_null_fast_path> (heal_addr=<optimized out>, addr=<optimized out>, p=0x100000f17350)
    at /oracle/valhalla_int/open/src/hotspot/share/gc/z/zBarrier.inline.hpp:106
#5  ZBarrier::barrier<&ZBarrier::is_good_or_null_fast_path, &ZBarrier::load_barrier_on_oop_slow_path> (o=..., p=<optimized out>)
    at /oracle/valhalla_int/open/src/hotspot/share/gc/z/zBarrier.inline.hpp:152
#6  ZBarrier::load_barrier_on_oop_field_preloaded (o=..., p=0x100000f17350) at /oracle/valhalla_int/open/src/hotspot/share/gc/z/zBarrier.inline.hpp:236
#7  ZBarrierSetRuntime::load_barrier_on_oop_field_preloaded (o=<optimized out>, p=0x100000f17350) at /oracle/valhalla_int/open/src/hotspot/share/gc/z/zBarrierSetRuntime.cpp:30
#8  0x00007fa9851a8774 in ?? ()
#9  0x0000000000000000 in ?? ()
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247746](https://bugs.openjdk.java.net/browse/JDK-8247746): [lworld] TestNullableArray::test78 fails with ZGC due to incorrect result


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/87/head:pull/87`
`$ git checkout pull/87`
