### PR TITLE
8250234: [lworld] [lw3] jdk/valhalla/valuetypes/SubstitutabilityTest.java fails with C1

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -2136,8 +2136,8 @@ LEAF(If, BlockEnd)
     s->append(fsux);
     set_sux(s);
     if (!_substitutability_check) {
-      assert(x->as_NewValueTypeInstance() == NULL || y->type() == objectNull, "Sanity check");
-      assert(y->as_NewValueTypeInstance() == NULL || x->type() == objectNull, "Sanity check");
+      assert(x->as_NewInlineTypeInstance() == NULL || y->type() == objectNull, "Sanity check");
+      assert(y->as_NewInlineTypeInstance() == NULL || x->type() == objectNull, "Sanity check");
     }
   }
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -2135,6 +2135,10 @@ LEAF(If, BlockEnd)
     s->append(tsux);
     s->append(fsux);
     set_sux(s);
+    if (!_substitutability_check) {
+      assert(x->as_NewValueTypeInstance() == NULL || y->type() == objectNull, "Sanity check");
+      assert(y->as_NewValueTypeInstance() == NULL || x->type() == objectNull, "Sanity check");
+    }
   }
 
   // accessors

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -2136,8 +2136,16 @@ void LIR_OpSubstitutabilityCheck::print_instr(outputStream* out) const {
   not_equal_result()->print(out);        out->print(" ");
   tmp1()->print(out);                    out->print(" ");
   tmp2()->print(out);                    out->print(" ");
-  left_klass()->print(out);              out->print(" ");
-  right_klass()->print(out);             out->print(" ");
+  if (left_klass() != NULL) {
+    left_klass()->print(out);              out->print(" ");
+  } else {
+    out->print("unknown ");
+  }
+  if (right_klass() != NULL) {
+    right_klass()->print(out);             out->print(" ");
+  } else {
+    out->print("unknown ");
+  }
   left_klass_op()->print(out);           out->print(" ");
   right_klass_op()->print(out);          out->print(" ");
   if (stub() != NULL) {

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -416,7 +416,7 @@ class BlockMerger: public BlockClosure {
             con  = if_->x()->as_Constant();
             swapped = true;
           }
-          if (con && ifop) {
+          if (con && ifop && !ifop->substitutability_check()) {
             Constant* tval = ifop->tval()->as_Constant();
             Constant* fval = ifop->fval()->as_Constant();
             if (tval && fval) {
@@ -441,7 +441,7 @@ class BlockMerger: public BlockClosure {
                 BlockBegin* fblock = fval->compare(cond, con, tsux, fsux);
                 if (tblock != fblock && !if_->is_safepoint()) {
                   If* newif = new If(ifop->x(), ifop->cond(), false, ifop->y(),
-                                     tblock, fblock, if_->state_before(), if_->is_safepoint(), if_->substitutability_check());
+                                     tblock, fblock, if_->state_before(), if_->is_safepoint(), ifop->substitutability_check());
                   newif->set_state(if_->state()->copy());
 
                   assert(prev->next() == if_, "must be guaranteed by above search");

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -333,11 +333,11 @@ void ciInstanceKlass::print_impl(outputStream* st) {
               bool_to_str(has_subklass()),
               layout_helper());
 
-    _flags.print_klass_flags();
+    _flags.print_klass_flags(st);
 
     if (_super) {
       st->print(" super=");
-      _super->print_name();
+      _super->print_name_on(st);
     }
     if (_java_mirror) {
       st->print(" mirror=PRESENT");


### PR DESCRIPTION
Please review this small changes to fix a bug in C1 transformations which cause an acmp involving inline types to be translated into a pointer comparison instead of a substitutability test.
The patch also includes a few fixes in C1 debugging features.

Thank you.

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250234](https://bugs.openjdk.java.net/browse/JDK-8250234): [lworld] [lw3] jdk/valhalla/valuetypes/SubstitutabilityTest.java fails with C1


### Reviewers
 * Tobias Hartmann ([thartmann](@TobiHartmann) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/128/head:pull/128`
`$ git checkout pull/128`
