### PR TITLE
JDK 8251107 [lworld] test lworld-values/TopInterfaceNegativeTest.java needs scrubbing

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.java
@@ -1,11 +1,12 @@
 /**
  * @test /nodynamiccopyright/
- * @bug 8237069
+ * @bug 8237069 8251107
  * @summary Introduce and wire-in the new top interfaces
  * @compile/fail/ref=TopInterfaceNegativeTest.out -XDrawDiagnostics TopInterfaceNegativeTest.java
  */
 
 public class TopInterfaceNegativeTest  {
+    interface InlineObject {}
 
     interface ID extends IdentityObject {}
     interface II extends InlineObject {}

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -1,7 +1,7 @@
-TopInterfaceNegativeTest.java:7:44: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:18:48: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:24:53: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:22:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
-TopInterfaceNegativeTest.java:23:19: compiler.err.empty.value.not.yet
-TopInterfaceNegativeTest.java:24:19: compiler.err.empty.value.not.yet
+TopInterfaceNegativeTest.java:14:44: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:25:48: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:31:53: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:29:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
+TopInterfaceNegativeTest.java:30:19: compiler.err.empty.value.not.yet
+TopInterfaceNegativeTest.java:31:19: compiler.err.empty.value.not.yet
 6 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -1,14 +1,7 @@
-TopInterfaceNegativeTest.java:29:39: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:11:26: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:13:44: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:14:44: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:17:28: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:20:32: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:24:48: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:30:39: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:30:53: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:28:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
-TopInterfaceNegativeTest.java:29:19: compiler.err.empty.value.not.yet
-TopInterfaceNegativeTest.java:30:19: compiler.err.empty.value.not.yet
-TopInterfaceNegativeTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TopInterfaceNegativeTest.V2, java.lang.IdentityObject)
-13 errors
+TopInterfaceNegativeTest.java:7:44: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:18:48: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:24:53: compiler.err.repeated.interface
+TopInterfaceNegativeTest.java:22:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
+TopInterfaceNegativeTest.java:23:19: compiler.err.empty.value.not.yet
+TopInterfaceNegativeTest.java:24:19: compiler.err.empty.value.not.yet
+6 errors


### PR DESCRIPTION
Test was somewhat out of date and still using InlineObject.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/135/head:pull/135`
`$ git checkout pull/135`
