### PR TITLE
8249886: Rename -XX: InlineArrayElemMaxFlat* options

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1585,7 +1585,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
   // This is called when we use aastore into a an array declared as "[LVT;",
-  // where we know VT is not flattened (due to FlatArrayElemMaxFlatSize, etc).
+  // where we know VT is not flattened (due to FlatArrayElementMaxSize, etc).
   // However, we need to do a NULL check if the actual array is a "[QVT;".
 
   __ load_storage_props(op->tmp()->as_register(), op->array()->as_register());

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1585,7 +1585,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
   // This is called when we use aastore into a an array declared as "[LVT;",
-  // where we know VT is not flattened (due to InlineArrayElemMaxFlatSize, etc).
+  // where we know VT is not flattened (due to FlatArrayElemMaxFlatSize, etc).
   // However, we need to do a NULL check if the actual array is a "[QVT;".
 
   __ load_storage_props(op->tmp()->as_register(), op->array()->as_register());

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -183,11 +183,11 @@ bool InlineKlass::flatten_array() {
   }
   // Too big
   int elem_bytes = raw_value_byte_size();
-  if ((FlatArrayElemMaxFlatSize >= 0) && (elem_bytes > FlatArrayElemMaxFlatSize)) {
+  if ((FlatArrayElementMaxSize >= 0) && (elem_bytes > FlatArrayElementMaxSize)) {
     return false;
   }
   // Too many embedded oops
-  if ((FlatArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > FlatArrayElemMaxFlatOops)) {
+  if ((FlatArrayElementMaxOops >= 0) && (nonstatic_oop_count() > FlatArrayElementMaxOops)) {
     return false;
   }
   // Declared atomic but not naturally atomic.

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -183,11 +183,11 @@ bool InlineKlass::flatten_array() {
   }
   // Too big
   int elem_bytes = raw_value_byte_size();
-  if ((InlineArrayElemMaxFlatSize >= 0) && (elem_bytes > InlineArrayElemMaxFlatSize)) {
+  if ((FlatArrayElemMaxFlatSize >= 0) && (elem_bytes > FlatArrayElemMaxFlatSize)) {
     return false;
   }
   // Too many embedded oops
-  if ((InlineArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > InlineArrayElemMaxFlatOops)) {
+  if ((FlatArrayElemMaxFlatOops >= 0) && (nonstatic_oop_count() > FlatArrayElemMaxFlatOops)) {
     return false;
   }
   // Declared atomic but not naturally atomic.

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -766,13 +766,13 @@ const size_t minimumSymbolTableSize = 1024;
   notproduct(bool, PrintFlatArrayLayout, false,                             \
           "Print array layout for each inline type array")                  \
                                                                             \
-  product(intx, FlatArrayElemMaxFlatSize, -1,                               \
+  product(intx, FlatArrayElementMaxSize, -1,                                \
           "Max size for flattening inline array elements, <0 no limit")     \
                                                                             \
   product(intx, InlineFieldMaxFlatSize, 128,                                \
           "Max size for flattening inline type fields, <0 no limit")        \
                                                                             \
-  product(intx, FlatArrayElemMaxFlatOops, 4,                                \
+  product(intx, FlatArrayElementMaxOops, 4,                                 \
           "Max nof embedded object references in an inline type to flatten, <0 no limit")  \
                                                                             \
   product(bool, InlineArrayAtomicAccess, false,                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -766,13 +766,13 @@ const size_t minimumSymbolTableSize = 1024;
   notproduct(bool, PrintFlatArrayLayout, false,                             \
           "Print array layout for each inline type array")                  \
                                                                             \
-  product(intx, InlineArrayElemMaxFlatSize, -1,                             \
+  product(intx, FlatArrayElemMaxFlatSize, -1,                               \
           "Max size for flattening inline array elements, <0 no limit")     \
                                                                             \
   product(intx, InlineFieldMaxFlatSize, 128,                                \
           "Max size for flattening inline type fields, <0 no limit")        \
                                                                             \
-  product(intx, InlineArrayElemMaxFlatOops, 4,                              \
+  product(intx, FlatArrayElemMaxFlatOops, 4,                                \
           "Max nof embedded object references in an inline type to flatten, <0 no limit")  \
                                                                             \
   product(bool, InlineArrayAtomicAccess, false,                             \

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1211,9 +1211,9 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
 
 // TEMP!!!!
 // This should be removed after LW2 arrays are implemented (JDK-8220790).
-// It's an alias to (EnableValhalla && (FlatArrayElemMaxFlatSize != 0)),
+// It's an alias to (EnableValhalla && (FlatArrayElementMaxSize != 0)),
 // which is actually not 100% correct, but works for the current set of C1/C2
 // implementation and test cases.
-#define UseFlatArray (EnableValhalla && (FlatArrayElemMaxFlatSize != 0))
+#define UseFlatArray (EnableValhalla && (FlatArrayElementMaxSize != 0))
 
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1211,9 +1211,9 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
 
 // TEMP!!!!
 // This should be removed after LW2 arrays are implemented (JDK-8220790).
-// It's an alias to (EnableValhalla && (InlineArrayElemMaxFlatSize != 0)),
+// It's an alias to (EnableValhalla && (FlatArrayElemMaxFlatSize != 0)),
 // which is actually not 100% correct, but works for the current set of C1/C2
 // implementation and test cases.
-#define UseFlatArray (EnableValhalla && (InlineArrayElemMaxFlatSize != 0))
+#define UseFlatArray (EnableValhalla && (FlatArrayElemMaxFlatSize != 0))
 
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
@@ -61,7 +61,7 @@ public class TestArrays extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElemMaxFlatSize=-1", "-XX:-UncommonNullCast"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1", "-XX:-UncommonNullCast"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast"};
         case 5: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
         }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestArrays.java
@@ -61,7 +61,7 @@ public class TestArrays extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:InlineArrayElemMaxFlatSize=-1", "-XX:-UncommonNullCast"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElemMaxFlatSize=-1", "-XX:-UncommonNullCast"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast"};
         case 5: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UncommonNullCast", "-XX:+StressArrayCopyMacroNode"};
         }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
@@ -43,7 +43,7 @@ public class TestBasicFunctionality extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-DVerifyIR=false"};
-        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBasicFunctionality.java
@@ -43,7 +43,7 @@ public class TestBasicFunctionality extends ValueTypeTest {
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
         case 2: return new String[] {"-DVerifyIR=false"};
-        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElementMaxSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
@@ -35,18 +35,18 @@ import jdk.internal.misc.Unsafe;
  * @summary Detect tearing on value type buffer writes due to missing barriers.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestBufferTearing.java
@@ -35,18 +35,18 @@ import jdk.internal.misc.Unsafe;
  * @summary Detect tearing on value type buffer writes due to missing barriers.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElementMaxSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElementMaxSize=0
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElementMaxSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   compiler.valhalla.valuetypes.TestBufferTearing
- * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElementMaxSize=0
  *                   -XX:CompileCommand=dontinline,*::incrementAndCheck*
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
@@ -47,7 +47,7 @@ public class TestCallingConvention extends ValueTypeTest {
         switch (scenario) {
         case 0: return new String[] {"-Dsun.reflect.inflationThreshold=10000"}; // Don't generate bytecodes but call through runtime for reflective calls
         case 1: return new String[] {"-Dsun.reflect.inflationThreshold=10000"};
-        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestCallingConvention.java
@@ -47,7 +47,7 @@ public class TestCallingConvention extends ValueTypeTest {
         switch (scenario) {
         case 0: return new String[] {"-Dsun.reflect.inflationThreshold=10000"}; // Don't generate bytecodes but call through runtime for reflective calls
         case 1: return new String[] {"-Dsun.reflect.inflationThreshold=10000"};
-        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElementMaxSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
@@ -44,32 +44,32 @@ import sun.hotspot.WhiteBox;
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:InlineArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  */

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestDeoptimizationWhenBuffering.java
@@ -44,32 +44,32 @@ import sun.hotspot.WhiteBox;
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=1
+ *                   -XX:-InlineTypePassFieldsAsArgs -XX:-InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=-1
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:-AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:-UseTLAB -Xbatch -XX:-MonomorphicArrayCheck -XX:+AlwaysIncrementalInline
- *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElemMaxFlatSize=-1 -XX:InlineFieldMaxFlatSize=0
+ *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=0
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.valuetypes.*::test*
  *                   compiler.valhalla.valuetypes.TestDeoptimizationWhenBuffering
  */

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
@@ -26,8 +26,8 @@
  * @summary Test accessing value type arrays that exceed the flattening threshold.
  * @library /test/lib
  * @run main/othervm -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:FlatArrayElemMaxFlatOops=1 -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:FlatArrayElemMaxFlatSize=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:FlatArrayElementMaxOops=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:FlatArrayElementMaxSize=1 -Xbatch TestFlatArrayThreshold
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestFlatArrayThreshold.java
@@ -26,8 +26,8 @@
  * @summary Test accessing value type arrays that exceed the flattening threshold.
  * @library /test/lib
  * @run main/othervm -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:InlineArrayElemMaxFlatOops=1 -Xbatch TestFlatArrayThreshold
- * @run main/othervm -XX:InlineArrayElemMaxFlatSize=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:FlatArrayElemMaxFlatOops=1 -Xbatch TestFlatArrayThreshold
+ * @run main/othervm -XX:FlatArrayElemMaxFlatSize=1 -Xbatch TestFlatArrayThreshold
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
@@ -49,7 +49,7 @@ public class TestIntrinsics extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestIntrinsics.java
@@ -49,7 +49,7 @@ public class TestIntrinsics extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:InlineArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
@@ -50,7 +50,7 @@ public class TestLWorld extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-DVerifyIR=false", "-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:InlineArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestLWorld.java
@@ -50,7 +50,7 @@ public class TestLWorld extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-DVerifyIR=false", "-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElementMaxSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
@@ -47,7 +47,7 @@ public class TestNullableValueTypes extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElementMaxSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestNullableValueTypes.java
@@ -47,7 +47,7 @@ public class TestNullableValueTypes extends ValueTypeTest {
         switch (scenario) {
         case 1: return new String[] {"-XX:-UseOptoBiasInlining"};
         case 2: return new String[] {"-XX:-UseBiasedLocking"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:InlineArrayElemMaxFlatSize=-1"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:-UseBiasedLocking", "-XX:FlatArrayElemMaxFlatSize=-1"};
         case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
@@ -43,7 +43,7 @@ public class TestOnStackReplacement extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElementMaxSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestOnStackReplacement.java
@@ -43,7 +43,7 @@ public class TestOnStackReplacement extends ValueTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 3: return new String[] {"-XX:InlineArrayElemMaxFlatSize=0"};
+        case 3: return new String[] {"-XX:FlatArrayElemMaxFlatSize=0"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
@@ -29,22 +29,22 @@
  * @run main/othervm -Xcomp
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=0
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElementMaxSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElementMaxSize=0
  *                   TestUnloadedValueTypeArray
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/TestUnloadedValueTypeArray.java
@@ -29,22 +29,22 @@
  * @run main/othervm -Xcomp
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElemMaxFlatSize=0
  *                   -XX:CompileCommand=compileonly,TestUnloadedValueTypeArray::test*
  *                   TestUnloadedValueTypeArray
  * @run main/othervm -Xcomp -XX:-TieredCompilation
  *                   TestUnloadedValueTypeArray
- * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:InlineArrayElemMaxFlatSize=0
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:FlatArrayElemMaxFlatSize=0
  *                   TestUnloadedValueTypeArray
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
@@ -180,7 +180,7 @@ public abstract class ValueTypeTest {
     protected static final int TypeProfileOn = 0x4000;
     protected static final int TypeProfileOff = 0x8000;
     protected static final boolean InlineTypePassFieldsAsArgs = (Boolean)WHITE_BOX.getVMFlag("InlineTypePassFieldsAsArgs");
-    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("InlineArrayElemMaxFlatSize") == -1); // FIXME - fix this if default of InlineArrayElemMaxFlatSize is changed
+    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("FlatArrayElemMaxFlatSize") == -1); // FIXME - fix this if default of FlatArrayElemMaxFlatSize is changed
     protected static final boolean InlineTypeReturnedAsFields = (Boolean)WHITE_BOX.getVMFlag("InlineTypeReturnedAsFields");
     protected static final boolean AlwaysIncrementalInline = (Boolean)WHITE_BOX.getVMFlag("AlwaysIncrementalInline");
     protected static final boolean G1GC = (Boolean)WHITE_BOX.getVMFlag("UseG1GC");
@@ -259,24 +259,24 @@ public abstract class ValueTypeTest {
         case 0: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:InlineArrayElemMaxFlatOops=5",
-                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElemMaxFlatOops=5",
+                "-XX:FlatArrayElemMaxFlatSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:InlineArrayElemMaxFlatOops=5",
-                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElemMaxFlatOops=5",
+                "-XX:FlatArrayElemMaxFlatSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:InlineArrayElemMaxFlatOops=0",
-                "-XX:InlineArrayElemMaxFlatSize=0",
+                "-XX:FlatArrayElemMaxFlatOops=0",
+                "-XX:FlatArrayElemMaxFlatSize=0",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields",
@@ -285,16 +285,16 @@ public abstract class ValueTypeTest {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:InlineArrayElemMaxFlatOops=0",
-                "-XX:InlineArrayElemMaxFlatSize=0",
+                "-XX:FlatArrayElemMaxFlatOops=0",
+                "-XX:FlatArrayElemMaxFlatSize=0",
                 "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
-                "-XX:InlineArrayElemMaxFlatOops=-1",
-                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElemMaxFlatOops=-1",
+                "-XX:FlatArrayElemMaxFlatSize=-1",
                 "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields",
@@ -302,8 +302,8 @@ public abstract class ValueTypeTest {
         case 5: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:InlineArrayElemMaxFlatOops=5",
-                "-XX:InlineArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElemMaxFlatOops=5",
+                "-XX:FlatArrayElemMaxFlatSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};

--- a/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/valuetypes/ValueTypeTest.java
@@ -180,7 +180,7 @@ public abstract class ValueTypeTest {
     protected static final int TypeProfileOn = 0x4000;
     protected static final int TypeProfileOff = 0x8000;
     protected static final boolean InlineTypePassFieldsAsArgs = (Boolean)WHITE_BOX.getVMFlag("InlineTypePassFieldsAsArgs");
-    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("FlatArrayElemMaxFlatSize") == -1); // FIXME - fix this if default of FlatArrayElemMaxFlatSize is changed
+    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("FlatArrayElementMaxSize") == -1); // FIXME - fix this if default of FlatArrayElementMaxSize is changed
     protected static final boolean InlineTypeReturnedAsFields = (Boolean)WHITE_BOX.getVMFlag("InlineTypeReturnedAsFields");
     protected static final boolean AlwaysIncrementalInline = (Boolean)WHITE_BOX.getVMFlag("AlwaysIncrementalInline");
     protected static final boolean G1GC = (Boolean)WHITE_BOX.getVMFlag("UseG1GC");
@@ -259,24 +259,24 @@ public abstract class ValueTypeTest {
         case 0: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:FlatArrayElemMaxFlatOops=5",
-                "-XX:FlatArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElementMaxOops=5",
+                "-XX:FlatArrayElementMaxSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:FlatArrayElemMaxFlatOops=5",
-                "-XX:FlatArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElementMaxOops=5",
+                "-XX:FlatArrayElementMaxSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
-                "-XX:FlatArrayElemMaxFlatOops=0",
-                "-XX:FlatArrayElemMaxFlatSize=0",
+                "-XX:FlatArrayElementMaxOops=0",
+                "-XX:FlatArrayElementMaxSize=0",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields",
@@ -285,16 +285,16 @@ public abstract class ValueTypeTest {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:FlatArrayElemMaxFlatOops=0",
-                "-XX:FlatArrayElemMaxFlatSize=0",
+                "-XX:FlatArrayElementMaxOops=0",
+                "-XX:FlatArrayElementMaxSize=0",
                 "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
-                "-XX:FlatArrayElemMaxFlatOops=-1",
-                "-XX:FlatArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElementMaxOops=-1",
+                "-XX:FlatArrayElementMaxSize=-1",
                 "-XX:InlineFieldMaxFlatSize=0",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields",
@@ -302,8 +302,8 @@ public abstract class ValueTypeTest {
         case 5: return new String[] {
                 "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
-                "-XX:FlatArrayElemMaxFlatOops=5",
-                "-XX:FlatArrayElemMaxFlatSize=-1",
+                "-XX:FlatArrayElementMaxOops=5",
+                "-XX:FlatArrayElementMaxSize=-1",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
@@ -40,8 +40,8 @@ import jdk.internal.vm.jni.SubElementSelector;
  * @requires (os.simpleArch == "x64")
  * @requires (os.family == "linux" | os.family == "mac")
  * @compile -XDallowWithFieldOperator TestJNIArrays.java
- * @run main/othervm/native/timeout=3000 -XX:InlineArrayElemMaxFlatSize=128 -XX:+UseCompressedOops TestJNIArrays
- * @run main/othervm/native/timeout=3000 -XX:InlineArrayElemMaxFlatSize=128 -XX:-UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElemMaxFlatSize=128 -XX:+UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElemMaxFlatSize=128 -XX:-UseCompressedOops TestJNIArrays
  */
 public class TestJNIArrays {
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/TestJNIArrays.java
@@ -40,8 +40,8 @@ import jdk.internal.vm.jni.SubElementSelector;
  * @requires (os.simpleArch == "x64")
  * @requires (os.family == "linux" | os.family == "mac")
  * @compile -XDallowWithFieldOperator TestJNIArrays.java
- * @run main/othervm/native/timeout=3000 -XX:FlatArrayElemMaxFlatSize=128 -XX:+UseCompressedOops TestJNIArrays
- * @run main/othervm/native/timeout=3000 -XX:FlatArrayElemMaxFlatSize=128 -XX:-UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128 -XX:+UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128 -XX:-UseCompressedOops TestJNIArrays
  */
 public class TestJNIArrays {
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -35,10 +35,10 @@ import static jdk.test.lib.Asserts.*;
  * @summary Plain array test for Inline Types
  * @library /test/lib
  * @compile ValueTypeArray.java Point.java Long8Value.java Person.java
- * @run main/othervm -Xint  -XX:InlineArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xint  -XX:InlineArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:FlatArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:FlatArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.ValueTypeArray
  */
 public class ValueTypeArray {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeArray.java
@@ -35,10 +35,10 @@ import static jdk.test.lib.Asserts.*;
  * @summary Plain array test for Inline Types
  * @library /test/lib
  * @compile ValueTypeArray.java Point.java Long8Value.java Person.java
- * @run main/othervm -Xint  -XX:FlatArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xint  -XX:FlatArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:FlatArrayElementMaxSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xint  -XX:FlatArrayElementMaxSize=0  runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1 runtime.valhalla.valuetypes.ValueTypeArray
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=0  runtime.valhalla.valuetypes.ValueTypeArray
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.valuetypes.ValueTypeArray
  */
 public class ValueTypeArray {

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
@@ -33,10 +33,10 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator ValueTypeDensity.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xint -XX:FlatArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xint -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI ValueTypeDensity
- * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI ValueTypeDensity
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions
@@ -49,8 +49,8 @@ public class ValueTypeDensity {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     public ValueTypeDensity() {
-        if (WHITE_BOX.getIntxVMFlag("FlatArrayElemMaxFlatSize") != -1) {
-            throw new IllegalStateException("FlatArrayElemMaxFlatSize should be -1");
+        if (WHITE_BOX.getIntxVMFlag("FlatArrayElementMaxSize") != -1) {
+            throw new IllegalStateException("FlatArrayElementMaxSize should be -1");
         }
     }
 

--- a/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/valuetypes/ValueTypeDensity.java
@@ -33,10 +33,10 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDemitQtypes -XDenableValueTypes -XDallowWithFieldOperator ValueTypeDensity.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xint -XX:InlineArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xint -XX:FlatArrayElemMaxFlatSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI ValueTypeDensity
- * @run main/othervm -Xcomp -XX:InlineArrayElemMaxFlatSize=-1
+ * @run main/othervm -Xcomp -XX:FlatArrayElemMaxFlatSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI ValueTypeDensity
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions
@@ -49,8 +49,8 @@ public class ValueTypeDensity {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     public ValueTypeDensity() {
-        if (WHITE_BOX.getIntxVMFlag("InlineArrayElemMaxFlatSize") != -1) {
-            throw new IllegalStateException("InlineArrayElemMaxFlatSize should be -1");
+        if (WHITE_BOX.getIntxVMFlag("FlatArrayElemMaxFlatSize") != -1) {
+            throw new IllegalStateException("FlatArrayElemMaxFlatSize should be -1");
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -25,8 +25,8 @@
 /*
  * @test
  * @summary test VarHandle on inline class array
- * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=-1 ArrayElementVarHandleTest
- * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=0  ArrayElementVarHandleTest
+ * @run testng/othervm -XX:FlatArrayElementMaxSize=-1 ArrayElementVarHandleTest
+ * @run testng/othervm -XX:FlatArrayElementMaxSize=0  ArrayElementVarHandleTest
  */
 
 import java.lang.invoke.*;

--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -25,8 +25,8 @@
 /*
  * @test
  * @summary test VarHandle on inline class array
- * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=-1 ArrayElementVarHandleTest
- * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=0  ArrayElementVarHandleTest
+ * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=-1 ArrayElementVarHandleTest
+ * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=0  ArrayElementVarHandleTest
  */
 
 import java.lang.invoke.*;

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
- * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=-1 ValueArray
- * @run testng/othervm -XX:InlineArrayElemMaxFlatSize=0  ValueArray
+ * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=-1 ValueArray
+ * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=0  ValueArray
  */
 
 import java.lang.reflect.Array;

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -24,8 +24,8 @@
 /*
  * @test
  * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
- * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=-1 ValueArray
- * @run testng/othervm -XX:FlatArrayElemMaxFlatSize=0  ValueArray
+ * @run testng/othervm -XX:FlatArrayElementMaxSize=-1 ValueArray
+ * @run testng/othervm -XX:FlatArrayElementMaxSize=0  ValueArray
  */
 
 import java.lang.reflect.Array;


### PR DESCRIPTION
Hi
Please review this change to rename InlineArrayElemMaxFlatSize to FlatArrayElemMaxFlatSize and rename InlineArrayElemMaxFlatOops to FlatArrayElemMaxFlatOops.

The change was tested with tiers 1-2 on Windows, MacOSX, and Linux x64.

Thanks, Harold
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8249886](https://bugs.openjdk.java.net/browse/JDK-8249886): Rename -XX: InlineArrayElemMaxFlat* options


### Reviewers
 * Frederic Parain ([fparain](@fparain) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/119/head:pull/119`
`$ git checkout pull/119`
