### PR TITLE
8248167: [lworld] [lw3] JdbInlineTypesTest fails

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/JNITypeParser.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/JNITypeParser.java
@@ -142,7 +142,8 @@ public class JNITypeParser {
     boolean isReference() {
         byte tag = jdwpTag();
         return tag == JDWP.Tag.ARRAY ||
-                tag == JDWP.Tag.OBJECT;
+                tag == JDWP.Tag.OBJECT ||
+                tag == JDWP.Tag.INLINE_OBJECT;
     }
 
     boolean isPrimitive() {


### PR DESCRIPTION
Please review this small fix to stop JdbInlineTypesTest from failing in our testing.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248167](https://bugs.openjdk.java.net/browse/JDK-8248167): [lworld] [lw3] JdbInlineTypesTest fails 


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/96/head:pull/96`
`$ git checkout pull/96`
