### PR TITLE
8242402: multianewarray is missing checks on the bottom class

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -359,6 +359,10 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
                                                          protection_domain,
                                                          CHECK_NULL);
     if (k != NULL) {
+      if ((class_name->is_Q_array_signature() && !k->is_inline_klass()) ||
+          (!class_name->is_Q_array_signature() && k->is_inline_klass())) {
+            THROW_NULL(vmSymbols::java_lang_IncompatibleClassChangeError());
+          }
       k = k->array_klass(ndims, CHECK_NULL);
     }
   } else {

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -361,7 +361,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
     if (k != NULL) {
       if ((class_name->is_Q_array_signature() && !k->is_inline_klass()) ||
           (!class_name->is_Q_array_signature() && k->is_inline_klass())) {
-            THROW_NULL(vmSymbols::java_lang_IncompatibleClassChangeError());
+            THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), "L/Q mismatch on bottom type");
           }
       k = k->array_klass(ndims, CHECK_NULL);
     }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element0.java
@@ -1,0 +1,3 @@
+public class Element0 {
+    int i=0,j=0;
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element0.java
@@ -1,3 +1,27 @@
-public class Element0 {
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+ public class Element0 {
     int i=0,j=0;
 }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element1.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element1.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
 public inline class Element1 {
     int i=0,j=0;
 }

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element1.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/Element1.java
@@ -1,0 +1,3 @@
+public inline class Element1 {
+    int i=0,j=0;
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @summary test that mismatches in bottom class of multi-dimensional
+            arrays are correctly detected
+ * @library /testlibrary /test/lib
+ * @compile MultiANewArrayTypeCheck.jcod MultiANewArrayTest.java Element0.java Element1.java
+ * @run main/othervm MultiANewArrayTest
+ */
+
+import jdk.test.lib.Asserts;
+
+public class MultiANewArrayTest {
+
+    public static void main(String[] args) {
+        Error ex = null;
+        try {
+            MultiANewArrayTypeCheck.createArray0();
+        } catch(Error e) {
+            ex = e;
+        }
+        Asserts.assertNotNull(ex, "An ICCE should have been thrown");
+        Asserts.assertEquals(ex.getClass(), IncompatibleClassChangeError.class, "Error is not an ICCE");
+        ex = null;
+        try {
+            MultiANewArrayTypeCheck.createArray1();
+        } catch(Error e) {
+            ex = e;
+        }
+        Asserts.assertNotNull(ex, "An ICCE should have been thrown");
+        Asserts.assertEquals(ex.getClass(), IncompatibleClassChangeError.class, "Error is not an ICCE");
+        ex = null;
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTypeCheck.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTypeCheck.jcod
@@ -1,0 +1,120 @@
+class MultiANewArrayTypeCheck {
+  0xCAFEBABE;
+  0; // minor version
+  60; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "java/lang/Object"; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "()V"; // #6
+    class #8; // #7
+    Utf8 "[[QElement0;"; // #8
+    class #10; // #9
+    Utf8 "[[LElement1;"; // #10
+    class #12; // #11
+    Utf8 "MultiANewArrayTypeCheck"; // #12
+    Utf8 "Code"; // #13
+    Utf8 "LineNumberTable"; // #14
+    Utf8 "createArray0"; // #15
+    Utf8 "createArray1"; // #16
+    Utf8 "SourceFile"; // #17
+    Utf8 "MultiANewArrayTypeCheck.java"; // #18
+  } // Constant Pool
+
+  0x0021; // access
+  #11;// this_cpx
+  #2;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#13) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#14) { // LineNumberTable
+              [] { // line_number_table
+                0  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0009; // access
+      #15; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#13) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x100A100AC5000702;
+            0x4BB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#14) { // LineNumberTable
+              [] { // line_number_table
+                0  4;
+                9  5;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0009; // access
+      #16; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#13) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x100A100AC5000902;
+            0x4BB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#14) { // LineNumberTable
+              [] { // line_number_table
+                0  8;
+                9  9;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#17) { // SourceFile
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class MultiANewArrayTypeCheck

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTypeCheck.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/MultiANewArrayTest/MultiANewArrayTypeCheck.jcod
@@ -1,3 +1,37 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * This class provides two static methods equivalent to this Java source code:
+ * void createArray0() {
+ *     Element0 array = new Element0[10][10]; // Element0 is expected to be an inline type
+ * }
+ * void createArray1() {
+ *     Element1 array = new Element1[10][10]; // Element1 is expected to be a reference type
+ * }
+ */
+
 class MultiANewArrayTypeCheck {
   0xCAFEBABE;
   0; // minor version


### PR DESCRIPTION
Please review this patch which adds a missing check in array class resolution.

When an array class is resolved and the bottom type is not a primitive type, the envelope of the bottom type signature is removed in order to extract the class name and load it. Currently, there's no check that the kind of the loaded class matches the enveloped stripped from the signature.

The patch adds this check and includes an unit test.

Tested on all all platforms with mach5, tiers 1 to 3.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8242402](https://bugs.openjdk.java.net/browse/JDK-8242402): multianewarray is missing checks on the bottom class


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/105/head:pull/105`
`$ git checkout pull/105`
