### PR TITLE
8244233: [lworld] Nested types are not handled properly across projections

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -2187,8 +2187,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             if (origin.isValue())
                 origin = (TypeSymbol) origin.referenceProjection();
 
-            if (this.owner.isValue())
-                return this.projection.overrides(_other, origin, types, checkResult, requireConcreteIfInherited);
+            if (this.owner.isValue()) {
+                return this.projection != null &&
+                        this.projection.overrides(_other, origin, types, checkResult, requireConcreteIfInherited);
+            }
 
             if (this == _other) return true;
             MethodSymbol other = (MethodSymbol)_other;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -418,6 +418,11 @@ public class Resolve {
                 sym = sym.referenceProjection();
             if (env.enclClass.sym.isValue())
                 env.enclClass.sym = env.enclClass.sym.referenceProjection();
+        } else if (sym.kind == TYP) {
+            // A type is accessible in a reference projection if it was
+            // accessible in the value projection.
+            if (site.isReferenceProjection())
+                site = site.valueProjection();
         }
         try {
             switch ((short)(sym.flags() & AccessFlags)) {
@@ -2200,6 +2205,10 @@ public class Resolve {
                                    Type site,
                                    Name name,
                                    TypeSymbol c) {
+        // ATM, inner/nested types are members of only the declaring inline class,
+        // although accessible via the reference projection.
+        if (c.isReferenceProjection())
+            c = (TypeSymbol) c.valueProjection();
         for (Symbol sym : c.members().getSymbolsByName(name)) {
             if (sym.kind == TYP) {
                 return isAccessible(env, site, sym)

--- a/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.java
@@ -1,0 +1,21 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8244233
+ * @summary Nested types are not handled properly across projections
+ * @compile/fail/ref=DualPathInnerType.out -XDrawDiagnostics DualPathInnerType.java
+ */
+
+public inline class DualPathInnerType  {
+
+    class Inner { }
+
+    static DualPathInnerType.Inner xi = new DualPathInnerType().new Inner();
+    DualPathInnerType.ref.Inner xri = xi;
+
+    void f (DualPathInnerType.Inner xri) {}
+    void f (DualPathInnerType.ref.Inner xri) {}
+
+    public static void main(String [] args) {
+        new DualPathInnerType();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.out
@@ -1,0 +1,2 @@
+DualPathInnerType.java:16:10: compiler.err.already.defined: kindname.method, f(DualPathInnerType.Inner), kindname.class, DualPathInnerType
+1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAsEnclosingClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAsEnclosingClass.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8244233
+ * @summary Nested types are not handled properly across projections
+ * @run main/othervm ValueAsEnclosingClass
+ */
+
+public inline class ValueAsEnclosingClass {
+
+    static inline class V {
+        int y = 52;
+
+        class Bar { }
+        static class Baz { }
+    }
+
+    class Inner { }
+
+    static ValueAsEnclosingClass.Inner xi = new ValueAsEnclosingClass().new Inner();
+    ValueAsEnclosingClass.ref.Inner xri = xi;
+
+    public static void main(String[] args) {
+        new V().new Bar();
+        V.Baz baz1 = new V.Baz();
+        V.ref.Baz baz2 = baz1;
+        new ValueAsEnclosingClass();
+    }
+}


### PR DESCRIPTION
Treatment for nested types.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244233](https://bugs.openjdk.java.net/browse/JDK-8244233): [lworld] Nested types are not handled properly across projections


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/141/head:pull/141`
`$ git checkout pull/141`
