### PR TITLE
JDK-8244315 [lworld] The hierarchy between V$ref and V$val must be sealed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1685,7 +1685,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             ct.projection = projectedType;
 
             Name projectionName = this.name.append('$', this.name.table.names.ref);
-            long projectionFlags = (this.flags() & ~(VALUE | UNATTRIBUTED));
+            long projectionFlags = (this.flags() & ~(VALUE | UNATTRIBUTED | FINAL)) | SEALED;
 
             projection = new ClassSymbol(projectionFlags, projectionName, projectedType, this.owner);
             projection.members_field = WriteableScope.create(projection);
@@ -1709,6 +1709,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             projection.completer = Completer.NULL_COMPLETER;
             projection.sourcefile = this.sourcefile;
             projection.flatname = this.flatname.append('$', this.name.table.names.ref);
+            projection.permitted = List.of(this);
             projection.projection = this;
             projectedType.tsym = projection;
             return projection;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionSealed.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionSealed.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Check to see if the reference projection is a sealed class
+ * @bug 8244315
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile -XDallowWithFieldOperator Point.java
+ * @run main ProjectionSealed
+ */
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
+
+public class ProjectionSealed {
+    public static void main(String[] args) throws Exception {
+        ClassFile clsProj = ClassFile.read(ProjectionSealed.class.getResourceAsStream("Point$ref.class"));
+
+        PermittedSubclasses_attribute permitted = (PermittedSubclasses_attribute)clsProj.attributes.get(Attribute.PermittedSubclasses);
+        CONSTANT_Class_info[] infos = permitted != null ? permitted.getSubtypes(clsProj.constant_pool) : new CONSTANT_Class_info[0];
+
+        if (infos.length != 1 || !infos[0].getName().equals("Point")) {
+            throw new RuntimeException("Sealed classes not present");
+        }
+    }
+}


### PR DESCRIPTION
- Remove final flag from V$ref.
- Set V$ref as SEALED.
- Add value V$val to list of V$ref's permitted classes.

Test ensures that the permitted classes of Point$ref is exactly Point$val ("Point").
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244315](https://bugs.openjdk.java.net/browse/JDK-8244315): [lworld] The hierarchy between V$ref and V$val must be sealed. ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Srikanth Adayapalam ([sadayapalam](@sadayapalam) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/123/head:pull/123`
`$ git checkout pull/123`
