### PR TITLE
JDK-8249244 Rename T_VALUETYPE to T_INLINE_TYPE

### DIFF
--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -48,7 +48,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 8; break;
     case T_OBJECT : i = 9; break;
     case T_ARRAY  : i = 9; break;
-    case T_VALUETYPE : i = 10; break;
+    case T_INLINE_TYPE : i = 10; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers,

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -572,7 +572,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       break;
     }
 
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_OBJECT: {
         if (patch_code != lir_patch_none) {
           jobject2reg_with_patching(dest->as_register(), info);
@@ -619,7 +619,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 void LIR_Assembler::const2stack(LIR_Opr src, LIR_Opr dest) {
   LIR_Const* c = src->as_constant_ptr();
   switch (c->type()) {
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
     {
       if (! c->as_jobject())
@@ -686,7 +686,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
     assert(c->as_jint() == 0, "should be");
     insn = &Assembler::strw;
     break;
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
   case T_ARRAY:
     // Non-null case is not handled on aarch64 but handled on x86
@@ -729,7 +729,7 @@ void LIR_Assembler::reg2reg(LIR_Opr src, LIR_Opr dest) {
       return;
     }
     assert(src->is_single_cpu(), "must match");
-    if (src->type() == T_OBJECT || src->type() == T_VALUETYPE) {
+    if (src->type() == T_OBJECT || src->type() == T_INLINE_TYPE) {
       __ verify_oop(src->as_register());
     }
     move_regs(src->as_register(), dest->as_register());
@@ -823,7 +823,7 @@ void LIR_Assembler::reg2mem(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -949,7 +949,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
   LIR_Address* addr = src->as_address_ptr();
   LIR_Address* from_addr = src->as_address_ptr();
 
-  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_VALUETYPE) {
+  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_INLINE_TYPE) {
     __ verify_oop(addr->base()->as_pointer_register());
   }
 
@@ -973,7 +973,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -1252,7 +1252,7 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   Register len =  op->len()->as_register();
   __ uxtw(len, len);
 
-  if (UseSlowPath || op->type() == T_VALUETYPE ||
+  if (UseSlowPath || op->type() == T_INLINE_TYPE ||
       (!UseFastNewObjectArray && is_reference_type(op->type())) ||
       (!UseFastNewTypeArray   && !is_reference_type(op->type()))) {
     __ b(*op->stub()->entry());
@@ -2129,7 +2129,7 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
       case T_METADATA:
         imm = (intptr_t)(opr2->as_constant_ptr()->as_metadata());
         break;
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_OBJECT:
       case T_ARRAY:
         jobject2reg(opr2->as_constant_ptr()->as_jobject(), rscratch1);
@@ -2296,7 +2296,7 @@ void LIR_Assembler::shift_op(LIR_Code code, LIR_Opr left, LIR_Opr count, LIR_Opr
       }
       break;
     case T_LONG:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_ADDRESS:
     case T_OBJECT:
       switch (code) {
@@ -2333,7 +2333,7 @@ void LIR_Assembler::shift_op(LIR_Code code, LIR_Opr left, jint count, LIR_Opr de
       break;
     case T_LONG:
     case T_ADDRESS:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_OBJECT:
       switch (code) {
       case lir_shl:  __ lsl (dreg, lreg, count); break;
@@ -3328,7 +3328,7 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
     xchg = &MacroAssembler::atomic_xchgal;
     add = &MacroAssembler::atomic_addal;
     break;
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
   case T_ARRAY:
     if (UseCompressedOops) {

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1235,7 +1235,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
 
   klass2reg_with_patching(klass_reg, obj, patching_info);
   if (x->is_never_null()) {
-    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_VALUETYPE, klass_reg, slow_path);
+    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
   }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -574,7 +574,7 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   }
 
   switch (type) {
-    case T_VALUETYPE :
+    case T_INLINE_TYPE :
     case T_OBJECT  :
     case T_ARRAY   : {
       oop obj;

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -693,7 +693,7 @@ void InterpreterMacroAssembler::remove_activation(
     ldr(rscratch1, Address(rfp, frame::interpreter_frame_method_offset * wordSize));
     ldr(rscratch1, Address(rscratch1, Method::const_offset()));
     ldrb(rscratch1, Address(rscratch1, ConstMethod::result_type_offset()));
-    cmpw(rscratch1, (u1) T_VALUETYPE);
+    cmpw(rscratch1, (u1) T_INLINE_TYPE);
     br(Assembler::NE, skip);
 
     // We are returning a value type, load its fields into registers

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5422,7 +5422,7 @@ bool MacroAssembler::unpack_value_helper(const GrowableArray<SigEntry>* sig, int
   do {
     sig_index--;
     BasicType bt = sig->at(sig_index)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       vt--;
     } else if (bt == T_VOID &&
                sig->at(sig_index-1)._bt != T_LONG &&
@@ -5501,7 +5501,7 @@ bool MacroAssembler::unpack_value_helper(const GrowableArray<SigEntry>* sig, int
 bool MacroAssembler::pack_value_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                                        VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
                                        int ret_off, int extra_stack_offset) {
-  assert(sig->at(sig_index)._bt == T_VALUETYPE, "should be at end delimiter");
+  assert(sig->at(sig_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
   assert(to->is_valid(), "must be");
 
   if (reg_state[to->value()] == reg_written) {
@@ -5525,7 +5525,7 @@ bool MacroAssembler::pack_value_helper(const GrowableArray<SigEntry>* sig, int& 
     val_obj = val_obj_tmp;
   }
 
-  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_VALUETYPE);
+  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_INLINE_TYPE);
   load_heap_oop(val_obj, Address(val_array, index));
 
   ScalarizedValueArgsStream stream(sig, sig_index, regs_from, regs_from_count, from_index);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -291,7 +291,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       if (int_args < Argument::n_int_register_parameters_j) {
         regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
       } else {
@@ -375,7 +375,7 @@ int SharedRuntime::java_return_convention(const BasicType *sig_bt, VMRegPair *re
     case T_ADDRESS:
       // Should T_METADATA be added to java_calling_convention as well ?
     case T_METADATA:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       if (int_args < SharedRuntime::java_return_convention_max_int) {
         regs[i].set2(INT_ArgReg[int_args]->as_VMReg());
         int_args ++;
@@ -450,23 +450,23 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
        BasicType bt = sig_extended->at(i)._bt;
        if (SigEntry::is_reserved_entry(sig_extended, i)) {
          // Ignore reserved entry
-       } else if (bt == T_VALUETYPE) {
+       } else if (bt == T_INLINE_TYPE) {
          // In sig_extended, a value type argument starts with:
-         // T_VALUETYPE, followed by the types of the fields of the
+         // T_INLINE_TYPE, followed by the types of the fields of the
          // value type and T_VOID to mark the end of the value
          // type. Value types are flattened so, for instance, in the
          // case of a value type with an int field and a value type
          // field that itself has 2 fields, an int and a long:
-         // T_VALUETYPE T_INT T_VALUETYPE T_INT T_LONG T_VOID (second
-         // slot for the T_LONG) T_VOID (inner T_VALUETYPE) T_VOID
-         // (outer T_VALUETYPE)
+         // T_INLINE_TYPE T_INT T_INLINE_TYPE T_INT T_LONG T_VOID (second
+         // slot for the T_LONG) T_VOID (inner T_INLINE_TYPE) T_VOID
+         // (outer T_INLINE_TYPE)
          total_args_passed++;
          int vt = 1;
          do {
            i++;
            BasicType bt = sig_extended->at(i)._bt;
            BasicType prev_bt = sig_extended->at(i-1)._bt;
-           if (bt == T_VALUETYPE) {
+           if (bt == T_INLINE_TYPE) {
              vt++;
            } else if (bt == T_VOID &&
                       prev_bt != T_LONG &&
@@ -488,7 +488,7 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
 
 static void gen_c2i_adapter_helper(MacroAssembler* masm, BasicType bt, const VMRegPair& reg_pair, int extraspace, const Address& to) {
 
-    assert(bt != T_VALUETYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
+    assert(bt != T_INLINE_TYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
 
     // Say 4 args:
     // i   st_off
@@ -564,7 +564,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
   if (InlineTypePassFieldsAsArgs) {
       // Is there an inline type argument?
      for (int i = 0; i < sig_extended->length() && !has_value_argument; i++) {
-       has_value_argument = (sig_extended->at(i)._bt == T_VALUETYPE);
+       has_value_argument = (sig_extended->at(i)._bt == T_INLINE_TYPE);
      }
      if (has_value_argument) {
       // There is at least a value type argument: we're coming from
@@ -631,7 +631,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // offset to start parameters
     int st_off   = (total_args_passed - next_arg_int - 1) * Interpreter::stackElementSize;
 
-    if (!InlineTypePassFieldsAsArgs || bt != T_VALUETYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
 
             if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
                continue; // Ignore reserved entry
@@ -651,7 +651,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
    } else {
        ignored++;
       // get the buffer from the just allocated pool of buffers
-      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_VALUETYPE);
+      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_INLINE_TYPE);
       __ load_heap_oop(rscratch1, Address(r10, index));
       next_vt_arg++;
       next_arg_int++;
@@ -666,7 +666,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         next_arg_comp++;
         BasicType bt = sig_extended->at(next_arg_comp)._bt;
         BasicType prev_bt = sig_extended->at(next_arg_comp - 1)._bt;
-        if (bt == T_VALUETYPE) {
+        if (bt == T_INLINE_TYPE) {
           vt++;
           ignored++;
         } else if (bt == T_VOID && prev_bt != T_LONG && prev_bt != T_DOUBLE) {
@@ -803,7 +803,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm, int comp_args_on_stack
   for (int i = 0; i < total_args_passed; i++) {
     BasicType bt = sig->at(i)._bt;
 
-    assert(bt != T_VALUETYPE, "i2c adapter doesn't unpack value args");
+    assert(bt != T_INLINE_TYPE, "i2c adapter doesn't unpack value args");
     if (bt == T_VOID) {
       assert(i > 0 && (sig->at(i - 1)._bt == T_LONG || sig->at(i - 1)._bt == T_DOUBLE), "missing half");
       continue;
@@ -1057,7 +1057,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
         // fall through
       case T_OBJECT:
       case T_ARRAY:
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_ADDRESS:
       case T_METADATA:
         if (int_args < Argument::n_int_register_parameters_c) {
@@ -1909,7 +1909,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
           int_args++;
           break;
         }
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_OBJECT:
         assert(!is_critical_native, "no oop arguments");
         object_move(masm, map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
@@ -2097,7 +2097,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in v0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;
@@ -3342,7 +3342,7 @@ BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       continue;
     }
     if (bt == T_VOID) {
@@ -3389,7 +3389,7 @@ BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const
   j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -304,7 +304,7 @@ class StubGenerator: public StubCodeGenerator {
     return_address = __ pc();
 
     // store result depending on type (everything that is not
-    // T_OBJECT, T_VALUETYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
+    // T_OBJECT, T_INLINE_TYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     // n.b. this assumes Java returns an integral result in r0
     // and a floating result in j_farg0
     __ ldr(j_rarg2, result);
@@ -312,7 +312,7 @@ class StubGenerator: public StubCodeGenerator {
     __ ldr(j_rarg1, result_type);
     __ cmp(j_rarg1, (u1)T_OBJECT);
     __ br(Assembler::EQ, is_long);
-    __ cmp(j_rarg1, (u1)T_VALUETYPE);
+    __ cmp(j_rarg1, (u1)T_INLINE_TYPE);
     __ br(Assembler::EQ, is_value);
     __ cmp(j_rarg1, (u1)T_LONG);
     __ br(Assembler::EQ, is_long);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -559,7 +559,7 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
   case T_VOID   : /* nothing to do */        break;
   case T_FLOAT  : /* nothing to do */        break;
   case T_DOUBLE : /* nothing to do */        break;
-  case T_VALUETYPE: // fall through (value types are handled with oops)
+  case T_INLINE_TYPE: // fall through (value types are handled with oops)
   case T_OBJECT :
     // retrieve result from frame
     __ ldr(r0, Address(rfp, frame::interpreter_frame_oop_temp_offset*wordSize));

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -133,7 +133,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 6; break;
     case T_OBJECT : // fall through
     case T_ARRAY  : i = 7; break;
-    case T_VALUETYPE : i = 8; break;
+    case T_INLINE_TYPE : i = 8; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers, "index out of bounds");
@@ -154,7 +154,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 8; break;
     case T_OBJECT : i = 9; break;
     case T_ARRAY  : i = 9; break;
-    case T_VALUETYPE : i = 10; break;
+    case T_INLINE_TYPE : i = 10; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers,

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -193,7 +193,7 @@ void LIR_Assembler::push(LIR_Opr opr) {
     __ push_addr(frame_map()->address_for_slot(opr->single_stack_ix()));
   } else if (opr->is_constant()) {
     LIR_Const* const_opr = opr->as_constant_ptr();
-    if (const_opr->type() == T_OBJECT || const_opr->type() == T_VALUETYPE) {
+    if (const_opr->type() == T_OBJECT || const_opr->type() == T_INLINE_TYPE) {
       __ push_oop(const_opr->as_jobject());
     } else if (const_opr->type() == T_INT) {
       __ push_jint(const_opr->as_jint());
@@ -638,7 +638,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       break;
     }
 
-    case T_VALUETYPE: // Fall through
+    case T_INLINE_TYPE: // Fall through
     case T_OBJECT: {
       if (patch_code != lir_patch_none) {
         jobject2reg_with_patching(dest->as_register(), info);
@@ -729,7 +729,7 @@ void LIR_Assembler::const2stack(LIR_Opr src, LIR_Opr dest) {
       __ movptr(frame_map()->address_for_slot(dest->single_stack_ix()), c->as_jint_bits());
       break;
 
-    case T_VALUETYPE: // Fall through
+    case T_INLINE_TYPE: // Fall through
     case T_OBJECT:
       __ movoop(frame_map()->address_for_slot(dest->single_stack_ix()), c->as_jobject());
       break;
@@ -769,7 +769,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
       __ movptr(as_Address(addr), c->as_jint_bits());
       break;
 
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY:
       if (c->as_jobject() == NULL) {
@@ -858,7 +858,7 @@ void LIR_Assembler::reg2reg(LIR_Opr src, LIR_Opr dest) {
     }
 #endif
     assert(src->is_single_cpu(), "must match");
-    if (src->type() == T_OBJECT || src->type() == T_VALUETYPE) {
+    if (src->type() == T_OBJECT || src->type() == T_INLINE_TYPE) {
       __ verify_oop(src->as_register());
     }
     move_regs(src->as_register(), dest->as_register());
@@ -1044,7 +1044,7 @@ void LIR_Assembler::reg2mem(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -1218,7 +1218,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
   Address from_addr = as_Address(addr);
   Register tmp_load_klass = LP64_ONLY(rscratch1) NOT_LP64(noreg);
 
-  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_VALUETYPE) {
+  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_INLINE_TYPE) {
     __ verify_oop(addr->base()->as_pointer_register());
   }
 
@@ -1279,7 +1279,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY:   // fall through
       if (UseCompressedOops && !wide) {
@@ -1666,7 +1666,7 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   Register len =  op->len()->as_register();
   LP64_ONLY( __ movslq(len, len); )
 
-  if (UseSlowPath || op->type() == T_VALUETYPE ||
+  if (UseSlowPath || op->type() == T_INLINE_TYPE ||
       (!UseFastNewObjectArray && is_reference_type(op->type())) ||
       (!UseFastNewTypeArray   && !is_reference_type(op->type()))) {
     __ jmp(*op->stub()->entry());

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1366,7 +1366,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   }
   klass2reg_with_patching(klass_reg, obj, patching_info);
   if (x->is_never_null()) {
-    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_VALUETYPE, klass_reg, slow_path);
+    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
   }

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -604,7 +604,7 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
 
   switch (type) {
     case T_OBJECT  :
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_ARRAY   : {
       oop obj;
       if (method->is_native()) {

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -44,7 +44,7 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
   bool atomic = (decorators & MO_RELAXED) != 0;
 
-  assert(type != T_VALUETYPE, "Not supported yet");
+  assert(type != T_INLINE_TYPE, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {
@@ -110,7 +110,7 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
   bool atomic = (decorators & MO_RELAXED) != 0;
 
-  assert(type != T_VALUETYPE, "Not supported yet");
+  assert(type != T_INLINE_TYPE, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -198,7 +198,7 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
                                     Register tmp3) {
   BLOCK_COMMENT("ZBarrierSetAssembler::store_at {");
 
-  assert(type != T_VALUETYPE, "Not supported yet");
+  assert(type != T_INLINE_TYPE, "Not supported yet");
   // Verify oop store
   if (is_reference_type(type)) {
     // Note that src could be noreg, which means we

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1160,7 +1160,7 @@ void InterpreterMacroAssembler::remove_activation(
     movptr(rdi, Address(rbp, frame::interpreter_frame_method_offset * wordSize));
     movptr(rdi, Address(rdi, Method::const_offset()));
     load_unsigned_byte(rdi, Address(rdi, ConstMethod::result_type_offset()));
-    cmpl(rdi, T_VALUETYPE);
+    cmpl(rdi, T_INLINE_TYPE);
     jcc(Assembler::notEqual, skip);
 
     // We are returning a value type, load its fields into registers

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4713,7 +4713,7 @@ void MacroAssembler::data_for_value_array_index(Register array, Register array_k
   andl(rcx, Klass::_lh_log2_element_size_mask);
   shlptr(index); // index << rcx
 
-  lea(data, Address(array, index, Address::times_1, arrayOopDesc::base_offset_in_bytes(T_VALUETYPE)));
+  lea(data, Address(array, index, Address::times_1, arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE)));
 }
 
 void MacroAssembler::resolve(DecoratorSet decorators, Register obj) {
@@ -5360,7 +5360,7 @@ bool MacroAssembler::unpack_value_helper(const GrowableArray<SigEntry>* sig, int
   do {
     sig_index--;
     BasicType bt = sig->at(sig_index)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       vt--;
     } else if (bt == T_VOID &&
                sig->at(sig_index-1)._bt != T_LONG &&
@@ -5434,7 +5434,7 @@ bool MacroAssembler::unpack_value_helper(const GrowableArray<SigEntry>* sig, int
 bool MacroAssembler::pack_value_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                                        VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
                                        int ret_off, int extra_stack_offset) {
-  assert(sig->at(sig_index)._bt == T_VALUETYPE, "should be at end delimiter");
+  assert(sig->at(sig_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
   assert(to->is_valid(), "must be");
 
   if (reg_state[to->value()] == reg_written) {
@@ -5458,7 +5458,7 @@ bool MacroAssembler::pack_value_helper(const GrowableArray<SigEntry>* sig, int& 
     val_obj = val_obj_tmp;
   }
 
-  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_VALUETYPE);
+  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_INLINE_TYPE);
   load_heap_oop(val_obj, Address(val_array, index));
 
   ScalarizedValueArgsStream stream(sig, sig_index, regs_from, regs_from_count, from_index);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -466,7 +466,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_INT:
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_ADDRESS:
       if( reg_arg0 == 9999 )  {
         reg_arg0 = i;
@@ -1022,7 +1022,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
     case T_SHORT:
     case T_INT:
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_ARRAY:
     case T_ADDRESS:
     case T_METADATA:
@@ -1304,7 +1304,7 @@ static void save_or_restore_arguments(MacroAssembler* masm,
           }
           break;
         case T_OBJECT:
-        case T_VALUETYPE:
+        case T_INLINE_TYPE:
         default: ShouldNotReachHere();
       }
     } else if (in_regs[i].first()->is_XMMRegister()) {
@@ -2022,7 +2022,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
           c_arg++;
           break;
         }
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_OBJECT:
         assert(!is_critical_native, "no oop arguments");
         object_move(masm, map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
@@ -2205,7 +2205,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in st0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_VALUETYPE:             // Really a handle
+  case T_INLINE_TYPE:           // Really a handle
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -494,7 +494,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       if (int_args < Argument::n_int_register_parameters_j) {
         regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
       } else {
@@ -573,7 +573,7 @@ int SharedRuntime::java_return_convention(const BasicType *sig_bt,
       assert(sig_bt[i + 1] == T_VOID, "expecting half");
       // fall through
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_ARRAY:
     case T_ADDRESS:
     case T_METADATA:
@@ -663,23 +663,23 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
       BasicType bt = sig_extended->at(i)._bt;
       if (SigEntry::is_reserved_entry(sig_extended, i)) {
         // Ignore reserved entry
-      } else if (bt == T_VALUETYPE) {
+      } else if (bt == T_INLINE_TYPE) {
         // In sig_extended, a value type argument starts with:
-        // T_VALUETYPE, followed by the types of the fields of the
+        // T_INLINE_TYPE, followed by the types of the fields of the
         // value type and T_VOID to mark the end of the value
         // type. Value types are flattened so, for instance, in the
         // case of a value type with an int field and a value type
         // field that itself has 2 fields, an int and a long:
-        // T_VALUETYPE T_INT T_VALUETYPE T_INT T_LONG T_VOID (second
-        // slot for the T_LONG) T_VOID (inner T_VALUETYPE) T_VOID
-        // (outer T_VALUETYPE)
+        // T_INLINE_TYPE T_INT T_INLINE_TYPE T_INT T_LONG T_VOID (second
+        // slot for the T_LONG) T_VOID (inner T_INLINE_TYPE) T_VOID
+        // (outer T_INLINE_TYPE)
         total_args_passed++;
         int vt = 1;
         do {
           i++;
           BasicType bt = sig_extended->at(i)._bt;
           BasicType prev_bt = sig_extended->at(i-1)._bt;
-          if (bt == T_VALUETYPE) {
+          if (bt == T_INLINE_TYPE) {
             vt++;
           } else if (bt == T_VOID &&
                      prev_bt != T_LONG &&
@@ -706,7 +706,7 @@ static void gen_c2i_adapter_helper(MacroAssembler* masm,
                                    const Address& to,
                                    int extraspace,
                                    bool is_oop) {
-  assert(bt != T_VALUETYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
+  assert(bt != T_INLINE_TYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
   if (bt == T_VOID) {
     assert(prev_bt == T_LONG || prev_bt == T_DOUBLE, "missing half");
     return;
@@ -783,7 +783,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // Is there an inline type argument?
     bool has_value_argument = false;
     for (int i = 0; i < sig_extended->length() && !has_value_argument; i++) {
-      has_value_argument = (sig_extended->at(i)._bt == T_VALUETYPE);
+      has_value_argument = (sig_extended->at(i)._bt == T_INLINE_TYPE);
     }
     if (has_value_argument) {
       // There is at least a value type argument: we're coming from
@@ -846,10 +846,10 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   // next_arg_comp is the next argument from the compiler point of
   // view (value type fields are passed in registers/on the stack). In
-  // sig_extended, a value type argument starts with: T_VALUETYPE,
+  // sig_extended, a value type argument starts with: T_INLINE_TYPE,
   // followed by the types of the fields of the value type and T_VOID
   // to mark the end of the value type. ignored counts the number of
-  // T_VALUETYPE/T_VOID. next_vt_arg is the next value type argument:
+  // T_INLINE_TYPE/T_VOID. next_vt_arg is the next value type argument:
   // used to get the buffer for that argument from the pool of buffers
   // we allocated above and want to pass to the
   // interpreter. next_arg_int is the next argument from the
@@ -860,7 +860,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     assert(next_arg_int <= total_args_passed, "more arguments for the interpreter than expected?");
     BasicType bt = sig_extended->at(next_arg_comp)._bt;
     int st_off = (total_args_passed - next_arg_int) * Interpreter::stackElementSize;
-    if (!InlineTypePassFieldsAsArgs || bt != T_VALUETYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
       if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
         continue; // Ignore reserved entry
       }
@@ -881,7 +881,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     } else {
       ignored++;
       // get the buffer from the just allocated pool of buffers
-      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_VALUETYPE);
+      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_INLINE_TYPE);
       __ load_heap_oop(r14, Address(rscratch2, index));
       next_vt_arg++; next_arg_int++;
       int vt = 1;
@@ -895,7 +895,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         next_arg_comp++;
         BasicType bt = sig_extended->at(next_arg_comp)._bt;
         BasicType prev_bt = sig_extended->at(next_arg_comp-1)._bt;
-        if (bt == T_VALUETYPE) {
+        if (bt == T_INLINE_TYPE) {
           vt++;
           ignored++;
         } else if (bt == T_VOID &&
@@ -1051,7 +1051,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   // rest through the floating point stack top.
   for (int i = 0; i < total_args_passed; i++) {
     BasicType bt = sig->at(i)._bt;
-    assert(bt != T_VALUETYPE, "i2c adapter doesn't unpack value args");
+    assert(bt != T_INLINE_TYPE, "i2c adapter doesn't unpack value args");
     if (bt == T_VOID) {
       // Longs and doubles are passed in native word order, but misaligned
       // in the 32-bit build.
@@ -1322,7 +1322,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
         // fall through
       case T_OBJECT:
       case T_ARRAY:
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_ADDRESS:
       case T_METADATA:
         if (int_args < Argument::n_int_register_parameters_c) {
@@ -1707,7 +1707,7 @@ static void save_or_restore_arguments(MacroAssembler* masm,
           // handled above
           break;
         case T_OBJECT:
-        case T_VALUETYPE:
+        case T_INLINE_TYPE:
         default: ShouldNotReachHere();
       }
     } else if (in_regs[i].first()->is_XMMRegister()) {
@@ -2621,7 +2621,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 #endif
           break;
         }
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_OBJECT:
         assert(!is_critical_native, "no oop arguments");
         object_move(masm, map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
@@ -2822,7 +2822,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in xmm0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_VALUETYPE:             // Really a handle
+  case T_INLINE_TYPE:           // Really a handle
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;
@@ -4349,7 +4349,7 @@ BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       continue;
     }
     if (bt == T_VOID) {
@@ -4389,7 +4389,7 @@ BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const
   j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -336,13 +336,13 @@ class StubGenerator: public StubCodeGenerator {
     return_address = __ pc();
 
     // store result depending on type (everything that is not
-    // T_OBJECT, T_VALUETYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
+    // T_OBJECT, T_INLINE_TYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     __ movptr(r13, result);
     Label is_long, is_float, is_double, is_value, exit;
     __ movl(rbx, result_type);
     __ cmpl(rbx, T_OBJECT);
     __ jcc(Assembler::equal, is_long);
-    __ cmpl(rbx, T_VALUETYPE);
+    __ cmpl(rbx, T_INLINE_TYPE);
     __ jcc(Assembler::equal, is_value);
     __ cmpl(rbx, T_LONG);
     __ jcc(Assembler::equal, is_long);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -352,7 +352,7 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
   case T_DOUBLE : /* nothing to do */        break;
 #endif // _LP64
 
-  case T_VALUETYPE: // fall through (value types are handled with oops)
+  case T_INLINE_TYPE: // fall through (inline types are handled with oops)
   case T_OBJECT :
     // retrieve result from frame
     __ movptr(rax, Address(rbp, frame::interpreter_frame_oop_temp_offset*wordSize));

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -79,7 +79,7 @@ void MacroAssembler::mark_reserved_entries_writable(const GrowableArray<SigEntry
       do {
         sig_index++;
         BasicType bt = sig_cc->at(sig_index)._bt;
-        if (bt == T_VALUETYPE) {
+        if (bt == T_INLINE_TYPE) {
           vt++;
         } else if (bt == T_VOID &&
                    sig_cc->at(sig_index-1)._bt != T_LONG &&

--- a/src/hotspot/share/c1/c1_FrameMap.cpp
+++ b/src/hotspot/share/c1/c1_FrameMap.cpp
@@ -41,7 +41,7 @@ BasicTypeArray* FrameMap::signature_type_array_for(const ciMethod* method) {
   for (int i = 0; i < sig->count(); i++) {
     ciType* type = sig->type_at(i);
     BasicType t = type->basic_type();
-    if (t == T_ARRAY || t == T_VALUETYPE) {
+    if (t == T_ARRAY || t == T_INLINE_TYPE) {
       t = T_OBJECT;
     }
     sta->append(t);

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -93,7 +93,7 @@ LIR_Address::Scale LIR_Address::scale(BasicType type) {
 char LIR_OprDesc::type_char(BasicType t) {
   switch (t) {
     case T_ARRAY:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       t = T_OBJECT;
     case T_BOOLEAN:
     case T_CHAR:
@@ -152,7 +152,7 @@ void LIR_OprDesc::validate_type() const {
     case T_OBJECT:
     case T_METADATA:
     case T_ARRAY:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       assert((kindfield == cpu_register || kindfield == stack_value) &&
              size_field() == single_size, "must match");
       break;
@@ -1059,7 +1059,7 @@ bool LIR_OpJavaCall::maybe_return_as_fields(ciValueKlass** vk_ret) const {
       }
     } else if (is_method_handle_invoke()) {
       BasicType bt = method()->return_type()->basic_type();
-      if (bt == T_OBJECT || bt == T_VALUETYPE) {
+      if (bt == T_OBJECT || bt == T_INLINE_TYPE) {
         // A value type might be returned from the call but we don't know its
         // type. Either we get a buffered value (and nothing needs to be done)
         // or one of the values being returned is the klass of the value type

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -316,7 +316,7 @@ class LIR_OprDesc: public CompilationResourceObj {
       case T_INT:
       case T_ADDRESS:
       case T_OBJECT:
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_ARRAY:
       case T_METADATA:
         return single_size;
@@ -467,7 +467,7 @@ inline LIR_OprDesc::OprType as_OprType(BasicType type) {
   case T_FLOAT:    return LIR_OprDesc::float_type;
   case T_DOUBLE:   return LIR_OprDesc::double_type;
   case T_OBJECT:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_ARRAY:    return LIR_OprDesc::object_type;
   case T_ADDRESS:  return LIR_OprDesc::address_type;
   case T_METADATA: return LIR_OprDesc::metadata_type;
@@ -653,7 +653,7 @@ class LIR_OprFact: public AllStatic {
     LIR_Opr res;
     switch (type) {
       case T_OBJECT: // fall through
-      case T_VALUETYPE: // fall through
+      case T_INLINE_TYPE: // fall through
       case T_ARRAY:
         res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift)  |
                                             LIR_OprDesc::object_type  |
@@ -759,7 +759,7 @@ class LIR_OprFact: public AllStatic {
   static LIR_Opr stack(int index, BasicType type) {
     LIR_Opr res;
     switch (type) {
-      case T_VALUETYPE: // fall through
+      case T_INLINE_TYPE: // fall through
       case T_OBJECT: // fall through
       case T_ARRAY:
         res = (LIR_Opr)(intptr_t)((index << LIR_OprDesc::data_shift) |

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3145,7 +3145,7 @@ void LIRGenerator::invoke_load_one_argument(LIRItem* param, LIR_Opr loc) {
   } else {
     LIR_Address* addr = loc->as_address_ptr();
     param->load_for_store(addr->type());
-    assert(addr->type() != T_VALUETYPE, "not supported yet");
+    assert(addr->type() != T_INLINE_TYPE, "not supported yet");
     if (addr->type() == T_OBJECT) {
       __ move_wide(param->result(), addr);
     } else {

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -135,7 +135,7 @@ ValueType* as_ValueType(BasicType type) {
     case T_DOUBLE : return doubleType;
     case T_ARRAY  : return arrayType;
     case T_OBJECT : return objectType;
-    case T_VALUETYPE: return objectType;
+    case T_INLINE_TYPE: return objectType;
     case T_ADDRESS: return addressType;
     case T_ILLEGAL: return illegalType;
     default       : ShouldNotReachHere();
@@ -155,7 +155,7 @@ ValueType* as_ValueType(ciConstant value) {
     case T_FLOAT  : return new FloatConstant (value.as_float ());
     case T_DOUBLE : return new DoubleConstant(value.as_double());
     case T_ARRAY  : // fall through (ciConstant doesn't have an array accessor)
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_OBJECT : {
       // TODO: Common the code with GraphBuilder::load_constant?
       ciObject* obj = value.as_object();

--- a/src/hotspot/share/ci/ciConstant.cpp
+++ b/src/hotspot/share/ci/ciConstant.cpp
@@ -56,7 +56,7 @@ void ciConstant::print() {
   case T_DOUBLE:
     tty->print("%lf", _value._double);
     break;
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   default:
     if (is_reference_type(basic_type())) {
       _value._object->print();

--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -70,7 +70,7 @@ ciConstant ciInstance::field_value_impl(BasicType field_btype, int offset) {
     case T_FLOAT:   return ciConstant(obj->float_field(offset));
     case T_DOUBLE:  return ciConstant(obj->double_field(offset));
     case T_LONG:    return ciConstant(obj->long_field(offset));
-    case T_VALUETYPE:  // fall through
+    case T_INLINE_TYPE:  // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY: {
       oop o = obj->obj_field(offset);

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -811,7 +811,7 @@ void StaticFieldPrinter::do_field_helper(fieldDescriptor* fd, oop mirror, bool f
       }
       break;
     }
-    case T_VALUETYPE: {
+    case T_INLINE_TYPE: {
       ResetNoHandleMark rnhm;
       Thread* THREAD = Thread::current();
       SignatureStream ss(fd->signature(), false);

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1487,7 +1487,7 @@ void ciMethod::print_impl(outputStream* st) {
 static BasicType erase_to_word_type(BasicType bt) {
   if (is_subword_type(bt))   return T_INT;
   if (is_reference_type(bt)) return T_OBJECT;
-  if (bt == T_VALUETYPE)   return T_OBJECT;
+  if (bt == T_INLINE_TYPE)   return T_OBJECT;
   return bt;
 }
 

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -503,7 +503,7 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
     BasicType element_type = ss.type();
     assert(element_type != T_ARRAY, "unsuccessful decomposition");
     ciKlass* element_klass = NULL;
-    if (element_type == T_OBJECT || element_type == T_VALUETYPE) {
+    if (element_type == T_OBJECT || element_type == T_INLINE_TYPE) {
       ciEnv *env = CURRENT_THREAD_ENV;
       ciSymbol* ci_name = env->get_symbol(ss.as_symbol());
       element_klass =

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -798,7 +798,7 @@ class CompileReplay : public StackObj {
 
     void do_field(fieldDescriptor* fd) {
       BasicType bt = fd->field_type();
-      const char* string_value = bt != T_VALUETYPE ? _replay->parse_escaped_string() : NULL;
+      const char* string_value = bt != T_INLINE_TYPE ? _replay->parse_escaped_string() : NULL;
       switch (bt) {
       case T_BYTE: {
         int value = atoi(string_value);
@@ -851,7 +851,7 @@ class CompileReplay : public StackObj {
         assert(res, "should succeed for arrays & objects");
         break;
       }
-      case T_VALUETYPE: {
+      case T_INLINE_TYPE: {
         ValueKlass* vk = ValueKlass::cast(fd->field_holder()->get_inline_type_field_klass(fd->index()));
         if (fd->is_inlined()) {
           int field_offset = fd->offset() - vk->first_field_offset();

--- a/src/hotspot/share/ci/ciSignature.cpp
+++ b/src/hotspot/share/ci/ciSignature.cpp
@@ -62,7 +62,7 @@ ciSignature::ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpo
       ciSymbol* klass_name = env->get_symbol(ss.as_symbol());
       type = env->get_klass_by_name_impl(_accessing_klass, cpool, klass_name, false);
     }
-    if (type->is_valuetype() && ss.type() == T_VALUETYPE) {
+    if (type->is_valuetype() && ss.type() == T_INLINE_TYPE) {
       type = env->make_never_null_wrapper(type);
     }
     _types->append(type);

--- a/src/hotspot/share/ci/ciType.cpp
+++ b/src/hotspot/share/ci/ciType.cpp
@@ -46,7 +46,7 @@ ciType::ciType(BasicType basic_type) : ciMetadata() {
 }
 
 ciType::ciType(Klass* k) : ciMetadata(k) {
-  _basic_type = k->is_array_klass() ? T_ARRAY : (k->is_inline_klass() ? T_VALUETYPE : T_OBJECT);
+  _basic_type = k->is_array_klass() ? T_ARRAY : (k->is_inline_klass() ? T_INLINE_TYPE : T_OBJECT);
 }
 
 
@@ -105,7 +105,7 @@ ciInstance* ciType::java_mirror() {
 // ciType::box_klass
 //
 ciKlass* ciType::box_klass() {
-  assert(basic_type() != T_VALUETYPE, "value type boxing not yet supported");
+  assert(basic_type() != T_INLINE_TYPE, "value type boxing not yet supported");
   if (!is_primitive_type())  return this->as_klass();  // reference types are "self boxing"
 
   // Void is "boxed" with a null.

--- a/src/hotspot/share/ci/ciValueArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciValueArrayKlass.cpp
@@ -58,7 +58,7 @@ ciValueArrayKlass::ciValueArrayKlass(Klass* h_k) : ciArrayKlass(h_k) {
 ciValueArrayKlass::ciValueArrayKlass(ciSymbol* array_name,
                                      ciValueKlass* base_element_klass,
                                      int dimension)
-  : ciArrayKlass(array_name, dimension, T_VALUETYPE) {
+  : ciArrayKlass(array_name, dimension, T_INLINE_TYPE) {
   _base_element_klass = base_element_klass;
   _element_klass = base_element_klass;
 }

--- a/src/hotspot/share/ci/ciValueKlass.hpp
+++ b/src/hotspot/share/ci/ciValueKlass.hpp
@@ -52,7 +52,7 @@ protected:
   };
 
   ciValueKlass(ciSymbol* name, jobject loader, jobject protection_domain) :
-    ciInstanceKlass(name, loader, protection_domain, T_VALUETYPE) {}
+    ciInstanceKlass(name, loader, protection_domain, T_INLINE_TYPE) {}
 
   int compute_nonstatic_fields();
   const char* type_string() { return "ciValueKlass"; }

--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -186,7 +186,7 @@ void BytecodeAssembler::load(BasicType bt, u4 index) {
     case T_FLOAT:   fload(index); break;
     case T_DOUBLE:  dload(index); break;
     case T_LONG:    lload(index); break;
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     default:
       if (is_reference_type(bt)) {
                     aload(index);
@@ -256,7 +256,7 @@ void BytecodeAssembler::_return(BasicType bt) {
     case T_FLOAT:   freturn(); break;
     case T_DOUBLE:  dreturn(); break;
     case T_LONG:    lreturn(); break;
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     case T_VOID:    _return(); break;
     default:
       if (is_reference_type(bt)) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1546,7 +1546,7 @@ static FieldAllocationType _basic_type_to_atype[2 * (T_CONFLICT + 1)] = {
   NONSTATIC_DOUBLE,    // T_LONG        = 11,
   NONSTATIC_OOP,       // T_OBJECT      = 12,
   NONSTATIC_OOP,       // T_ARRAY       = 13,
-  NONSTATIC_OOP,       // T_VALUETYPE   = 14,
+  NONSTATIC_OOP,       // T_INLINE_TYPE = 14,
   BAD_ALLOCATION_TYPE, // T_VOID        = 15,
   BAD_ALLOCATION_TYPE, // T_ADDRESS     = 16,
   BAD_ALLOCATION_TYPE, // T_NARROWOOP   = 17,
@@ -1567,7 +1567,7 @@ static FieldAllocationType _basic_type_to_atype[2 * (T_CONFLICT + 1)] = {
   STATIC_DOUBLE,       // T_LONG        = 11,
   STATIC_OOP,          // T_OBJECT      = 12,
   STATIC_OOP,          // T_ARRAY       = 13,
-  STATIC_OOP,          // T_VALUETYPE   = 14,
+  STATIC_OOP,          // T_INLINE_TYPE = 14,
   BAD_ALLOCATION_TYPE, // T_VOID        = 15,
   BAD_ALLOCATION_TYPE, // T_ADDRESS     = 16,
   BAD_ALLOCATION_TYPE, // T_NARROWOOP   = 17,
@@ -1753,7 +1753,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     const BasicType type = cp->basic_type_for_signature_at(signature_index);
 
     // Remember how many oops we encountered and compute allocation type
-    const FieldAllocationType atype = fac->update(is_static, type, type == T_VALUETYPE);
+    const FieldAllocationType atype = fac->update(is_static, type, type == T_INLINE_TYPE);
     field->set_allocation_type(atype);
 
     // After field is initialized with type, we can augment it with aux info
@@ -7282,7 +7282,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
 
 
   for (AllFieldStream fs(_fields, cp); !fs.done(); fs.next()) {
-    if (Signature::basic_type(fs.signature()) == T_VALUETYPE  && !fs.access_flags().is_static()) {
+    if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE  && !fs.access_flags().is_static()) {
       // Pre-load inline class
       Klass* klass = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
           Handle(THREAD, _loader_data->class_loader()),

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -320,7 +320,7 @@ bool FieldLayout::reconstruct_layout(const InstanceKlass* ik) {
       if (fs.access_flags().is_static()) continue;
       has_instance_fields = true;
       LayoutRawBlock* block;
-      if (type == T_VALUETYPE) {
+      if (type == T_INLINE_TYPE) {
         ValueKlass* vk = ValueKlass::cast(ik->get_inline_type_field_klass(fs.index()));
         block = new LayoutRawBlock(fs.index(), LayoutRawBlock::INHERITED, vk->get_exact_size_in_bytes(),
                                    vk->get_alignment(), false);
@@ -614,7 +614,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
       if (group != _static_fields) _nonstatic_oopmap_count++;
       group->add_oop_field(fs);
       break;
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
 //      fs.set_inline(true);
       _has_inline_type_fields = true;
       if (group == _static_fields) {
@@ -716,7 +716,7 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
       }
       group->add_oop_field(fs);
       break;
-    case T_VALUETYPE: {
+    case T_INLINE_TYPE: {
 //      fs.set_inline(true);
       _has_inline_type_fields = true;
       if (group == _static_fields) {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1130,7 +1130,7 @@ class ResetMirrorField: public FieldClosure {
       case T_BOOLEAN:
         _m()->bool_field_put(fd->offset(), false);
         break;
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_ARRAY:
       case T_OBJECT: {
         // It might be useful to cache the String field, but

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -100,7 +100,7 @@ VerificationType StackMapFrame::set_locals_from_arg(
   switch (ss.type()) {
     case T_OBJECT:
     case T_ARRAY:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
     {
       Symbol* sig = ss.as_symbol();
       if (!sig->is_permanent()) {
@@ -111,7 +111,7 @@ VerificationType StackMapFrame::set_locals_from_arg(
         assert(sig_copy == sig, "symbols don't match");
         sig = sig_copy;
       }
-      if (ss.type() == T_VALUETYPE) {
+      if (ss.type() == T_INLINE_TYPE) {
         return VerificationType::inline_type(sig);
       }
       return VerificationType::reference_type(sig);

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1088,7 +1088,7 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
     SignatureStream ss(class_name, false);
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
-    if (t != T_OBJECT && t != T_VALUETYPE) {
+    if (t != T_OBJECT && t != T_INLINE_TYPE) {
       k = Universe::typeArrayKlassObj(t);
     } else {
       k = SystemDictionary::find(ss.as_symbol(), class_loader, protection_domain, THREAD);
@@ -1487,7 +1487,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
 
   if (ik->has_inline_type_fields()) {
     for (AllFieldStream fs(ik->fields(), ik->constants()); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
         if (!fs.access_flags().is_static()) {
           // Pre-load inline class
           Klass* real_k = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
@@ -1610,7 +1610,7 @@ void SystemDictionary::quick_resolve(InstanceKlass* klass, ClassLoaderData* load
 
   if (klass->has_inline_type_fields()) {
     for (AllFieldStream fs(klass->fields(), klass->constants()); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
         if (!fs.access_flags().is_static()) {
           Klass* real_k = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
             Handle(THREAD, loader_data->class_loader()), domain, true, CHECK);
@@ -2438,7 +2438,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     SignatureStream ss(class_name, false);
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
-    if (t != T_OBJECT && t != T_VALUETYPE) {
+    if (t != T_OBJECT && t != T_INLINE_TYPE) {
       klass = Universe::typeArrayKlassObj(t);
     } else {
       MutexLocker mu(THREAD, SystemDictionary_lock);

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -214,13 +214,13 @@ VerificationType VerificationType::get_component(ClassVerifier *context, TRAPS) 
     case T_DOUBLE:  return VerificationType(Double);
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE: {
+    case T_INLINE_TYPE: {
       guarantee(ss.is_reference(), "unchecked verifier input?");
       Symbol* component = ss.as_symbol();
       // Create another symbol to save as signature stream unreferences this symbol.
       Symbol* component_copy = context->create_temporary_symbol(component);
       assert(component_copy == component, "symbols don't match");
-      return (ss.type() == T_VALUETYPE) ?
+      return (ss.type() == T_INLINE_TYPE) ?
         VerificationType::inline_type(component_copy) :
         VerificationType::reference_type(component_copy);
    }

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -501,7 +501,7 @@ inline int ClassVerifier::change_sig_to_verificationType(
         *inference_type = VerificationType::reference_type(name_copy);
         return 1;
       }
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       {
         Symbol* vname = sig_type->as_symbol();
         // Create another symbol to save as signature stream unreferences this symbol.

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -207,7 +207,7 @@ void G1BarrierSetC2::pre_barrier(GraphKit* kit,
     if (pre_val->bottom_type() == TypePtr::NULL_PTR) return;
     assert(pre_val->bottom_type()->basic_type() == T_OBJECT, "or we shouldn't be here");
   }
-  assert(bt == T_OBJECT || bt == T_VALUETYPE, "or we shouldn't be here");
+  assert(bt == T_OBJECT || bt == T_INLINE_TYPE, "or we shouldn't be here");
 
   IdealKit ideal(kit, true);
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -290,7 +290,7 @@ void copy_primitive_argument(intptr_t* addr, Handle instance, int offset, BasicT
     break;
   case T_OBJECT:
   case T_ARRAY:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
     fatal("Should not be handled with this method");
     break;
   default:
@@ -351,7 +351,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
     oop aoop = *(oop*)f.interpreter_frame_expression_stack_at(tos_idx);
     assert(aoop == NULL || oopDesc::is_oop(aoop),"argument must be a reference type");
     new_value_h()->obj_field_put(field_offset, aoop);
-  } else if (field_type == T_VALUETYPE) {
+  } else if (field_type == T_INLINE_TYPE) {
     if (cp_entry->is_inlined()) {
       oop vt_oop = *(oop*)f.interpreter_frame_expression_stack_at(tos_idx);
       assert(vt_oop != NULL && oopDesc::is_oop(vt_oop) && vt_oop->is_inline_type(),"argument must be an inline type");
@@ -366,7 +366,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
       assert(voop == NULL || oopDesc::is_oop(voop),"checking argument");
       new_value_h()->obj_field_put(field_offset, voop);
     }
-  } else { // not T_OBJECT nor T_ARRAY nor T_VALUETYPE
+  } else { // not T_OBJECT nor T_ARRAY nor T_INLINE_TYPE
     intptr_t* addr = f.interpreter_frame_expression_stack_at(tos_idx);
     copy_primitive_argument(addr, new_value_h, field_offset, field_type);
   }

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -53,7 +53,7 @@ static const BasicType types[Interpreter::number_of_result_handlers] = {
   T_FLOAT  ,
   T_DOUBLE ,
   T_OBJECT ,
-  T_VALUETYPE
+  T_INLINE_TYPE
 };
 
 void TemplateInterpreterGenerator::generate_all() {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -153,7 +153,7 @@ class JavaArgumentUnboxer : public SignatureIterator {
   friend class SignatureIterator;  // so do_parameters_on can call do_type
   void do_type(BasicType type) {
     if (is_reference_type(type)) {
-      (type == T_VALUETYPE) ? _jca->push_oop(next_arg(T_VALUETYPE)) : _jca->push_oop(next_arg(T_OBJECT));
+      (type == T_INLINE_TYPE) ? _jca->push_oop(next_arg(T_INLINE_TYPE)) : _jca->push_oop(next_arg(T_OBJECT));
       return;
     }
     Handle arg = next_arg(type);

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -528,7 +528,7 @@ private:
   const int index() { return _index; }
   const InstanceKlass* holder() { return _holder; }
   const AccessFlags& access_flags() { return _access_flags; }
-  const bool is_inline_type() { return Signature::basic_type(_signature) == T_VALUETYPE; }
+  const bool is_inline_type() { return Signature::basic_type(_signature) == T_INLINE_TYPE; }
 };
 
 static int compare_offset(FieldDesc* f1, FieldDesc* f2) {

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -65,7 +65,7 @@ protected:
   // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
   // strongly.
   static bool element_type_should_be_aligned(BasicType type) {
-    return type == T_DOUBLE || type == T_LONG || type == T_VALUETYPE;
+    return type == T_DOUBLE || type == T_LONG || type == T_INLINE_TYPE;
   }
 
  public:

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -156,7 +156,7 @@ static inline bool is_class_loader(const Symbol* class_name,
   return false;
 }
 
-bool InstanceKlass::field_is_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_VALUETYPE; }
+bool InstanceKlass::field_is_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_INLINE_TYPE; }
 
 // private: called to verify that k is a static member of this nest.
 // We know that k is an instance class in the same package and hence the
@@ -1006,7 +1006,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
           if (ss.is_array()) {
             ss.skip_array_prefix();
           }
-          if (ss.type() == T_VALUETYPE) {
+          if (ss.type() == T_INLINE_TYPE) {
             Symbol* symb = ss.as_symbol();
 
             oop loader = class_loader();
@@ -1259,7 +1259,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
   // Initialize classes of inline fields
   {
     for (AllFieldStream fs(this); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
         Klass* klass = get_inline_type_field_klass_or_null(fs.index());
         if (fs.access_flags().is_static() && klass == NULL) {
           klass = SystemDictionary::resolve_or_fail(field_signature(fs.index())->fundamental_name(THREAD),
@@ -2665,7 +2665,7 @@ void InstanceKlass::remove_unshareable_info() {
 
   if (has_inline_type_fields()) {
     for (AllFieldStream fs(fields(), constants()); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_VALUETYPE) {
+      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
         reset_inline_type_field_klass(fs.index());
       }
     }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -417,7 +417,7 @@ protected:
   static BasicType layout_helper_element_type(jint lh) {
     assert(lh < (jint)_lh_neutral_value, "must be array");
     int btvalue = (lh >> _lh_element_type_shift) & _lh_element_type_mask;
-    assert((btvalue >= T_BOOLEAN && btvalue <= T_OBJECT) || btvalue == T_VALUETYPE, "sanity");
+    assert((btvalue >= T_BOOLEAN && btvalue <= T_OBJECT) || btvalue == T_INLINE_TYPE, "sanity");
     return (BasicType) btvalue;
   }
 
@@ -438,7 +438,7 @@ protected:
   static int layout_helper_log2_element_size(jint lh) {
     assert(lh < (jint)_lh_neutral_value, "must be array");
     int l2esz = (lh >> _lh_log2_element_size_shift) & _lh_log2_element_size_mask;
-    assert(layout_helper_element_type(lh) == T_VALUETYPE || l2esz <= LogBytesPerLong,
+    assert(layout_helper_element_type(lh) == T_INLINE_TYPE || l2esz <= LogBytesPerLong,
            "sanity. l2esz: 0x%x for lh: 0x%x", (uint)l2esz, (uint)lh);
     return l2esz;
   }

--- a/src/hotspot/share/oops/valueArrayKlass.cpp
+++ b/src/hotspot/share/oops/valueArrayKlass.cpp
@@ -160,7 +160,7 @@ oop ValueArrayKlass::multi_allocate(int rank, jint* last_size, TRAPS) {
 }
 
 jint ValueArrayKlass::array_layout_helper(ValueKlass* vk) {
-  BasicType etype = T_VALUETYPE;
+  BasicType etype = T_INLINE_TYPE;
   int esize = upper_log2(vk->raw_value_byte_size());
   int hsize = arrayOopDesc::base_offset_in_bytes(etype);
 
@@ -192,7 +192,7 @@ int ValueArrayKlass::oop_size(oop obj) const {
 jint ValueArrayKlass::max_elements() const {
   // Check the max number of heap words limit first (because of int32_t in oopDesc_oop_size() etc)
   size_t max_size = max_jint;
-  max_size -= arrayOopDesc::header_size(T_VALUETYPE);
+  max_size -= arrayOopDesc::header_size(T_INLINE_TYPE);
   max_size = align_down(max_size, MinObjAlignment);
   max_size <<= LogHeapWordSize;                                  // convert to max payload size in bytes
   max_size >>= layout_helper_log2_element_size(_layout_helper);  // divide by element size (in bytes) = max elements

--- a/src/hotspot/share/oops/valueArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/valueArrayOop.inline.hpp
@@ -32,7 +32,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/globals.hpp"
 
-inline void* valueArrayOopDesc::base() const { return arrayOopDesc::base(T_VALUETYPE); }
+inline void* valueArrayOopDesc::base() const { return arrayOopDesc::base(T_INLINE_TYPE); }
 
 inline void* valueArrayOopDesc::value_at_addr(int index, jint lh) const {
   assert(is_within_bounds(index), "index out of bounds");

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -270,11 +270,11 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     BasicType src_elem  = ary_src->klass()->as_array_klass()->element_type()->basic_type();
     BasicType dest_elem = ary_dest->klass()->as_array_klass()->element_type()->basic_type();
     if (src_elem  == T_ARRAY ||
-        (src_elem == T_VALUETYPE && ary_src->klass()->is_obj_array_klass())) {
+        (src_elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
       src_elem  = T_OBJECT;
     }
     if (dest_elem == T_ARRAY ||
-        (dest_elem == T_VALUETYPE && ary_dest->klass()->is_obj_array_klass())) {
+        (dest_elem == T_INLINE_TYPE && ary_dest->klass()->is_obj_array_klass())) {
       dest_elem = T_OBJECT;
     }
 
@@ -285,7 +285,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     if (bs->array_copy_requires_gc_barriers(is_alloc_tightly_coupled(), dest_elem, false, BarrierSetC2::Optimization) ||
-        (src_elem == T_VALUETYPE && ary_src->elem()->value_klass()->contains_oops() &&
+        (src_elem == T_INLINE_TYPE && ary_src->elem()->value_klass()->contains_oops() &&
          bs->array_copy_requires_gc_barriers(is_alloc_tightly_coupled(), T_OBJECT, false, BarrierSetC2::Optimization))) {
       // It's an object array copy but we can't emit the card marking that is needed
       return false;
@@ -294,7 +294,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     value_type = ary_src->elem();
 
     uint shift  = exact_log2(type2aelembytes(dest_elem));
-    if (dest_elem == T_VALUETYPE) {
+    if (dest_elem == T_INLINE_TYPE) {
       ciValueArrayKlass* vak = ary_src->klass()->as_value_array_klass();
       shift = vak->log2_element_size();
     }
@@ -333,13 +333,13 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     BasicType elem = ary_src->klass()->as_array_klass()->element_type()->basic_type();
     if (elem == T_ARRAY ||
-        (elem == T_VALUETYPE && ary_src->klass()->is_obj_array_klass())) {
+        (elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
       elem = T_OBJECT;
     }
 
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     if (bs->array_copy_requires_gc_barriers(true, elem, true, BarrierSetC2::Optimization) ||
-        (elem == T_VALUETYPE && ary_src->elem()->value_klass()->contains_oops() &&
+        (elem == T_INLINE_TYPE && ary_src->elem()->value_klass()->contains_oops() &&
          bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, BarrierSetC2::Optimization))) {
       return false;
     }
@@ -399,7 +399,7 @@ void ArrayCopyNode::copy(GraphKit& kit,
                          const Type* value_type) {
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   Node* ctl = kit.control();
-  if (copy_type == T_VALUETYPE) {
+  if (copy_type == T_INLINE_TYPE) {
     ciValueArrayKlass* vak = atp_src->klass()->as_value_array_klass();
     ciValueKlass* vk = vak->element_klass()->as_value_klass();
     for (int j = 0; j < vk->nof_nonstatic_fields(); j++) {
@@ -409,7 +409,7 @@ void ArrayCopyNode::copy(GraphKit& kit,
       ciType* ft = field->type();
       BasicType bt = type2field[ft->basic_type()];
       assert(!field->is_flattened(), "flattened field encountered");
-      if (bt == T_VALUETYPE) {
+      if (bt == T_INLINE_TYPE) {
         bt = T_OBJECT;
       }
       const Type* rt = Type::get_const_type(ft);
@@ -538,7 +538,7 @@ bool ArrayCopyNode::finish_transform(PhaseGVN *phase, bool can_reshape,
       BasicType elem = ary_src != NULL ? ary_src->klass()->as_array_klass()->element_type()->basic_type() : T_CONFLICT;
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       assert(!is_clonebasic() || bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, BarrierSetC2::Optimization) ||
-             (ary_src != NULL && elem == T_VALUETYPE && ary_src->klass()->is_obj_array_klass()), "added control for clone?");
+             (ary_src != NULL && elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass()), "added control for clone?");
 #endif
       assert(!is_clonebasic() || UseShenandoahGC, "added control for clone?");
       phase->record_for_igvn(this);

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -715,7 +715,7 @@ void Parse::do_call() {
             const TypeOopPtr* arg_type = TypeOopPtr::make_from_klass(rtype->as_klass());
             const Type*       sig_type = TypeOopPtr::make_from_klass(ctype->as_klass());
             if (declared_signature->returns_never_null()) {
-              assert(ct == T_VALUETYPE, "should be a value type");
+              assert(ct == T_INLINE_TYPE, "should be a value type");
               sig_type = sig_type->join_speculative(TypePtr::NOTNULL);
             }
             if (arg_type != NULL && !arg_type->higher_equal(sig_type) && !peek()->is_ValueType()) {
@@ -744,12 +744,12 @@ void Parse::do_call() {
              "mismatched return types: rtype=%s, ctype=%s", rtype->name(), ctype->name());
     }
 
-    if (rtype->basic_type() == T_VALUETYPE && !peek()->is_ValueType()) {
+    if (rtype->basic_type() == T_INLINE_TYPE && !peek()->is_ValueType()) {
       Node* retnode = pop();
       if (!gvn().type(retnode)->maybe_null() && rtype->as_value_klass()->is_scalarizable()) {
         retnode = ValueTypeNode::make_from_oop(this, retnode, rtype->as_value_klass());
       }
-      push_node(T_VALUETYPE, retnode);
+      push_node(T_INLINE_TYPE, retnode);
     }
 
     // If the return type of the method is not loaded, assert that the

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1225,7 +1225,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
   switch(type) {
     case T_LONG   : chk = new CmpLNode(value, _gvn.zerocon(T_LONG)); break;
     case T_INT    : chk = new CmpINode(value, _gvn.intcon(0)); break;
-    case T_VALUETYPE : // fall through
+    case T_INLINE_TYPE : // fall through
     case T_ARRAY  : // fall through
       type = T_OBJECT;  // simplify further tests
     case T_OBJECT : {
@@ -1552,7 +1552,7 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
   }
   ld = _gvn.transform(ld);
 
-  if (((bt == T_OBJECT || bt == T_VALUETYPE) && C->do_escape_analysis()) || C->eliminate_boxing()) {
+  if (((bt == T_OBJECT || bt == T_INLINE_TYPE) && C->do_escape_analysis()) || C->eliminate_boxing()) {
     // Improve graph before escape analysis and boxing elimination.
     record_for_igvn(ld);
   }
@@ -1778,7 +1778,7 @@ Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
 Node* GraphKit::load_array_element(Node* ctl, Node* ary, Node* idx, const TypeAryPtr* arytype) {
   const Type* elemtype = arytype->elem();
   BasicType elembt = elemtype->array_element_basic_type();
-  assert(elembt != T_VALUETYPE, "value types are not supported by this method");
+  assert(elembt != T_INLINE_TYPE, "value types are not supported by this method");
   Node* adr = array_element_address(ary, idx, elembt, arytype->size());
   if (elembt == T_NARROWOOP) {
     elembt = T_OBJECT; // To satisfy switch in LoadNode::make()

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -802,7 +802,7 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       elem_type = klass->as_array_klass()->element_type();
       basic_elem_type = elem_type->basic_type();
       if (elem_type->is_valuetype() && !klass->is_value_array_klass()) {
-        assert(basic_elem_type == T_VALUETYPE, "unexpected element basic type");
+        assert(basic_elem_type == T_INLINE_TYPE, "unexpected element basic type");
         basic_elem_type = T_OBJECT;
       }
       array_base = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
@@ -1048,7 +1048,7 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc, bool inline_
       } else if (use->is_ValueType()) {
         assert(use->isa_ValueType()->get_oop() == res, "unexpected value type use");
          _igvn.rehash_node_delayed(use);
-        use->isa_ValueType()->set_oop(_igvn.zerocon(T_VALUETYPE));
+        use->isa_ValueType()->set_oop(_igvn.zerocon(T_INLINE_TYPE));
       } else if (use->is_Store()) {
         _igvn.replace_node(use, use->in(MemNode::Memory));
       } else {

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -837,7 +837,7 @@ void PhaseMacroExpand::generate_clear_array(Node* ctrl, MergeMemNode* merge_mem,
   Node* mem = merge_mem->memory_at(alias_idx); // memory slice to operate on
 
   // scaling and rounding of indexes:
-  assert(basic_elem_type != T_VALUETYPE, "should have been converted to a basic type copy");
+  assert(basic_elem_type != T_INLINE_TYPE, "should have been converted to a basic type copy");
   int scale = exact_log2(type2aelembytes(basic_elem_type));
   int abase = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
   int clear_low = (-1 << scale) & (BytesPerInt  - 1);
@@ -1206,7 +1206,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     if (top_dest != NULL && top_dest->klass() != NULL) {
       dest_elem = top_dest->klass()->as_array_klass()->element_type()->basic_type();
     }
-    if (dest_elem == T_ARRAY || (dest_elem == T_VALUETYPE && top_dest->klass()->is_obj_array_klass())) {
+    if (dest_elem == T_ARRAY || (dest_elem == T_INLINE_TYPE && top_dest->klass()->is_obj_array_klass())) {
       dest_elem = T_OBJECT;
     }
 
@@ -1219,11 +1219,11 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
       alloc = AllocateArrayNode::Ideal_array_allocation(dest, &_igvn);
       assert(alloc != NULL, "expect alloc");
     }
-    assert(dest_elem != T_VALUETYPE || alloc != NULL, "unsupported");
+    assert(dest_elem != T_INLINE_TYPE || alloc != NULL, "unsupported");
     Node* dest_length = (alloc != NULL) ? alloc->in(AllocateNode::ALength) : NULL;
 
     const TypePtr* adr_type = NULL;
-    if (dest_elem == T_VALUETYPE) {
+    if (dest_elem == T_INLINE_TYPE) {
       adr_type = adjust_parameters_for_vt(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
     } else {
       adr_type = dest_type->is_oopptr()->add_offset(Type::OffsetBot);
@@ -1272,7 +1272,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   }
   if (src_elem == T_ARRAY) {
     src_elem = T_OBJECT;
-  } else if (src_elem == T_VALUETYPE && top_src->klass()->is_obj_array_klass()) {
+  } else if (src_elem == T_INLINE_TYPE && top_src->klass()->is_obj_array_klass()) {
     if (top_src->klass_is_exact()) {
       src_elem = T_OBJECT;
     } else {
@@ -1282,7 +1282,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   }
   if (dest_elem == T_ARRAY) {
     dest_elem = T_OBJECT;
-  } else if (dest_elem == T_VALUETYPE && top_dest->klass()->is_obj_array_klass()) {
+  } else if (dest_elem == T_INLINE_TYPE && top_dest->klass()->is_obj_array_klass()) {
     if (top_dest->klass_is_exact()) {
       dest_elem = T_OBJECT;
     } else {
@@ -1365,7 +1365,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // (9) each element of an oop array must be assignable
 
   Node* mem = ac->in(TypeFunc::Memory);
-  if (dest_elem == T_VALUETYPE) {
+  if (dest_elem == T_INLINE_TYPE) {
     // copy modifies more than 1 slice
     insert_mem_bar(&ctrl, &mem, Op_MemBarCPUOrder);
   }
@@ -1427,7 +1427,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
   Node* dest_length = alloc != NULL ? alloc->in(AllocateNode::ALength) : NULL;
 
-  if (dest_elem == T_VALUETYPE) {
+  if (dest_elem == T_INLINE_TYPE) {
     adr_type = adjust_parameters_for_vt(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
   } else if (ac->_dest_type != TypeOopPtr::BOTTOM) {
     adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -833,7 +833,7 @@ Node *LoadNode::make(PhaseGVN& gvn, Node *ctl, Node *mem, Node *adr, const TypeP
   case T_FLOAT:   load = new LoadFNode (ctl, mem, adr, adr_type, rt,            mo, control_dependency); break;
   case T_DOUBLE:  load = new LoadDNode (ctl, mem, adr, adr_type, rt,            mo, control_dependency); break;
   case T_ADDRESS: load = new LoadPNode (ctl, mem, adr, adr_type, rt->is_ptr(),  mo, control_dependency); break;
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
 #ifdef _LP64
     if (adr->bottom_type()->is_ptr_to_narrowoop()) {
@@ -1095,7 +1095,7 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
       // (This is one of the few places where a generic PhaseTransform
       // can create new nodes.  Think of it as lazily manifesting
       // virtually pre-existing constants.)
-      assert(memory_type() != T_VALUETYPE, "should not be used for value types");
+      assert(memory_type() != T_INLINE_TYPE, "should not be used for value types");
       Node* default_value = ld_alloc->in(AllocateNode::DefaultValue);
       if (default_value != NULL) {
         return default_value;
@@ -2540,7 +2540,7 @@ StoreNode* StoreNode::make(PhaseGVN& gvn, Node* ctl, Node* mem, Node* adr, const
   case T_DOUBLE:  return new StoreDNode(ctl, mem, adr, adr_type, val, mo);
   case T_METADATA:
   case T_ADDRESS:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
 #ifdef _LP64
     if (adr->bottom_type()->is_ptr_to_narrowoop()) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -124,7 +124,7 @@ Node* Parse::fetch_interpreter_state(int index,
   case T_INT:     l = new LoadINode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeInt::INT,        MemNode::unordered); break;
   case T_FLOAT:   l = new LoadFNode(ctl, mem, adr, TypeRawPtr::BOTTOM, Type::FLOAT,         MemNode::unordered); break;
   case T_ADDRESS: l = new LoadPNode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeRawPtr::BOTTOM,  MemNode::unordered); break;
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:  l = new LoadPNode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeInstPtr::BOTTOM, MemNode::unordered); break;
   case T_LONG:
   case T_DOUBLE: {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -89,7 +89,7 @@ void Parse::array_load(BasicType bt) {
     return;
   } else if (elemptr != NULL && elemptr->is_valuetypeptr() && !elemptr->maybe_null()) {
     // Load from non-flattened but flattenable value type array (elements can never be null)
-    bt = T_VALUETYPE;
+    bt = T_INLINE_TYPE;
   } else if (!ary_t->is_not_flat()) {
     // Cannot statically determine if array is flattened, emit runtime check
     assert(ValueArrayFlatten && is_reference_type(bt) && elemptr->can_be_value_type() && !ary_t->klass_is_exact() && !ary_t->is_not_null_free() &&
@@ -116,7 +116,7 @@ void Parse::array_load(BasicType bt) {
         ciArrayKlass* array_klass = ciArrayKlass::make(vk);
         const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
         Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, arytype));
-        Node* casted_adr = array_element_address(cast, idx, T_VALUETYPE, ary_t->size(), control());
+        Node* casted_adr = array_element_address(cast, idx, T_INLINE_TYPE, ary_t->size(), control());
         // Re-execute flattened array load if buffering triggers deoptimization
         PreserveReexecuteState preexecs(this);
         jvms()->set_should_reexecute(true);
@@ -160,7 +160,7 @@ void Parse::array_load(BasicType bt) {
           assert(Klass::_lh_log2_element_size_shift == 0, "use shift in place");
           Node* lhp = basic_plus_adr(kls, in_bytes(Klass::layout_helper_offset()));
           Node* elem_shift = make_load(NULL, lhp, TypeInt::INT, T_INT, MemNode::unordered);
-          uint header = arrayOopDesc::base_offset_in_bytes(T_VALUETYPE);
+          uint header = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE);
           Node* base  = basic_plus_adr(ary, header);
           idx = Compile::conv_I2X_index(&_gvn, idx, TypeInt::POS, control());
           Node* scale = _gvn.transform(new LShiftXNode(idx, elem_shift));
@@ -210,7 +210,7 @@ void Parse::array_load(BasicType bt) {
   const TypeAryPtr* adr_type = TypeAryPtr::get_array_body_type(bt);
   Node* ld = access_load_at(ary, adr, adr_type, elemtype, bt,
                             IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD);
-  if (bt == T_VALUETYPE) {
+  if (bt == T_INLINE_TYPE) {
     // Loading a non-flattened (but flattenable) value type from an array
     assert(!gvn().type(ld)->maybe_null(), "value type array elements should never be null");
     if (elemptr->value_klass()->is_scalarizable()) {

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -174,7 +174,7 @@ void Parse::do_get_xxx(Node* obj, ciField* field) {
       assert(type != NULL, "field singleton type must be consistent");
     } else {
       type = TypeOopPtr::make_from_klass(field_klass->as_klass());
-      if (bt == T_VALUETYPE && field->is_static() && flattenable) {
+      if (bt == T_INLINE_TYPE && field->is_static() && flattenable) {
         // Check if static value type field is already initialized
         assert(!flattened, "static fields should not be flattened");
         ciInstance* mirror = field->holder()->java_mirror();

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -382,7 +382,7 @@ void Parse::do_withfield() {
 
   // Clone the value type node and set the new field value
   ValueTypeNode* new_vt = holder->clone()->as_ValueType();
-  new_vt->set_oop(_gvn.zerocon(T_VALUETYPE));
+  new_vt->set_oop(_gvn.zerocon(T_INLINE_TYPE));
   gvn().set_type(new_vt, new_vt->bottom_type());
   new_vt->set_field_value_by_offset(field->offset(), val);
   Node* res = new_vt;

--- a/src/hotspot/share/opto/valuetypenode.cpp
+++ b/src/hotspot/share/opto/valuetypenode.cpp
@@ -495,7 +495,7 @@ Node* ValueTypeBaseNode::allocate_fields(GraphKit* kit) {
 
 ValueTypeNode* ValueTypeNode::make_uninitialized(PhaseGVN& gvn, ciValueKlass* vk) {
   // Create a new ValueTypeNode with uninitialized values and NULL oop
-  Node* oop = vk->is_empty() ? default_oop(gvn, vk) : gvn.zerocon(T_VALUETYPE);
+  Node* oop = vk->is_empty() ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
   return new ValueTypeNode(vk, oop);
 }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -896,7 +896,7 @@ class JNI_ArgumentPusherVaArg : public JNI_ArgumentPusher {
 
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:   push_object(va_arg(_ap, jobject)); break;
+    case T_INLINE_TYPE: push_object(va_arg(_ap, jobject)); break;
     default:            ShouldNotReachHere();
     }
   }
@@ -933,7 +933,7 @@ class JNI_ArgumentPusherArray : public JNI_ArgumentPusher {
     case T_DOUBLE:      push_double((_ap++)->d); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:   push_object((_ap++)->l); break;
+    case T_INLINE_TYPE: push_object((_ap++)->l); break;
     default:            ShouldNotReachHere();
     }
   }
@@ -1087,7 +1087,7 @@ JNI_ENTRY(jobject, jni_NewObjectA(JNIEnv *env, jclass clazz, jmethodID methodID,
     JNI_ArgumentPusherArray ap(methodID, args);
     jni_invoke_nonstatic(env, &jvalue, obj, JNI_NONVIRTUAL, methodID, &ap, CHECK_NULL);
   } else {
-    JavaValue jvalue(T_VALUETYPE);
+    JavaValue jvalue(T_INLINE_TYPE);
     JNI_ArgumentPusherArray ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     obj = jvalue.get_jobject();
@@ -1121,7 +1121,7 @@ JNI_ENTRY(jobject, jni_NewObjectV(JNIEnv *env, jclass clazz, jmethodID methodID,
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_nonstatic(env, &jvalue, obj, JNI_NONVIRTUAL, methodID, &ap, CHECK_NULL);
   } else {
-    JavaValue jvalue(T_VALUETYPE);
+    JavaValue jvalue(T_INLINE_TYPE);
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     obj = jvalue.get_jobject();
@@ -1160,7 +1160,7 @@ JNI_ENTRY(jobject, jni_NewObject(JNIEnv *env, jclass clazz, jmethodID methodID, 
   } else {
     va_list args;
     va_start(args, methodID);
-    JavaValue jvalue(T_VALUETYPE);
+    JavaValue jvalue(T_INLINE_TYPE);
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     va_end(args);

--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -279,7 +279,7 @@ checkStaticFieldID(JavaThread* thr, jfieldID fid, jclass cls, int ftype)
     ReportJNIFatalError(thr, fatal_static_field_not_found);
   if ((fd.field_type() != ftype) &&
       !(fd.field_type() == T_ARRAY && ftype == T_OBJECT) &&
-      !(fd.field_type() == T_VALUETYPE && ftype == T_OBJECT)) {
+      !(fd.field_type() == T_INLINE_TYPE && ftype == T_OBJECT)) {
     ReportJNIFatalError(thr, fatal_static_field_mismatch);
   }
 }
@@ -317,7 +317,7 @@ checkInstanceFieldID(JavaThread* thr, jfieldID fid, jobject obj, int ftype)
 
   if ((fd.field_type() != ftype) &&
       !(fd.field_type() == T_ARRAY && ftype == T_OBJECT) &&
-      !(fd.field_type() == T_VALUETYPE && ftype == T_OBJECT)) {
+      !(fd.field_type() == T_INLINE_TYPE && ftype == T_OBJECT)) {
     ReportJNIFatalError(thr, fatal_instance_field_mismatch);
   }
 }

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -581,7 +581,7 @@ bool VM_GetOrSetLocal::check_slot_type_lvt(javaVFrame* jvf) {
     slot_type = T_INT;
     break;
   case T_ARRAY:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
     slot_type = T_OBJECT;
     break;
   default:
@@ -701,7 +701,7 @@ void VM_GetOrSetLocal::doit() {
       // since the handle will be long gone by the time the deopt
       // happens. The oop stored in the deferred local will be
       // gc'd on its own.
-      if (_type == T_OBJECT || _type == T_VALUETYPE) {
+      if (_type == T_OBJECT || _type == T_INLINE_TYPE) {
         _value.l = cast_from_oop<jobject>(JNIHandles::resolve_external_guard(_value.l));
       }
       // Re-read the vframe so we can see that it is deoptimized
@@ -719,7 +719,7 @@ void VM_GetOrSetLocal::doit() {
       case T_FLOAT:  locals->set_float_at (_index, _value.f); break;
       case T_DOUBLE: locals->set_double_at(_index, _value.d); break;
       case T_OBJECT:
-      case T_VALUETYPE: {
+      case T_INLINE_TYPE: {
         Handle ob_h(Thread::current(), JNIHandles::resolve_external_guard(_value.l));
         locals->set_obj_at (_index, ob_h);
         break;
@@ -741,7 +741,7 @@ void VM_GetOrSetLocal::doit() {
         case T_FLOAT:  _value.f = locals->float_at (_index);   break;
         case T_DOUBLE: _value.d = locals->double_at(_index);   break;
         case T_OBJECT:
-        case T_VALUETYPE: {
+        case T_INLINE_TYPE: {
           // Wrap the oop to be returned in a local JNI handle since
           // oops_do() no longer applies after doit() is finished.
           oop obj = locals->obj_at(_index)();

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1281,14 +1281,14 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         ReassignedField field;
         field._offset = fs.offset();
         field._type = Signature::basic_type(fs.signature());
-        if (field._type == T_VALUETYPE) {
+        if (field._type == T_INLINE_TYPE) {
           field._type = T_OBJECT;
         }
         if (fs.is_inlined()) {
           // Resolve klass of flattened value type field
           Klass* vk = klass->get_inline_type_field_klass(fs.index());
           field._klass = ValueKlass::cast(vk);
-          field._type = T_VALUETYPE;
+          field._type = T_INLINE_TYPE;
         }
         fields->append(field);
       }
@@ -1309,7 +1309,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         obj->obj_field_put(offset, value->get_obj()());
         break;
 
-      case T_VALUETYPE: {
+      case T_INLINE_TYPE: {
         // Recursively re-assign flattened value type fields
         InstanceKlass* vk = fields->at(i)._klass;
         assert(vk != NULL, "must be resolved");
@@ -1398,7 +1398,7 @@ void Deoptimization::reassign_value_array_elements(frame* fr, RegisterMap* reg_m
   ValueKlass* vk = vak->element_klass();
   assert(vk->flatten_array(), "should only be used for flattened value type arrays");
   // Adjust offset to omit oop header
-  int base_offset = arrayOopDesc::base_offset_in_bytes(T_VALUETYPE) - ValueKlass::cast(vk)->first_field_offset();
+  int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - ValueKlass::cast(vk)->first_field_offset();
   // Initialize all elements of the flattened value type array
   for (int i = 0; i < sv->field_size(); i++) {
     ScopeValue* val = sv->field_at(i);

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -150,7 +150,7 @@ void fieldDescriptor::print() const { print_on(tty); }
 
 void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
   BasicType ft = field_type();
-  if (ft != T_VALUETYPE) {
+  if (ft != T_INLINE_TYPE) {
     print_on(st);
   }
   jint as_int = 0;
@@ -190,7 +190,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       as_int = obj->bool_field(offset());
       st->print(" %s", obj->bool_field(offset()) ? "true" : "false");
       break;
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       if (is_inlined()) {
         // Print fields of inlined fields (recursively)
         ValueKlass* vk = ValueKlass::cast(field_holder()->get_inline_type_field_klass(index()));

--- a/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
@@ -80,6 +80,6 @@ inline BasicType fieldDescriptor::field_type() const {
 }
 
 inline bool fieldDescriptor::is_inlined()  const  { return field()->is_inlined(); }
-inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_VALUETYPE; }
+inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_INLINE_TYPE; }
 
 #endif // SHARE_RUNTIME_FIELDDESCRIPTOR_INLINE_HPP

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -162,7 +162,7 @@ static BasicType runtime_type_from(JavaValue* result) {
 #ifndef _LP64
     case T_OBJECT   : // fall through
     case T_ARRAY    : // fall through
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
 #endif
     case T_BYTE     : // fall through
     case T_VOID     : return T_INT;
@@ -172,7 +172,7 @@ static BasicType runtime_type_from(JavaValue* result) {
 #ifdef _LP64
     case T_ARRAY    : // fall through
     case T_OBJECT   : return T_OBJECT;
-    case T_VALUETYPE: return T_VALUETYPE;
+    case T_INLINE_TYPE: return T_INLINE_TYPE;
 #endif
     default:
       ShouldNotReachHere();
@@ -442,7 +442,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
 #endif
 
   jobject value_buffer = NULL;
-  if (InlineTypeReturnedAsFields && result->get_type() == T_VALUETYPE) {
+  if (InlineTypeReturnedAsFields && result->get_type() == T_INLINE_TYPE) {
     // Pre allocate buffered value in case the result is returned
     // flattened by compiled code
     ValueKlass* vk = method->returned_value_type(thread);
@@ -627,7 +627,7 @@ class SignatureChekker : public SignatureIterator {
       check_double_word(); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       check_reference(); break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -1182,7 +1182,7 @@ oop Reflection::invoke_method(oop method_mirror, Handle receiver, objArrayHandle
   if (java_lang_Class::is_primitive(return_type_mirror)) {
     rtype = basic_type_mirror_to_basic_type(return_type_mirror, CHECK_NULL);
   } else if (java_lang_Class::as_Klass(return_type_mirror)->is_inline_klass()) {
-    rtype = T_VALUETYPE;
+    rtype = T_INLINE_TYPE;
   } else {
     rtype = T_OBJECT;
   }
@@ -1226,7 +1226,7 @@ oop Reflection::invoke_constructor(oop constructor_mirror, objArrayHandle args, 
     if (klass->is_hidden()) {
       rtype = T_OBJECT;
     } else {
-      rtype = T_VALUETYPE;
+      rtype = T_INLINE_TYPE;
     }
     return invoke(klass, method, no_receiver, override, ptypes, rtype, args, false, CHECK_NULL);
   }

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -1054,7 +1054,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
       while (!ss.at_return_type()) {
         ss.next();
       }
-      if (ss.type() == T_VALUETYPE) {
+      if (ss.type() == T_INLINE_TYPE) {
         // Check if value type is returned as fields
         vk = ValueKlass::returned_value_klass(map);
         if (vk != NULL) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2372,9 +2372,9 @@ class AdapterFingerPrint : public CHeapObj<mtCode> {
         }
       }
 
-      case T_VALUETYPE: {
+      case T_INLINE_TYPE: {
         // If inline types are passed as fields, return 'in' to differentiate
-        // between a T_VALUETYPE and a T_OBJECT in the signature.
+        // between a T_INLINE_TYPE and a T_OBJECT in the signature.
         return InlineTypePassFieldsAsArgs ? in : adapter_encoding(T_OBJECT, false);
       }
 
@@ -2431,7 +2431,7 @@ class AdapterFingerPrint : public CHeapObj<mtCode> {
         int bt = 0;
         if (sig_index < total_args_passed) {
           BasicType sbt = sig->at(sig_index++)._bt;
-          if (InlineTypePassFieldsAsArgs && sbt == T_VALUETYPE) {
+          if (InlineTypePassFieldsAsArgs && sbt == T_INLINE_TYPE) {
             // Found start of inline type in signature
             vt_count++;
             if (sig_index == 1 && has_ro_adapter) {
@@ -2756,7 +2756,7 @@ int CompiledEntrySignature::compute_scalarized_cc(GrowableArray<SigEntry>*& sig_
   }
   Thread* THREAD = Thread::current();
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_VALUETYPE) {
+    if (ss.type() == T_INLINE_TYPE) {
       ValueKlass* vk = ss.as_value_klass(holder);
       if (vk->can_be_passed_as_fields()) {
         sig_cc->appendAll(vk->extended_sig());
@@ -2843,7 +2843,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
   }
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
     BasicType bt = ss.type();
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       if (ss.as_value_klass(_method->method_holder())->can_be_passed_as_fields()) {
         _num_value_args++;
       }
@@ -3603,7 +3603,7 @@ oop SharedRuntime::allocate_value_types_impl(JavaThread* thread, methodHandle ca
     nb_slots++;
   }
   for (SignatureStream ss(callee->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_VALUETYPE) {
+    if (ss.type() == T_INLINE_TYPE) {
       nb_slots++;
     }
   }
@@ -3617,7 +3617,7 @@ oop SharedRuntime::allocate_value_types_impl(JavaThread* thread, methodHandle ca
     i++;
   }
   for (SignatureStream ss(callee->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_VALUETYPE) {
+    if (ss.type() == T_INLINE_TYPE) {
       ValueKlass* vk = ss.as_value_klass(holder);
       oop res = vk->allocate_instance(CHECK_NULL);
       array->obj_at_put(i, res);
@@ -3683,7 +3683,7 @@ JRT_LEAF(void, SharedRuntime::load_value_type_fields_in_regs(JavaThread* thread,
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_VALUETYPE) {
+    if (bt == T_INLINE_TYPE) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -218,7 +218,7 @@ inline int SignatureStream::scan_type(BasicType type) {
   const u1* tem;
   switch (type) {
   case T_OBJECT:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
     tem = (const u1*) memchr(&base[end], JVM_SIGNATURE_ENDCLASS, limit - end);
     return (tem == NULL ? limit : tem + 1 - base);
 
@@ -578,7 +578,7 @@ void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, int offset)
 
 // Inserts a reserved argument at position 'i'
 void SigEntry::insert_reserved_entry(GrowableArray<SigEntry>* sig, int i, BasicType bt) {
-  if (bt == T_OBJECT || bt == T_ARRAY || bt == T_VALUETYPE) {
+  if (bt == T_OBJECT || bt == T_ARRAY || bt == T_INLINE_TYPE) {
     // Treat this as INT to not confuse the GC
     bt = T_INT;
   } else if (bt == T_LONG || bt == T_DOUBLE) {
@@ -595,7 +595,7 @@ bool SigEntry::is_reserved_entry(const GrowableArray<SigEntry>* sig, int i) {
 
 // Returns true if the argument at index 'i' is not a value type delimiter
 bool SigEntry::skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i) {
-  return (sig->at(i)._bt != T_VALUETYPE &&
+  return (sig->at(i)._bt != T_INLINE_TYPE &&
           (sig->at(i)._bt != T_VOID || sig->at(i-1)._bt == T_LONG || sig->at(i-1)._bt == T_DOUBLE));
 }
 
@@ -619,7 +619,7 @@ TempNewSymbol SigEntry::create_symbol(const GrowableArray<SigEntry>* sig) {
   sig_str[idx++] = '(';
   for (int i = 0; i < length; i++) {
     BasicType bt = sig->at(i)._bt;
-    if (bt == T_VALUETYPE || bt == T_VOID) {
+    if (bt == T_INLINE_TYPE || bt == T_VOID) {
       // Ignore
     } else {
       if (bt == T_ARRAY) {

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -274,7 +274,7 @@ class SignatureTypeNames : public SignatureIterator {
     case T_VOID:    type_name("void"    ); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:  type_name("jobject" ); break;
+    case T_INLINE_TYPE:  type_name("jobject" ); break;
     default: ShouldNotReachHere();
     }
   }
@@ -408,7 +408,7 @@ class NativeSignatureIterator: public SignatureIterator {
     }
     case T_ARRAY:
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       pass_object(); _jni_offset++; _offset++;
       break;
     default:
@@ -596,16 +596,16 @@ class SigEntry {
     }
     assert((e1->_bt == T_LONG && (e2->_bt == T_LONG || e2->_bt == T_VOID)) ||
            (e1->_bt == T_DOUBLE && (e2->_bt == T_DOUBLE || e2->_bt == T_VOID)) ||
-           e1->_bt == T_VALUETYPE || e2->_bt == T_VALUETYPE || e1->_bt == T_VOID || e2->_bt == T_VOID, "bad bt");
+           e1->_bt == T_INLINE_TYPE || e2->_bt == T_INLINE_TYPE || e1->_bt == T_VOID || e2->_bt == T_VOID, "bad bt");
     if (e1->_bt == e2->_bt) {
-      assert(e1->_bt == T_VALUETYPE || e1->_bt == T_VOID, "only ones with duplicate offsets");
+      assert(e1->_bt == T_INLINE_TYPE || e1->_bt == T_VOID, "only ones with duplicate offsets");
       return 0;
     }
     if (e1->_bt == T_VOID ||
-        e2->_bt == T_VALUETYPE) {
+        e2->_bt == T_INLINE_TYPE) {
       return 1;
     }
-    if (e1->_bt == T_VALUETYPE ||
+    if (e1->_bt == T_INLINE_TYPE ||
         e2->_bt == T_VOID) {
       return -1;
     }
@@ -624,7 +624,7 @@ class SigEntry {
 
 class SigEntryFilter {
 public:
-  bool operator()(const SigEntry& entry) { return entry._bt != T_VALUETYPE && entry._bt != T_VOID; }
+  bool operator()(const SigEntry& entry) { return entry._bt != T_INLINE_TYPE && entry._bt != T_VOID; }
 };
 
 // Specialized SignatureStream: used for invoking SystemDictionary to either find

--- a/src/hotspot/share/runtime/signature_cc.hpp
+++ b/src/hotspot/share/runtime/signature_cc.hpp
@@ -39,7 +39,7 @@ class ScalarizedValueArgsStream : public StackObj {
 public:
   ScalarizedValueArgsStream(const GrowableArray<SigEntry>* sig_cc, int sig_cc_index, VMRegPair* regs_cc, int regs_cc_count, int regs_cc_index) :
     _sig_cc(sig_cc), _sig_cc_index(sig_cc_index), _regs_cc(regs_cc), _regs_cc_count(regs_cc_count), _regs_cc_index(regs_cc_index) {
-    assert(_sig_cc->at(_sig_cc_index)._bt == T_VALUETYPE, "should be at end delimiter");
+    assert(_sig_cc->at(_sig_cc_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
     _vt = 1;
     DEBUG_ONLY(_finished = false);
   }
@@ -49,7 +49,7 @@ public:
     do {
       _sig_cc_index++;
       bt = _sig_cc->at(_sig_cc_index)._bt;
-      if (bt == T_VALUETYPE) {
+      if (bt == T_INLINE_TYPE) {
         _vt++;
       } else if (bt == T_VOID &&
                  _sig_cc->at(_sig_cc_index-1)._bt != T_LONG &&

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -520,7 +520,7 @@ address StubRoutines::select_fill_function(BasicType t, bool aligned, const char
   case T_DOUBLE:
   case T_LONG:
   case T_ARRAY:
-  case T_VALUETYPE:
+  case T_INLINE_TYPE:
   case T_OBJECT:
   case T_NARROWOOP:
   case T_NARROWKLASS:

--- a/src/hotspot/share/runtime/vframe_hp.cpp
+++ b/src/hotspot/share/runtime/vframe_hp.cpp
@@ -388,7 +388,7 @@ void jvmtiDeferredLocalVariableSet::update_value(StackValueCollection* locals, B
       locals->set_long_at(index, value.j);
       break;
     case T_OBJECT:
-    case T_VALUETYPE:
+    case T_INLINE_TYPE:
       {
         Handle obj(Thread::current(), (oop)value.l);
         locals->set_obj_at(index, obj);

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -128,7 +128,7 @@ void basic_types_init() {
       case T_DOUBLE:
       case T_LONG:
       case T_OBJECT:
-      case T_VALUETYPE:
+      case T_INLINE_TYPE:
       case T_ADDRESS:     // random raw pointer
       case T_METADATA:    // metadata pointer
       case T_NARROWOOP:   // compressed pointer
@@ -194,7 +194,7 @@ void basic_types_init() {
   }
   _type2aelembytes[T_OBJECT] = heapOopSize;
   _type2aelembytes[T_ARRAY]  = heapOopSize;
-  _type2aelembytes[T_VALUETYPE]  = heapOopSize;
+  _type2aelembytes[T_INLINE_TYPE]  = heapOopSize;
 }
 
 
@@ -260,7 +260,7 @@ BasicType type2field[T_CONFLICT+1] = {
   T_LONG,                  // T_LONG     = 11,
   T_OBJECT,                // T_OBJECT   = 12,
   T_OBJECT,                // T_ARRAY    = 13,
-  T_VALUETYPE,             // T_VALUETYPE = 14,
+  T_INLINE_TYPE,           // T_INLINE_TYPE = 14,
   T_VOID,                  // T_VOID     = 15,
   T_ADDRESS,               // T_ADDRESS  = 16,
   T_NARROWOOP,             // T_NARROWOOP= 17,
@@ -285,7 +285,7 @@ BasicType type2wfield[T_CONFLICT+1] = {
   T_LONG,    // T_LONG     = 11,
   T_OBJECT,  // T_OBJECT   = 12,
   T_OBJECT,  // T_ARRAY    = 13,
-  T_OBJECT,  // T_VALUETYPE = 14,
+  T_OBJECT,  // T_INLINE_TYPE = 14,
   T_VOID,    // T_VOID     = 15,
   T_ADDRESS, // T_ADDRESS  = 16,
   T_NARROWOOP, // T_NARROWOOP  = 17,
@@ -310,7 +310,7 @@ int _type2aelembytes[T_CONFLICT+1] = {
   T_LONG_aelem_bytes,        // T_LONG     = 11,
   T_OBJECT_aelem_bytes,      // T_OBJECT   = 12,
   T_ARRAY_aelem_bytes,       // T_ARRAY    = 13,
-  T_VALUETYPE_aelem_bytes,   // T_VALUETYPE = 14,
+  T_INLINE_TYPE_aelem_bytes,   // T_INLINE_TYPE = 14,
   0,                         // T_VOID     = 15,
   T_OBJECT_aelem_bytes,      // T_ADDRESS  = 16,
   T_NARROWOOP_aelem_bytes,   // T_NARROWOOP= 17,

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -625,7 +625,7 @@ enum BasicType {
   // types in their own right.
   T_OBJECT      = 12,
   T_ARRAY       = 13,
-  T_VALUETYPE   = 14,
+  T_INLINE_TYPE = 14,
   T_VOID        = 15,
   T_ADDRESS     = 16,
   T_NARROWOOP   = 17,
@@ -646,7 +646,7 @@ enum BasicType {
     F(JVM_SIGNATURE_LONG,    T_LONG,    N)      \
     F(JVM_SIGNATURE_CLASS,   T_OBJECT,  N)      \
     F(JVM_SIGNATURE_ARRAY,   T_ARRAY,   N)      \
-    F(JVM_SIGNATURE_INLINE_TYPE, T_VALUETYPE, N) \
+    F(JVM_SIGNATURE_INLINE_TYPE, T_INLINE_TYPE, N) \
     F(JVM_SIGNATURE_VOID,    T_VOID,    N)      \
     /*end*/
 
@@ -672,7 +672,7 @@ inline bool is_double_word_type(BasicType t) {
 }
 
 inline bool is_reference_type(BasicType t) {
-  return (t == T_OBJECT || t == T_ARRAY || t == T_VALUETYPE);
+  return (t == T_OBJECT || t == T_ARRAY || t == T_INLINE_TYPE);
 }
 
 extern char type2char_tab[T_CONFLICT+1];     // Map a BasicType to a jchar
@@ -702,7 +702,7 @@ enum BasicTypeSize {
   T_NARROWOOP_size   = 1,
   T_NARROWKLASS_size = 1,
   T_VOID_size        = 0,
-  T_VALUETYPE_size   = 1
+  T_INLINE_TYPE_size = 1
 };
 
 // this works on valid parameter types but not T_VOID, T_CONFLICT, etc.
@@ -732,11 +732,11 @@ enum ArrayElementSize {
 #ifdef _LP64
   T_OBJECT_aelem_bytes      = 8,
   T_ARRAY_aelem_bytes       = 8,
-  T_VALUETYPE_aelem_bytes   = 8,
+  T_INLINE_TYPE_aelem_bytes = 8,
 #else
   T_OBJECT_aelem_bytes      = 4,
   T_ARRAY_aelem_bytes       = 4,
-  T_VALUETYPE_aelem_bytes   = 4,
+  T_INLINE_TYPE_aelem_bytes = 4,
 #endif
   T_NARROWOOP_aelem_bytes   = 4,
   T_NARROWKLASS_aelem_bytes = 4,
@@ -840,7 +840,7 @@ inline TosState as_TosState(BasicType type) {
     case T_FLOAT  : return ftos;
     case T_DOUBLE : return dtos;
     case T_VOID   : return vtos;
-    case T_VALUETYPE: // fall through
+    case T_INLINE_TYPE: // fall through
     case T_ARRAY  :   // fall through
     case T_OBJECT : return atos;
     default       : return ilgl;


### PR DESCRIPTION
Global rename of T_VALUETYPE to T_INLINE_TYPE in the JVM.  Tested with tiers 1,2 and some of tier3 on windows, mac, and Linux x64.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8249244](https://bugs.openjdk.java.net/browse/JDK-8249244): Rename T_VALUETYPE to T_INLINE_TYPE


### Reviewers
 * Mandy Chung ([mchung](@mlchung) - Committer)
 * Frederic Parain ([fparain](@fparain) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/107/head:pull/107`
`$ git checkout pull/107`
