### PR TITLE
8222784: [lworld] Remove stale compiler option: -XDallowGenericsOverValues

### DIFF
--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
- * @compile -XDallowGenericsOverValues StreamTest.java
+ * @compile StreamTest.java
  * @run testng StreamTest
  */
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/RefDotClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RefDotClass.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8222784
+ * @summary Check that we are able to get a class literal for a reference projection type
+ * @run main RefDotClass
+ */
+
+public inline class RefDotClass {
+    final int value;
+
+    public RefDotClass(int value) {
+        this.value = value;
+    }
+
+    private static <T> T foo(Class<T> type) {
+        return null;
+    }
+
+    public static void main(String[] args) {
+        foo(RefDotClass.ref.class);
+        String tName = RefDotClass.ref.class.getTypeName();
+        if (!tName.equals("RefDotClass$ref"))
+            throw new AssertionError("Unexpected type name " + tName);
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @summary Test that values code like a class - i.e are accepted in some places where only references used be, when invoked with the experimental mode -XDallowGenericsOverValues
+ * @summary Test that values code like a class - i.e are accepted in some places where only references used be, when suitable reference projection is used.
    @compile  ValuesAsRefs.java
  * @run main/othervm ValuesAsRefs
  */


### PR DESCRIPTION
Update tests not to use this garbage collected option
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8222784](https://bugs.openjdk.java.net/browse/JDK-8222784): [lworld] Remove stale compiler option: -XDallowGenericsOverValues


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/129/head:pull/129`
`$ git checkout pull/129`
