### PR TITLE
8250823: [lworld] Various cleanups and small fixes in JIT code

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1228,13 +1228,13 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   LIR_Opr len = length.result();
 
   ciKlass* obj = (ciKlass*) x->exact_type();
-  CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info, x->is_never_null());
+  CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info, x->is_null_free());
   if (obj == ciEnv::unloaded_ciobjarrayklass()) {
     BAILOUT("encountered unloaded_ciobjarrayklass due to out of memory error");
   }
 
   klass2reg_with_patching(klass_reg, obj, patching_info);
-  if (x->is_never_null()) {
+  if (x->is_null_free()) {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
@@ -1314,7 +1314,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   CodeEmitInfo* info_for_exception =
       (x->needs_exception_state() ? state_for(x) :
                                     state_for(x, x->state_before(), true /*ignore_xhandler*/));
-  if (x->is_never_null()) {
+  if (x->is_null_free()) {
     __ null_check(obj.result(), new CodeEmitInfo(info_for_exception));
   }
 
@@ -1340,7 +1340,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   __ checkcast(reg, obj.result(), x->klass(),
                new_register(objectType), new_register(objectType), tmp3,
                x->direct_compare(), info_for_exception, patching_info, stub,
-               x->profiled_method(), x->profiled_bci(), x->is_never_null());
+               x->profiled_method(), x->profiled_bci(), x->is_null_free());
 
 }
 

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1360,12 +1360,12 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   LIR_Opr len = length.result();
 
   ciKlass* obj = (ciKlass*) x->exact_type();
-  CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info, x->is_never_null());
+  CodeStub* slow_path = new NewObjectArrayStub(klass_reg, len, reg, info, x->is_null_free());
   if (obj == ciEnv::unloaded_ciobjarrayklass()) {
     BAILOUT("encountered unloaded_ciobjarrayklass due to out of memory error");
   }
   klass2reg_with_patching(klass_reg, obj, patching_info);
