### PR TITLE
8248251 don't all java.lang.IdentityObject to be redefined or retrans…

### DIFF
--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -292,6 +292,11 @@ bool VM_RedefineClasses::is_modifiable_class(oop klass_mirror) {
     return false;
   }
 
+  // Cannot redefine or retransform interface java.lang.IdentityObject.
+  if (k->name() == vmSymbols::java_lang_IdentityObject()) {
+    return false;
+  }
+
   // Cannot redefine or retransform a hidden or an unsafe anonymous class.
   if (InstanceKlass::cast(k)->is_hidden() ||
       InstanceKlass::cast(k)->is_unsafe_anonymous()) {

--- a/test/jdk/java/lang/instrument/IsModifiableClassAgent.java
+++ b/test/jdk/java/lang/instrument/IsModifiableClassAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,10 @@ public class IsModifiableClassAgent
                     }
                     if (isMod && klass.isPrimitive()) {
                         System.err.println("Error: primitive class returned as modifiable: " + klass);
+                        fail = true;
+                    }
+                    if (isMod && klass == java.lang.IdentityObject.class) {
+                        System.err.println("Error: java.lang.IdentityObject class returned as modifiable: " + klass);
                         fail = true;
                     }
                     try {


### PR DESCRIPTION
Add check to prevent interface java.lang.IdentityObject from being redefined or retransformed.  And, add test case.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248251](https://bugs.openjdk.java.net/browse/JDK-8248251): test IsModifiableClassAgent.java fails trying to retransform java.lang.IdentityObject ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/101/head:pull/101`
`$ git checkout pull/101`
