### PR TITLE
8244232: [lworld] Improve javadoc comments for various methods dealing with projection types

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -434,7 +434,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
     }
 
     /**
-     * Return the reference projection IFF 'this' happens to be value projection, null
+     * Return the reference projection IFF 'this' happens to be inline class, null
      * otherwise.
      */
     public Symbol referenceProjection() {
@@ -1671,7 +1671,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override
         public ClassSymbol referenceProjection() {
-            if (!isValue() || projection != null)
+            if (!isValue())
+                return null;
+
+            if (projection != null)
                 return projection;
 
             ClassType ct = (ClassType) this.type;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -239,14 +239,26 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         return false;
     }
 
+    /**
+     * @return true IFF the receiver is a reference projection of an inline type and false
+     * for primitives or plain references
+     */
     public boolean isReferenceProjection() {
         return false;
     }
 
+    /**
+     * @return the value projection type IFF the receiver is a reference projection of an inline type
+     * and null otherwise
+     */
     public Type valueProjection() {
         return null;
     }
 
+    /**
+     * @return the reference projection type IFF the receiver is an inline type
+     * and null otherwise
+     */
     public Type referenceProjection() {
         return null;
     }
@@ -1194,7 +1206,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         @Override
         public Type valueProjection() {
-            if (!isReferenceProjection() || projection !=  null)
+            if (!isReferenceProjection())
+                return null;
+
+            if (projection !=  null)
                 return projection;
 
             // Make a best case effort to cache the other projection.


### PR DESCRIPTION
Update javadoc to reflect differences between referenceProjection APIs and the ref operator of the spec.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8244232](https://bugs.openjdk.java.net/browse/JDK-8244232): [lworld] Improve javadoc comments for various methods dealing with projection types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/148/head:pull/148`
`$ git checkout pull/148`
