### PR TITLE
8250877: [lworld] Remove special acmp handling for isSubstitutable0 method in the JIT

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1279,11 +1279,7 @@ void GraphBuilder::if_node(Value x, If::Condition cond, Value y, ValueStack* sta
   bool is_bb = tsux->bci() < stream()->cur_bci() || fsux->bci() < stream()->cur_bci();
 
   bool subst_check = false;
-  if (EnableValhalla && (stream()->cur_bc() == Bytecodes::_if_acmpeq || stream()->cur_bc() == Bytecodes::_if_acmpne) &&
-      method() != ciEnv::current()->ValueBootstrapMethods_klass()->find_method(ciSymbol::isSubstitutable_name(), ciSymbol::object_object_boolean_signature())) {
-    // If current method is ValueBootstrapMethods::isSubstitutable(),
-    // compile the acmp as a regular pointer comparison otherwise we
-    // could call ValueBootstrapMethods::isSubstitutable() back
+  if (EnableValhalla && (stream()->cur_bc() == Bytecodes::_if_acmpeq || stream()->cur_bc() == Bytecodes::_if_acmpne)) {
     ValueType* left_vt = x->type();
     ValueType* right_vt = y->type();
     if (left_vt->is_object()) {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2047,11 +2047,7 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool new_path, Node** ctrl_take
 }
 
 void Parse::do_acmp(BoolTest::mask btest, Node* a, Node* b) {
-  ciMethod* subst_method = ciEnv::current()->ValueBootstrapMethods_klass()->find_method(ciSymbol::isSubstitutable_name(), ciSymbol::object_object_boolean_signature());
-  // If current method is ValueBootstrapMethods::isSubstitutable(),
-  // compile the acmp as a regular pointer comparison otherwise we
-  // could call ValueBootstrapMethods::isSubstitutable() back
-  if (!EnableValhalla || (method() == subst_method)) {
+  if (!EnableValhalla) {
     Node* cmp = CmpP(a, b);
     cmp = optimize_cmp_with_klass(cmp);
     do_if(btest, cmp);
@@ -2199,6 +2195,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* a, Node* b) {
   set_all_memory(mem);
 
   kill_dead_locals();
+  ciMethod* subst_method = ciEnv::current()->ValueBootstrapMethods_klass()->find_method(ciSymbol::isSubstitutable_name(), ciSymbol::object_object_boolean_signature());
   CallStaticJavaNode *call = new CallStaticJavaNode(C, TypeFunc::make(subst_method), SharedRuntime::get_resolve_static_call_stub(), subst_method, bci());
   call->set_override_symbolic_info(true);
   call->init_req(TypeFunc::Parms, not_null_a);


### PR DESCRIPTION
The isSubstitutable0 Java method called by the VM to perform a substitutability test does not perform == on its arguments. Special casing can be removed from the JIT.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250877](https://bugs.openjdk.java.net/browse/JDK-8250877): [lworld] Remove special acmp handling for isSubstitutable0 method in the JIT


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/126/head:pull/126`
`$ git checkout pull/126`
