### PR TITLE
8251504: [lworld] Support empty inline classes without -XDallowEmptyValues

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -171,7 +171,6 @@ public class Attr extends JCTree.Visitor {
                 (!preview.isPreview(Feature.REIFIABLE_TYPES_INSTANCEOF) || preview.isEnabled());
         sourceName = source.name;
         useBeforeDeclarationWarning = options.isSet("useBeforeDeclarationWarning");
-        allowEmptyValues = options.isSet("allowEmptyValues");
         allowValueMemberCycles = options.isSet("allowValueMemberCycles");
 
         statInfo = new ResultInfo(KindSelector.NIL, Type.noType);
@@ -216,11 +215,6 @@ public class Attr extends JCTree.Visitor {
      * RFE: 6425594
      */
     boolean useBeforeDeclarationWarning;
-
-    /**
-     * Switch: Allow value types with no instance state?
-     */
-    boolean allowEmptyValues;
 
     /**
      * Switch: Allow value type member cycles?
@@ -5428,14 +5422,9 @@ public class Attr extends JCTree.Visitor {
         //check that a resource implementing AutoCloseable cannot throw InterruptedException
         checkAutoCloseable(tree.pos(), env, c.type);
 
-        boolean hasInstanceFields = false;
         for (List<JCTree> l = tree.defs; l.nonEmpty(); l = l.tail) {
             // Attribute declaration
             attribStat(l.head, env);
-
-            if (l.head.hasTag(VARDEF) && (TreeInfo.flags(l.head) & STATIC) == 0)
-                hasInstanceFields = true;
-
             // Check that declarations in inner classes are not static (JLS 8.1.2)
             // Make an exception for static constants.
             if (c.owner.kind != PCK &&
@@ -5448,9 +5437,6 @@ public class Attr extends JCTree.Visitor {
                     ((VarSymbol) sym).getConstValue() == null)
                     log.error(l.head.pos(), Errors.IclsCantHaveStaticDecl(c));
             }
-        }
-        if (!allowEmptyValues && !hasInstanceFields && (c.flags() & (VALUE | SYNTHETIC)) == VALUE) {
-            log.error(tree.pos(), Errors.EmptyValueNotYet);
         }
 
         // Check for cycles among non-initial constructors.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3750,9 +3750,6 @@ compiler.warn.potential.null.pollution=\
 compiler.err.with.field.operator.disallowed=\
     WithField operator is allowed only with -XDallowWithFieldOperator
 
-compiler.err.empty.value.not.yet=\
-    Inline types with zero instance size are not supported yet
-
 compiler.err.this.exposed.prematurely=\
     Inine type instance should not be passed around before being fully initialized
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Method;
  * @summary Test inline type calling convention optimizations
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @compile -XDallowEmptyValues TestCallingConvention.java
+ * @compile TestCallingConvention.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Asserts;
  * @modules java.base/jdk.experimental.value
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @compile -XDallowEmptyValues TestLWorld.java
+ * @compile TestLWorld.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Field;
  * @test
  * @summary Test support for empty inline types (no instance fields)
  * @library /test/lib
- * @compile -XDallowEmptyValues EmptyInlineTest.java
+ * @compile EmptyInlineTest.java
  * @run main/othervm -XX:+EnableValhalla runtime.valhalla.inlinetypes.EmptyInlineTest
 
  */

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -205,7 +205,6 @@ compiler.err.cyclic.value.type.membership
 compiler.err.value.does.not.support
 compiler.err.value.may.not.extend
 compiler.warn.potential.null.pollution
-compiler.err.empty.value.not.yet
 compiler.err.this.exposed.prematurely
 compiler.warn.this.exposed.prematurely
 compiler.err.inline.type.must.not.implement.identity.object

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
@@ -2,8 +2,8 @@
  * @test /nodynamiccopyright/
  * @bug 8242900
  * @summary Verify various constraints for an inline class's BINARY super types.
- * @compile -XDallowEmptyValues -XDrawDiagnostics -XDdev SuperclassCollections.java
- * @compile/fail/ref=BinarySuperclassConstraints.out -XDallowEmptyValues -XDrawDiagnostics -XDdev BinarySuperclassConstraints.java
+ * @compile -XDrawDiagnostics -XDdev SuperclassCollections.java
+ * @compile/fail/ref=BinarySuperclassConstraints.out -XDrawDiagnostics -XDdev BinarySuperclassConstraints.java
  */
 
 public class BinarySuperclassConstraints {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
@@ -1,8 +1,6 @@
 CheckClone.java:11:21: compiler.err.value.does.not.support: clone
 CheckClone.java:12:18: compiler.err.value.does.not.support: clone
-CheckClone.java:9:18: compiler.err.empty.value.not.yet
 CheckClone.java:16:16: compiler.err.value.does.not.support: clone
 CheckClone.java:17:14: compiler.err.value.does.not.support: clone
 CheckClone.java:20:22: compiler.err.inline.class.may.not.override: clone
-CheckClone.java:8:14: compiler.err.empty.value.not.yet
-7 errors
+5 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
@@ -1,9 +1,11 @@
 /*
  * @test /nodynamiccopyright/
- * @summary Values may not extend a concrete type other than jlO
+ * @summary Values may not extend an identity class
  *
  * @compile/fail/ref=CheckExtends.out -XDrawDiagnostics CheckExtends.java
  */
 
 final inline class CheckExtends extends Object {
+    static class Nested {}
+    static inline class NestedValue extends Nested {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:8:14: compiler.err.empty.value.not.yet
+CheckExtends.java:10:19: compiler.err.inline.type.must.not.implement.identity.object: CheckExtends.NestedValue
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.out
@@ -2,6 +2,6 @@ CheckFinal.java:14:13: compiler.err.cant.assign.val.to.final.var: fi
 CheckFinal.java:15:13: compiler.err.cant.assign.val.to.final.var: fe
 CheckFinal.java:17:13: compiler.err.cant.assign.val.to.final.var: xsf
 CheckFinal.java:19:29: compiler.err.cant.inherit.from.final: CheckFinal
-CheckFinal.java:19:42: compiler.err.empty.value.not.yet
+CheckFinal.java:19:42: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: CheckFinal$1, CheckFinal
 CheckFinal.java:19:25: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.anonymous.class: CheckFinal, CheckFinal)
 6 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.java
@@ -1,9 +1,33 @@
 /*
- * @test /nodynamiccopyright/
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251504
  * @summary Test behavior with empty value type.
- * @compile/fail/ref=EmptyValueTest.out -XDrawDiagnostics -XDdev EmptyValueTest.java
- * @compile -XDrawDiagnostics -XDdev -XDallowEmptyValues EmptyValueTest.java
+ * @compile -XDrawDiagnostics -XDdev EmptyValueTest.java
  */
 public final inline class EmptyValueTest {
-    static int x;
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.out
@@ -1,2 +1,0 @@
-EmptyValueTest.java:7:21: compiler.err.empty.value.not.yet
-1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.out
@@ -1,3 +1,2 @@
 InlineAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: inline
-InlineAnnotationOnAnonymousClass.java:12:29: compiler.err.empty.value.not.yet
-2 errors
+1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Check inlineness via __inline__ annotation
  * @bug 8222745
- * @compile/fail/ref=InlineAnnotationTest.out -XDallowEmptyValues -XDrawDiagnostics InlineAnnotationTest.java
+ * @compile/fail/ref=InlineAnnotationTest.out -XDrawDiagnostics InlineAnnotationTest.java
  */
 
 @__inline__

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8242900
  * @summary Verify various constraints for an inline class's super types.
- * @compile/fail/ref=SuperclassConstraints.out -XDallowEmptyValues -XDrawDiagnostics -XDdev SuperclassConstraints.java
+ * @compile/fail/ref=SuperclassConstraints.out -XDrawDiagnostics -XDdev SuperclassConstraints.java
  */
 
 public class SuperclassConstraints {

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -8,7 +8,5 @@ TopInterfaceNegativeTest.java:24:48: compiler.err.repeated.interface
 TopInterfaceNegativeTest.java:30:39: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:30:53: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:28:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
-TopInterfaceNegativeTest.java:29:19: compiler.err.empty.value.not.yet
-TopInterfaceNegativeTest.java:30:19: compiler.err.empty.value.not.yet
 TopInterfaceNegativeTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TopInterfaceNegativeTest.V2, java.lang.IdentityObject)
-13 errors
+11 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.out
@@ -1,3 +1,2 @@
 ValueAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: inline
-ValueAnnotationOnAnonymousClass.java:12:29: compiler.err.empty.value.not.yet
-2 errors
+1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
@@ -1,5 +1,3 @@
 ValueAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
-ValueAnnotationTest.java:9:1: compiler.err.empty.value.not.yet
-ValueAnnotationTest.java:13:1: compiler.err.empty.value.not.yet
 ValueAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
-4 errors
+2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -1,7 +1,5 @@
-ValueModifierTest.java:11:28: compiler.err.empty.value.not.yet
-ValueModifierTest.java:14:16: compiler.err.empty.value.not.yet
 ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:15:21: compiler.err.empty.value.not.yet
+ValueModifierTest.java:15:21: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$2, value
 ValueModifierTest.java:16:20: compiler.err.cant.inherit.from.final: value
 ValueModifierTest.java:16:28: compiler.err.override.meth: (compiler.misc.cant.override: toString(), compiler.misc.anonymous.class: ValueModifierTest$3, toString(), value), final
-6 errors
+4 errors


### PR DESCRIPTION
Support empty inline classes
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251504](https://bugs.openjdk.java.net/browse/JDK-8251504): [lworld] Support empty inline classes without -XDallowEmptyValues


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/146/head:pull/146`
`$ git checkout pull/146`
