### PR TITLE
8248003: [lworld] [lw3] VM crashes when classes with inline type fields are loaded from CDS archive

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3616,7 +3616,7 @@ void MacroAssembler::zero_memory(Register address, Register length_in_bytes, int
 }
 
 void MacroAssembler::get_value_field_klass(Register klass, Register index, Register value_klass) {
-  movptr(value_klass, Address(klass, InstanceKlass::value_field_klasses_offset()));
+  movptr(value_klass, Address(klass, InstanceKlass::inline_type_field_klasses_offset()));
 #ifdef ASSERT
   {
     Label done;

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -552,7 +552,7 @@ GrowableArray<ciField*>* ciInstanceKlass::compute_nonstatic_fields_impl(Growable
       // Value type fields are embedded
       int field_offset = fd.offset();
       // Get ValueKlass and adjust number of fields
-      Klass* k = get_instanceKlass()->get_value_field_klass(fd.index());
+      Klass* k = get_instanceKlass()->get_inline_type_field_klass(fd.index());
       ciValueKlass* vk = CURRENT_ENV->get_klass(k)->as_value_klass();
       flen += vk->nof_nonstatic_fields() - 1;
       // Iterate over fields of the flattened value type and copy them to 'this'

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -852,7 +852,7 @@ class CompileReplay : public StackObj {
         break;
       }
       case T_VALUETYPE: {
-        ValueKlass* vk = ValueKlass::cast(fd->field_holder()->get_value_field_klass(fd->index()));
+        ValueKlass* vk = ValueKlass::cast(fd->field_holder()->get_inline_type_field_klass(fd->index()));
         if (fd->is_inlined()) {
           int field_offset = fd->offset() - vk->first_field_offset();
           oop obj = (oop)(cast_from_oop<address>(_vt) + field_offset);

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6432,7 +6432,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   int nfields = ik->java_fields_count();
   if (ik->is_inline_klass()) nfields++;
   for (int i = 0; i < nfields; i++) {
-    if (ik->field_is_inline_type(i)) {
+    if (ik->field_is_inline_type(i) && ((ik->field_access_flags(i) & JVM_ACC_STATIC) == 0)) {
       Symbol* klass_name = ik->field_signature(i)->fundamental_name(CHECK);
       // Inline classes for instance fields must have been pre-loaded
       // Inline classes for static fields might not have been loaded yet
@@ -6441,7 +6441,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
           Handle(THREAD, ik->protection_domain()), CHECK);
       if (klass != NULL) {
         assert(klass->access_flags().is_inline_type(), "Inline type expected");
-        ik->set_value_field_klass(i, klass);
+        ik->set_inline_type_field_klass(i, klass);
       }
       klass_name->decrement_refcount();
     } else

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -321,7 +321,7 @@ bool FieldLayout::reconstruct_layout(const InstanceKlass* ik) {
       has_instance_fields = true;
       LayoutRawBlock* block;
       if (type == T_VALUETYPE) {
-        ValueKlass* vk = ValueKlass::cast(ik->get_value_field_klass(fs.index()));
+        ValueKlass* vk = ValueKlass::cast(ik->get_inline_type_field_klass(fs.index()));
         block = new LayoutRawBlock(fs.index(), LayoutRawBlock::INHERITED, vk->get_exact_size_in_bytes(),
                                    vk->get_alignment(), false);
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1071,6 +1071,8 @@ void java_lang_Class::create_mirror(Klass* k, Handle class_loader,
         // set the reference projection type
         set_ref_type_mirror(mirror(), ref_type_oop);
 
+        assert(oopDesc::is_oop(ref_type_oop), "Sanity check");
+
         // set the value and reference projection types
         set_val_type_mirror(ref_type_oop, mirror());
         set_ref_type_mirror(ref_type_oop, ref_type_oop);
@@ -1128,6 +1130,7 @@ class ResetMirrorField: public FieldClosure {
       case T_BOOLEAN:
         _m()->bool_field_put(fd->offset(), false);
         break;
+      case T_VALUETYPE:
       case T_ARRAY:
       case T_OBJECT: {
         // It might be useful to cache the String field, but

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1493,8 +1493,6 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
             // oops, the app has substituted a different version of k!
             return NULL;
           }
-        } else {
-         ik->reset_inline_type_field_klass(fs.index());
         }
       }
     }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -70,7 +70,7 @@
 #include "oops/oopHandle.inline.hpp"
 #include "oops/symbol.hpp"
 #include "oops/typeArrayKlass.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/valueKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/arguments.hpp"

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1480,6 +1480,26 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
     return NULL;
   }
 
+
+  if (ik->has_inline_type_fields()) {
+    for (AllFieldStream fs(ik->fields(), ik->constants()); !fs.done(); fs.next()) {
+      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+        if (!fs.access_flags().is_static()) {
+          // Pre-load inline class
+          Klass* real_k = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
+            class_loader, protection_domain, true, CHECK_NULL);
+          Klass* k = ik->get_inline_type_field_klass_or_null(fs.index());
+          if (real_k != k) {
+            // oops, the app has substituted a different version of k!
+            return NULL;
+          }
+        } else {
+         ik->reset_inline_type_field_klass(fs.index());
+        }
+      }
+    }
+  }
+
   InstanceKlass* new_ik = NULL;
   // CFLH check is skipped for VM hidden or anonymous classes (see KlassFactory::create_from_stream).
   // It will be skipped for shared VM hidden lambda proxy classes.
@@ -1516,6 +1536,13 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   }
 
   load_shared_class_misc(ik, loader_data, CHECK_NULL);
+
+  if (ik->is_inline_klass()) {
+    ValueKlass* vk = ValueKlass::cast(ik);
+    oop val = ik->allocate_instance(CHECK_NULL);
+    vk->set_default_value(val);
+  }
+
   return ik;
 }
 
@@ -1576,6 +1603,21 @@ void SystemDictionary::quick_resolve(InstanceKlass* klass, ClassLoaderData* load
     InstanceKlass* ik = ifs->at(i);
     if (ik->class_loader_data()  == NULL) {
       quick_resolve(ik, loader_data, domain, CHECK);
+    }
+  }
+
+  if (klass->has_inline_type_fields()) {
+    for (AllFieldStream fs(klass->fields(), klass->constants()); !fs.done(); fs.next()) {
+      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+        if (!fs.access_flags().is_static()) {
+          Klass* real_k = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
+            Handle(THREAD, loader_data->class_loader()), domain, true, CHECK);
+          Klass* k = klass->get_inline_type_field_klass_or_null(fs.index());
+          assert(real_k == k, "oops, the app has substituted a different version of k!");
+        } else {
+          klass->reset_inline_type_field_klass(fs.index());
+        }
+      }
     }
   }
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -355,7 +355,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
     if (cp_entry->is_inlined()) {
       oop vt_oop = *(oop*)f.interpreter_frame_expression_stack_at(tos_idx);
       assert(vt_oop != NULL && oopDesc::is_oop(vt_oop) && vt_oop->is_inline_type(),"argument must be an inline type");
-      ValueKlass* field_vk = ValueKlass::cast(vklass->get_value_field_klass(field_index));
+      ValueKlass* field_vk = ValueKlass::cast(vklass->get_inline_type_field_klass(field_index));
       assert(vt_oop != NULL && field_vk == vt_oop->klass(), "Must match");
       field_vk->write_inlined_field(new_value_h(), offset, vt_oop, CHECK_(return_offset));
     } else { // not inlined
@@ -392,14 +392,14 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_value_field(JavaThread*
   InstanceKlass* klass = InstanceKlass::cast(java_lang_Class::as_Klass(mirror));
   if (klass->is_being_initialized() && klass->is_reentrant_initialization(THREAD)) {
     int offset = klass->field_offset(index);
-    Klass* field_k = klass->get_value_field_klass_or_null(index);
+    Klass* field_k = klass->get_inline_type_field_klass_or_null(index);
     if (field_k == NULL) {
       field_k = SystemDictionary::resolve_or_fail(klass->field_signature(index)->fundamental_name(THREAD),
           Handle(THREAD, klass->class_loader()),
           Handle(THREAD, klass->protection_domain()),
           true, CHECK);
       assert(field_k != NULL, "Should have been loaded or an exception thrown above");
-      klass->set_value_field_klass(index, field_k);
+      klass->set_inline_type_field_klass(index, field_k);
     }
     field_k->initialize(CHECK);
     oop defaultvalue = ValueKlass::cast(field_k)->default_value();
@@ -435,7 +435,7 @@ JRT_ENTRY(void, InterpreterRuntime::read_inlined_field(JavaThread* thread, oopDe
 
   assert(klass->field_is_inlined(index), "Sanity check");
 
-  ValueKlass* field_vklass = ValueKlass::cast(klass->get_value_field_klass(index));
+  ValueKlass* field_vklass = ValueKlass::cast(klass->get_inline_type_field_klass(index));
   assert(field_vklass->is_initialized(), "Must be initialized at this point");
 
   oop res = field_vklass->read_inlined_field(obj_h(), klass->field_offset(index), CHECK);

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -565,7 +565,7 @@ static void print_inlined_field(outputStream* st, int level, int offset, Instanc
         fd.is_inline_type(), fd.holder()->field_is_inlined(fd.index()));
     if (fd.holder()->field_is_inlined(fd.index())) {
       print_inlined_field(st, level + 1, offset2 ,
-          InstanceKlass::cast(fd.holder()->get_value_field_klass(fd.index())));
+          InstanceKlass::cast(fd.holder()->get_inline_type_field_klass(fd.index())));
     }
   }
 }
@@ -606,7 +606,7 @@ void PrintClassLayout::print_class_layout(outputStream* st, char* class_name) {
       print_field(st, 0, fd.offset(), fd, fd.is_inline_type(), fd.holder()->field_is_inlined(fd.index()));
       if (fd.holder()->field_is_inlined(fd.index())) {
         print_inlined_field(st, 1, fd.offset(),
-            InstanceKlass::cast(fd.holder()->get_value_field_klass(fd.index())));
+            InstanceKlass::cast(fd.holder()->get_inline_type_field_klass(fd.index())));
       }
     }
   }

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -402,6 +402,7 @@ void ConstantPool::remove_unshareable_info() {
   _flags |= (_on_stack | _is_shared);
   int num_klasses = 0;
   for (int index = 1; index < length(); index++) { // Index 0 is unused
+    jbyte qdesc_bit = tag_at(index).is_Qdescriptor_klass() ? (jbyte) JVM_CONSTANT_QDescBit : 0;
     if (!DynamicDumpSharedSpaces) {
       assert(!tag_at(index).is_unresolved_klass_in_error(), "This must not happen during static dump time");
     } else {
@@ -409,7 +410,7 @@ void ConstantPool::remove_unshareable_info() {
           tag_at(index).is_method_handle_in_error()    ||
           tag_at(index).is_method_type_in_error()      ||
           tag_at(index).is_dynamic_constant_in_error()) {
-        tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
+        tag_at_put(index, JVM_CONSTANT_UnresolvedClass | qdesc_bit);
       }
     }
     if (tag_at(index).is_klass()) {
@@ -429,7 +430,7 @@ void ConstantPool::remove_unshareable_info() {
         int name_index = kslot.name_index();
         assert(tag_at(name_index).is_symbol(), "sanity");
         resolved_klasses()->at_put(resolved_klass_index, NULL);
-        tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
+        tag_at_put(index, JVM_CONSTANT_UnresolvedClass | qdesc_bit);
         assert(klass_name_at(index) == symbol_at(name_index), "sanity");
       }
     }
@@ -564,7 +565,11 @@ Klass* ConstantPool::klass_at_impl(const constantPoolHandle& this_cp, int which,
   // to resolve this constant pool entry fail with the same error (JVMS 5.4.3).
   if (HAS_PENDING_EXCEPTION) {
     if (save_resolution_error) {
-      save_and_throw_exception(this_cp, which, constantTag(JVM_CONSTANT_UnresolvedClass), CHECK_NULL);
+      jbyte tag = JVM_CONSTANT_UnresolvedClass;
+      if (this_cp->tag_at(which).is_Qdescriptor_klass()) {
+        tag |= JVM_CONSTANT_QDescBit;
+      }
+      save_and_throw_exception(this_cp, which, constantTag(tag), CHECK_NULL);
       // If CHECK_NULL above doesn't return the exception, that means that
       // some other thread has beaten us and has resolved the class.
       // To preserve old behavior, we return the resolved class.

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -55,6 +55,7 @@ class RecordComponent;
 //    [EMBEDDED implementor of the interface] only exist for interface
 //    [EMBEDDED unsafe_anonymous_host klass] only exist for an unsafe anonymous class (JSR 292 enabled)
 //    [EMBEDDED fingerprint       ] only if should_store_fingerprint()==true
+//    [EMBEDDED inline_type_field_klasses] only if has_inline_fields() == true
 //    [EMBEDDED ValueKlassFixedBlock] only if is a ValueKlass instance
 
 
@@ -225,8 +226,6 @@ class InstanceKlass: public Klass {
   // By always being set it makes nest-member access checks simpler.
   InstanceKlass* _nest_host;
 
-  Array<InlineTypes>* _inline_types;
-
   // The PermittedSubclasses attribute. An array of shorts, where each is a
   // class info index for the class that is a permitted subclass.
   Array<jushort>* _permitted_subclasses;
@@ -295,7 +294,7 @@ class InstanceKlass: public Klass {
     _misc_has_resolved_methods                = 1 << 13, // resolved methods table entries added for this class
     _misc_is_being_redefined                  = 1 << 14, // used for locking redefinition
     _misc_has_contended_annotations           = 1 << 15,  // has @Contended annotation
-    _misc_has_inline_fields                   = 1 << 16, // has inline fields and related embedded section is not empty
+    _misc_has_inline_type_fields              = 1 << 16, // has inline fields and related embedded section is not empty
     _misc_is_empty_inline_type                = 1 << 17, // empty inline type
     _misc_is_naturally_atomic                 = 1 << 18, // loaded/stored in one instruction
     _misc_is_declared_atomic                  = 1 << 19, // implements jl.NonTearable
@@ -358,7 +357,7 @@ class InstanceKlass: public Klass {
   //     [generic signature index]
   //     ...
   Array<u2>*      _fields;
-  const Klass**   _value_field_klasses; // For "inline class" fields, NULL if none present
+  const Klass**   _inline_type_field_klasses; // For "inline class" fields, NULL if none present
 
   const ValueKlassFixedBlock* _adr_valueklass_fixed_block;
 
@@ -421,11 +420,11 @@ class InstanceKlass: public Klass {
     }
   }
 
-  bool has_inline_fields() const          {
-    return (_misc_flags & _misc_has_inline_fields) != 0;
+  bool has_inline_type_fields() const          {
+    return (_misc_flags & _misc_has_inline_type_fields) != 0;
   }
-  void set_has_inline_fields()  {
-    _misc_flags |= _misc_has_inline_fields;
+  void set_has_inline_type_fields()  {
+    _misc_flags |= _misc_has_inline_type_fields;
   }
 
   bool is_empty_inline_type() const {
@@ -1140,7 +1139,7 @@ public:
   JFR_ONLY(DEFINE_KLASS_TRACE_ID_OFFSET;)
   static ByteSize init_thread_offset() { return in_ByteSize(offset_of(InstanceKlass, _init_thread)); }
 
-  static ByteSize value_field_klasses_offset() { return in_ByteSize(offset_of(InstanceKlass, _value_field_klasses)); }
+  static ByteSize inline_type_field_klasses_offset() { return in_ByteSize(offset_of(InstanceKlass, _inline_type_field_klasses)); }
   static ByteSize adr_valueklass_fixed_block_offset() { return in_ByteSize(offset_of(InstanceKlass, _adr_valueklass_fixed_block)); }
 
   // subclass/subinterface checks
@@ -1217,7 +1216,7 @@ public:
                                                is_interface(),
                                                is_unsafe_anonymous(),
                                                has_stored_fingerprint(),
-                                               has_inline_fields() ? java_fields_count() : 0,
+                                               has_inline_type_fields() ? java_fields_count() : 0,
                                                is_inline_klass());
   }
 
@@ -1278,8 +1277,8 @@ public:
     }
   }
 
-  address adr_value_fields_klasses() const {
-    if (has_inline_fields()) {
+  address adr_inline_type_field_klasses() const {
+    if (has_inline_type_fields()) {
       address adr_fing = adr_fingerprint();
       if (adr_fing != NULL) {
         return adr_fingerprint() + sizeof(u8);
@@ -1301,26 +1300,35 @@ public:
     }
   }
 
-  Klass* get_value_field_klass(int idx) const {
-    assert(has_inline_fields(), "Sanity checking");
-    Klass* k = ((Klass**)adr_value_fields_klasses())[idx];
+  Klass* get_inline_type_field_klass(int idx) const {
+    assert(has_inline_type_fields(), "Sanity checking");
+    assert(idx < java_fields_count(), "IOOB");
+    Klass* k = ((Klass**)adr_inline_type_field_klasses())[idx];
     assert(k != NULL, "Should always be set before being read");
     assert(k->is_inline_klass(), "Must be a inline type");
     return k;
   }
 
-  Klass* get_value_field_klass_or_null(int idx) const {
-    assert(has_inline_fields(), "Sanity checking");
-    Klass* k = ((Klass**)adr_value_fields_klasses())[idx];
+  Klass* get_inline_type_field_klass_or_null(int idx) const {
+    assert(has_inline_type_fields(), "Sanity checking");
+    assert(idx < java_fields_count(), "IOOB");
+    Klass* k = ((Klass**)adr_inline_type_field_klasses())[idx];
     assert(k == NULL || k->is_inline_klass(), "Must be a inline type");
     return k;
   }
 
-  void set_value_field_klass(int idx, Klass* k) {
-    assert(has_inline_fields(), "Sanity checking");
+  void set_inline_type_field_klass(int idx, Klass* k) {
+    assert(has_inline_type_fields(), "Sanity checking");
+    assert(idx < java_fields_count(), "IOOB");
     assert(k != NULL, "Should not be set to NULL");
-    assert(((Klass**)adr_value_fields_klasses())[idx] == NULL, "Should not be set twice");
-    ((Klass**)adr_value_fields_klasses())[idx] = k;
+    assert(((Klass**)adr_inline_type_field_klasses())[idx] == NULL, "Should not be set twice");
+    ((Klass**)adr_inline_type_field_klasses())[idx] = k;
+  }
+
+  void reset_inline_type_field_klass(int idx) {
+    assert(has_inline_type_fields(), "Sanity checking");
+    assert(idx < java_fields_count(), "IOOB");
+    ((Klass**)adr_inline_type_field_klasses())[idx] = NULL;
   }
 
   // Use this to return the size of an instance in heap words:

--- a/src/hotspot/share/oops/valueKlass.cpp
+++ b/src/hotspot/share/oops/valueKlass.cpp
@@ -215,8 +215,6 @@ void ValueKlass::remove_unshareable_info() {
 
 void ValueKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS) {
   InstanceKlass::restore_unshareable_info(loader_data, protection_domain, pkg_entry, CHECK);
-  oop val = allocate_instance(CHECK);
-  set_default_value(val);
 }
 
 
@@ -299,7 +297,7 @@ int ValueKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
     int offset = base_off + fs.offset() - (base_off > 0 ? first_field_offset() : 0);
     if (fs.is_inlined()) {
       // Resolve klass of inlined field and recursively collect fields
-      Klass* vk = get_value_field_klass(fs.index());
+      Klass* vk = get_inline_type_field_klass(fs.index());
       count += ValueKlass::cast(vk)->collect_fields(sig, offset);
     } else {
       BasicType bt = Signature::basic_type(fs.signature());

--- a/src/hotspot/share/oops/valueKlass.hpp
+++ b/src/hotspot/share/oops/valueKlass.hpp
@@ -46,7 +46,7 @@ class ValueKlass: public InstanceKlass {
   ValueKlass(const ClassFileParser& parser);
 
   ValueKlassFixedBlock* valueklass_static_block() const {
-    address adr_jf = adr_value_fields_klasses();
+    address adr_jf = adr_inline_type_field_klasses();
     if (adr_jf != NULL) {
       return (ValueKlassFixedBlock*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
     }

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1967,7 +1967,7 @@ JNI_ENTRY(jobject, jni_GetObjectField(JNIEnv *env, jobject obj, jfieldID fieldID
     fieldDescriptor fd;
     ik->find_field_from_offset(offset, false, &fd);  // performance bottleneck
     InstanceKlass* holder = fd.field_holder();
-    ValueKlass* field_vklass = ValueKlass::cast(holder->get_value_field_klass(fd.index()));
+    ValueKlass* field_vklass = ValueKlass::cast(holder->get_inline_type_field_klass(fd.index()));
     res = field_vklass->read_inlined_field(o, ik->field_offset(fd.index()), CHECK_NULL);
   }
   jobject ret = JNIHandles::make_local(env, res);
@@ -2076,7 +2076,7 @@ JNI_ENTRY_NO_PRESERVE(void, jni_SetObjectField(JNIEnv *env, jobject obj, jfieldI
     fieldDescriptor fd;
     ik->find_field_from_offset(offset, false, &fd);
     InstanceKlass* holder = fd.field_holder();
-    ValueKlass* vklass = ValueKlass::cast(holder->get_value_field_klass(fd.index()));
+    ValueKlass* vklass = ValueKlass::cast(holder->get_inline_type_field_klass(fd.index()));
     oop v = JNIHandles::resolve_non_null(value);
     vklass->write_inlined_field(o, offset, v, CHECK);
   }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1286,7 +1286,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         }
         if (fs.is_inlined()) {
           // Resolve klass of flattened value type field
-          Klass* vk = klass->get_value_field_klass(fs.index());
+          Klass* vk = klass->get_inline_type_field_klass(fs.index());
           field._klass = ValueKlass::cast(vk);
           field._type = T_VALUETYPE;
         }

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -193,7 +193,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
     case T_VALUETYPE:
       if (is_inlined()) {
         // Print fields of inlined fields (recursively)
-        ValueKlass* vk = ValueKlass::cast(field_holder()->get_value_field_klass(index()));
+        ValueKlass* vk = ValueKlass::cast(field_holder()->get_inline_type_field_klass(index()));
         int field_offset = offset() - vk->first_field_offset();
         obj = (oop)(cast_from_oop<address>(obj) + field_offset);
         st->print_cr("Inline type field inlined '%s':", vk->name()->as_C_string());

--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -30,7 +30,7 @@
  * @bug 8231610
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloRelocation
- * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
+ * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
  * @run driver ArchiveRelocationTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
- * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
+ * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
  * @run driver HelloInlineClassTest
  */
 
@@ -40,7 +40,8 @@ public class HelloInlineClassTest {
         String mainClass = "HelloInlineClassApp";
         OutputAnalyzer output =
             TestCommon.dump(appJar, TestCommon.list(mainClass,
-                                                    "HelloInlineClassApp$Point"));
+                                                    "HelloInlineClassApp$Point",
+                                                    "HelloInlineClassApp$Rectangle"));
         output.shouldHaveExitValue(0);
 
         TestCommon.run("-Xint", "-cp", appJar,  mainClass)

--- a/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Use Lookup.defineClass() to load a class with rewritten bytecode. Make sure
+ *          the archived class with the same name is not loaded.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/RewriteBytecodesInline.java test-classes/Util.java test-classes/Point.java test-classes/WithInlinedField.java
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver RewriteBytecodesInlineTest
+ */
+
+import java.io.File;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class RewriteBytecodesInlineTest {
+  public static void main(String[] args) throws Exception {
+    String wbJar = JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
+    String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+
+    String appJar = JarBuilder.build("dynamic_define", "RewriteBytecodesInline", "Util", "Point", "Point$ref", "WithInlinedField");
+    String superClsFile = (new File(System.getProperty("test.classes", "."), "Point.class")).getPath();
+
+    TestCommon.dump(appJar, TestCommon.list("RewriteBytecodesInline", "Point", "Point$ref", "WithInlinedField"),
+                    // command-line arguments ...
+                    use_whitebox_jar);
+
+    OutputAnalyzer output = TestCommon.exec(appJar,
+                    // command-line arguments ...
+                    use_whitebox_jar,
+                    "-XX:+UnlockDiagnosticVMOptions",
+                    "-XX:+WhiteBoxAPI",
+                    "RewriteBytecodesInline", superClsFile);
+    TestCommon.checkExec(output);
+  }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -32,7 +32,7 @@
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloRelocation
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
+ * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicArchiveRelocationTest
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
@@ -29,7 +29,7 @@
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref
+ * @run driver ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. HelloDynamicInlineClass
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/HelloInlineClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/HelloInlineClassApp.java
@@ -48,6 +48,14 @@ public class HelloInlineClassApp {
         }
     }
 
+    static inline class Rectangle {
+        Point p0 = new Point(0,0);
+        Point p1 = new Point(1,1);
+    }
+
+    Point point;
+    static Rectangle rectangle;
+
     public static void main(String[] args) throws Exception {
         Point p = new Point(0, 123);
         System.out.println("Point = " + p);
@@ -83,6 +91,16 @@ public class HelloInlineClassApp {
 
         if (p.x != expectedX || p.y != expectedY) {
             throw new RuntimeException("Expected (" + expectedX + ", " + expectedY + " but got " + p);
+        }
+
+        Point pzero = new Point(0,0);
+        if (HelloInlineClassApp.rectangle.p0 != pzero || HelloInlineClassApp.rectangle.p1 != pzero) {
+            throw new RuntimeException("Static field rectangle not as expected");
+        }
+
+        HelloInlineClassApp app = new HelloInlineClassApp();
+        if (app.point != pzero) {
+            throw new RuntimeException("Non-static field point not as expected");
         }
 
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/Point.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/Point.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public inline class Point {
+  int i = 0, j = 0;
+
+  public String msg() {
+    return "___xxx___";
+  }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/RewriteBytecodesInline.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/RewriteBytecodesInline.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import sun.hotspot.WhiteBox;
+
+public class RewriteBytecodesInline {
+  public static void main(String args[]) throws Throwable {
+    String from = "___xxx___";
+    String to   = "___yyy___";
+    File clsFile = new File(args[0]);
+    Class fieldClass = Util.defineModifiedClass(MethodHandles.lookup(), clsFile, from, to);
+
+    WithInlinedField wif = new WithInlinedField();
+
+    if (wif.p.getClass() != fieldClass) {
+      throw new RuntimeException("Mismatched field class");
+    }
+
+    // Even if the Point class is not loaded from the CDS archive, make sure the WithInlineField class
+    // can still be loaded successfully, and properly get the rewritten version of Point.
+
+    if (!wif.p.msg().equals(to)) {
+      throw new RuntimeException("Wrong output, expected: " + to + ", but got: " + wif.p.msg());
+    }
+
+    WhiteBox wb = WhiteBox.getWhiteBox();
+    if (wb.isSharedClass(fieldClass)) {
+      throw new RuntimeException("wb.isSharedClass(superClass) should be false");
+    }
+    if (wb.isSharedClass(wif.p.getClass())) {
+      throw new RuntimeException("wb.isSharedClass(child.getClass()) should be false");
+    }
+  }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/RewriteBytecodesInline.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/RewriteBytecodesInline.java
@@ -39,8 +39,10 @@ public class RewriteBytecodesInline {
       throw new RuntimeException("Mismatched field class");
     }
 
-    // Even if the Point class is not loaded from the CDS archive, make sure the WithInlineField class
+    // Even if the Point class is not loaded from the CDS archive, make sure the WithInlinedField class
     // can still be loaded successfully, and properly get the rewritten version of Point.
+    // The archived version of WithInlinedField must not be loaded, because it references the archived
+    // version of Point, but a different version of Point has been loaded.
 
     if (!wif.p.msg().equals(to)) {
       throw new RuntimeException("Wrong output, expected: " + to + ", but got: " + wif.p.msg());

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/WithInlinedField.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/WithInlinedField.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public class WithInlinedField {
+  Point p;
+}


### PR DESCRIPTION
Please review this changeset fixing several issues in CDS related to inline type metadata removal and restoration.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248003](https://bugs.openjdk.java.net/browse/JDK-8248003): [lworld] [lw3] VM crashes when classes with inline type fields are loaded from CDS archive


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/95/head:pull/95`
`$ git checkout pull/95`
