### PR TITLE
8220710: [lworld] Improve propagation of nullability information

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1428,6 +1428,11 @@ Node* GraphKit::cast_not_null(Node* obj, bool do_replace_in_map) {
   cast->init_req(0, control());
   cast = _gvn.transform( cast );
 
+  if (t->is_valuetypeptr() && t->value_klass()->is_scalarizable()) {
+    // Scalarize inline type know that we know it's non-null
+    cast = ValueTypeNode::make_from_oop(this, cast, t->value_klass())->buffer(this, false);
+  }
+
   // Scan for instances of 'obj' in the current JVM mapping.
   // These instances are known to be not-null after the test.
   if (do_replace_in_map)

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
@@ -898,4 +898,63 @@ public class TestNullableValueTypes extends ValueTypeTest {
         test35(true);
         test35(false);
     }
+
+    // Test that when explicitly null checking a value type, we keep
+    // track of the information that the value can never be null.
+    @Test(failOn = ALLOC + STORE)
+    public int test37(boolean b, MyValue1.ref vt1, MyValue1.val vt2) {
+        if (vt1 == null) {
+            return 0;
+        }
+        // vt1 should be scalarized because it's always non-null
+        Object obj = b ? vt1 : vt2; // We should not allocate vt2 here
+        test25_callee(vt1);
+        return ((MyValue1)obj).x;
+    }
+
+    @DontCompile
+    public void test37_verifier(boolean warmup) {
+        int res = test37(true, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+        res = test37(false, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+    }
+
+    // Test that when explicitly null checking a value type receiver,
+    // we keep track of the information that the value can never be null.
+    @Test(failOn = ALLOC + STORE)
+    public int test38(boolean b, MyValue1.ref vt1, MyValue1.val vt2) {
+        vt1.hash(); // Inlined - Explicit null check
+        // vt1 should be scalarized because it's always non-null
+        Object obj = b ? vt1 : vt2; // We should not allocate vt2 here
+        test25_callee(vt1);
+        return ((MyValue1)obj).x;
+    }
+
+    @DontCompile
+    public void test38_verifier(boolean warmup) {
+        int res = test38(true, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+        res = test38(false, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+    }
+
+    // Test that when implicitly null checking a value type receiver,
+    // we keep track of the information that the value can never be null.
+    @Test(failOn = ALLOC + STORE)
+    public int test39(boolean b, MyValue1.ref vt1, MyValue1.val vt2) {
+        vt1.hashInterpreted(); // Not inlined - Implicit null check
+        // vt1 should be scalarized because it's always non-null
+        Object obj = b ? vt1 : vt2; // We should not allocate vt2 here
+        test25_callee(vt1);
+        return ((MyValue1)obj).x;
+    }
+
+    @DontCompile
+    public void test39_verifier(boolean warmup) {
+        int res = test39(true, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+        res = test39(false, testValue1, testValue1);
+        Asserts.assertEquals(res, testValue1.x);
+    }
 }


### PR DESCRIPTION
There are cases where C2 is not able to keep track of the fact that an inline type is never null. For example, after explicit null checks and implicit receiver null checks on MyValue.ref.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8220710](https://bugs.openjdk.java.net/browse/JDK-8220710): [lworld] Improve propagation of nullability information


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/118/head:pull/118`
`$ git checkout pull/118`
