### PR TITLE
More renaming from value type to inline type

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2680,7 +2680,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
           __ b(Done);
         __ bind(isUninitialized);
           __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
-          __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_static_value_field), obj, raw_flags);
+          __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_static_inline_type_field), obj, raw_flags);
           __ verify_oop(r0);
           __ push(atos);
           __ b(Done);
@@ -2700,7 +2700,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
           __ load_heap_oop(r0, field);
           __ cbnz(r0, isInitialized);
             __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
-            __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_value_field), obj, raw_flags);
+            __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_inline_type_field), obj, raw_flags);
           __ bind(isInitialized);
           __ verify_oop(r0);
           __ push(atos);
@@ -3340,7 +3340,7 @@ void TemplateTable::fast_accessfield(TosState state)
           __ mov(r0, r9);
           __ ldrw(r9, Address(r2, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset())));
           __ andw(r9, r9, ConstantPoolCacheEntry::field_index_mask);
-          __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_value_field), r0, r9);
+          __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_inline_type_field), r0, r9);
         __ bind(isInitialized);
         __ verify_oop(r0);
         __ b(Done);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1227,10 +1227,10 @@ void InterpreterMacroAssembler::read_inlined_field(Register holder_klass,
   // Grap the inline field klass
   push(holder_klass);
   const Register field_klass = holder_klass;
-  get_value_field_klass(holder_klass, field_index, field_klass);
+  get_inline_type_field_klass(holder_klass, field_index, field_klass);
 
   //check for empty value klass
-  test_klass_is_empty_value(field_klass, dst_temp, empty_value);
+  test_klass_is_empty_inline_type(field_klass, dst_temp, empty_value);
 
   // allocate buffer
   push(obj); // save holder
@@ -1248,7 +1248,7 @@ void InterpreterMacroAssembler::read_inlined_field(Register holder_klass,
   jmp(done);
 
   bind(empty_value);
-  get_empty_value_oop(field_klass, dst_temp, obj);
+  get_empty_inline_type_oop(field_klass, dst_temp, obj);
   pop(holder_klass);
   jmp(done);
 
@@ -1277,7 +1277,7 @@ void InterpreterMacroAssembler::read_flattened_element(Register array, Register 
   movptr(elem_klass, Address(array_klass, ArrayKlass::element_klass_offset()));
 
   //check for empty value klass
-  test_klass_is_empty_value(elem_klass, dst_temp, empty_value);
+  test_klass_is_empty_inline_type(elem_klass, dst_temp, empty_value);
 
   // calc source into "array_klass" and free up some regs
   const Register src = array_klass;
@@ -1293,7 +1293,7 @@ void InterpreterMacroAssembler::read_flattened_element(Register array, Register 
   jmp(done);
 
   bind(empty_value);
-  get_empty_value_oop(elem_klass, dst_temp, obj);
+  get_empty_inline_type_oop(elem_klass, dst_temp, obj);
   jmp(done);
 
   bind(alloc_failed);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2617,24 +2617,24 @@ void MacroAssembler::null_check(Register reg, int offset) {
   }
 }
 
-void MacroAssembler::test_klass_is_value(Register klass, Register temp_reg, Label& is_value) {
+void MacroAssembler::test_klass_is_inline_type(Register klass, Register temp_reg, Label& is_inline_type) {
   movl(temp_reg, Address(klass, Klass::access_flags_offset()));
   testl(temp_reg, JVM_ACC_VALUE);
-  jcc(Assembler::notZero, is_value);
+  jcc(Assembler::notZero, is_inline_type);
 }
 
-void MacroAssembler::test_klass_is_empty_value(Register klass, Register temp_reg, Label& is_empty_value) {
+void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register temp_reg, Label& is_empty_inline_type) {
 #ifdef ASSERT
   {
     Label done_check;
-    test_klass_is_value(klass, temp_reg, done_check);
-    stop("test_klass_is_empty_value with non value klass");
+    test_klass_is_inline_type(klass, temp_reg, done_check);
+    stop("test_klass_is_empty_inline_type with non inline type klass");
     bind(done_check);
   }
 #endif
   movl(temp_reg, Address(klass, InstanceKlass::misc_flags_offset()));
   testl(temp_reg, InstanceKlass::misc_flags_is_empty_inline_type());
-  jcc(Assembler::notZero, is_empty_value);
+  jcc(Assembler::notZero, is_empty_inline_type);
 }
 
 void MacroAssembler::test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline_type) {
@@ -3615,26 +3615,26 @@ void MacroAssembler::zero_memory(Register address, Register length_in_bytes, int
   bind(done);
 }
 
-void MacroAssembler::get_value_field_klass(Register klass, Register index, Register value_klass) {
-  movptr(value_klass, Address(klass, InstanceKlass::inline_type_field_klasses_offset()));
+void MacroAssembler::get_inline_type_field_klass(Register klass, Register index, Register inline_klass) {
+  movptr(inline_klass, Address(klass, InstanceKlass::inline_type_field_klasses_offset()));
 #ifdef ASSERT
   {
     Label done;
-    cmpptr(value_klass, 0);
+    cmpptr(inline_klass, 0);
     jcc(Assembler::notEqual, done);
-    stop("get_value_field_klass contains no inline klasses");
+    stop("get_inline_type_field_klass contains no inline klass");
     bind(done);
   }
 #endif
-  movptr(value_klass, Address(value_klass, index, Address::times_ptr));
+  movptr(inline_klass, Address(inline_klass, index, Address::times_ptr));
 }
 
 void MacroAssembler::get_default_value_oop(Register value_klass, Register temp_reg, Register obj) {
 #ifdef ASSERT
   {
     Label done_check;
-    test_klass_is_value(value_klass, temp_reg, done_check);
-    stop("get_default_value_oop from non-value klass");
+    test_klass_is_inline_type(value_klass, temp_reg, done_check);
+    stop("get_default_value_oop from non inline type klass");
     bind(done_check);
   }
 #endif
@@ -3652,16 +3652,16 @@ void MacroAssembler::get_default_value_oop(Register value_klass, Register temp_r
   load_heap_oop(obj, field);
 }
 
-void MacroAssembler::get_empty_value_oop(Register value_klass, Register temp_reg, Register obj) {
+void MacroAssembler::get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj) {
 #ifdef ASSERT
   {
     Label done_check;
-    test_klass_is_empty_value(value_klass, temp_reg, done_check);
-    stop("get_empty_value from non-empty value klass");
+    test_klass_is_empty_inline_type(inline_klass, temp_reg, done_check);
+    stop("get_empty_value from non-empty inline klass");
     bind(done_check);
   }
 #endif
-  get_default_value_oop(value_klass, temp_reg, obj);
+  get_default_value_oop(inline_klass, temp_reg, obj);
 }
 
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -102,14 +102,14 @@ class MacroAssembler: public Assembler {
   static bool uses_implicit_null_check(void* address);
 
   // valueKlass queries, kills temp_reg
-  void test_klass_is_value(Register klass, Register temp_reg, Label& is_value);
-  void test_klass_is_empty_value(Register klass, Register temp_reg, Label& is_empty_value);
+  void test_klass_is_inline_type(Register klass, Register temp_reg, Label& is_inline_type);
+  void test_klass_is_empty_inline_type(Register klass, Register temp_reg, Label& is_empty_inline_type);
 
   // Get the default value oop for the given InlineKlass
-  void get_default_value_oop(Register value_klass, Register temp_reg, Register obj);
+  void get_default_value_oop(Register inline_klass, Register temp_reg, Register obj);
   // The empty value oop, for the given InlineKlass ("empty" as in no instance fields)
   // get_default_value_oop with extra assertion for empty inline klass
-  void get_empty_value_oop(Register value_klass, Register temp_reg, Register obj);
+  void get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj);
 
   void test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline);
   void test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline);
@@ -577,7 +577,7 @@ class MacroAssembler: public Assembler {
   void zero_memory(Register address, Register length_in_bytes, int offset_in_bytes, Register temp);
 
   // For field "index" within "klass", return value_klass ...
-  void get_value_field_klass(Register klass, Register index, Register value_klass);
+  void get_inline_type_field_klass(Register klass, Register index, Register value_klass);
 
   // interface method calling
   void lookup_interface_method(Register recv_klass,

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -37,7 +37,7 @@
 LayoutRawBlock::LayoutRawBlock(Kind kind, int size) :
   _next_block(NULL),
   _prev_block(NULL),
-  _value_klass(NULL),
+  _inline_klass(NULL),
   _kind(kind),
   _offset(-1),
   _alignment(1),
@@ -53,7 +53,7 @@ LayoutRawBlock::LayoutRawBlock(Kind kind, int size) :
 LayoutRawBlock::LayoutRawBlock(int index, Kind kind, int size, int alignment, bool is_reference) :
  _next_block(NULL),
  _prev_block(NULL),
- _value_klass(NULL),
+ _inline_klass(NULL),
  _kind(kind),
  _offset(-1),
  _alignment(alignment),
@@ -104,7 +104,7 @@ void FieldGroup::add_oop_field(AllFieldStream fs) {
 void FieldGroup::add_inlined_field(AllFieldStream fs, InlineKlass* vk) {
   // _inlined_fields list might be merged with the _primitive_fields list in the future
   LayoutRawBlock* block = new LayoutRawBlock(fs.index(), LayoutRawBlock::INLINED, vk->get_exact_size_in_bytes(), vk->get_alignment(), false);
-  block->set_value_klass(vk);
+  block->set_inline_klass(vk);
   if (_inlined_fields == NULL) {
     _inlined_fields = new(ResourceObj::RESOURCE_AREA, mtInternal) GrowableArray<LayoutRawBlock*>(INITIAL_LIST_SIZE);
   }
@@ -915,7 +915,7 @@ void FieldLayoutBuilder::epilogue() {
   if (ff != NULL) {
     for (int i = 0; i < ff->length(); i++) {
       LayoutRawBlock* f = ff->at(i);
-      InlineKlass* vk = f->value_klass();
+      InlineKlass* vk = f->inline_klass();
       assert(vk != NULL, "Should have been initialized");
       if (vk->contains_oops()) {
         add_inlined_field_oopmap(nonstatic_oop_maps, vk, f->offset());

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -64,7 +64,7 @@ class LayoutRawBlock : public ResourceObj {
  private:
   LayoutRawBlock* _next_block;
   LayoutRawBlock* _prev_block;
-  InlineKlass* _value_klass;
+  InlineKlass* _inline_klass;
   Kind _kind;
   int _offset;
   int _alignment;
@@ -93,11 +93,11 @@ class LayoutRawBlock : public ResourceObj {
     return _field_index;
   }
   bool is_reference() const { return _is_reference; }
-  InlineKlass* value_klass() const {
-    assert(_value_klass != NULL, "Must be initialized");
-    return _value_klass;
+  InlineKlass* inline_klass() const {
+    assert(_inline_klass != NULL, "Must be initialized");
+    return _inline_klass;
   }
-  void set_value_klass(InlineKlass* value_klass) { _value_klass = value_klass; }
+  void set_inline_klass(InlineKlass* inline_klass) { _inline_klass = inline_klass; }
 
   bool fit(int size, int alignment);
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -376,7 +376,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* thread, ConstantPoolCac
   return return_offset;
 JRT_END
 
-JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_value_field(JavaThread* thread, oopDesc* mirror, int index))
+JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_inline_type_field(JavaThread* thread, oopDesc* mirror, int index))
   // The interpreter tries to access an inline static field that has not been initialized.
   // This situation can happen in different scenarios:
   //   1 - if the load or initialization of the field failed during step 8 of

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -67,7 +67,7 @@ class InterpreterRuntime: AllStatic {
   static void    register_finalizer(JavaThread* thread, oopDesc* obj);
   static void    defaultvalue  (JavaThread* thread, ConstantPool* pool, int index);
   static int     withfield     (JavaThread* thread, ConstantPoolCache* cp_cache);
-  static void    uninitialized_static_value_field(JavaThread* thread, oopDesc* mirror, int offset);
+  static void    uninitialized_static_inline_type_field(JavaThread* thread, oopDesc* mirror, int offset);
   static void    write_heap_copy (JavaThread* thread, oopDesc* value, int offset, oopDesc* rcv);
   static void    read_inlined_field(JavaThread* thread, oopDesc* value, int index, Klass* field_holder);
 


### PR DESCRIPTION
Please review this small patch with more renaming of symbols from "value type" to "inline type".

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/113/head:pull/113`
`$ git checkout pull/113`
