### PR TITLE
8244513: [lworld] Typing of conditional expressions involving values.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4039,23 +4039,6 @@ public class Types {
         final int CLASS_BOUND = 2;
 
         int[] kinds = new int[ts.length];
-
-        boolean haveValues = false;
-        boolean haveRefs = false;
-        for (int i = 0 ; i < ts.length ; i++) {
-            if (ts[i].isValue())
-                haveValues = true;
-            else
-                haveRefs = true;
-        }
-        if (haveRefs && haveValues) {
-            System.arraycopy(ts, 0, ts = new Type[ts.length], 0, ts.length);
-            for (int i = 0; i < ts.length; i++) {
-                if (ts[i].isValue())
-                    ts[i] = ts[i].referenceProjection();
-            }
-        }
-
         int boundkind = UNKNOWN_BOUND;
         for (int i = 0 ; i < ts.length ; i++) {
             Type t = ts[i];

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConditionalInlineTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConditionalInlineTypeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8244513
+ * @summary Test conditional expression typing involving inlines.
+ * @run main ConditionalInlineTypeTest
+ */
+
+public class ConditionalInlineTypeTest {
+
+    static inline class V {}
+
+    public static void main(String [] args) {
+
+        var r1 = args.length == 0 ? new V() : new V();
+        System.out.println(r1.getClass());
+
+        var r2 = args.length == 0 ? (V.ref) new V() : (V.ref) new V();
+        System.out.println(r2.getClass());
+
+        int npe = 0;
+        try {
+            var r3 = args.length != 0 ? new V() : (V.ref) null;
+            System.out.println(r3.getClass());
+        } catch (NullPointerException e) {
+            npe++;
+        }
+        try {
+            var r4 = args.length == 0 ? (V.ref) null : new V();
+            System.out.println(r4.getClass());
+        } catch (NullPointerException e) {
+            npe++;
+        }
+        if (npe != 2) {
+            throw new AssertionError("NPEs = " + npe);
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.java
@@ -1,0 +1,36 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8244513
+ * @summary Test conditional expression typing involving inlines.
+ * @compile/fail/ref=ConditionalTypeTest.out -XDrawDiagnostics ConditionalTypeTest.java
+ */
+
+final class ConditionalTypeTest {
+    interface I {}
+    static inline class Node implements I {}
+    static void foo(int i) {
+        var ret1 = (i == 0) ? new XNodeWrapper() : new Node();
+        ret1 = "String cannot be assigned to I";
+        var ret2 = (i == 0) ? 10 : new XNodeWrapper();
+        ret2 = "String can be assigned to I";
+        var ret3 = (i == 0) ? new XNodeWrapper() : 10;
+        ret3 = "String can be assigned to Object";
+        var ret4 = (i == 0) ? new XNodeWrapper() : new ConditionalTypeTest();
+        ret4 = "String can be assigned to Object";
+        var ret5 = (i == 0) ? Integer.valueOf(10) : new ConditionalTypeTest();
+        ret5 = "String can be assigned to Object";
+
+        var ret6 = (i == 0) ? new Node() : new Node();
+        ret6 = "String cannot be assigned to Node";
+
+        var ret7 = (i == 0) ? (Node.ref) new Node() : (Node.ref) null;
+        ret7 = "String cannot be assigned to Node.ref";
+
+        var ret8 = (i == 0) ? new Node() : (Node.ref) null;
+        ret8 = "String cannot be assigned to Node";
+
+        var ret9 = (i == 0) ? (Node.ref) new Node() : new Node();
+        ret9 = "String cannot be assigned to Node";
+    }
+    static inline class XNodeWrapper implements I {}
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.out
@@ -1,0 +1,6 @@
+ConditionalTypeTest.java:13:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, ConditionalTypeTest.I)
+ConditionalTypeTest.java:24:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, ConditionalTypeTest.Node)
+ConditionalTypeTest.java:27:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, ConditionalTypeTest.Node$ref)
+ConditionalTypeTest.java:30:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, ConditionalTypeTest.Node)
+ConditionalTypeTest.java:33:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.String, ConditionalTypeTest.Node)
+5 errors


### PR DESCRIPTION
For now, make typing of conditionals mimic the rules for primitives and boxing.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244513](https://bugs.openjdk.java.net/browse/JDK-8244513): [lworld] Typing of conditional expressions involving values.


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/147/head:pull/147`
`$ git checkout pull/147`
