### PR TITLE
8251940: [lworld] Incorrect Signature attribute in class file.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -508,9 +508,11 @@ public class PoolWriter {
         if (typarams.nonEmpty()) {
             signatureGen.assembleParamsSig(typarams);
         }
-        signatureGen.assembleSig(types.supertype(t));
-        for (Type i : types.interfaces(t))
-            signatureGen.assembleSig(i);
+        signatureGen.assembleSig(t.isValue() ? t.referenceProjection() : types.supertype(t));
+        if (!t.isValue()) {
+            for (Type i : types.interfaces(t))
+                signatureGen.assembleSig(i);
+        }
         return signatureGen.toName();
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SignatureTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SignatureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8251940
+ * @summary Incorrect Signature attribute in class file
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @run main SignatureTest
+ */
+
+import com.sun.tools.classfile.*;
+
+public inline class SignatureTest<T> implements java.io.Serializable {
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(SignatureTest.class.getResourceAsStream("SignatureTest$ref.class"));
+        Signature_attribute signature = (Signature_attribute) cls.attributes.get(Attribute.Signature);
+        String s = signature.getSignature(cls.constant_pool);
+        if (!s.equals("<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/io/Serializable;"))
+            throw new AssertionError("Unexpected signature: " + s);
+
+        cls = ClassFile.read(SignatureTest.class.getResourceAsStream("SignatureTest.class"));
+        signature = (Signature_attribute) cls.attributes.get(Attribute.Signature);
+        s = signature.getSignature(cls.constant_pool);
+        if (!s.equals("<T:Ljava/lang/Object;>LSignatureTest$ref<TT;>;"))
+            throw new AssertionError("Unexpected signature: " + s);
+    }
+}


### PR DESCRIPTION
Fix signature in inline class to reflect super type correctly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251940](https://bugs.openjdk.java.net/browse/JDK-8251940): [lworld] Incorrect Signature attribute in class file.


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/150/head:pull/150`
`$ git checkout pull/150`
