### PR TITLE
8249257 Rename ValueKlass to InlineKlass

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -35,7 +35,7 @@
 #include "oops/markWord.hpp"
 #include "oops/method.hpp"
 #include "oops/methodData.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/basicLock.hpp"
@@ -700,8 +700,8 @@ void InterpreterMacroAssembler::remove_activation(
     // Load fields from a buffered value with a value class specific handler
 
     load_klass(rscratch1 /*dst*/, r0 /*src*/);
-    ldr(rscratch1, Address(rscratch1, InstanceKlass::adr_valueklass_fixed_block_offset()));
-    ldr(rscratch1, Address(rscratch1, ValueKlass::unpack_handler_offset()));
+    ldr(rscratch1, Address(rscratch1, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+    ldr(rscratch1, Address(rscratch1, InlineKlass::unpack_handler_offset()));
     cbz(rscratch1, skip);
 
     blr(rscratch1);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5281,12 +5281,12 @@ int MacroAssembler::store_value_type_fields_to_buf(ciValueKlass* vk, bool from_i
 
     if (vk != NULL) {
       // Called from C1, where the return type is statically known.
-      mov(r1, (intptr_t)vk->get_ValueKlass());
+      mov(r1, (intptr_t)vk->get_InlineKlass());
       jint lh = vk->layout_helper();
       assert(lh != Klass::_lh_neutral_value, "inline class in return type must have been resolved");
       mov(r14, lh);
     } else {
-       // Call from interpreter. R0 contains ((the ValueKlass* of the return type) | 0x01)
+       // Call from interpreter. R0 contains ((the InlineKlass* of the return type) | 0x01)
        andr(r1, r0, -2);
        // get obj size
        ldrw(r14, Address(rscratch1 /*klass*/, Klass::layout_helper_offset()));
@@ -5326,8 +5326,8 @@ int MacroAssembler::store_value_type_fields_to_buf(ciValueKlass* vk, bool from_i
 
         // We have our new buffered value, initialize its fields with a
         // value class specific handler
-        ldr(r1, Address(r0, InstanceKlass::adr_valueklass_fixed_block_offset()));
-        ldr(r1, Address(r1, ValueKlass::pack_handler_offset()));
+        ldr(r1, Address(r0, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+        ldr(r1, Address(r1, InlineKlass::pack_handler_offset()));
 
         // Mov new class to r0 and call pack_handler
         mov(r0, r13);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -3324,7 +3324,7 @@ void OptoRuntime::generate_exception_blob() {
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }
 
-BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const ValueKlass* vk) {
+BufferedValueTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   BufferBlob* buf = BufferBlob::create("value types pack/unpack", 16 * K);
   CodeBuffer buffer(buf);
   short buffer_locs[20];

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -375,8 +375,8 @@ class StubGenerator: public StubCodeGenerator {
       // Initialize pre-allocated buffer
       __ mov(r1, r0);
       __ andr(r1, r1, -2);
-      __ ldr(r1, Address(r1, InstanceKlass::adr_valueklass_fixed_block_offset()));
-      __ ldr(r1, Address(r1, ValueKlass::pack_handler_offset()));
+      __ ldr(r1, Address(r1, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      __ ldr(r1, Address(r1, InlineKlass::pack_handler_offset()));
       __ ldr(r0, Address(j_rarg2, 0));
       __ blr(r1);
       __ b(exit);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -38,7 +38,7 @@
 #include "oops/methodData.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/arguments.hpp"

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -31,7 +31,7 @@
 #include "oops/markWord.hpp"
 #include "oops/methodData.hpp"
 #include "oops/method.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/basicLock.hpp"
@@ -1170,8 +1170,8 @@ void InterpreterMacroAssembler::remove_activation(
     // Load fields from a buffered value with a value class specific handler
     Register tmp_load_klass = LP64_ONLY(rscratch1) NOT_LP64(noreg);
     load_klass(rdi, rax, tmp_load_klass);
-    movptr(rdi, Address(rdi, InstanceKlass::adr_valueklass_fixed_block_offset()));
-    movptr(rdi, Address(rdi, ValueKlass::unpack_handler_offset()));
+    movptr(rdi, Address(rdi, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+    movptr(rdi, Address(rdi, InlineKlass::unpack_handler_offset()));
 
     testptr(rdi, rdi);
     jcc(Assembler::equal, skip);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3640,8 +3640,8 @@ void MacroAssembler::get_default_value_oop(Register value_klass, Register temp_r
 #endif
   Register offset = temp_reg;
   // Getting the offset of the pre-allocated default value
-  movptr(offset, Address(value_klass, in_bytes(InstanceKlass::adr_valueklass_fixed_block_offset())));
-  movl(offset, Address(offset, in_bytes(ValueKlass::default_value_offset_offset())));
+  movptr(offset, Address(value_klass, in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset())));
+  movl(offset, Address(offset, in_bytes(InlineKlass::default_value_offset_offset())));
 
   // Getting the mirror
   movptr(obj, Address(value_klass, in_bytes(Klass::java_mirror_offset())));
@@ -4683,8 +4683,8 @@ void MacroAssembler::access_value_copy(DecoratorSet decorators, Register src, Re
 }
 
 void MacroAssembler::first_field_offset(Register value_klass, Register offset) {
-  movptr(offset, Address(value_klass, InstanceKlass::adr_valueklass_fixed_block_offset()));
-  movl(offset, Address(offset, ValueKlass::first_field_offset_offset()));
+  movptr(offset, Address(value_klass, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+  movl(offset, Address(offset, InlineKlass::first_field_offset_offset()));
 }
 
 void MacroAssembler::data_for_oop(Register oop, Register data, Register value_klass) {
@@ -5228,7 +5228,7 @@ int MacroAssembler::store_value_type_fields_to_buf(ciValueKlass* vk, bool from_i
       assert(lh != Klass::_lh_neutral_value, "inline class in return type must have been resolved");
       movl(r14, lh);
     } else {
-      // Call from interpreter. RAX contains ((the ValueKlass* of the return type) | 0x01)
+      // Call from interpreter. RAX contains ((the InlineKlass* of the return type) | 0x01)
       mov(rbx, rax);
       andptr(rbx, -2);
       movl(r14, Address(rbx, Klass::layout_helper_offset()));
@@ -5258,8 +5258,8 @@ int MacroAssembler::store_value_type_fields_to_buf(ciValueKlass* vk, bool from_i
       mov(rax, r13);
       call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
     } else {
-      movptr(rbx, Address(rax, InstanceKlass::adr_valueklass_fixed_block_offset()));
-      movptr(rbx, Address(rbx, ValueKlass::pack_handler_offset()));
+      movptr(rbx, Address(rax, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      movptr(rbx, Address(rbx, InlineKlass::pack_handler_offset()));
       mov(rax, r13);
       call(rbx);
     }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -105,9 +105,9 @@ class MacroAssembler: public Assembler {
   void test_klass_is_value(Register klass, Register temp_reg, Label& is_value);
   void test_klass_is_empty_value(Register klass, Register temp_reg, Label& is_empty_value);
 
-  // Get the default value oop for the given ValueKlass
+  // Get the default value oop for the given InlineKlass
   void get_default_value_oop(Register value_klass, Register temp_reg, Register obj);
-  // The empty value oop, for the given ValueKlass ("empty" as in no instance fields)
+  // The empty value oop, for the given InlineKlass ("empty" as in no instance fields)
   // get_default_value_oop with extra assertion for empty value klass
   void get_empty_value_oop(Register value_klass, Register temp_reg, Register obj);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -108,7 +108,7 @@ class MacroAssembler: public Assembler {
   // Get the default value oop for the given InlineKlass
   void get_default_value_oop(Register value_klass, Register temp_reg, Register obj);
   // The empty value oop, for the given InlineKlass ("empty" as in no instance fields)
-  // get_default_value_oop with extra assertion for empty value klass
+  // get_default_value_oop with extra assertion for empty inline klass
   void get_empty_value_oop(Register value_klass, Register temp_reg, Register obj);
 
   void test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -3325,7 +3325,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   return RuntimeStub::new_runtime_stub(name, &buffer, frame_complete, frame_size_words, oop_maps, true);
 }
 
-BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const ValueKlass* vk) {
+BufferedValueTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -4323,7 +4323,7 @@ void OptoRuntime::generate_exception_blob() {
 }
 #endif // COMPILER2
 
-BufferedValueTypeBlob* SharedRuntime::generate_buffered_value_type_adapter(const ValueKlass* vk) {
+BufferedValueTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   BufferBlob* buf = BufferBlob::create("value types pack/unpack", 16 * K);
   CodeBuffer buffer(buf);
   short buffer_locs[20];

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -421,8 +421,8 @@ class StubGenerator: public StubCodeGenerator {
       __ jcc(Assembler::zero, is_long);
       // Load pack handler address
       __ andptr(rax, -2);
-      __ movptr(rax, Address(rax, InstanceKlass::adr_valueklass_fixed_block_offset()));
-      __ movptr(rbx, Address(rax, ValueKlass::pack_handler_jobject_offset()));
+      __ movptr(rax, Address(rax, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      __ movptr(rbx, Address(rax, InlineKlass::pack_handler_jobject_offset()));
       // Call pack handler to initialize the buffer
       __ call(rbx);
       __ jmp(exit);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -36,7 +36,7 @@
 #include "oops/methodData.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/arguments.hpp"

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -33,7 +33,7 @@
 #include "oops/methodData.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/safepointMechanism.hpp"
@@ -4421,7 +4421,7 @@ void TemplateTable::defaultvalue() {
   __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
   __ jcc(Assembler::notEqual, slow_case);
 
-  // have a resolved ValueKlass in rcx, return the default value oop from it
+  // have a resolved InlineKlass in rcx, return the default value oop from it
   __ get_default_value_oop(rcx, rdx, rax);
   __ jmp(done);
 

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -27,7 +27,7 @@
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/signature_cc.hpp"
 #include "runtime/sharedRuntime.hpp"
 #ifdef COMPILER2
@@ -148,7 +148,7 @@ int MacroAssembler::unpack_value_args_common(Compile* C, bool receiver_only) {
   } else {
     // Only unpack the receiver, all other arguments are already scalarized
     InstanceKlass* holder = method->method_holder();
-    int rec_len = holder->is_inline_klass() ? ValueKlass::cast(holder)->extended_sig()->length() : 1;
+    int rec_len = holder->is_inline_klass() ? InlineKlass::cast(holder)->extended_sig()->length() : 1;
     // Copy scalarized signature but skip receiver, value type delimiters and reserved entries
     for (int i = 0; i < sig_cc->length(); i++) {
       if (!SigEntry::is_reserved_entry(sig_cc, i)) {

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -34,7 +34,7 @@
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
@@ -551,7 +551,7 @@ GrowableArray<ciField*>* ciInstanceKlass::compute_nonstatic_fields_impl(Growable
     if (fd.is_inlined() && flatten) {
       // Value type fields are embedded
       int field_offset = fd.offset();
-      // Get ValueKlass and adjust number of fields
+      // Get InlineKlass and adjust number of fields
       Klass* k = get_instanceKlass()->get_inline_type_field_klass(fd.index());
       ciValueKlass* vk = CURRENT_ENV->get_klass(k)->as_value_klass();
       flen += vk->nof_nonstatic_fields() - 1;
@@ -821,7 +821,7 @@ void StaticFieldPrinter::do_field_helper(fieldDescriptor* fd, oop mirror, bool f
       Klass* k = SystemDictionary::find(name, Handle(THREAD, holder->class_loader()),
                                         Handle(THREAD, holder->protection_domain()), THREAD);
       assert(k != NULL && !HAS_PENDING_EXCEPTION, "can resolve klass?");
-      ValueKlass* vk = ValueKlass::cast(k);
+      InlineKlass* vk = InlineKlass::cast(k);
       oop obj;
       if (flattened) {
         int field_offset = fd->offset() - vk->first_field_offset();

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -37,7 +37,7 @@
 #include "oops/constantPool.hpp"
 #include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "utilities/copy.hpp"
@@ -852,7 +852,7 @@ class CompileReplay : public StackObj {
         break;
       }
       case T_INLINE_TYPE: {
-        ValueKlass* vk = ValueKlass::cast(fd->field_holder()->get_inline_type_field_klass(fd->index()));
+        InlineKlass* vk = InlineKlass::cast(fd->field_holder()->get_inline_type_field_klass(fd->index()));
         if (fd->is_inlined()) {
           int field_offset = fd->offset() - vk->first_field_offset();
           oop obj = (oop)(cast_from_oop<address>(_vt) + field_offset);
@@ -1001,7 +1001,7 @@ class CompileReplay : public StackObj {
       java_mirror->double_field_put(fd.offset(), value);
     } else if (field_signature[0] == JVM_SIGNATURE_INLINE_TYPE) {
       Klass* kelem = resolve_klass(field_signature, CHECK);
-      ValueKlass* vk = ValueKlass::cast(kelem);
+      InlineKlass* vk = InlineKlass::cast(kelem);
       oop value = vk->allocate_instance(CHECK);
       ValueTypeFieldInitializer init_fields(value, this);
       vk->do_nonstatic_fields(&init_fields);

--- a/src/hotspot/share/ci/ciValueArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciValueArrayKlass.cpp
@@ -42,7 +42,7 @@
 // Constructor for loaded value array klasses.
 ciValueArrayKlass::ciValueArrayKlass(Klass* h_k) : ciArrayKlass(h_k) {
   assert(get_Klass()->is_valueArray_klass(), "wrong type");
-  ValueKlass* element_Klass = get_ValueArrayKlass()->element_klass();
+  InlineKlass* element_Klass = get_ValueArrayKlass()->element_klass();
   _base_element_klass = CURRENT_ENV->get_klass(element_Klass);
   assert(_base_element_klass->is_valuetype(), "bad base klass");
   if (dimension() == 1) {

--- a/src/hotspot/share/ci/ciValueKlass.cpp
+++ b/src/hotspot/share/ci/ciValueKlass.cpp
@@ -26,7 +26,7 @@
 #include "ci/ciField.hpp"
 #include "ci/ciUtilities.inline.hpp"
 #include "ci/ciValueKlass.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 
 int ciValueKlass::compute_nonstatic_fields() {
   int result = ciInstanceKlass::compute_nonstatic_fields();
@@ -134,6 +134,6 @@ address ciValueKlass::unpack_handler() const {
   GUARDED_VM_ENTRY(return get_ValueKlass()->unpack_handler();)
 }
 
-ValueKlass* ciValueKlass::get_ValueKlass() const {
+InlineKlass* ciValueKlass::get_ValueKlass() const {
   GUARDED_VM_ENTRY(return to_ValueKlass();)
 }

--- a/src/hotspot/share/ci/ciValueKlass.hpp
+++ b/src/hotspot/share/ci/ciValueKlass.hpp
@@ -30,7 +30,7 @@
 #include "ci/ciFlags.hpp"
 #include "ci/ciInstanceKlass.hpp"
 #include "ci/ciSymbol.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 
 // ciValueKlass
 //
@@ -42,13 +42,13 @@ private:
   // Fields declared in the bytecode (without flattened value type fields)
   GrowableArray<ciField*>* _declared_nonstatic_fields;
 
-  ValueKlass* to_ValueKlass() const {
-    return ValueKlass::cast(get_Klass());
+  InlineKlass* to_ValueKlass() const {
+    return InlineKlass::cast(get_Klass());
   }
 
 protected:
   ciValueKlass(Klass* h_k) : ciInstanceKlass(h_k), _declared_nonstatic_fields(NULL) {
-    assert(is_final(), "ValueKlass must be final");
+    assert(is_final(), "InlineKlass must be final");
   };
 
   ciValueKlass(ciSymbol* name, jobject loader, jobject protection_domain) :
@@ -89,7 +89,7 @@ public:
   Array<SigEntry>* extended_sig() const;
   address pack_handler() const;
   address unpack_handler() const;
-  ValueKlass* get_ValueKlass() const;
+  InlineKlass* get_ValueKlass() const;
 };
 
 #endif // SHARE_VM_CI_CIVALUEKLASS_HPP

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -59,7 +59,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/recordComponent.hpp"
 #include "oops/symbol.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/arguments.hpp"
@@ -4485,7 +4485,7 @@ void ClassFileParser::layout_fields(ConstantPool* cp,
       if (!klass->access_flags().is_inline_type()) {
         THROW(vmSymbols::java_lang_IncompatibleClassChangeError());
       }
-      ValueKlass* vk = ValueKlass::cast(klass);
+      InlineKlass* vk = InlineKlass::cast(klass);
       // Conditions to apply flattening or not should be defined in a single place
       bool too_big_to_allocate_inline = (InlineFieldMaxFlatSize >= 0 &&
                                  (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
@@ -4501,7 +4501,7 @@ void ClassFileParser::layout_fields(ConstantPool* cp,
         nonstatic_inline_type_klasses[nonstatic_inline_type_count] = klass;
         nonstatic_inline_type_count++;
 
-        ValueKlass* vklass = ValueKlass::cast(klass);
+        InlineKlass* vklass = InlineKlass::cast(klass);
         if (vklass->contains_oops()) {
           inline_type_oop_map_count += vklass->nonstatic_oop_map_count();
         }
@@ -4697,7 +4697,7 @@ void ClassFileParser::layout_fields(ConstantPool* cp,
           Klass* klass = nonstatic_inline_type_klasses[next_inline_type_index];
           assert(klass != NULL, "Klass should have been loaded and resolved earlier");
           assert(klass->access_flags().is_inline_type(),"Must be an inline type");
-          ValueKlass* vklass = ValueKlass::cast(klass);
+          InlineKlass* vklass = InlineKlass::cast(klass);
           real_offset = next_nonstatic_inline_type_offset;
           next_nonstatic_inline_type_offset += (vklass->size_helper()) * wordSize - vklass->first_field_offset();
           // aligning next inline type on a 64 bits boundary
@@ -6178,7 +6178,7 @@ InstanceKlass* ClassFileParser::create_instance_klass(bool changed_by_loadhook,
   }
 
   if (ik->is_inline_klass()) {
-    ValueKlass* vk = ValueKlass::cast(ik);
+    InlineKlass* vk = InlineKlass::cast(ik);
     oop val = ik->allocate_instance(CHECK_NULL);
     vk->set_default_value(val);
   }
@@ -6450,12 +6450,12 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
     } else
       if (is_inline_type() && ((ik->field_access_flags(i) & JVM_ACC_FIELD_INTERNAL) != 0)
         && ((ik->field_access_flags(i) & JVM_ACC_STATIC) != 0)) {
-      ValueKlass::cast(ik)->set_default_value_offset(ik->field_offset(i));
+      InlineKlass::cast(ik)->set_default_value_offset(ik->field_offset(i));
     }
   }
 
   if (is_inline_type()) {
-    ValueKlass* vk = ValueKlass::cast(ik);
+    InlineKlass* vk = InlineKlass::cast(ik);
     if (UseNewFieldLayout) {
       vk->set_alignment(_alignment);
       vk->set_first_field_offset(_first_field_offset);
@@ -6463,7 +6463,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
     } else {
       vk->set_first_field_offset(vk->first_field_offset_old());
     }
-    ValueKlass::cast(ik)->initialize_calling_convention(CHECK);
+    InlineKlass::cast(ik)->initialize_calling_convention(CHECK);
   }
 
   ClassLoadingService::notify_class_loaded(ik, false /* not shared class */);

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -63,7 +63,7 @@
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "oops/weakHandle.inline.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
@@ -374,11 +374,11 @@ void ClassLoaderData::classes_do(void f(InstanceKlass*)) {
   }
 }
 
-void ClassLoaderData::value_classes_do(void f(ValueKlass*)) {
+void ClassLoaderData::inline_classes_do(void f(InlineKlass*)) {
   // Lock-free access requires load_acquire
   for (Klass* k = Atomic::load_acquire(&_klasses); k != NULL; k = k->next_link()) {
     if (k->is_inline_klass()) {
-      f(ValueKlass::cast(k));
+      f(InlineKlass::cast(k));
     }
     assert(k != k->next_link(), "no loops!");
   }
@@ -550,7 +550,7 @@ void ClassLoaderData::unload() {
   // if they are not already on the _klasses list.
   free_deallocate_list_C_heap_structures();
 
-  value_classes_do(ValueKlass::cleanup);
+  inline_classes_do(InlineKlass::cleanup);
 
   // Clean up class dependencies and tell serviceability tools
   // these classes are unloading.  Must be called
@@ -849,7 +849,7 @@ void ClassLoaderData::free_deallocate_list() {
         if (!((Klass*)m)->is_inline_klass()) {
           MetadataFactory::free_metadata(this, (InstanceKlass*)m);
         } else {
-          MetadataFactory::free_metadata(this, (ValueKlass*)m);
+          MetadataFactory::free_metadata(this, (InlineKlass*)m);
         }
       } else {
         ShouldNotReachHere();

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -189,7 +189,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   void classes_do(void f(Klass* const));
   void loaded_classes_do(KlassClosure* klass_closure);
   void classes_do(void f(InstanceKlass*));
-  void value_classes_do(void f(ValueKlass*));
+  void inline_classes_do(void f(InlineKlass*));
   void methods_do(void f(Method*));
   void modules_do(void f(ModuleEntry*));
   void packages_do(void f(PackageEntry*));

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -64,7 +64,7 @@ class LayoutRawBlock : public ResourceObj {
  private:
   LayoutRawBlock* _next_block;
   LayoutRawBlock* _prev_block;
-  ValueKlass* _value_klass;
+  InlineKlass* _value_klass;
   Kind _kind;
   int _offset;
   int _alignment;
@@ -93,11 +93,11 @@ class LayoutRawBlock : public ResourceObj {
     return _field_index;
   }
   bool is_reference() const { return _is_reference; }
-  ValueKlass* value_klass() const {
+  InlineKlass* value_klass() const {
     assert(_value_klass != NULL, "Must be initialized");
     return _value_klass;
   }
-  void set_value_klass(ValueKlass* value_klass) { _value_klass = value_klass; }
+  void set_value_klass(InlineKlass* value_klass) { _value_klass = value_klass; }
 
   bool fit(int size, int alignment);
 
@@ -150,7 +150,7 @@ class FieldGroup : public ResourceObj {
 
   void add_primitive_field(AllFieldStream fs, BasicType type);
   void add_oop_field(AllFieldStream fs);
-  void add_inlined_field(AllFieldStream fs, ValueKlass* vk);
+  void add_inlined_field(AllFieldStream fs, InlineKlass* vk);
   void add_block(LayoutRawBlock** list, LayoutRawBlock* block);
   void sort_by_size();
 };
@@ -292,7 +292,7 @@ class FieldLayoutBuilder : public ResourceObj {
   void epilogue();
   void regular_field_sorting();
   void inline_class_field_sorting(TRAPS);
-  void add_inlined_field_oopmap(OopMapBlocksBuilder* nonstatic_oop_map, ValueKlass* vk, int offset);
+  void add_inlined_field_oopmap(OopMapBlocksBuilder* nonstatic_oop_map, InlineKlass* vk, int offset);
 };
 
 #endif // SHARE_CLASSFILE_FIELDLAYOUTBUILDER_HPP

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -53,7 +53,7 @@
 #include "oops/recordComponent.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "oops/valueArrayKlass.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/resolvedMethodTable.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
@@ -1010,7 +1010,7 @@ void java_lang_Class::create_mirror(Klass* k, Handle class_loader,
       if (k->is_valueArray_klass()) {
         Klass* element_klass = (Klass*) ValueArrayKlass::cast(k)->element_klass();
         assert(element_klass->is_inline_klass(), "Must be inline type component");
-        ValueKlass* vk = ValueKlass::cast(InstanceKlass::cast(element_klass));
+        InlineKlass* vk = InlineKlass::cast(InstanceKlass::cast(element_klass));
         comp_mirror = Handle(THREAD, vk->java_mirror());
       } else if (k->is_typeArray_klass()) {
         BasicType type = TypeArrayKlass::cast(k)->element_type();

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -70,7 +70,7 @@
 #include "oops/oopHandle.inline.hpp"
 #include "oops/symbol.hpp"
 #include "oops/typeArrayKlass.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/arguments.hpp"
@@ -1540,7 +1540,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
   load_shared_class_misc(ik, loader_data, CHECK_NULL);
 
   if (ik->is_inline_klass()) {
-    ValueKlass* vk = ValueKlass::cast(ik);
+    InlineKlass* vk = InlineKlass::cast(ik);
     oop val = ik->allocate_instance(CHECK_NULL);
     vk->set_default_value(val);
   }

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -33,7 +33,7 @@
 #include "memory/iterator.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "oops/compressedOops.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/handles.inline.hpp"

--- a/src/hotspot/share/gc/shared/barrierSet.hpp
+++ b/src/hotspot/share/gc/shared/barrierSet.hpp
@@ -315,7 +315,7 @@ public:
       Raw::clone(src, dst, size);
     }
 
-    static void value_copy_in_heap(void* src, void* dst, ValueKlass* md) {
+    static void value_copy_in_heap(void* src, void* dst, InlineKlass* md) {
       Raw::value_copy(src, dst, md);
     }
 

--- a/src/hotspot/share/gc/shared/barrierSetRuntime.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetRuntime.cpp
@@ -28,12 +28,12 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "utilities/macros.hpp"
 
-JRT_LEAF(void, BarrierSetRuntime::value_copy(void* src, void* dst, ValueKlass* md))
+JRT_LEAF(void, BarrierSetRuntime::value_copy(void* src, void* dst, InlineKlass* md))
   assert(md->is_inline_type_klass(), "invariant");
   HeapAccess<>::value_copy(src, dst, md);
 JRT_END
 
-JRT_LEAF(void, BarrierSetRuntime::value_copy_is_dest_uninitialized(void* src, void* dst, ValueKlass* md))
+JRT_LEAF(void, BarrierSetRuntime::value_copy_is_dest_uninitialized(void* src, void* dst, InlineKlass* md))
   assert(md->is_inline_type_klass(), "invariant");
   HeapAccess<IS_DEST_UNINITIALIZED>::value_copy(src, dst, md);
 JRT_END

--- a/src/hotspot/share/gc/shared/barrierSetRuntime.hpp
+++ b/src/hotspot/share/gc/shared/barrierSetRuntime.hpp
@@ -27,7 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "oops/oopsHierarchy.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
@@ -37,8 +37,8 @@ class JavaThread;
 class BarrierSetRuntime: public AllStatic {
 public:
   // Template interpreter...
-  static void value_copy(void* src, void* dst, ValueKlass* md);
-  static void value_copy_is_dest_uninitialized(void* src, void* dst, ValueKlass* md);
+  static void value_copy(void* src, void* dst, InlineKlass* md);
+  static void value_copy_is_dest_uninitialized(void* src, void* dst, InlineKlass* md);
 };
 
 #endif // SHARE_GC_SHARED_BARRIERSETRUNTIME_HPP

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
@@ -105,7 +105,7 @@ public:
       return oop_atomic_cmpxchg_in_heap(AccessInternal::oop_field_addr<decorators>(base, offset), compare_value, new_value);
     }
 
-    static void value_copy_in_heap(void* src, void* dst, ValueKlass* md);
+    static void value_copy_in_heap(void* src, void* dst, InlineKlass* md);
   };
 };
 

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
@@ -31,7 +31,7 @@
 #include "oops/klass.inline.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oop.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 
 // count is number of array elements being written
 void ModRefBarrierSet::write_ref_array(HeapWord* start, size_t count) {
@@ -155,7 +155,7 @@ clone_in_heap(oop src, oop dst, size_t size) {
 
 template <DecoratorSet decorators, typename BarrierSetT>
 inline void ModRefBarrierSet::AccessBarrier<decorators, BarrierSetT>::
-value_copy_in_heap(void* src, void* dst, ValueKlass* md) {
+value_copy_in_heap(void* src, void* dst, InlineKlass* md) {
   if (HasDecorator<decorators, IS_DEST_UNINITIALIZED>::value || (!md->contains_oops())) {
     Raw::value_copy(src, dst, md);
   } else {

--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -26,7 +26,7 @@
 
 #include "memory/allocation.hpp"
 #include "oops/oop.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 
 typedef bool (*ZBarrierFastPath)(uintptr_t);
 typedef uintptr_t (*ZBarrierSlowPath)(uintptr_t);

--- a/src/hotspot/share/gc/z/zBarrierSet.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.hpp
@@ -84,7 +84,7 @@ public:
 
     static void clone_in_heap(oop src, oop dst, size_t size);
 
-    static void value_copy_in_heap(void* src, void* dst, ValueKlass* md);
+    static void value_copy_in_heap(void* src, void* dst, InlineKlass* md);
 
     //
     // Not in heap

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -215,7 +215,7 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
 }
 
 template <DecoratorSet decorators, typename BarrierSetT>
-inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::value_copy_in_heap(void* src, void* dst, ValueKlass* md) {
+inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::value_copy_in_heap(void* src, void* dst, InlineKlass* md) {
   if (md->contains_oops()) {
     // src/dst aren't oops, need offset to adjust oop map offset
     const address src_oop_addr_offset = ((address) src) - md->first_field_offset();

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -51,7 +51,7 @@
 #include "oops/symbol.hpp"
 #include "oops/valueArrayKlass.hpp"
 #include "oops/valueArrayOop.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/nativeLookup.hpp"
 #include "runtime/atomic.hpp"
@@ -299,7 +299,7 @@ void copy_primitive_argument(intptr_t* addr, Handle instance, int offset, BasicT
 }
 
 JRT_ENTRY(void, InterpreterRuntime::defaultvalue(JavaThread* thread, ConstantPool* pool, int index))
-  // Getting the ValueKlass
+  // Getting the InlineKlass
   Klass* k = pool->klass_at(index, CHECK);
   if (!k->is_inline_klass()) {
     // inconsistency with 'new' which throws an InstantiationError
@@ -307,7 +307,7 @@ JRT_ENTRY(void, InterpreterRuntime::defaultvalue(JavaThread* thread, ConstantPoo
     THROW(vmSymbols::java_lang_IncompatibleClassChangeError());
   }
   assert(k->is_inline_klass(), "defaultvalue argument must be the inline type class");
-  ValueKlass* vklass = ValueKlass::cast(k);
+  InlineKlass* vklass = InlineKlass::cast(k);
 
   vklass->initialize(THREAD);
   oop res = vklass->default_value();
@@ -316,13 +316,13 @@ JRT_END
 
 JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCache* cp_cache))
   LastFrameAccessor last_frame(thread);
-  // Getting the ValueKlass
+  // Getting the InlineKlass
   int index = ConstantPool::decode_cpcache_index(last_frame.get_index_u2_cpcache(Bytecodes::_withfield));
   ConstantPoolCacheEntry* cp_entry = cp_cache->entry_at(index);
   assert(cp_entry->is_resolved(Bytecodes::_withfield), "Should have been resolved");
   Klass* klass = cp_entry->f1_as_klass();
   assert(klass->is_inline_klass(), "withfield only applies to inline types");
-  ValueKlass* vklass = ValueKlass::cast(klass);
+  InlineKlass* vklass = InlineKlass::cast(klass);
 
   // Getting Field information
   int offset = cp_entry->f2_as_index();
@@ -344,7 +344,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
   instanceOop new_value = vklass->allocate_instance(
       CHECK_((type2size[field_type]) * AbstractInterpreter::stackElementSize));
   Handle new_value_h = Handle(THREAD, new_value);
-  vklass->value_copy_oop_to_new_oop(old_value_h(), new_value_h());
+  vklass->inline_copy_oop_to_new_oop(old_value_h(), new_value_h());
 
   // Updating the field specified in arguments
   if (field_type == T_ARRAY || field_type == T_OBJECT) {
@@ -355,7 +355,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
     if (cp_entry->is_inlined()) {
       oop vt_oop = *(oop*)f.interpreter_frame_expression_stack_at(tos_idx);
       assert(vt_oop != NULL && oopDesc::is_oop(vt_oop) && vt_oop->is_inline_type(),"argument must be an inline type");
-      ValueKlass* field_vk = ValueKlass::cast(vklass->get_inline_type_field_klass(field_index));
+      InlineKlass* field_vk = InlineKlass::cast(vklass->get_inline_type_field_klass(field_index));
       assert(vt_oop != NULL && field_vk == vt_oop->klass(), "Must match");
       field_vk->write_inlined_field(new_value_h(), offset, vt_oop, CHECK_(return_offset));
     } else { // not inlined
@@ -402,7 +402,7 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_value_field(JavaThread*
       klass->set_inline_type_field_klass(index, field_k);
     }
     field_k->initialize(CHECK);
-    oop defaultvalue = ValueKlass::cast(field_k)->default_value();
+    oop defaultvalue = InlineKlass::cast(field_k)->default_value();
     // It is safe to initialized the static field because 1) the current thread is the initializing thread
     // and is the only one that can access it, and 2) the field is actually not initialized (i.e. null)
     // otherwise the JVM should not be executing this code.
@@ -435,7 +435,7 @@ JRT_ENTRY(void, InterpreterRuntime::read_inlined_field(JavaThread* thread, oopDe
 
   assert(klass->field_is_inlined(index), "Sanity check");
 
-  ValueKlass* field_vklass = ValueKlass::cast(klass->get_inline_type_field_klass(index));
+  InlineKlass* field_vklass = InlineKlass::cast(klass->get_inline_type_field_klass(index));
   assert(field_vklass->is_initialized(), "Must be initialized at this point");
 
   oop res = field_vklass->read_inlined_field(obj_h(), klass->field_offset(index), CHECK);

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -35,7 +35,7 @@
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/reflectionAccessorImplKlassHelper.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -550,7 +550,7 @@ static void print_field(outputStream* st, int level, int offset, FieldDesc& fd, 
 
 static void print_inlined_field(outputStream* st, int level, int offset, InstanceKlass* klass) {
   assert(klass->is_inline_klass(), "Only inline types can be inlined");
-  ValueKlass* vklass = ValueKlass::cast(klass);
+  InlineKlass* vklass = InlineKlass::cast(klass);
   GrowableArray<FieldDesc>* fields = new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<FieldDesc>(100, mtServiceability);
   for (FieldStream fd(klass, false, false); !fd.eos(); fd.next()) {
     if (!fd.access_flags().is_static()) {

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -60,7 +60,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayKlass.hpp"
 #include "oops/valueArrayKlass.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiRedefineClasses.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/os.hpp"
@@ -770,7 +770,7 @@ void MetaspaceShared::rewrite_nofast_bytecodes_and_calculate_fingerprints(Thread
   f(ObjArrayKlass) \
   f(TypeArrayKlass) \
   f(ValueArrayKlass) \
-  f(ValueKlass)
+  f(InlineKlass)
 
 class CppVtableInfo {
   intptr_t _vtable_size;
@@ -959,7 +959,7 @@ intptr_t* MetaspaceShared::fix_cpp_vtable_for_dynamic_archive(MetaspaceObj::Type
       Klass* k = (Klass*)obj;
       assert(k->is_klass(), "must be");
       if (k->is_inline_klass()) {
-        kind = ValueKlass_Kind;
+        kind = InlineKlass_Kind;
       } else if (k->is_instance_klass()) {
         InstanceKlass* ik = InstanceKlass::cast(k);
         if (ik->is_class_loader_instance_klass()) {

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -39,7 +39,6 @@
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayKlass.hpp"
 #include "oops/typeArrayOop.inline.hpp"
-#include "oops/inlineKlass.hpp"
 #include "oops/valueArrayKlass.hpp"
 #include "oops/valueArrayOop.inline.hpp"
 #include "oops/valueArrayOop.hpp"

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -39,7 +39,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayKlass.hpp"
 #include "oops/typeArrayOop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "oops/valueArrayKlass.hpp"
 #include "oops/valueArrayOop.inline.hpp"
 #include "oops/valueArrayOop.hpp"

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -223,7 +223,7 @@ public:
   // inline type heap access (when inlined)...
 
   // Copy value type data from src to dst
-  static inline void value_copy(void* src, void* dst, ValueKlass* md) {
+  static inline void value_copy(void* src, void* dst, InlineKlass* md) {
     verify_heap_value_decorators<IN_HEAP>();
     AccessInternal::value_copy<decorators>(src, dst, md);
   }

--- a/src/hotspot/share/oops/access.inline.hpp
+++ b/src/hotspot/share/oops/access.inline.hpp
@@ -200,7 +200,7 @@ namespace AccessInternal {
 
   template <class GCBarrierType, DecoratorSet decorators>
   struct PostRuntimeDispatch<GCBarrierType, BARRIER_VALUE_COPY, decorators>: public AllStatic {
-    static void access_barrier(void* src, void* dst, ValueKlass* md) {
+    static void access_barrier(void* src, void* dst, InlineKlass* md) {
       GCBarrierType::value_copy_in_heap(src, dst, md);
     }
   };
@@ -361,7 +361,7 @@ namespace AccessInternal {
   }
 
   template <DecoratorSet decorators, typename T>
-  void RuntimeDispatch<decorators, T, BARRIER_VALUE_COPY>::value_copy_init(void* src, void* dst, ValueKlass* md) {
+  void RuntimeDispatch<decorators, T, BARRIER_VALUE_COPY>::value_copy_init(void* src, void* dst, InlineKlass* md) {
     func_t function = BarrierResolver<decorators, func_t, BARRIER_VALUE_COPY>::resolve_barrier();
     _value_copy_func = function;
     function(src, dst, md);

--- a/src/hotspot/share/oops/accessBackend.cpp
+++ b/src/hotspot/share/oops/accessBackend.cpp
@@ -26,7 +26,7 @@
 #include "accessBackend.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/copy.hpp"

--- a/src/hotspot/share/oops/accessBackend.hpp
+++ b/src/hotspot/share/oops/accessBackend.hpp
@@ -123,7 +123,7 @@ namespace AccessInternal {
                                      arrayOop dst_obj, size_t dst_offset_in_bytes, T* dst_raw,
                                      size_t length);
     typedef void (*clone_func_t)(oop src, oop dst, size_t size);
-    typedef void (*value_copy_func_t)(void* src, void* dst, ValueKlass* md);
+    typedef void (*value_copy_func_t)(void* src, void* dst, InlineKlass* md);
     typedef oop (*resolve_func_t)(oop obj);
   };
 
@@ -403,7 +403,7 @@ public:
 
   static void clone(oop src, oop dst, size_t size);
 
-  static void value_copy(void* src, void* dst, ValueKlass* md);
+  static void value_copy(void* src, void* dst, InlineKlass* md);
 
   static oop resolve(oop obj) { return obj; }
 };
@@ -592,9 +592,9 @@ namespace AccessInternal {
     typedef typename AccessFunction<decorators, T, BARRIER_VALUE_COPY>::type func_t;
     static func_t _value_copy_func;
 
-    static void value_copy_init(void* src, void* dst, ValueKlass* md);
+    static void value_copy_init(void* src, void* dst, InlineKlass* md);
 
-    static inline void value_copy(void* src, void* dst, ValueKlass* md) {
+    static inline void value_copy(void* src, void* dst, InlineKlass* md) {
       _value_copy_func(src, dst, md);
     }
   };
@@ -979,7 +979,7 @@ namespace AccessInternal {
     template <DecoratorSet decorators>
     inline static typename EnableIf<
       HasDecorator<decorators, AS_RAW>::value>::type
-    value_copy(void* src, void* dst, ValueKlass* md) {
+    value_copy(void* src, void* dst, InlineKlass* md) {
       typedef RawAccessBarrier<decorators & RAW_DECORATOR_MASK> Raw;
       Raw::value_copy(src, dst, md);
     }
@@ -987,7 +987,7 @@ namespace AccessInternal {
     template <DecoratorSet decorators>
     inline static typename EnableIf<
       !HasDecorator<decorators, AS_RAW>::value>::type
-      value_copy(void* src, void* dst, ValueKlass* md) {
+      value_copy(void* src, void* dst, InlineKlass* md) {
       const DecoratorSet expanded_decorators = decorators;
       RuntimeDispatch<expanded_decorators, void*, BARRIER_VALUE_COPY>::value_copy(src, dst, md);
     }
@@ -1300,7 +1300,7 @@ namespace AccessInternal {
   }
 
   template <DecoratorSet decorators>
-  inline void value_copy(void* src, void* dst, ValueKlass* md) {
+  inline void value_copy(void* src, void* dst, InlineKlass* md) {
     const DecoratorSet expanded_decorators = DecoratorFixup<decorators>::value;
     PreRuntimeDispatch::value_copy<expanded_decorators>(src, dst, md);
   }

--- a/src/hotspot/share/oops/accessBackend.inline.hpp
+++ b/src/hotspot/share/oops/accessBackend.inline.hpp
@@ -31,7 +31,7 @@
 #include "oops/oopsHierarchy.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/orderAccess.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 
 template <DecoratorSet decorators>
 template <DecoratorSet idecorators, typename T>
@@ -366,7 +366,7 @@ inline void RawAccessBarrier<decorators>::clone(oop src, oop dst, size_t size) {
 }
 
 template <DecoratorSet decorators>
-inline void RawAccessBarrier<decorators>::value_copy(void* src, void* dst, ValueKlass* md) {
+inline void RawAccessBarrier<decorators>::value_copy(void* src, void* dst, InlineKlass* md) {
   assert(is_aligned(src, md->get_alignment()) && is_aligned(dst, md->get_alignment()), "Unalign value_copy");
   AccessInternal::arraycopy_conjoint_atomic(src, dst, static_cast<size_t>(md->get_exact_size_in_bytes()));
 }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -186,9 +186,8 @@ class InlineKlass: public InstanceKlass {
   // Casting from Klass*
   static InlineKlass* cast(Klass* k);
 
-  // Use this to return the size of an instance in heap words
-  // Implementation is currently simple because all inline types are allocated
-  // in Java heap like Java objects.
+  // Use this to return the size of an instance in heap words.
+  // Note that this size only applies to heap allocated stand-alone instances.
   virtual int size_helper() const {
     return layout_helper_to_size_helper(layout_helper());
   }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -22,87 +22,87 @@
  *
  */
 
-#ifndef SHARE_VM_OOPS_VALUEKLASS_HPP
-#define SHARE_VM_OOPS_VALUEKLASS_HPP
+#ifndef SHARE_VM_OOPS_INLINEKLASS_HPP
+#define SHARE_VM_OOPS_INLINEKLASS_HPP
 
 #include "classfile/javaClasses.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/method.hpp"
 //#include "oops/oop.inline.hpp"
 
-// A ValueKlass is a specialized InstanceKlass for value types.
+// An InlineKlass is a specialized InstanceKlass for inline types.
 
 
-class ValueKlass: public InstanceKlass {
+class InlineKlass: public InstanceKlass {
   friend class VMStructs;
   friend class InstanceKlass;
 
  public:
-  ValueKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }
+  InlineKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }
 
  private:
 
   // Constructor
-  ValueKlass(const ClassFileParser& parser);
+  InlineKlass(const ClassFileParser& parser);
 
-  ValueKlassFixedBlock* valueklass_static_block() const {
+  InlineKlassFixedBlock* inlineklass_static_block() const {
     address adr_jf = adr_inline_type_field_klasses();
     if (adr_jf != NULL) {
-      return (ValueKlassFixedBlock*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
+      return (InlineKlassFixedBlock*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
     }
 
     address adr_fing = adr_fingerprint();
     if (adr_fing != NULL) {
-      return (ValueKlassFixedBlock*)(adr_fingerprint() + sizeof(u8));
+      return (InlineKlassFixedBlock*)(adr_fingerprint() + sizeof(u8));
     }
 
     InstanceKlass** adr_host = adr_unsafe_anonymous_host();
     if (adr_host != NULL) {
-      return (ValueKlassFixedBlock*)(adr_host + 1);
+      return (InlineKlassFixedBlock*)(adr_host + 1);
     }
 
     Klass* volatile* adr_impl = adr_implementor();
     if (adr_impl != NULL) {
-      return (ValueKlassFixedBlock*)(adr_impl + 1);
+      return (InlineKlassFixedBlock*)(adr_impl + 1);
     }
 
-    return (ValueKlassFixedBlock*)end_of_nonstatic_oop_maps();
+    return (InlineKlassFixedBlock*)end_of_nonstatic_oop_maps();
   }
 
   address adr_extended_sig() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _extended_sig));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _extended_sig));
   }
 
   address adr_return_regs() const {
-    ValueKlassFixedBlock* vkst = valueklass_static_block();
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _return_regs));
+    InlineKlassFixedBlock* vkst = inlineklass_static_block();
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _return_regs));
   }
 
-  // pack and unpack handlers for value types return
+  // pack and unpack handlers for inline types return
   address adr_pack_handler() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _pack_handler));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _pack_handler));
   }
 
   address adr_pack_handler_jobject() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _pack_handler_jobject));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _pack_handler_jobject));
   }
 
   address adr_unpack_handler() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _unpack_handler));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _unpack_handler));
   }
 
   address adr_default_value_offset() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(default_value_offset_offset());
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(default_value_offset_offset());
   }
 
   address adr_value_array_klass() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _value_array_klass));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _value_array_klass));
   }
 
   Klass* get_value_array_klass() const {
@@ -116,18 +116,18 @@ class ValueKlass: public InstanceKlass {
   Klass* allocate_value_array_klass(TRAPS);
 
   address adr_alignment() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _alignment));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _alignment));
   }
 
   address adr_first_field_offset() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _first_field_offset));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _first_field_offset));
   }
 
   address adr_exact_size_in_bytes() const {
-    assert(_adr_valueklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_valueklass_fixed_block) + in_bytes(byte_offset_of(ValueKlassFixedBlock, _exact_size_in_bytes));
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _exact_size_in_bytes));
   }
 
  public:
@@ -184,10 +184,10 @@ class ValueKlass: public InstanceKlass {
   bool is_inline_klass_slow() const        { return true; }
 
   // Casting from Klass*
-  static ValueKlass* cast(Klass* k);
+  static InlineKlass* cast(Klass* k);
 
   // Use this to return the size of an instance in heap words
-  // Implementation is currently simple because all value types are allocated
+  // Implementation is currently simple because all inline types are allocated
   // in Java heap like Java objects.
   virtual int size_helper() const {
     return layout_helper_to_size_helper(layout_helper());
@@ -200,9 +200,9 @@ class ValueKlass: public InstanceKlass {
   // allocate_instance() allocates a stand alone value in the Java heap
   // initialized to default value (cleared memory)
   instanceOop allocate_instance(TRAPS);
-  // allocates a stand alone value buffer in the Java heap
+  // allocates a stand alone inline buffer in the Java heap
   // DOES NOT have memory cleared, user MUST initialize payload before
-  // returning to Java (i.e.: value_copy)
+  // returning to Java (i.e.: inline_copy)
   instanceOop allocate_instance_buffer(TRAPS);
 
   // minimum number of bytes occupied by nonstatic fields, HeapWord aligned or pow2
@@ -222,19 +222,19 @@ class ValueKlass: public InstanceKlass {
   // General store methods
   //
   // Normally loads and store methods would be found in *Oops classes, but since values can be
-  // "in-lined" (flattened) into containing oops, these methods reside here in ValueKlass.
+  // "in-lined" (flattened) into containing oops, these methods reside here in InlineKlass.
   //
-  // "value_copy_*_to_new_*" assume new memory (i.e. IS_DEST_UNINITIALIZED for write barriers)
+  // "inline_copy_*_to_new_*" assume new memory (i.e. IS_DEST_UNINITIALIZED for write barriers)
 
-  void value_copy_payload_to_new_oop(void* src, oop dst);
-  void value_copy_oop_to_new_oop(oop src, oop dst);
-  void value_copy_oop_to_new_payload(oop src, void* dst);
-  void value_copy_oop_to_payload(oop src, void* dst);
+  void inline_copy_payload_to_new_oop(void* src, oop dst);
+  void inline_copy_oop_to_new_oop(oop src, oop dst);
+  void inline_copy_oop_to_new_payload(oop src, void* dst);
+  void inline_copy_oop_to_payload(oop src, void* dst);
 
   oop read_inlined_field(oop obj, int offset, TRAPS);
   void write_inlined_field(oop obj, int offset, oop value, TRAPS);
 
-  // oop iterate raw value type data pointer (where oop_addr may not be an oop, but backing/array-element)
+  // oop iterate raw inline type data pointer (where oop_addr may not be an oop, but backing/array-element)
   template <typename T, class OopClosureType>
   inline void oop_iterate_specialized(const address oop_addr, OopClosureType* closure);
 
@@ -255,7 +255,7 @@ class ValueKlass: public InstanceKlass {
   void save_oop_fields(const RegisterMap& map, GrowableArray<Handle>& handles) const;
   void restore_oop_results(RegisterMap& map, GrowableArray<Handle>& handles) const;
   oop realloc_result(const RegisterMap& reg_map, const GrowableArray<Handle>& handles, TRAPS);
-  static ValueKlass* returned_value_klass(const RegisterMap& reg_map);
+  static InlineKlass* returned_inline_klass(const RegisterMap& reg_map);
 
   address pack_handler() const {
     return *(address*)adr_pack_handler();
@@ -268,23 +268,23 @@ class ValueKlass: public InstanceKlass {
   // pack and unpack handlers. Need to be loadable from generated code
   // so at a fixed offset from the base of the klass pointer.
   static ByteSize pack_handler_offset() {
-    return byte_offset_of(ValueKlassFixedBlock, _pack_handler);
+    return byte_offset_of(InlineKlassFixedBlock, _pack_handler);
   }
 
   static ByteSize pack_handler_jobject_offset() {
-    return byte_offset_of(ValueKlassFixedBlock, _pack_handler_jobject);
+    return byte_offset_of(InlineKlassFixedBlock, _pack_handler_jobject);
   }
 
   static ByteSize unpack_handler_offset() {
-    return byte_offset_of(ValueKlassFixedBlock, _unpack_handler);
+    return byte_offset_of(InlineKlassFixedBlock, _unpack_handler);
   }
 
   static ByteSize default_value_offset_offset() {
-    return byte_offset_of(ValueKlassFixedBlock, _default_value_offset);
+    return byte_offset_of(InlineKlassFixedBlock, _default_value_offset);
   }
 
   static ByteSize first_field_offset_offset() {
-    return byte_offset_of(ValueKlassFixedBlock, _first_field_offset);
+    return byte_offset_of(InlineKlassFixedBlock, _first_field_offset);
   }
 
   void set_default_value_offset(int offset) {
@@ -303,7 +303,7 @@ class ValueKlass: public InstanceKlass {
 
   oop default_value();
   void deallocate_contents(ClassLoaderData* loader_data);
-  static void cleanup(ValueKlass* ik) ;
+  static void cleanup(InlineKlass* ik) ;
 
   // Verification
   void verify_on(outputStream* st);
@@ -311,4 +311,4 @@ class ValueKlass: public InstanceKlass {
 
 };
 
-#endif /* SHARE_VM_OOPS_VALUEKLASS_HPP */
+#endif /* SHARE_VM_OOPS_INLINEKLASS_HPP */

--- a/src/hotspot/share/oops/inlineKlass.inline.hpp
+++ b/src/hotspot/share/oops/inlineKlass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,50 +21,50 @@
  * questions.
  *
  */
-#ifndef SHARE_VM_OOPS_VALUEKLASS_INLINE_HPP
-#define SHARE_VM_OOPS_VALUEKLASS_INLINE_HPP
+#ifndef SHARE_VM_OOPS_INLINEKLASS_INLINE_HPP
+#define SHARE_VM_OOPS_INLINEKLASS_INLINE_HPP
 
 #include "memory/iterator.hpp"
 #include "oops/klass.hpp"
 #include "oops/valueArrayKlass.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "utilities/macros.hpp"
 
-inline ValueKlass* ValueKlass::cast(Klass* k) {
-  assert(k->is_inline_klass(), "cast to ValueKlass");
-  return (ValueKlass*) k;
+inline InlineKlass* InlineKlass::cast(Klass* k) {
+  assert(k->is_inline_klass(), "cast to InlineKlass");
+  return (InlineKlass*) k;
 }
 
-inline address ValueKlass::data_for_oop(oop o) const {
+inline address InlineKlass::data_for_oop(oop o) const {
   return ((address) (void*) o) + first_field_offset();
 }
 
-inline oop ValueKlass::oop_for_data(address data) const {
+inline oop InlineKlass::oop_for_data(address data) const {
   oop o = (oop) (data - first_field_offset());
   assert(oopDesc::is_oop(o, false), "Not an oop");
   return o;
 }
 
-inline void ValueKlass::value_copy_payload_to_new_oop(void* src, oop dst) {
+inline void InlineKlass::inline_copy_payload_to_new_oop(void* src, oop dst) {
   HeapAccess<IS_DEST_UNINITIALIZED>::value_copy(src, data_for_oop(dst), this);
 }
 
-inline void ValueKlass::value_copy_oop_to_new_oop(oop src, oop dst) {
+inline void InlineKlass::inline_copy_oop_to_new_oop(oop src, oop dst) {
   HeapAccess<IS_DEST_UNINITIALIZED>::value_copy(data_for_oop(src), data_for_oop(dst), this);
 }
 
-inline void ValueKlass::value_copy_oop_to_new_payload(oop src, void* dst) {
+inline void InlineKlass::inline_copy_oop_to_new_payload(oop src, void* dst) {
   HeapAccess<IS_DEST_UNINITIALIZED>::value_copy(data_for_oop(src), dst, this);
 }
 
-inline void ValueKlass::value_copy_oop_to_payload(oop src, void* dst) {
+inline void InlineKlass::inline_copy_oop_to_payload(oop src, void* dst) {
   HeapAccess<>::value_copy(data_for_oop(src), dst, this);
 }
 
 
 template <typename T, class OopClosureType>
-void ValueKlass::oop_iterate_specialized(const address oop_addr, OopClosureType* closure) {
+void InlineKlass::oop_iterate_specialized(const address oop_addr, OopClosureType* closure) {
   OopMapBlock* map = start_of_nonstatic_oop_maps();
   OopMapBlock* const end_map = map + nonstatic_oop_map_count();
 
@@ -78,7 +78,7 @@ void ValueKlass::oop_iterate_specialized(const address oop_addr, OopClosureType*
 }
 
 template <typename T, class OopClosureType>
-inline void ValueKlass::oop_iterate_specialized_bounded(const address oop_addr, OopClosureType* closure, void* lo, void* hi) {
+inline void InlineKlass::oop_iterate_specialized_bounded(const address oop_addr, OopClosureType* closure, void* lo, void* hi) {
   OopMapBlock* map = start_of_nonstatic_oop_maps();
   OopMapBlock* const end_map = map + nonstatic_oop_map_count();
 
@@ -101,4 +101,4 @@ inline void ValueKlass::oop_iterate_specialized_bounded(const address oop_addr, 
 }
 
 
-#endif // SHARE_VM_OOPS_VALUEKLASS_INLINE_HPP
+#endif // SHARE_VM_OOPS_INLINEKLASS_INLINE_HPP

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -65,7 +65,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/recordComponent.hpp"
 #include "oops/symbol.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiRedefineClasses.hpp"
 #include "prims/jvmtiThreadState.hpp"
@@ -497,7 +497,7 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
       ik = new (loader_data, size, THREAD) InstanceClassLoaderKlass(parser);
     } else if (parser.is_inline_type()) {
       // inline type
-      ik = new (loader_data, size, THREAD) ValueKlass(parser);
+      ik = new (loader_data, size, THREAD) InlineKlass(parser);
     } else {
       // normal
       ik = new (loader_data, size, THREAD) InstanceKlass(parser, InstanceKlass::_kind_other);
@@ -582,7 +582,7 @@ InstanceKlass::InstanceKlass(const ClassFileParser& parser, unsigned kind, Klass
   _reference_type(parser.reference_type()),
   _init_thread(NULL),
   _inline_type_field_klasses(NULL),
-  _adr_valueklass_fixed_block(NULL)
+  _adr_inlineklass_fixed_block(NULL)
 {
   set_vtable_length(parser.vtable_size());
   set_kind(kind);
@@ -1277,7 +1277,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
         InstanceKlass::cast(klass)->initialize(CHECK);
         if (fs.access_flags().is_static()) {
           if (java_mirror()->obj_field(fs.offset()) == NULL) {
-            java_mirror()->obj_field_put(fs.offset(), ValueKlass::cast(klass)->default_value());
+            java_mirror()->obj_field_put(fs.offset(), InlineKlass::cast(klass)->default_value());
           }
         }
       }
@@ -1720,7 +1720,7 @@ Klass* InstanceKlass::find_field(Symbol* name, Symbol* sig, bool is_static, fiel
 
 bool InstanceKlass::contains_field_offset(int offset) {
   if (this->is_inline_klass()) {
-    ValueKlass* vk = ValueKlass::cast(this);
+    InlineKlass* vk = InlineKlass::cast(this);
     return offset >= vk->first_field_offset() && offset < (vk->first_field_offset() + vk->get_exact_size_in_bytes());
   } else {
     fieldDescriptor fd;
@@ -2711,7 +2711,7 @@ void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handl
   Klass::restore_unshareable_info(loader_data, protection_domain, CHECK);
 
   if (is_inline_klass()) {
-    ValueKlass::cast(this)->initialize_calling_convention(CHECK);
+    InlineKlass::cast(this)->initialize_calling_convention(CHECK);
   }
 
   Array<Method*>* methods = this->methods();

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -56,7 +56,7 @@ class RecordComponent;
 //    [EMBEDDED unsafe_anonymous_host klass] only exist for an unsafe anonymous class (JSR 292 enabled)
 //    [EMBEDDED fingerprint       ] only if should_store_fingerprint()==true
 //    [EMBEDDED inline_type_field_klasses] only if has_inline_fields() == true
-//    [EMBEDDED ValueKlassFixedBlock] only if is a ValueKlass instance
+//    [EMBEDDED InlineKlassFixedBlock] only if is a InlineKlass instance
 
 
 // forward declaration for class -- see below for definition
@@ -138,7 +138,7 @@ struct JvmtiCachedClassFileData;
 
 class SigEntry;
 
-class ValueKlassFixedBlock {
+class InlineKlassFixedBlock {
   Array<SigEntry>** _extended_sig;
   Array<VMRegPair>** _return_regs;
   address* _pack_handler;
@@ -150,7 +150,7 @@ class ValueKlassFixedBlock {
   int _first_field_offset;
   int _exact_size_in_bytes;
 
-  friend class ValueKlass;
+  friend class InlineKlass;
 };
 
 class InlineTypes {
@@ -359,7 +359,7 @@ class InstanceKlass: public Klass {
   Array<u2>*      _fields;
   const Klass**   _inline_type_field_klasses; // For "inline class" fields, NULL if none present
 
-  const ValueKlassFixedBlock* _adr_valueklass_fixed_block;
+  const InlineKlassFixedBlock* _adr_inlineklass_fixed_block;
 
   // embedded Java vtable follows here
   // embedded Java itables follows here
@@ -1140,7 +1140,7 @@ public:
   static ByteSize init_thread_offset() { return in_ByteSize(offset_of(InstanceKlass, _init_thread)); }
 
   static ByteSize inline_type_field_klasses_offset() { return in_ByteSize(offset_of(InstanceKlass, _inline_type_field_klasses)); }
-  static ByteSize adr_valueklass_fixed_block_offset() { return in_ByteSize(offset_of(InstanceKlass, _adr_valueklass_fixed_block)); }
+  static ByteSize adr_inlineklass_fixed_block_offset() { return in_ByteSize(offset_of(InstanceKlass, _adr_inlineklass_fixed_block)); }
 
   // subclass/subinterface checks
   bool implements_interface(Klass* k) const;
@@ -1208,7 +1208,7 @@ public:
            (is_unsafe_anonymous ? (int)sizeof(Klass*)/wordSize : 0) +
            (has_stored_fingerprint ? (int)sizeof(uint64_t*)/wordSize : 0) +
            (java_fields * (int)sizeof(Klass*)/wordSize) +
-           (is_inline_type ? (int)sizeof(ValueKlassFixedBlock) : 0));
+           (is_inline_type ? (int)sizeof(InlineKlassFixedBlock) : 0));
   }
   int size() const                    { return size(vtable_length(),
                                                itable_length(),

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -54,7 +54,7 @@
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "prims/nativeLookup.hpp"
@@ -602,10 +602,10 @@ void Method::compute_from_signature(Symbol* sig) {
   constMethod()->set_fingerprint(fp.fingerprint());
 }
 
-// ValueKlass the method is declared to return. This must not
+// InlineKlass the method is declared to return. This must not
 // safepoint as it is called with references live on the stack at
 // locations the GC is unaware of.
-ValueKlass* Method::returned_value_type(Thread* thread) const {
+InlineKlass* Method::returned_inline_type(Thread* thread) const {
   SignatureStream ss(signature());
   while (!ss.at_return_type()) {
     ss.next();
@@ -618,7 +618,7 @@ ValueKlass* Method::returned_value_type(Thread* thread) const {
     k = ss.as_klass(class_loader, protection_domain, SignatureStream::ReturnNull, thread);
   }
   assert(k != NULL && !thread->has_pending_exception(), "can't resolve klass");
-  return ValueKlass::cast(k);
+  return InlineKlass::cast(k);
 }
 bool Method::is_empty_method() const {
   return  code_size() == 1

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -629,7 +629,7 @@ public:
   Symbol* klass_name() const;                    // returns the name of the method holder
   BasicType result_type() const                  { return constMethod()->result_type(); }
   bool is_returning_oop() const                  { BasicType r = result_type(); return is_reference_type(r); }
-  ValueKlass* returned_value_type(Thread* thread) const;
+  InlineKlass* returned_inline_type(Thread* thread) const;
 
   // Checked exceptions thrown by this method (resolved to mirrors)
   objArrayHandle resolved_checked_exceptions(TRAPS) { return resolved_checked_exceptions_impl(this, THREAD); }

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -159,11 +159,11 @@ objArrayOop ObjArrayKlass::allocate(int length, TRAPS) {
     assert(dimension() == 1, "Can only populate the final dimension");
     assert(element_klass()->is_inline_klass(), "Unexpected");
     assert(!element_klass()->is_array_klass(), "ArrayKlass unexpected here");
-    assert(!ValueKlass::cast(element_klass())->flatten_array(), "Expected valueArrayOop allocation");
+    assert(!InlineKlass::cast(element_klass())->flatten_array(), "Expected valueArrayOop allocation");
     element_klass()->initialize(CHECK_NULL);
     // Populate default values...
     objArrayHandle array_h(THREAD, array);
-    instanceOop value = (instanceOop) ValueKlass::cast(element_klass())->default_value();
+    instanceOop value = (instanceOop) InlineKlass::cast(element_klass())->default_value();
     for (int i = 0; i < length; i++) {
       array_h->obj_at_put(i, value);
     }

--- a/src/hotspot/share/oops/oopsHierarchy.hpp
+++ b/src/hotspot/share/oops/oopsHierarchy.hpp
@@ -179,7 +179,7 @@ class   InstanceKlass;
 class     InstanceMirrorKlass;
 class     InstanceClassLoaderKlass;
 class     InstanceRefKlass;
-class     ValueKlass;
+class     InlineKlass;
 class   ArrayKlass;
 class     ObjArrayKlass;
 class     TypeArrayKlass;

--- a/src/hotspot/share/oops/valueArrayKlass.hpp
+++ b/src/hotspot/share/oops/valueArrayKlass.hpp
@@ -27,7 +27,7 @@
 
 #include "classfile/classLoaderData.hpp"
 #include "oops/arrayKlass.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "utilities/macros.hpp"
 
 /**
@@ -54,7 +54,7 @@ class ValueArrayKlass : public ArrayKlass {
 
   ValueArrayKlass() {}
 
-  virtual ValueKlass* element_klass() const;
+  virtual InlineKlass* element_klass() const;
   virtual void set_element_klass(Klass* k);
 
   // Casting from Klass*
@@ -90,7 +90,7 @@ class ValueArrayKlass : public ArrayKlass {
 
   oop protection_domain() const;
 
-  static jint array_layout_helper(ValueKlass* vklass); // layout helper for values
+  static jint array_layout_helper(InlineKlass* vklass); // layout helper for values
 
   // sizing
   static int header_size()  { return sizeof(ValueArrayKlass)/HeapWordSize; }

--- a/src/hotspot/share/oops/valueArrayKlass.inline.hpp
+++ b/src/hotspot/share/oops/valueArrayKlass.inline.hpp
@@ -32,8 +32,8 @@
 #include "oops/valueArrayKlass.hpp"
 #include "oops/valueArrayOop.hpp"
 #include "oops/valueArrayOop.inline.hpp"
-#include "oops/valueKlass.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "utilities/macros.hpp"
 
 /*

--- a/src/hotspot/share/oops/valueArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/valueArrayOop.inline.hpp
@@ -28,7 +28,7 @@
 #include "oops/access.inline.hpp"
 #include "oops/arrayOop.inline.hpp"
 #include "oops/valueArrayOop.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/globals.hpp"
 
@@ -48,35 +48,35 @@ inline int valueArrayOopDesc::object_size() const {
 
 inline oop valueArrayOopDesc::value_alloc_copy_from_index(valueArrayHandle vah, int index, TRAPS) {
   ValueArrayKlass* vaklass = ValueArrayKlass::cast(vah->klass());
-  ValueKlass* vklass = vaklass->element_klass();
+  InlineKlass* vklass = vaklass->element_klass();
   if (vklass->is_empty_inline_type()) {
     return vklass->default_value();
   } else {
     oop buf = vklass->allocate_instance(CHECK_NULL);
-    vklass->value_copy_payload_to_new_oop(vah->value_at_addr(index, vaklass->layout_helper()) ,buf);
+    vklass->inline_copy_payload_to_new_oop(vah->value_at_addr(index, vaklass->layout_helper()) ,buf);
     return buf;
   }
 }
 
 inline void valueArrayOopDesc::value_copy_from_index(int index, oop dst) const {
   ValueArrayKlass* vaklass = ValueArrayKlass::cast(klass());
-  ValueKlass* vklass = vaklass->element_klass();
+  InlineKlass* vklass = vaklass->element_klass();
   if (vklass->is_empty_inline_type()) {
     return; // Assumes dst was a new and clean buffer (OptoRuntime::load_unknown_value())
   } else {
     void* src = value_at_addr(index, vaklass->layout_helper());
-    return vklass->value_copy_payload_to_new_oop(src ,dst);
+    return vklass->inline_copy_payload_to_new_oop(src ,dst);
   }
 }
 
 inline void valueArrayOopDesc::value_copy_to_index(oop src, int index) const {
   ValueArrayKlass* vaklass = ValueArrayKlass::cast(klass());
-  ValueKlass* vklass = vaklass->element_klass();
+  InlineKlass* vklass = vaklass->element_klass();
   if (vklass->is_empty_inline_type()) {
     return;
   }
   void* dst = value_at_addr(index, vaklass->layout_helper());
-  vklass->value_copy_oop_to_payload(src, dst);
+  vklass->inline_copy_oop_to_payload(src, dst);
 }
 
 

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3248,7 +3248,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         intptr_t ptr = igvn->type(klass)->isa_rawptr()->get_con();
         clear_nth_bit(ptr, 0);
         assert(Metaspace::contains((void*)ptr), "should be klass");
-        assert(((InlineKlass*)ptr)->contains_oops(), "returned value type must contain a reference field");
+        assert(((InlineKlass*)ptr)->contains_oops(), "returned inline type must contain a reference field");
       } else {
         uint op = use->Opcode();
         if ((op == Op_StrCompressedCopy || op == Op_StrInflatedCopy) &&

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3243,12 +3243,12 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
         }
       } else if (use->Opcode() == Op_Return) {
         assert(_compile->tf()->returns_value_type_as_fields(), "must return a value type");
-        // Get ValueKlass by removing the tag bit from the metadata pointer
+        // Get InlineKlass by removing the tag bit from the metadata pointer
         Node* klass = use->in(TypeFunc::Parms);
         intptr_t ptr = igvn->type(klass)->isa_rawptr()->get_con();
         clear_nth_bit(ptr, 0);
         assert(Metaspace::contains((void*)ptr), "should be klass");
-        assert(((ValueKlass*)ptr)->contains_oops(), "returned value type must contain a reference field");
+        assert(((InlineKlass*)ptr)->contains_oops(), "returned value type must contain a reference field");
       } else {
         uint op = use->Opcode();
         if ((op == Op_StrCompressedCopy || op == Op_StrInflatedCopy) &&

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4239,9 +4239,9 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
     set_control(_gvn.transform(new IfTrueNode(iff)));
     Node* p = basic_plus_adr(klass_node, in_bytes(ArrayKlass::element_klass_offset()));
     Node* eklass = _gvn.transform(LoadKlassNode::make(_gvn, control(), immutable_memory(), p, TypeInstPtr::KLASS));
-    Node* adr_fixed_block_addr = basic_plus_adr(eklass, in_bytes(InstanceKlass::adr_valueklass_fixed_block_offset()));
+    Node* adr_fixed_block_addr = basic_plus_adr(eklass, in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset()));
     Node* adr_fixed_block = make_load(control(), adr_fixed_block_addr, TypeRawPtr::NOTNULL, T_ADDRESS, MemNode::unordered);
-    Node* default_value_offset_addr = basic_plus_adr(adr_fixed_block, in_bytes(ValueKlass::default_value_offset_offset()));
+    Node* default_value_offset_addr = basic_plus_adr(adr_fixed_block, in_bytes(InlineKlass::default_value_offset_offset()));
     Node* default_value_offset = make_load(control(), default_value_offset_addr, TypeInt::INT, T_INT, MemNode::unordered);
     Node* elem_mirror = load_mirror_from_klass(eklass);
     Node* default_value_addr = basic_plus_adr(elem_mirror, ConvI2X(default_value_offset));

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2770,8 +2770,8 @@ void PhaseMacroExpand::expand_mh_intrinsic_return(CallStaticJavaNode* call) {
   if (UseCompressedClassPointers) {
     rawmem = make_store(slowpath_false, rawmem, old_top, oopDesc::klass_gap_offset_in_bytes(), intcon(0), T_INT);
   }
-  Node* fixed_block  = make_load(slowpath_false, rawmem, klass_node, in_bytes(InstanceKlass::adr_valueklass_fixed_block_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
-  Node* pack_handler = make_load(slowpath_false, rawmem, fixed_block, in_bytes(ValueKlass::pack_handler_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
+  Node* fixed_block  = make_load(slowpath_false, rawmem, klass_node, in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
+  Node* pack_handler = make_load(slowpath_false, rawmem, fixed_block, in_bytes(InlineKlass::pack_handler_offset()), TypeRawPtr::BOTTOM, T_ADDRESS);
 
   CallLeafNoFPNode* handler_call = new CallLeafNoFPNode(OptoRuntime::pack_value_type_Type(),
                                                         NULL,

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1932,14 +1932,14 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
         }
       }
     } else {
-      // Check for a load of the default value offset from the ValueKlassFixedBlock:
-      // LoadI(LoadP(value_klass, adr_valueklass_fixed_block_offset), default_value_offset_offset)
+      // Check for a load of the default value offset from the InlineKlassFixedBlock:
+      // LoadI(LoadP(value_klass, adr_inlineklass_fixed_block_offset), default_value_offset_offset)
       intptr_t offset = 0;
       Node* base = AddPNode::Ideal_base_and_offset(adr, phase, offset);
-      if (base != NULL && base->is_Load() && offset == in_bytes(ValueKlass::default_value_offset_offset())) {
+      if (base != NULL && base->is_Load() && offset == in_bytes(InlineKlass::default_value_offset_offset())) {
         const TypeKlassPtr* tkls = phase->type(base->in(MemNode::Address))->isa_klassptr();
         if (tkls != NULL && tkls->is_loaded() && tkls->klass_is_exact() && tkls->isa_valuetype() &&
-            tkls->offset() == in_bytes(InstanceKlass::adr_valueklass_fixed_block_offset())) {
+            tkls->offset() == in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset())) {
           assert(base->Opcode() == Op_LoadP, "must load an oop from klass");
           assert(Opcode() == Op_LoadI, "must load an int from fixed block");
           return TypeInt::make(tkls->klass()->as_value_klass()->default_value_offset());

--- a/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
@@ -22,7 +22,7 @@
  *
  */
 
-#include <oops/valueKlass.hpp>
+#include <oops/inlineKlass.hpp>
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/dictionary.hpp"
@@ -78,7 +78,7 @@ public:
       for (Klass* l = k->array_klass_or_null(); l != NULL; l = l->array_klass_or_null()) {
         _classStack.push((jclass) _env->jni_reference(Handle(_cur_thread, l->java_mirror())));
       }
-      // CMH flat arrays (ValueKlass)
+      // CMH flat arrays (InlineKlass)
     }
   }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -51,7 +49,7 @@
 #include "oops/typeArrayOop.inline.hpp"
 #include "oops/valueArrayKlass.hpp"
 #include "oops/valueArrayOop.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "oops/verifyOopClosure.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/atomic.hpp"
@@ -190,9 +188,9 @@ static bool eliminate_allocations(JavaThread* thread, int exec_mode, CompiledMet
   // In case of the return of multiple values, we must take care
   // of all oop return values.
   GrowableArray<Handle> return_oops;
-  ValueKlass* vk = NULL;
+  InlineKlass* vk = NULL;
   if (save_oop_result && scope->return_vt()) {
-    vk = ValueKlass::returned_value_klass(map);
+    vk = InlineKlass::returned_inline_klass(map);
     if (vk != NULL) {
       vk->save_oop_fields(map, return_oops);
       save_oop_result = false;
@@ -214,7 +212,7 @@ static bool eliminate_allocations(JavaThread* thread, int exec_mode, CompiledMet
     bool skip_internal = (compiled_method != NULL) && !compiled_method->is_compiled_by_jvmci();
     JRT_BLOCK
       if (vk != NULL) {
-        realloc_failures = Deoptimization::realloc_value_type_result(vk, map, return_oops, THREAD);
+        realloc_failures = Deoptimization::realloc_inline_type_result(vk, map, return_oops, THREAD);
       }
       if (objects != NULL) {
         realloc_failures = realloc_failures || Deoptimization::realloc_objects(thread, &deoptee, &map, objects, THREAD);
@@ -1069,11 +1067,11 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
   return failures;
 }
 
-// We're deoptimizing at the return of a call, value type fields are
+// We're deoptimizing at the return of a call, inline type fields are
 // in registers. When we go back to the interpreter, it will expect a
-// reference to a value type instance. Allocate and initialize it from
+// reference to an inline type instance. Allocate and initialize it from
 // the register values here.
-bool Deoptimization::realloc_value_type_result(ValueKlass* vk, const RegisterMap& map, GrowableArray<Handle>& return_oops, TRAPS) {
+bool Deoptimization::realloc_inline_type_result(InlineKlass* vk, const RegisterMap& map, GrowableArray<Handle>& return_oops, TRAPS) {
   oop new_vt = vk->realloc_result(map, return_oops, THREAD);
   if (new_vt == NULL) {
     CLEAR_PENDING_EXCEPTION;
@@ -1287,7 +1285,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         if (fs.is_inlined()) {
           // Resolve klass of flattened value type field
           Klass* vk = klass->get_inline_type_field_klass(fs.index());
-          field._klass = ValueKlass::cast(vk);
+          field._klass = InlineKlass::cast(vk);
           field._type = T_INLINE_TYPE;
         }
         fields->append(field);
@@ -1313,7 +1311,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         // Recursively re-assign flattened value type fields
         InstanceKlass* vk = fields->at(i)._klass;
         assert(vk != NULL, "must be resolved");
-        offset -= ValueKlass::cast(vk)->first_field_offset(); // Adjust offset to omit oop header
+        offset -= InlineKlass::cast(vk)->first_field_offset(); // Adjust offset to omit oop header
         svIndex = reassign_fields_by_klass(vk, fr, reg_map, sv, svIndex, obj, skip_internal, offset, CHECK_0);
         continue; // Continue because we don't need to increment svIndex
       }
@@ -1395,10 +1393,10 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
 
 // restore fields of an eliminated value type array
 void Deoptimization::reassign_value_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, valueArrayOop obj, ValueArrayKlass* vak, TRAPS) {
-  ValueKlass* vk = vak->element_klass();
+  InlineKlass* vk = vak->element_klass();
   assert(vk->flatten_array(), "should only be used for flattened value type arrays");
   // Adjust offset to omit oop header
-  int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - ValueKlass::cast(vk)->first_field_offset();
+  int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - InlineKlass::cast(vk)->first_field_offset();
   // Initialize all elements of the flattened value type array
   for (int i = 0; i < sv->field_size(); i++) {
     ScopeValue* val = sv->field_at(i);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1391,13 +1391,13 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
   return svIndex;
 }
 
-// restore fields of an eliminated value type array
+// restore fields of an eliminated inline type array
 void Deoptimization::reassign_value_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, valueArrayOop obj, ValueArrayKlass* vak, TRAPS) {
   InlineKlass* vk = vak->element_klass();
-  assert(vk->flatten_array(), "should only be used for flattened value type arrays");
+  assert(vk->flatten_array(), "should only be used for flattened inline type arrays");
   // Adjust offset to omit oop header
   int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - InlineKlass::cast(vk)->first_field_offset();
-  // Initialize all elements of the flattened value type array
+  // Initialize all elements of the flattened inline type array
   for (int i = 0; i < sv->field_size(); i++) {
     ScopeValue* val = sv->field_at(i);
     int offset = base_offset + (i << Klass::layout_helper_log2_element_size(vak->layout_helper()));

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -170,7 +170,7 @@ class Deoptimization : AllStatic {
 
   // Support for restoring non-escaping objects
   static bool realloc_objects(JavaThread* thread, frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, TRAPS);
-  static bool realloc_value_type_result(ValueKlass* vk, const RegisterMap& map, GrowableArray<Handle>& return_oops, TRAPS);
+  static bool realloc_inline_type_result(InlineKlass* vk, const RegisterMap& map, GrowableArray<Handle>& return_oops, TRAPS);
   static void reassign_type_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type);
   static void reassign_object_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, objArrayOop obj);
   static void reassign_value_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, valueArrayOop obj, ValueArrayKlass* vak, TRAPS);

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -31,7 +31,7 @@
 #include "oops/instanceKlass.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/fieldStreams.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/signature.hpp"
@@ -193,7 +193,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
     case T_INLINE_TYPE:
       if (is_inlined()) {
         // Print fields of inlined fields (recursively)
-        ValueKlass* vk = ValueKlass::cast(field_holder()->get_inline_type_field_klass(index()));
+        InlineKlass* vk = InlineKlass::cast(field_holder()->get_inline_type_field_klass(index()));
         int field_offset = offset() - vk->first_field_offset();
         obj = (oop)(cast_from_oop<address>(obj) + field_offset);
         st->print_cr("Inline type field inlined '%s':", vk->name()->as_C_string());

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -37,7 +37,7 @@
 #include "oops/method.hpp"
 #include "oops/methodData.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "oops/verifyOopClosure.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/frame.inline.hpp"

--- a/src/hotspot/share/runtime/handles.cpp
+++ b/src/hotspot/share/runtime/handles.cpp
@@ -26,7 +26,7 @@
 #include "memory/allocation.inline.hpp"
 #include "oops/constantPool.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/thread.inline.hpp"

--- a/src/hotspot/share/runtime/handles.hpp
+++ b/src/hotspot/share/runtime/handles.hpp
@@ -29,7 +29,7 @@
 #include "oops/oop.hpp"
 #include "oops/oopsHierarchy.hpp"
 
-class ValueKlass;
+class InlineKlass;
 class InstanceKlass;
 class Klass;
 class Thread;

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -33,7 +33,7 @@
 #include "memory/universe.hpp"
 #include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "prims/jniCheck.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
@@ -445,7 +445,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
   if (InlineTypeReturnedAsFields && result->get_type() == T_INLINE_TYPE) {
     // Pre allocate buffered value in case the result is returned
     // flattened by compiled code
-    ValueKlass* vk = method->returned_value_type(thread);
+    InlineKlass* vk = method->returned_inline_type(thread);
     if (vk->can_be_returned_as_fields()) {
       oop instance = vk->allocate_instance(CHECK);
       value_buffer = JNIHandles::make_local(thread, instance);

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -40,7 +40,7 @@
 #include "oops/objArrayKlass.hpp"
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/arguments.hpp"

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -47,7 +47,7 @@
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/frame.inline.hpp"
@@ -1047,7 +1047,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
     bool return_oop = method->is_returning_oop();
 
     GrowableArray<Handle> return_values;
-    ValueKlass* vk = NULL;
+    InlineKlass* vk = NULL;
 
     if (return_oop && InlineTypeReturnedAsFields) {
       SignatureStream ss(method->signature());
@@ -1056,12 +1056,12 @@ void ThreadSafepointState::handle_polling_page_exception() {
       }
       if (ss.type() == T_INLINE_TYPE) {
         // Check if value type is returned as fields
-        vk = ValueKlass::returned_value_klass(map);
+        vk = InlineKlass::returned_inline_klass(map);
         if (vk != NULL) {
           // We're at a safepoint at the return of a method that returns
           // multiple values. We must make sure we preserve the oop values
           // across the safepoint.
-          assert(vk == method->returned_value_type(thread()), "bad value klass");
+          assert(vk == method->returned_inline_type(thread()), "bad value klass");
           vk->save_oop_fields(map, return_values);
           return_oop = false;
         }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2833,7 +2833,7 @@ CodeOffsets::Entries CompiledEntrySignature::c1_value_ro_entry_type() const {
 
 
 void CompiledEntrySignature::compute_calling_conventions() {
-  // Get the (non-scalarized) signature and check for value type arguments
+  // Get the (non-scalarized) signature and check for inline type arguments
   if (!_method->is_static()) {
     if (_method->method_holder()->is_inline_klass() && InlineKlass::cast(_method->method_holder())->can_be_passed_as_fields()) {
       _has_value_recv = true;
@@ -2914,7 +2914,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
     // bailing out of compilation ("unsupported incoming calling sequence").
     // TODO we need a reasonable limit (flag?) here
     if (_args_on_stack_cc > 50) {
-      // Don't scalarize value type arguments
+      // Don't scalarize inline type arguments
       _sig_cc = _sig;
       _sig_cc_ro = _sig;
       _regs_cc = _regs;
@@ -2967,7 +2967,7 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter0(const methodHandle& met
 
     if (method->is_abstract()) {
       if (ces.has_scalarized_args()) {
-        // Save a C heap allocated version of the signature for abstract methods with scalarized value type arguments
+        // Save a C heap allocated version of the signature for abstract methods with scalarized inline type arguments
         address wrong_method_abstract = SharedRuntime::get_handle_wrong_method_abstract_stub();
         entry = AdapterHandlerLibrary::new_entry(new AdapterFingerPrint(NULL),
                                                  StubRoutines::throw_AbstractMethodError_entry(),
@@ -3589,7 +3589,7 @@ void SharedRuntime::on_slowpath_allocation_exit(JavaThread* thread) {
 }
 
 // We are at a compiled code to interpreter call. We need backing
-// buffers for all value type arguments. Allocate an object array to
+// buffers for all inline type arguments. Allocate an object array to
 // hold them (convenient because once we're done with it we don't have
 // to worry about freeing it).
 oop SharedRuntime::allocate_value_types_impl(JavaThread* thread, methodHandle callee, bool allocate_receiver, TRAPS) {
@@ -3636,7 +3636,7 @@ JRT_END
 
 // TODO remove this once the AARCH64 dependency is gone
 // Iterate over the array of heap allocated value types and apply the GC post barrier to all reference fields.
-// This is called from the C2I adapter after value type arguments are heap allocated and initialized.
+// This is called from the C2I adapter after inline type arguments are heap allocated and initialized.
 JRT_LEAF(void, SharedRuntime::apply_post_barriers(JavaThread* thread, objArrayOopDesc* array))
 {
   assert(InlineTypePassFieldsAsArgs, "no reason to call this");

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -554,7 +554,7 @@ class SharedRuntime: AllStatic {
 
   static address handle_unsafe_access(JavaThread* thread, address next_pc);
 
-  static BufferedValueTypeBlob* generate_buffered_value_type_adapter(const ValueKlass* vk);
+  static BufferedValueTypeBlob* generate_buffered_inline_type_adapter(const InlineKlass* vk);
 #ifndef PRODUCT
 
   // Collect and print inline cache miss statistics

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -32,7 +32,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "oops/typeArrayKlass.hpp"
-#include "oops/valueKlass.inline.hpp"
+#include "oops/inlineKlass.inline.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/safepointVerifiers.hpp"
@@ -374,13 +374,13 @@ Symbol* SignatureStream::find_symbol() {
   return name;
 }
 
-ValueKlass* SignatureStream::as_value_klass(InstanceKlass* holder) {
+InlineKlass* SignatureStream::as_inline_klass(InstanceKlass* holder) {
   Thread* THREAD = Thread::current();
   Handle class_loader(THREAD, holder->class_loader());
   Handle protection_domain(THREAD, holder->protection_domain());
   Klass* k = as_klass(class_loader, protection_domain, SignatureStream::ReturnNull, THREAD);
   assert(k != NULL && !HAS_PENDING_EXCEPTION, "unresolved value klass");
-  return ValueKlass::cast(k);
+  return InlineKlass::cast(k);
 }
 
 Klass* SignatureStream::as_klass(Handle class_loader, Handle protection_domain,

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -572,7 +572,7 @@ class SigEntryFilter;
 typedef GrowableArrayFilterIterator<SigEntry, SigEntryFilter> ExtendedSignature;
 
 // Used for adapter generation. One SigEntry is used per element of
-// the signature of the method. Value type arguments are treated
+// the signature of the method. Inline type arguments are treated
 // specially. See comment for InlineKlass::collect_fields().
 class SigEntry {
  public:

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -564,7 +564,7 @@ class SignatureStream : public StackObj {
   enum FailureMode { ReturnNull, NCDFError, CachedOrNull };
 
   Klass* as_klass(Handle class_loader, Handle protection_domain, FailureMode failure_mode, TRAPS);
-  ValueKlass* as_value_klass(InstanceKlass* holder);
+  InlineKlass* as_inline_klass(InstanceKlass* holder);
   oop as_java_mirror(Handle class_loader, Handle protection_domain, FailureMode failure_mode, TRAPS);
 };
 
@@ -573,7 +573,7 @@ typedef GrowableArrayFilterIterator<SigEntry, SigEntryFilter> ExtendedSignature;
 
 // Used for adapter generation. One SigEntry is used per element of
 // the signature of the method. Value type arguments are treated
-// specially. See comment for ValueKlass::collect_fields().
+// specially. See comment for InlineKlass::collect_fields().
 class SigEntry {
  public:
   BasicType _bt;

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -58,7 +58,7 @@
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "oops/typeArrayOop.inline.hpp"
-#include "oops/valueKlass.hpp"
+#include "oops/inlineKlass.hpp"
 #include "oops/verifyOopClosure.hpp"
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"


### PR DESCRIPTION
Please review this tedious change.  It renames class ValueKlass to InlineKlass and renames its fields and methods.  It does not rename ValueArrayKlass.  That will be a future change.

Also, this change does not rename things defined in gc or jit source files.

The change was tested with tiers 1 and 2 on Mac, Windows, and Linux x64, and tiers 3-5 on Linux x64.

Thanks, Harold
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8249257](https://bugs.openjdk.java.net/browse/JDK-8249257): Rename ValueKlass to InlineKlass


### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer) ⚠️ Review applies to e832a5c4df356abd91c25255571dccbad6202b2e


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/109/head:pull/109`
`$ git checkout pull/109`
