### PR TITLE
8248662: [lworld][lw3] vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java fails after 8245216

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
@@ -126,8 +126,7 @@ public class interfaces001 {
                     int interfaces = reply.getInt();
                     log.display("  interfaces: " + interfaces);
 
-                    // Adding one to the number of interfaces because of the injection of IdentityObject by the VM
-                    if (interfaces != DECLARED_INTERFACES + 1) {
+                    if (interfaces != DECLARED_INTERFACES) {
                         log.complain("Unexpected number of declared interfaces in the reply packet:" + interfaces
                                     + " (expected: " + DECLARED_INTERFACES + ")");
                         success = false;


### PR DESCRIPTION
Simple fix to remove a work around related to the IdentityObject interface.

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248662](https://bugs.openjdk.java.net/browse/JDK-8248662): [lworld][lw3] vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001/TestDescription.java fails after 8245216


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/103/head:pull/103`
`$ git checkout pull/103`
