### PR TITLE
8250881: [lworld] Crash in AOT code with -XX:-EnableValhalla

### DIFF
--- a/src/hotspot/share/aot/aotCompiledMethod.hpp
+++ b/src/hotspot/share/aot/aotCompiledMethod.hpp
@@ -195,9 +195,9 @@ private:
 
   virtual int comp_level() const { return CompLevel_aot; }
   virtual address verified_entry_point() const { return _code + _meta->verified_entry_offset(); }
-  virtual address inline_entry_point() const { return NULL; }
-  virtual address verified_inline_entry_point() const { return NULL; }
-  virtual address verified_inline_ro_entry_point() const { return NULL; }
+  virtual address inline_entry_point() const { return _code + _meta->verified_entry_offset(); }
+  virtual address verified_inline_entry_point() const { return _code + _meta->verified_entry_offset(); }
+  virtual address verified_inline_ro_entry_point() const { return _code + _meta->verified_entry_offset(); }
   virtual void log_identity(xmlStream* stream) const;
   virtual void log_state_change() const;
   virtual bool make_entrant() NOT_TIERED({ ShouldNotReachHere(); return false; });


### PR DESCRIPTION
We need to set the new entry points in AOTCompiledMethod because they are used even if EnableValhalla is not set (although they all point to the same location).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250881](https://bugs.openjdk.java.net/browse/JDK-8250881): [lworld] Crash in AOT code with -XX:-EnableValhalla


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/127/head:pull/127`
`$ git checkout pull/127`
