### PR TITLE
8249613: [lworld] Use initialization free allocation when copying a value

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -341,7 +341,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
   Handle old_value_h(THREAD, old_value);
 
   // Creating new value by copying the one passed in argument
-  instanceOop new_value = vklass->allocate_instance(
+  instanceOop new_value = vklass->allocate_instance_buffer(
       CHECK_((type2size[field_type]) * AbstractInterpreter::stackElementSize));
   Handle new_value_h = Handle(THREAD, new_value);
   vklass->inline_copy_oop_to_new_oop(old_value_h(), new_value_h());

--- a/src/hotspot/share/oops/valueArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/valueArrayOop.inline.hpp
@@ -52,7 +52,7 @@ inline oop valueArrayOopDesc::value_alloc_copy_from_index(valueArrayHandle vah, 
   if (vklass->is_empty_inline_type()) {
     return vklass->default_value();
   } else {
-    oop buf = vklass->allocate_instance(CHECK_NULL);
+    oop buf = vklass->allocate_instance_buffer(CHECK_NULL);
     vklass->inline_copy_payload_to_new_oop(vah->value_at_addr(index, vaklass->layout_helper()) ,buf);
     return buf;
   }

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3562,7 +3562,7 @@ JNI_ENTRY(jobject, jni_GetObjectSubElement(JNIEnv* env, jarray array, jobject se
     res = HeapAccess<ON_UNKNOWN_OOP_REF>::oop_load_at(ar, offset);
   } else {
     InlineKlass* fieldKlass = InlineKlass::cast(java_lang_Class::as_Klass(jdk_internal_vm_jni_SubElementSelector::getSubElementType(slct)));
-    res = fieldKlass->allocate_instance(CHECK_NULL);
+    res = fieldKlass->allocate_instance_buffer(CHECK_NULL);
     // The array might have been moved by the GC, refreshing the arrayOop
     ar =  (valueArrayOop)JNIHandles::resolve_non_null(array);
     address addr = (address)ar->value_at_addr(index, vak->layout_helper())

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -386,7 +386,7 @@ UNSAFE_ENTRY(jobject, Unsafe_MakePrivateBuffer(JNIEnv *env, jobject unsafe, jobj
   assert(v->is_inline_type(), "must be an inline type instance");
   Handle vh(THREAD, v);
   InlineKlass* vk = InlineKlass::cast(v->klass());
-  instanceOop new_value = vk->allocate_instance(CHECK_NULL);
+  instanceOop new_value = vk->allocate_instance_buffer(CHECK_NULL);
   vk->inline_copy_oop_to_new_oop(vh(),  new_value);
   markWord mark = new_value->mark();
   new_value->set_mark(mark.enter_larval_state());


### PR DESCRIPTION
Please review this patch which removes some unnecessary zeroing of heap allocated inline type instances.

Passed tests tier 1 to 3 with Mach5.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8249613](https://bugs.openjdk.java.net/browse/JDK-8249613): [lworld] Use initialization free allocation when copying a value


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/110/head:pull/110`
`$ git checkout pull/110`