-  if (x->is_never_null()) {
+  if (x->is_null_free()) {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
@@ -1448,7 +1448,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
       (x->needs_exception_state() ? state_for(x) :
                                     state_for(x, x->state_before(), true /*ignore_xhandler*/));
 
-  if (x->is_never_null()) {
+  if (x->is_null_free()) {
     __ null_check(obj.result(), new CodeEmitInfo(info_for_exception));
   }
 
@@ -1470,7 +1470,7 @@ void LIRGenerator::do_CheckCast(CheckCast* x) {
   __ checkcast(reg, obj.result(), x->klass(),
                new_register(objectType), new_register(objectType), tmp3,
                x->direct_compare(), info_for_exception, patching_info, stub,
-               x->profiled_method(), x->profiled_bci(), x->is_never_null());
+               x->profiled_method(), x->profiled_bci(), x->is_null_free());
 }
 
 

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2418,9 +2418,9 @@ void GraphBuilder::new_type_array() {
 void GraphBuilder::new_object_array() {
   bool will_link;
   ciKlass* klass = stream()->get_klass(will_link);
-  bool never_null = stream()->is_inline_klass();
+  bool null_free = stream()->is_inline_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_exhandling();
-  NewArray* n = new NewObjectArray(klass, ipop(), state_before, never_null);
+  NewArray* n = new NewObjectArray(klass, ipop(), state_before, null_free);
   apush(append_split(n));
 }
 
@@ -2445,9 +2445,9 @@ bool GraphBuilder::direct_compare(ciKlass* k) {
 void GraphBuilder::check_cast(int klass_index) {
   bool will_link;
   ciKlass* klass = stream()->get_klass(will_link);
-  bool never_null = stream()->is_inline_klass();
+  bool null_free = stream()->is_inline_klass();
   ValueStack* state_before = !klass->is_loaded() || PatchALot ? copy_state_before() : copy_state_for_exception();
-  CheckCast* c = new CheckCast(klass, apop(), state_before, never_null);
+  CheckCast* c = new CheckCast(klass, apop(), state_before, null_free);
   apush(append_split(c));
   c->set_direct_compare(direct_compare(klass));
 
@@ -3457,7 +3457,7 @@ ValueStack* GraphBuilder::state_at_entry() {
   if (!method()->is_static()) {
     // we should always see the receiver
     state->store_local(idx, new Local(method()->holder(), objectType, idx,
-             /*receiver*/ true, /*never_null*/ method()->holder()->is_flat_array_klass()));
+             /*receiver*/ true, /*null_free*/ method()->holder()->is_flat_array_klass()));
     idx = 1;
   }
 

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -423,7 +423,7 @@ void BlockBegin::state_values_do(ValueVisitor* f) {
 
 
 Invoke::Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values* args,
-               int vtable_index, ciMethod* target, ValueStack* state_before, bool never_null)
+               int vtable_index, ciMethod* target, ValueStack* state_before, bool null_free)
   : StateSplit(result_type, state_before)
   , _code(code)
   , _recv(recv)
@@ -434,7 +434,7 @@ Invoke::Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values*
   set_flag(TargetIsLoadedFlag,   target->is_loaded());
   set_flag(TargetIsFinalFlag,    target_is_loaded() && target->is_final_method());
   set_flag(TargetIsStrictfpFlag, target_is_loaded() && target->is_strict());
-  set_never_null(never_null);
+  set_null_free(null_free);
 
   assert(args != NULL, "args must exist");
 #ifdef ASSERT

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -472,8 +472,8 @@ class Instruction: public CompilationResourceObj {
 
   void set_needs_null_check(bool f)              { set_flag(NeedsNullCheckFlag, f); }
   bool needs_null_check() const                  { return check_flag(NeedsNullCheckFlag); }
-  void set_never_null(bool f)                    { set_flag(NeverNullFlag, f); }
-  bool is_never_null() const                     { return check_flag(NeverNullFlag); }
+  void set_null_free(bool f)                    { set_flag(NeverNullFlag, f); }
+  bool is_null_free() const                     { return check_flag(NeverNullFlag); }
   bool is_linked() const                         { return check_flag(IsLinkedInBlockFlag); }
   bool can_be_linked()                           { return as_Local() == NULL && as_Phi() == NULL; }
 
@@ -742,13 +742,13 @@ LEAF(Local, Instruction)
   ciType*  _declared_type;
  public:
   // creation
-  Local(ciType* declared, ValueType* type, int index, bool receiver, bool never_null)
+  Local(ciType* declared, ValueType* type, int index, bool receiver, bool null_free)
     : Instruction(type)
     , _java_index(index)
     , _is_receiver(receiver)
     , _declared_type(declared)
   {
-    set_never_null(never_null);
+    set_null_free(null_free);
     NOT_PRODUCT(set_printable_bci(-1));
   }
 
@@ -872,7 +872,7 @@ LEAF(LoadField, AccessField)
             ciInlineKlass* inline_klass = NULL, Value default_value = NULL )
   : AccessField(obj, offset, field, is_static, state_before, needs_patching)
   {
-    set_never_null(field->signature()->is_Q_signature());
+    set_null_free(field->signature()->is_Q_signature());
   }
 
   ciType* declared_type() const;
@@ -1310,7 +1310,7 @@ LEAF(Invoke, StateSplit)
  public:
   // creation
   Invoke(Bytecodes::Code code, ValueType* result_type, Value recv, Values* args,
-         int vtable_index, ciMethod* target, ValueStack* state_before, bool never_null);
+         int vtable_index, ciMethod* target, ValueStack* state_before, bool null_free);
 
   // accessors
   Bytecodes::Code code() const                   { return _code; }
@@ -1392,7 +1392,7 @@ public:
     } else {
       _depends_on = depends_on;
     }
-    set_never_null(true);
+    set_null_free(true);
   }
 
   // accessors
@@ -1477,9 +1477,9 @@ LEAF(NewObjectArray, NewArray)
 
  public:
   // creation
-  NewObjectArray(ciKlass* klass, Value length, ValueStack* state_before, bool never_null)
+  NewObjectArray(ciKlass* klass, Value length, ValueStack* state_before, bool null_free)
   : NewArray(length, state_before), _klass(klass) {
-    set_never_null(never_null);
+    set_null_free(null_free);
   }
 
   // accessors
