### PR TITLE
8251107: [lworld] test lworld-values/TopInterfaceNegativeTest.java is failing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1818,7 +1818,7 @@ public class Types {
                     // Sidecast
                     if (s.hasTag(CLASS)) {
                         if ((s.tsym.flags() & INTERFACE) != 0) {
-                            return ((t.tsym.flags() & FINAL) == 0)
+                            return (dynamicTypeMayImplementAdditionalInterfaces(t.tsym))
                                 ? sideCast(t, s, warnStack.head)
                                 : sideCastFinal(t, s, warnStack.head);
                         } else if ((t.tsym.flags() & INTERFACE) != 0) {
@@ -4616,7 +4616,7 @@ public class Types {
             to = from;
             from = target;
         }
-        Assert.check((from.tsym.flags() & FINAL) != 0);
+        Assert.check(!dynamicTypeMayImplementAdditionalInterfaces(from.tsym));
         Type t1 = asSuper(from, to.tsym);
         if (t1 == null) return false;
         Type t2 = to;
@@ -4626,6 +4626,10 @@ public class Types {
             (reverse ? giveWarning(t2, t1) : giveWarning(t1, t2)))
             warn.warn(LintCategory.UNCHECKED);
         return true;
+    }
+
+    private boolean dynamicTypeMayImplementAdditionalInterfaces(TypeSymbol tsym) {
+        return (tsym.flags() & FINAL) == 0 && !tsym.isReferenceProjection();
     }
 
     private boolean giveWarning(Type from, Type to) {


### PR DESCRIPTION
Fix problems exposed by sealing
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251107](https://bugs.openjdk.java.net/browse/JDK-8251107): [lworld] test lworld-values/TopInterfaceNegativeTest.java is failing


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/139/head:pull/139`
`$ git checkout pull/139`
