### PR TITLE
JDK-8244314 [lworld] V.ref and V.val are supposed to be nest mates

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -866,17 +866,26 @@ public class ClassWriter extends ClassFile {
      * Write NestMembers attribute (if needed)
      */
     int writeNestMembersIfNeeded(ClassSymbol csym) {
-        ListBuffer<ClassSymbol> nested = new ListBuffer<>();
-        listNested(csym, nested);
-        Set<ClassSymbol> nestedUnique = new LinkedHashSet<>(nested);
-        if (csym.owner.kind == PCK && !nestedUnique.isEmpty()) {
-            int alenIdx = writeAttr(names.NestMembers);
-            databuf.appendChar(nestedUnique.size());
-            for (ClassSymbol s : nestedUnique) {
-                databuf.appendChar(poolWriter.putClass(s));
+        Set<ClassSymbol> nestedUnique = new LinkedHashSet<>();
+        if (csym.owner.kind == PCK) {
+            if (csym.isValue()) {
+                // reference projection is the host
+            } else if (csym.isReferenceProjection()) {
+                ClassSymbol valueProjection = csym.valueProjection();
+                nestedUnique.add(valueProjection);
+                listNested(valueProjection, nestedUnique);
+            } else {
+                listNested(csym, nestedUnique);
             }
-            endAttr(alenIdx);
-            return 1;
+            if (!nestedUnique.isEmpty()) {
+                int alenIdx = writeAttr(names.NestMembers);
+                databuf.appendChar(nestedUnique.size());
+                for (ClassSymbol s : nestedUnique) {
+                    databuf.appendChar(poolWriter.putClass(s));
+                }
+                endAttr(alenIdx);
+                return 1;
+            }
         }
         return 0;
     }
@@ -885,16 +894,20 @@ public class ClassWriter extends ClassFile {
      * Write NestHost attribute (if needed)
      */
     int writeNestHostIfNeeded(ClassSymbol csym) {
-        if (csym.owner.kind != PCK) {
+        if (csym.owner.kind != PCK || csym.isValue()) {
             int alenIdx = writeAttr(names.NestHost);
-            databuf.appendChar(poolWriter.putClass(csym.outermostClass()));
+            ClassSymbol outerMost = csym.outermostClass();
+            if (outerMost.isValue()) {
+                outerMost = outerMost.referenceProjection();
+            }
+            databuf.appendChar(poolWriter.putClass(outerMost));
             endAttr(alenIdx);
             return 1;
         }
         return 0;
     }
 
-    private void listNested(Symbol sym, ListBuffer<ClassSymbol> seen) {
+    private void listNested(Symbol sym, Set<ClassSymbol> seen) {
         if (sym.kind != TYP) return;
         ClassSymbol csym = (ClassSymbol)sym;
         if (csym.owner.kind != PCK) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineNestingAttributesTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineNestingAttributesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test nest host - member attributes
+ * @bug 8244314
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile -XDallowWithFieldOperator Point.java
+ * @run main InlineNestingAttributesTest
+ */
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
+
+public class InlineNestingAttributesTest {
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(InlineNestingAttributesTest.class.getResourceAsStream("Point.class"));
+        ClassFile clsProj = ClassFile.read(InlineNestingAttributesTest.class.getResourceAsStream("Point$ref.class"));
+
+        NestMembers_attribute nestMembers = (NestMembers_attribute)clsProj.attributes.get(Attribute.NestMembers);
+        CONSTANT_Class_info[] members = nestMembers != null ? nestMembers.getChildren(clsProj.constant_pool) : new CONSTANT_Class_info[0];
+
+        if (members.length != 1 || !members[0].getName().equals("Point")) {
+            throw new RuntimeException("Nest members not present");
+        }
+
+        NestHost_attribute nestHost = (NestHost_attribute)cls.attributes.get(Attribute.NestHost);
+        CONSTANT_Class_info host = nestHost != null ? nestHost.getNestTop(cls.constant_pool) : null;
+
+        if (host == null || !host.getName().equals("Point$ref")) {
+            throw new RuntimeException("Nest host not present");
+        }
+    }
+}


### PR DESCRIPTION
- Reworked nest list to use LinkedHashSet (had unnecessary step.)
- Only attempt to add nested members if set is non-empty.
- If top level and an inline class don't use as host, use referenceProjection instead.
- If top level and an inline class do add as a nest member. 

Test ensures that the correct host (Point$ref)  is selected and that nest members are exactly just Point$val ("Point").
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244314](https://bugs.openjdk.java.net/browse/JDK-8244314): [lworld] V.ref and V.val are supposed to be nest mates 


### Reviewers
 * Srikanth Adayapalam ([sadayapalam](@sadayapalam) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/124/head:pull/124`
`$ git checkout pull/124`
