### PR TITLE
8251116: [lworld] test lworld-values/ValuesAsRefs.java failing.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5260,7 +5260,7 @@ public class Attr extends JCTree.Visitor {
                         log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.NonSealedWithNoSealedSupertype(c));
                     }
                 }
-            } else {
+            } else if ((c.flags_field & Flags.COMPOUND) == 0) {
                 if (c.isLocal() && !c.isEnum()) {
                     log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.LocalClassesCantExtendSealed);
                 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8251116
  * @summary Test that values code like a class - i.e are accepted in some places where only references used be, when suitable reference projection is used.
    @compile  ValuesAsRefs.java
  * @run main/othervm ValuesAsRefs


### PR DESCRIPTION
Fix incorrect error reporting
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251116](https://bugs.openjdk.java.net/browse/JDK-8251116): [lworld] test lworld-values/ValuesAsRefs.java failing.


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/138/head:pull/138`
`$ git checkout pull/138`