@@ -1576,9 +1576,9 @@ BASE(TypeCheck, StateSplit)
 LEAF(CheckCast, TypeCheck)
  public:
   // creation
-  CheckCast(ciKlass* klass, Value obj, ValueStack* state_before, bool never_null = false)
+  CheckCast(ciKlass* klass, Value obj, ValueStack* state_before, bool null_free = false)
   : TypeCheck(klass, obj, objectType, state_before) {
-    set_never_null(never_null);
+    set_null_free(null_free);
   }
 
   void set_incompatible_class_change_check() {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1506,10 +1506,10 @@ void check_LIR() {
 void LIR_List::checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                           LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check,
                           CodeEmitInfo* info_for_exception, CodeEmitInfo* info_for_patch, CodeStub* stub,
-                          ciMethod* profiled_method, int profiled_bci, bool is_never_null) {
+                          ciMethod* profiled_method, int profiled_bci, bool is_null_free) {
   // If klass is non-nullable,  LIRGenerator::do_CheckCast has already performed null-check
   // on the object.
-  bool need_null_check = !is_never_null;
+  bool need_null_check = !is_null_free;
   LIR_OpTypeCheck* c = new LIR_OpTypeCheck(lir_checkcast, result, object, klass,
                                            tmp1, tmp2, tmp3, fast_check, info_for_exception, info_for_patch, stub,
                                            need_null_check);

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -2341,7 +2341,7 @@ class LIR_List: public CompilationResourceObj {
   void checkcast (LIR_Opr result, LIR_Opr object, ciKlass* klass,
                   LIR_Opr tmp1, LIR_Opr tmp2, LIR_Opr tmp3, bool fast_check,
                   CodeEmitInfo* info_for_exception, CodeEmitInfo* info_for_patch, CodeStub* stub,
-                  ciMethod* profiled_method, int profiled_bci, bool is_never_null);
+                  ciMethod* profiled_method, int profiled_bci, bool is_null_free);
   // MethodData* profiling
   void profile_call(ciMethod* method, int bci, ciMethod* callee, LIR_Opr mdo, LIR_Opr recv, LIR_Opr t1, ciKlass* cha_klass) {
     append(new LIR_OpProfileCall(method, bci, callee, mdo, recv, t1, cha_klass));

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1781,7 +1781,7 @@ void LIRGenerator::do_StoreIndexed(StoreIndexed* x) {
   }
 
   if (is_loaded_flattened_array) {
-    if (!x->value()->is_never_null()) {
+    if (!x->value()->is_null_free()) {
       __ null_check(value.result(), new CodeEmitInfo(range_check_info));
     }
     access_flattened_array(false, array, index, value);

--- a/src/hotspot/share/ci/ciFlatArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciFlatArrayKlass.cpp
@@ -26,6 +26,7 @@
 #include "ci/ciFlatArrayKlass.hpp"
 #include "ci/ciInlineKlass.hpp"
 #include "ci/ciInstanceKlass.hpp"
+#include "ci/ciObjArrayKlass.hpp"
 #include "ci/ciSymbol.hpp"
 #include "ci/ciUtilities.hpp"
 #include "ci/ciUtilities.inline.hpp"
@@ -126,20 +127,19 @@ ciSymbol* ciFlatArrayKlass::construct_array_name(ciSymbol* element_name,
 // ciFlatArrayKlass::make_impl
 //
 // Implementation of make.
-ciFlatArrayKlass* ciFlatArrayKlass::make_impl(ciKlass* element_klass) {
-  assert(UseFlatArray, "should only be used for arrays");
-  assert(element_klass->is_inlinetype(), "element type must be inline type");
-  assert(element_klass->is_loaded(), "unloaded Q klasses are represented by ciInstanceKlass");
+ciArrayKlass* ciFlatArrayKlass::make_impl(ciKlass* element_klass) {
+  assert(UseFlatArray, "should only be used for flat arrays");
+  assert(element_klass->is_inlinetype(), "element type must be an inline type");
+  assert(element_klass->is_loaded(), "unloaded inline klasses are represented by ciInstanceKlass");
   {
     EXCEPTION_CONTEXT;
-    // The element klass is loaded
     Klass* array = element_klass->get_Klass()->array_klass(THREAD);
     if (HAS_PENDING_EXCEPTION) {
       CLEAR_PENDING_EXCEPTION;
       CURRENT_THREAD_ENV->record_out_of_memory_failure();
-      // TODO handle this
-      guarantee(false, "out of memory");
-      return NULL;
+      // Use unloaded ciObjArrayKlass here because flatArrayKlasses are always loaded
+      // and since this is only used for OOM detection, the actual type does not matter.
+      return ciEnv::unloaded_ciobjarrayklass();
     }
     return CURRENT_THREAD_ENV->get_flat_array_klass(array);
   }
@@ -149,7 +149,7 @@ ciFlatArrayKlass* ciFlatArrayKlass::make_impl(ciKlass* element_klass) {
 // ciFlatArrayKlass::make
 //
 // Make an array klass corresponding to the specified primitive type.
-ciFlatArrayKlass* ciFlatArrayKlass::make(ciKlass* element_klass) {
+ciArrayKlass* ciFlatArrayKlass::make(ciKlass* element_klass) {
   GUARDED_VM_ENTRY(return make_impl(element_klass);)
 }
 

--- a/src/hotspot/share/ci/ciFlatArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciFlatArrayKlass.hpp
@@ -49,7 +49,7 @@ protected:
     return (FlatArrayKlass*)get_Klass();
   }
 
-  static ciFlatArrayKlass* make_impl(ciKlass* element_klass);
+  static ciArrayKlass* make_impl(ciKlass* element_klass);
   static ciSymbol* construct_array_name(ciSymbol* element_name,
                                         int       dimension);
 
@@ -77,7 +77,7 @@ public:
   // What kind of ciObject is this?
   bool is_flat_array_klass() const { return true; }
 
-  static ciFlatArrayKlass* make(ciKlass* element_klass);
+  static ciArrayKlass* make(ciKlass* element_klass);
 
   virtual ciKlass* exact_klass();
 

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -676,28 +676,14 @@ bool ciInstanceKlass::can_be_inline_klass(bool is_exact) {
   if (!EnableValhalla) {
     return false;
   }
-  if (!is_loaded() ||   // Not loaded, might be an inline klass
-      is_inlinetype() || // Known to be an inline klass
-      // Non-exact j.l.Object or interface klass
-      ((is_java_lang_Object() || is_interface()) && !is_exact)) {
+  if (!is_loaded() || is_inlinetype()) {
+    // Not loaded or known to be an inline klass
     return true;
   }
-  if (is_abstract() && !is_exact && !has_nonstatic_fields()) {
-    // TODO Factor out and re-use similar code from the ClassFileParser
-    // An abstract class can only be implemented by an inline type if it has no instance
-    // fields, no synchronized instance methods and an empty, no-arg constructor.
+  if (!is_exact) {
+    // Not exact, check if this is a valid super for an inline klass
     VM_ENTRY_MARK;
-    Array<Method*>* methods = get_instanceKlass()->methods();
-    for (int i = 0; i < methods->length(); i++) {
-      Method* m = methods->at(i);
-      if ((m->is_synchronized() && !m->is_static()) ||
-          (m->is_object_constructor() &&
-           (m->signature() != vmSymbols::void_method_signature() ||
-            !m->is_vanilla_constructor()))) {
-        return false;
-      }
-    }
-    return true;
+    return !get_instanceKlass()->invalid_inline_super();
   }
   return false;
 }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1399,6 +1399,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
 }
 
 Node* GraphKit::null2default(Node* value, ciInlineKlass* vk) {
+  assert(!vk->is_scalarizable(), "Should only be used for non scalarizable inline klasses");
   Node* null_ctl = top();
   value = null_check_oop(value, &null_ctl);
   if (!null_ctl->is_top()) {
@@ -1431,7 +1432,7 @@ Node* GraphKit::cast_not_null(Node* obj, bool do_replace_in_map) {
 
   if (t->is_inlinetypeptr() && t->inline_klass()->is_scalarizable()) {
     // Scalarize inline type now that we know it's non-null
-    cast = InlineTypeNode::make_from_oop(this, cast, t->inline_klass())->buffer(this, false);
+    cast = InlineTypeNode::make_from_oop(this, cast, t->inline_klass())->as_ptr(&gvn());
   }
 
   // Scan for instances of 'obj' in the current JVM mapping.

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -88,6 +88,7 @@ public:
   // Allocates the inline type (if not yet allocated)
   InlineTypePtrNode* buffer(GraphKit* kit, bool safe_for_replace = true);
   bool is_allocated(PhaseGVN* phase) const;
+  InlineTypePtrNode* as_ptr(PhaseGVN* phase) const;
 
   void replace_call_results(GraphKit* kit, Node* call, Compile* C);
 
@@ -111,7 +112,7 @@ private:
   Node* is_loaded(PhaseGVN* phase, ciInlineKlass* vk = NULL, Node* base = NULL, int holder_offset = 0);
 
   // Checks if the inline type fields are all set to default values
-  bool is_default(PhaseGVN& gvn) const;
+  bool is_default(PhaseGVN* gvn) const;
 
   const TypeInstPtr* inline_ptr() const { return TypeInstPtr::make(TypePtr::BotPTR, inline_klass()); }
 
@@ -156,7 +157,7 @@ class InlineTypePtrNode : public InlineTypeBaseNode {
 private:
   const TypeInstPtr* inline_ptr() const { return type()->isa_instptr(); }
 
-  InlineTypePtrNode(InlineTypeBaseNode* vt)
+  InlineTypePtrNode(const InlineTypeBaseNode* vt)
     : InlineTypeBaseNode(TypeInstPtr::make(TypePtr::NotNull, vt->type()->inline_klass()), vt->req()) {
     init_class_id(Class_InlineTypePtr);
     init_req(Oop, vt->get_oop());

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1212,7 +1212,7 @@ static Node* is_inner_of_stripmined_loop(const Node* out) {
 
 bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
   // If the CmpP is a subtype check for a value that has just been
-  // loaded from an array, the subtype checks guarantees the value
+  // loaded from an array, the subtype check guarantees the value
   // can't be stored in a flattened array and the load of the value
   // happens with a flattened array check then: push the type check
   // through the phi of the flattened array check. This needs special
@@ -1286,7 +1286,7 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
     _igvn.set_type(klassptr_clone, klassptr_clone->Value(&_igvn));
     if (klassptr != n->in(1)) {
       Node* decode = n->in(1);
-      assert(decode->is_DecodeNarrowPtr(), "inconcistent subgraph");
+      assert(decode->is_DecodeNarrowPtr(), "inconsistent subgraph");
       Node* decode_clone = decode->clone();
       decode_clone->set_req(1, klassptr_clone);
       register_new_node(decode_clone, ctrl);

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -875,7 +875,6 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
       kit.set_control(map->control());
       Node* old_mem = map->memory();
       // Use immutable memory for inline type loads and restore it below
-      // TODO make sure inline types are always loaded from immutable memory
       kit.set_all_memory(C->immutable_memory());
       parm = InlineTypeNode::make_from_multi(&kit, start, sig_cc, t->inline_klass(), j, true);
       map->set_control(kit.control());

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1606,6 +1606,15 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
       }
     }
 
+    // Inline type nodes can have other inline types as users. If an input gets
+    // updated, make sure that inline type users get a chance for optimization.
+    if (use->is_InlineTypeBase()) {
+      for (DUIterator_Fast i2max, i2 = use->fast_outs(i2max); i2 < i2max; i2++) {
+        Node* u = use->fast_out(i2);
+        if (u->is_InlineTypeBase())
+          _worklist.push(u);
+      }
+    }
     // If changed Cast input, check Phi users for simple cycles
     if (use->is_ConstraintCast()) {
       for (DUIterator_Fast i2max, i2 = use->fast_outs(i2max); i2 < i2max; i2++) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 
 /*
  * @test
+ * @key randomness
  * @summary Test inline type arrays
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -27,6 +27,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Test the basic inline type implementation in C2
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires os.simpleArch == "x64"

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBimorphicInlining.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBimorphicInlining.java
@@ -28,6 +28,7 @@ import jdk.test.lib.Asserts;
 
 /**
  * @test
+ * @key randomness
  * @bug 8209009
  * @summary Test bimorphic inlining with inline type receivers.
  * @library /testlibrary /test/lib

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
@@ -32,6 +32,7 @@ import jdk.internal.misc.Unsafe;
 
 /**
  * @test TestBufferTearing
+ * @key randomness
  * @summary Detect tearing on inline type buffer writes due to missing barriers.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -33,6 +33,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Various tests that are specific for C1.
  * @modules java.base/jdk.experimental.value
  * @library /testlibrary /test/lib /compiler/whitebox /

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC2CCalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC2CCalls.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @summary Test inline type calling convention with compiled to compiled calls.
  * @library /test/lib /test/lib /compiler/whitebox /
  * @compile TestC2CCalls.java

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Method;
 
 /*
  * @test
+ * @key randomness
  * @summary Test inline type calling convention optimizations
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
@@ -28,6 +28,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Test calls from {C1} to {C2, Interpreter}, and vice versa.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -33,6 +33,7 @@ import jdk.internal.misc.Unsafe;
 
 /*
  * @test
+ * @key randomness
  * @summary Test intrinsic support for inline types
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestJNICalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestJNICalls.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 
 /*
  * @test
+ * @key randomness
  * @summary Test calling native methods with inline type arguments from compiled code.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -32,6 +32,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Test inline types in LWorld.
  * @modules java.base/jdk.experimental.value
  * @library /testlibrary /test/lib /compiler/whitebox /

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 
 /*
  * @test
+ * @key randomness
  * @summary Test inline type specific profiling
  * @modules java.base/jdk.experimental.value
  * @library /testlibrary /test/lib /compiler/whitebox /

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Test method handle support for inline types
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires os.simpleArch == "x64"

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 
 /*
  * @test
+ * @key randomness
  * @summary Test nullable inline type arrays
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -30,6 +30,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Test correct handling of nullable inline types.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 
 /*
  * @test
+ * @key randomness
  * @summary Test on stack replacement (OSR) with inline types
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -26,6 +26,7 @@ import jdk.test.lib.Asserts;
 
 /**
  * @test
+ * @key randomness
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @summary Test the handling of fields of unloaded inline classes.
  * @compile hack/GetUnresolvedInlineFieldWrongSignature.java
@@ -37,7 +38,7 @@ import jdk.test.lib.Asserts;
  *                               compiler.valhalla.inlinetypes.TestUnloadedInlineTypeField
  */
 
-public class TestUnloadedInlineTypeField extends compiler.valhalla.inlinetypes.InlineTypeTest {
+public class TestUnloadedInlineTypeField extends InlineTypeTest {
     public static void main(String[] args) throws Throwable {
         TestUnloadedInlineTypeField test = new TestUnloadedInlineTypeField();
         test.run(args);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
@@ -33,6 +33,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key randomness
  * @summary Verify that C1 performs escape analysis before optimizing withfield bytecode to putfield.
  * @modules java.base/jdk.experimental.value
  * @library /testlibrary /test/lib /compiler/whitebox /


### PR DESCRIPTION
- Rename is_never_null -> is_null_free in C1 code
- Use is_invalid_super() in ciInstanceKlass::can_be_inline_klass() and clean up code
- Handle OOM when creating ciFlatArrayKlass
- Removed some dead code from inlinetypenode.cpp and did various refactorings
- Make sure non-captured initializing stores are removed when removing the corresponding allocation
- Added @key randomness to tests
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250823](https://bugs.openjdk.java.net/browse/JDK-8250823): [lworld] Various cleanups and small fixes in JIT code


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/125/head:pull/125`
`$ git checkout pull/125`
