### PR TITLE
8247923: [lworld] Empty inline types break calling convention optimization

### DIFF
--- a/src/hotspot/share/ci/ciValueKlass.cpp
+++ b/src/hotspot/share/ci/ciValueKlass.cpp
@@ -76,14 +76,23 @@ bool ciValueKlass::flatten_array() const {
   GUARDED_VM_ENTRY(return to_ValueKlass()->flatten_array();)
 }
 
+// Can this value type be scalarized?
+bool ciValueKlass::is_scalarizable() const {
+  GUARDED_VM_ENTRY(return to_ValueKlass()->is_scalarizable();)
+}
+
+// Can this value type be passed as multiple values?
+bool ciValueKlass::can_be_passed_as_fields() const {
+  GUARDED_VM_ENTRY(return to_ValueKlass()->can_be_passed_as_fields();)
+}
+
 // Can this value type be returned as multiple values?
 bool ciValueKlass::can_be_returned_as_fields() const {
   GUARDED_VM_ENTRY(return to_ValueKlass()->can_be_returned_as_fields();)
 }
 
-// Can this value type be scalarized?
-bool ciValueKlass::is_scalarizable() const {
-  GUARDED_VM_ENTRY(return to_ValueKlass()->is_scalarizable();)
+bool ciValueKlass::is_empty() const {
+  GUARDED_VM_ENTRY(return to_ValueKlass()->is_empty_inline_type();)
 }
 
 // When passing a value type's fields as arguments, count the number

--- a/src/hotspot/share/ci/ciValueKlass.hpp
+++ b/src/hotspot/share/ci/ciValueKlass.hpp
@@ -78,8 +78,10 @@ public:
   int field_index_by_offset(int offset);
 
   bool flatten_array() const;
-  bool can_be_returned_as_fields() const;
   bool is_scalarizable() const;
+  bool can_be_passed_as_fields() const;
+  bool can_be_returned_as_fields() const;
+  bool is_empty() const;
   int value_arg_slots();
   int default_value_offset() const;
   ciInstance* default_value_instance() const;

--- a/src/hotspot/share/oops/valueKlass.hpp
+++ b/src/hotspot/share/oops/valueKlass.hpp
@@ -250,7 +250,8 @@ class ValueKlass: public InstanceKlass {
     return *((Array<VMRegPair>**)adr_return_regs());
   }
   bool is_scalarizable() const;
-  bool can_be_returned_as_fields() const;
+  bool can_be_passed_as_fields() const;
+  bool can_be_returned_as_fields(bool init = false) const;
   void save_oop_fields(const RegisterMap& map, GrowableArray<Handle>& handles) const;
   void restore_oop_results(RegisterMap& map, GrowableArray<Handle>& handles) const;
   oop realloc_result(const RegisterMap& reg_map, const GrowableArray<Handle>& handles, TRAPS);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2037,7 +2037,7 @@ const TypeTuple *TypeTuple::make_domain(ciMethod* method, bool vt_fields_as_args
   const Type** field_array = fields(arg_cnt);
   if (!method->is_static()) {
     ciInstanceKlass* recv = method->holder();
-    if (vt_fields_as_args && recv->is_valuetype() && recv->as_value_klass()->is_scalarizable()) {
+    if (vt_fields_as_args && recv->is_valuetype() && recv->as_value_klass()->can_be_passed_as_fields()) {
       collect_value_fields(recv->as_value_klass(), field_array, pos, sig_cc);
     } else {
       field_array[pos++] = get_const_type(recv)->join_speculative(TypePtr::NOTNULL);
@@ -2076,7 +2076,7 @@ const TypeTuple *TypeTuple::make_domain(ciMethod* method, bool vt_fields_as_args
       break;
     case T_VALUETYPE: {
       bool never_null = sig->is_never_null_at(i);
-      if (vt_fields_as_args && type->as_value_klass()->is_scalarizable() && never_null) {
+      if (vt_fields_as_args && type->as_value_klass()->can_be_passed_as_fields() && never_null) {
         is_flattened = true;
         collect_value_fields(type->as_value_klass(), field_array, pos, sig_cc);
       } else {

--- a/src/hotspot/share/opto/valuetypenode.cpp
+++ b/src/hotspot/share/opto/valuetypenode.cpp
@@ -495,7 +495,8 @@ Node* ValueTypeBaseNode::allocate_fields(GraphKit* kit) {
 
 ValueTypeNode* ValueTypeNode::make_uninitialized(PhaseGVN& gvn, ciValueKlass* vk) {
   // Create a new ValueTypeNode with uninitialized values and NULL oop
-  return new ValueTypeNode(vk, gvn.zerocon(T_VALUETYPE));
+  Node* oop = vk->is_empty() ? default_oop(gvn, vk) : gvn.zerocon(T_VALUETYPE);
+  return new ValueTypeNode(vk, oop);
 }
 
 Node* ValueTypeNode::default_oop(PhaseGVN& gvn, ciValueKlass* vk) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1142,8 +1142,9 @@ Handle SharedRuntime::find_callee_info_helper(JavaThread* thread,
         THROW_(vmSymbols::java_lang_NoSuchMethodException(), nullHandle);
       }
     }
-    if (!caller_is_c1 && callee->has_scalarized_args() && callee->method_holder()->is_inline_klass()) {
-      // If the receiver is a value type that is passed as fields, no oop is available.
+    if (!caller_is_c1 && callee->method_holder()->is_inline_klass() &&
+        ValueKlass::cast(callee->method_holder())->can_be_passed_as_fields()) {
+      // If the receiver is an inline type that is passed as fields, no oop is available
       // Resolve the call without receiver null checking.
       assert(attached_method.not_null() && !attached_method->is_abstract(), "must have non-abstract attached method");
       if (bc == Bytecodes::_invokeinterface) {
@@ -1285,7 +1286,8 @@ bool SharedRuntime::resolve_sub_helper_internal(methodHandle callee_method, cons
 
   if (is_virtual) {
     Klass* receiver_klass = NULL;
-    if (InlineTypePassFieldsAsArgs && !caller_is_c1 && callee_method->method_holder()->is_inline_klass()) {
+    if (!caller_is_c1 && callee_method->method_holder()->is_inline_klass() &&
+        ValueKlass::cast(callee_method->method_holder())->can_be_passed_as_fields()) {
       // If the receiver is an inline type that is passed as fields, no oop is available
       receiver_klass = callee_method->method_holder();
     } else {
@@ -2746,7 +2748,7 @@ int CompiledEntrySignature::compute_scalarized_cc(GrowableArray<SigEntry>*& sig_
   InstanceKlass* holder = _method->method_holder();
   sig_cc = new GrowableArray<SigEntry>(_method->size_of_parameters());
   if (!_method->is_static()) {
-    if (holder->is_inline_klass() && scalar_receiver && ValueKlass::cast(holder)->is_scalarizable()) {
+    if (holder->is_inline_klass() && scalar_receiver && ValueKlass::cast(holder)->can_be_passed_as_fields()) {
       sig_cc->appendAll(ValueKlass::cast(holder)->extended_sig());
     } else {
       SigEntry::add_entry(sig_cc, T_OBJECT);
@@ -2756,7 +2758,7 @@ int CompiledEntrySignature::compute_scalarized_cc(GrowableArray<SigEntry>*& sig_
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
     if (ss.type() == T_VALUETYPE) {
       ValueKlass* vk = ss.as_value_klass(holder);
-      if (vk->is_scalarizable()) {
+      if (vk->can_be_passed_as_fields()) {
         sig_cc->appendAll(vk->extended_sig());
       } else {
         SigEntry::add_entry(sig_cc, T_OBJECT);
@@ -2833,7 +2835,7 @@ CodeOffsets::Entries CompiledEntrySignature::c1_value_ro_entry_type() const {
 void CompiledEntrySignature::compute_calling_conventions() {
   // Get the (non-scalarized) signature and check for value type arguments
   if (!_method->is_static()) {
-    if (_method->method_holder()->is_inline_klass() && ValueKlass::cast(_method->method_holder())->is_scalarizable()) {
+    if (_method->method_holder()->is_inline_klass() && ValueKlass::cast(_method->method_holder())->can_be_passed_as_fields()) {
       _has_value_recv = true;
       _num_value_args++;
     }
@@ -2842,14 +2844,14 @@ void CompiledEntrySignature::compute_calling_conventions() {
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
     BasicType bt = ss.type();
     if (bt == T_VALUETYPE) {
-      if (ss.as_value_klass(_method->method_holder())->is_scalarizable()) {
+      if (ss.as_value_klass(_method->method_holder())->can_be_passed_as_fields()) {
         _num_value_args++;
       }
       bt = T_OBJECT;
     }
     SigEntry::add_entry(_sig, bt);
   }
-  if (_method->is_abstract() && !(InlineTypePassFieldsAsArgs && has_value_arg())) {
+  if (_method->is_abstract() && !has_value_arg()) {
     return;
   }
 
@@ -2865,7 +2867,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
   _args_on_stack_cc = _args_on_stack;
   _args_on_stack_cc_ro = _args_on_stack;
 
-  if (InlineTypePassFieldsAsArgs && has_value_arg() && !_method->is_native()) {
+  if (has_value_arg() && !_method->is_native()) {
     _args_on_stack_cc = compute_scalarized_cc(_sig_cc, _regs_cc, /* scalar_receiver = */ true);
 
     _sig_cc_ro = _sig_cc;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1142,7 +1142,7 @@ Handle SharedRuntime::find_callee_info_helper(JavaThread* thread,
         THROW_(vmSymbols::java_lang_NoSuchMethodException(), nullHandle);
       }
     }
-    if (!caller_is_c1 && callee->method_holder()->is_inline_klass() &&
+    if (!caller_is_c1 && callee->has_scalarized_args() && callee->method_holder()->is_inline_klass() &&
         ValueKlass::cast(callee->method_holder())->can_be_passed_as_fields()) {
       // If the receiver is an inline type that is passed as fields, no oop is available
       // Resolve the call without receiver null checking.
@@ -1286,7 +1286,7 @@ bool SharedRuntime::resolve_sub_helper_internal(methodHandle callee_method, cons
 
   if (is_virtual) {
     Klass* receiver_klass = NULL;
-    if (!caller_is_c1 && callee_method->method_holder()->is_inline_klass() &&
+    if (!caller_is_c1 && callee_method->has_scalarized_args() && callee_method->method_holder()->is_inline_klass() &&
         ValueKlass::cast(callee_method->method_holder())->can_be_passed_as_fields()) {
       // If the receiver is an inline type that is passed as fields, no oop is available
       receiver_klass = callee_method->method_holder();

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/MyValueEmpty.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/MyValueEmpty.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.valuetypes;
+
+public final inline class MyValueEmpty extends MyAbstract {
+    public long hash() { return 0; }
+
+    public MyValueEmpty copy(MyValueEmpty other) { return other; }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Method;
  * @summary Test value type calling convention optimizations
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @compile TestCallingConvention.java
+ * @compile -XDallowEmptyValues TestCallingConvention.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI
@@ -785,5 +785,18 @@ public class TestCallingConvention extends ValueTypeTest {
         Test37Value vt = new Test37Value();
         int res = test37(vt);
         Asserts.assertEQ(res, rI);
+    }
+
+    // Test passing/returning an empty inline type
+    @Test(failOn = ALLOC + LOAD + STORE + TRAP)
+    public MyValueEmpty test38(MyValueEmpty vt) {
+        return vt.copy(vt);
+    }
+
+    @DontCompile
+    public void test38_verifier(boolean warmup) {
+        MyValueEmpty vt = new MyValueEmpty();
+        MyValueEmpty res = test38(vt);
+        Asserts.assertEQ(res, vt);
     }
 }


### PR DESCRIPTION
Empty inline types confuse the calling convention optimization because the injected byte field is not picked up by ciValueKlass::_declared_nonstatic_fields. This patch disables the calling convention optimization for empty inline types and makes sure empty inline types are not allocated by C2. I've filed JDK-8248220 to evaluate further optimization opportunities for empty inline types.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247923](https://bugs.openjdk.java.net/browse/JDK-8247923): [lworld] Empty inline types break calling convention optimization


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/97/head:pull/97`
`$ git checkout pull/97`
