### PR TITLE
8248330: [lworld] [lw3] test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/TestDescription.java fails because of IdentityObject

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2632,16 +2632,21 @@ JvmtiEnv::GetImplementedInterfaces(oop k_mirror, jint* interface_count_ptr, jcla
       return JVMTI_ERROR_NONE;
     }
 
-    Array<InstanceKlass*>* interface_list = InstanceKlass::cast(k)->local_interfaces();
-    const int result_length = (interface_list == NULL ? 0 : interface_list->length());
+    InstanceKlass* ik = InstanceKlass::cast(k);
+    Array<InstanceKlass*>* interface_list = ik->local_interfaces();
+    int result_length = (interface_list == NULL ? 0 : interface_list->length());
+    if (ik->has_injected_identityObject()) result_length--;
     jclass* result_list = (jclass*) jvmtiMalloc(result_length * sizeof(jclass));
+    int cursor = 0;
     for (int i_index = 0; i_index < result_length; i_index += 1) {
       InstanceKlass* klass_at = interface_list->at(i_index);
       assert(klass_at->is_klass(), "interfaces must be Klass*s");
       assert(klass_at->is_interface(), "interfaces must be interfaces");
-      oop mirror_at = klass_at->java_mirror();
-      Handle handle_at = Handle(current_thread, mirror_at);
-      result_list[i_index] = (jclass) jni_reference(handle_at);
+      if (klass_at != SystemDictionary::IdentityObject_klass() || !ik->has_injected_identityObject()) {
+        oop mirror_at = klass_at->java_mirror();
+        Handle handle_at = Handle(current_thread, mirror_at);
+        result_list[cursor++] = (jclass) jni_reference(handle_at);
+      }
     }
     *interface_count_ptr = result_length;
     *interfaces_ptr = result_list;

--- a/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
@@ -195,7 +195,7 @@ check_hidden_class_impl_interf(jvmtiEnv* jvmti, JNIEnv* jni, jclass klass) {
   // check that hidden class implements just one interface
   err = jvmti->GetImplementedInterfaces(klass, &count, &interfaces);
   CHECK_JVMTI_ERROR(jni, err, "check_hidden_class_impl_interf: Error in JVMTI GetImplementedInterfaces");
-  if (count != 2) {
+  if (count != 1) {
     LOG1("check_hidden_class_impl_interf: FAIL: implemented interfaces count: %d, expected to be 1\n", count);
     failed = true;
     return;


### PR DESCRIPTION
Please review this small fix in JVMTI.

The problem is that GetImplementedInterfaces doesn't return the expected set of interfaces because of the injection of the java.lang.IdentityObject interface by the JVM. The fix simply filters out this interface if it has been injected by the JVM, providing the same behavior as for reflection.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248330](https://bugs.openjdk.java.net/browse/JDK-8248330): [lworld] [lw3] test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/TestDescription.java fails because of IdentityObject


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer) ⚠️ Review applies to 9846fd0cd09a21fdf7904219193b6487817bd09b


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/100/head:pull/100`
`$ git checkout pull/100`
