### PR TITLE
8250997: [lworld] Javac should not allow constructor reference expression to mention projection types

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -793,21 +793,30 @@ public class Check {
 
     /** Check that type is a valid qualifier for a constructor reference expression
      */
-    Type checkConstructorRefType(DiagnosticPosition pos, Type t) {
-        t = checkClassOrArrayType(pos, t);
+    Type checkConstructorRefType(JCExpression expr, Type t) {
+        t = checkClassOrArrayType(expr, t);
         if (t.hasTag(CLASS)) {
             if ((t.tsym.flags() & (ABSTRACT | INTERFACE)) != 0) {
-                log.error(pos, Errors.AbstractCantBeInstantiated(t.tsym));
+                log.error(expr, Errors.AbstractCantBeInstantiated(t.tsym));
                 t = types.createErrorType(t);
             } else if ((t.tsym.flags() & ENUM) != 0) {
-                log.error(pos, Errors.EnumCantBeInstantiated);
+                log.error(expr, Errors.EnumCantBeInstantiated);
                 t = types.createErrorType(t);
             } else {
-                t = checkClassType(pos, t, true);
+                // Projection types may not be mentioned in constructor references
+                if (expr.hasTag(SELECT)) {
+                    JCFieldAccess fieldAccess = (JCFieldAccess) expr;
+                    if (fieldAccess.selected.type.isValue() &&
+                            (fieldAccess.name == names.ref || fieldAccess.name == names.val)) {
+                        log.error(expr, Errors.ProjectionCantBeInstantiated);
+                        t = types.createErrorType(t);
+                    }
+                }
+                t = checkClassType(expr, t, true);
             }
         } else if (t.hasTag(ARRAY)) {
             if (!types.isReifiable(((ArrayType)t).elemtype)) {
-                log.error(pos, Errors.GenericArrayCreation);
+                log.error(expr, Errors.GenericArrayCreation);
                 t = types.createErrorType(t);
             }
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
@@ -1,9 +1,10 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8244561
+ * @bug 8244561 8250997
  * @summary Javac should not allow instantiation of V.ref or V.val
  * @compile/fail/ref=ProjectionInstantiationTest.out -XDrawDiagnostics ProjectionInstantiationTest.java
  */
+import java.util.function.Supplier;
 
 final inline class ProjectionInstantiationTest {
     int x = 42;
@@ -11,5 +12,11 @@ final inline class ProjectionInstantiationTest {
         new ProjectionInstantiationTest();
         new ProjectionInstantiationTest.ref();
         new ProjectionInstantiationTest.val();
+        foo(ProjectionInstantiationTest::new);
+        foo(ProjectionInstantiationTest.ref::new);
+        foo(ProjectionInstantiationTest.val::new);
     }
+    static void foo(Supplier<ProjectionInstantiationTest.ref> sx) {
+		sx.get();
+	}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
@@ -17,6 +17,6 @@ final inline class ProjectionInstantiationTest {
         foo(ProjectionInstantiationTest.val::new);
     }
     static void foo(Supplier<ProjectionInstantiationTest.ref> sx) {
-		sx.get();
-	}
+        sx.get();
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.out
@@ -1,3 +1,5 @@
-ProjectionInstantiationTest.java:12:9: compiler.err.projection.cant.be.instantiated
 ProjectionInstantiationTest.java:13:9: compiler.err.projection.cant.be.instantiated
-2 errors
+ProjectionInstantiationTest.java:14:9: compiler.err.projection.cant.be.instantiated
+ProjectionInstantiationTest.java:16:40: compiler.err.projection.cant.be.instantiated
+ProjectionInstantiationTest.java:17:40: compiler.err.projection.cant.be.instantiated
+4 errors


### PR DESCRIPTION
Follow up work to JDK-8244561
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250997](https://bugs.openjdk.java.net/browse/JDK-8250997): [lworld] Javac should not allow constructor reference expression to mention projection types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/131/head:pull/131`
`$ git checkout pull/131`
