### PR TITLE
8251442: [lworld] C2 compilation fails with assert(value->bottom_type()->higher_equal(_type))

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -146,7 +146,7 @@ bool Instruction::maybe_flattened_array() {
         }
       } else if (type->is_flat_array_klass()) {
         ciKlass* element_klass = type->as_flat_array_klass()->element_klass();
-        assert(!element_klass->is_loaded() || element_klass->as_inline_klass()->flatten_array(), "must be flattened");
+        assert(!element_klass->is_loaded() || element_klass->flatten_array(), "must be flattened");
         return true;
       } else if (type->is_klass() && type->as_klass()->is_java_lang_Object()) {
         // This can happen as a parameter to System.arraycopy()

--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -104,7 +104,7 @@ bool ciArrayKlass::is_leaf_type() {
 ciArrayKlass* ciArrayKlass::make(ciType* element_type) {
   if (element_type->is_primitive_type()) {
     return ciTypeArrayKlass::make(element_type->basic_type());
-  } else if (element_type->is_inlinetype() && element_type->as_inline_klass()->flatten_array()) {
+  } else if (element_type->flatten_array()) {
     return ciFlatArrayKlass::make(element_type->as_klass());
   } else {
     return ciObjArrayKlass::make(element_type->as_klass());

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -313,6 +313,13 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   const TypePtr *my_type   = _type->isa_ptr();
   const Type *result = _type;
   if( in_type != NULL && my_type != NULL ) {
+    if (my_type->isa_aryptr() && in_type->isa_aryptr()) {
+      // Propagate array properties (not flat/null-free)
+      my_type = my_type->is_aryptr()->update_properties(in_type->is_aryptr());
+      if (my_type == NULL) {
+        return Type::TOP; // Inconsistent properties
+      }
+    }
     TypePtr::PTR   in_ptr    = in_type->ptr();
     if (in_ptr == TypePtr::Null) {
       result = in_type;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3805,7 +3805,7 @@ Node* GraphKit::get_layout_helper(Node* klass_node, jint& constant_value) {
     bool can_be_flattened = false;
     if (UseFlatArray && klass->is_obj_array_klass()) {
       ciKlass* elem = klass->as_obj_array_klass()->element_klass();
-      can_be_flattened = elem->can_be_inline_klass() && (!elem->is_inlinetype() || elem->as_inline_klass()->flatten_array());
+      can_be_flattened = elem->can_be_inline_klass() && (!elem->is_inlinetype() || elem->flatten_array());
     }
     if (xklass || (klass->is_array_klass() && !can_be_flattened)) {
       jint lhelper = klass->layout_helper();
@@ -4439,7 +4439,7 @@ Node* GraphKit::load_String_length(Node* str, bool set_ctrl) {
 Node* GraphKit::load_String_value(Node* str, bool set_ctrl) {
   int value_offset = java_lang_String::value_offset();
   const TypeInstPtr* string_type = TypeInstPtr::make(TypePtr::NotNull, C->env()->String_klass(),
-                                                     false, NULL, Type::Offset(0), false);
+                                                     false, NULL, Type::Offset(0));
   const TypePtr* value_field_type = string_type->add_offset(value_offset);
   const TypeAryPtr* value_type = TypeAryPtr::make(TypePtr::NotNull,
                                                   TypeAry::make(TypeInt::BYTE, TypeInt::POS, false, true, true),
@@ -4456,7 +4456,7 @@ Node* GraphKit::load_String_coder(Node* str, bool set_ctrl) {
   }
   int coder_offset = java_lang_String::coder_offset();
   const TypeInstPtr* string_type = TypeInstPtr::make(TypePtr::NotNull, C->env()->String_klass(),
-                                                     false, NULL, Type::Offset(0), false);
+                                                     false, NULL, Type::Offset(0));
   const TypePtr* coder_field_type = string_type->add_offset(coder_offset);
 
   Node* p = basic_plus_adr(str, str, coder_offset);
@@ -4468,7 +4468,7 @@ Node* GraphKit::load_String_coder(Node* str, bool set_ctrl) {
 void GraphKit::store_String_value(Node* str, Node* value) {
   int value_offset = java_lang_String::value_offset();
   const TypeInstPtr* string_type = TypeInstPtr::make(TypePtr::NotNull, C->env()->String_klass(),
-                                                     false, NULL, Type::Offset(0), false);
+                                                     false, NULL, Type::Offset(0));
   const TypePtr* value_field_type = string_type->add_offset(value_offset);
 
   access_store_at(str,  basic_plus_adr(str, value_offset), value_field_type,
@@ -4478,7 +4478,7 @@ void GraphKit::store_String_value(Node* str, Node* value) {
 void GraphKit::store_String_coder(Node* str, Node* value) {
   int coder_offset = java_lang_String::coder_offset();
   const TypeInstPtr* string_type = TypeInstPtr::make(TypePtr::NotNull, C->env()->String_klass(),
-                                                     false, NULL, Type::Offset(0), false);
+                                                     false, NULL, Type::Offset(0));
   const TypePtr* coder_field_type = string_type->add_offset(coder_offset);
 
   access_store_at(str, basic_plus_adr(str, coder_offset), coder_field_type,

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -99,7 +99,6 @@ InlineTypeBaseNode* InlineTypeBaseNode::merge_with(PhaseGVN* gvn, const InlineTy
       val1->as_InlineTypeBase()->merge_with(gvn, val2->as_InlineTypeBase(), pnum, transform);
     } else {
       assert(val1->is_Phi(), "must be a phi node");
-      assert(!val2->is_InlineType(), "inconsistent merge values");
       val1->set_req(pnum, val2);
     }
     if (transform) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3893,19 +3893,6 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
   Node* end               = is_copyOfRange? argument(2): argument(1);
   Node* array_type_mirror = is_copyOfRange? argument(3): argument(2);
 
-  const TypeAryPtr* original_t = _gvn.type(original)->isa_aryptr();
-  const TypeInstPtr* mirror_t = _gvn.type(array_type_mirror)->isa_instptr();
-  if (EnableValhalla && UseFlatArray &&
-      (original_t == NULL || mirror_t == NULL ||
-       (mirror_t->java_mirror_type() == NULL &&
-        (original_t->elem()->isa_inlinetype() ||
-         (original_t->elem()->make_oopptr() != NULL &&
-          original_t->elem()->make_oopptr()->can_be_inline_type()))))) {
-    // We need to know statically if the copy is to a flattened array
-    // or not but can't tell.
-    return false;
-  }
-
   Node* newcopy = NULL;
 
   // Set the original stack and the reexecute bit for the interpreter to reexecute
@@ -3937,7 +3924,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     if (not_objArray != NULL) {
       // Improve the klass node's type from the new optimistic assumption:
       ciKlass* ak = ciArrayKlass::make(env()->Object_klass());
-      const Type* akls = TypeKlassPtr::make(TypePtr::NotNull, ak, Type::Offset(0), false);
+      const Type* akls = TypeKlassPtr::make(TypePtr::NotNull, ak, Type::Offset(0));
       Node* cast = new CastPPNode(klass_node, akls);
       cast->init_req(0, control());
       klass_node = _gvn.transform(cast);
@@ -3968,8 +3955,9 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     if (UseFlatArray) {
       // Either both or neither new array klass and original array
       // klass must be flattened
+      const TypeAryPtr* t_original = _gvn.type(original)->isa_aryptr();
       Node* is_flat = generate_flatArray_guard(klass_node, NULL);
-      if (!original_t->is_not_flat()) {
+      if (t_original == NULL || !t_original->is_not_flat()) {
         generate_flatArray_guard(original_kls, bailout);
       }
       if (is_flat != NULL) {
@@ -3977,7 +3965,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
         record_for_igvn(r);
         r->init_req(1, control());
         set_control(is_flat);
-        if (!original_t->is_not_flat()) {
+        if (t_original == NULL || !t_original->is_not_flat()) {
           generate_flatArray_guard(original_kls, r);
         }
         bailout->add_req(control());
@@ -5065,9 +5053,13 @@ bool LibraryCallKit::inline_arraycopy() {
         // If we can have both exact types, emit the missing guards
         if (could_have_src && !src_spec) {
           src = maybe_cast_profiled_obj(src, src_k, true);
+          src_type = _gvn.type(src);
+          top_src = src_type->isa_aryptr();
         }
         if (could_have_dest && !dest_spec) {
           dest = maybe_cast_profiled_obj(dest, dest_k, true);
+          dest_type = _gvn.type(dest);
+          top_dest = dest_type->isa_aryptr();
         }
       }
     }
@@ -5143,13 +5135,16 @@ bool LibraryCallKit::inline_arraycopy() {
     src_type = _gvn.type(src);
     top_src  = src_type->isa_aryptr();
 
-    if (top_dest != NULL && !top_dest->elem()->isa_inlinetype() && !top_dest->is_not_flat()) {
+    if (top_dest != NULL && !top_dest->is_flat() && !top_dest->is_not_flat()) {
       generate_flatArray_guard(dest_klass, slow_region);
+      top_dest = top_dest->cast_to_not_flat();
+      dest = _gvn.transform(new CheckCastPPNode(control(), dest, top_dest));
     }
-
-    if (top_src != NULL && !top_src->elem()->isa_inlinetype() && !top_src->is_not_flat()) {
+    if (top_src != NULL && !top_src->is_flat() && !top_src->is_not_flat()) {
       Node* src_klass = load_object_klass(src);
       generate_flatArray_guard(src_klass, slow_region);
+      top_src = top_src->cast_to_not_flat();
+      src = _gvn.transform(new CheckCastPPNode(control(), src, top_src));
     }
 
     {

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1414,11 +1414,11 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // (9) each element of an oop array must be assignable
     // The generate_arraycopy subroutine checks this.
 
-    if (dest_elem == T_OBJECT && !top_dest->elem()->isa_inlinetype() && !top_dest->is_not_flat()) {
+    if (dest_elem == T_OBJECT && !top_dest->is_flat() && !top_dest->is_not_flat()) {
       generate_flattened_array_guard(&ctrl, merge_mem, dest, slow_region);
     }
 
-    if (src_elem == T_OBJECT && !top_src->elem()->isa_inlinetype() && !top_src->is_not_flat()) {
+    if (src_elem == T_OBJECT && !top_src->is_flat() && !top_src->is_not_flat()) {
       generate_flattened_array_guard(&ctrl, merge_mem, src, slow_region);
     }
   }

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -941,10 +941,13 @@ const Type *CmpPNode::sub( const Type *t1, const Type *t2 ) const {
       } else {                  // Neither subtypes the other
         unrelated_classes = true;
       }
-      if ((r0->flat_array() && (!r1->can_be_inline_type() || (klass1->is_inlinetype() && !klass1->flatten_array()))) ||
-          (r1->flat_array() && (!r0->can_be_inline_type() || (klass0->is_inlinetype() && !klass0->flatten_array())))) {
-        // One type is flattened in arrays and the other type is not. Must be unrelated.
-        unrelated_classes = true;
+      if (!unrelated_classes) {
+        // Handle inline type arrays
+        if ((r0->flatten_array() && (!r1->can_be_inline_type() || (klass1->is_inlinetype() && !klass1->flatten_array()))) ||
+            (r1->flatten_array() && (!r0->can_be_inline_type() || (klass0->is_inlinetype() && !klass0->flatten_array())))) {
+          // One type is flattened in arrays but the other type is not. Must be unrelated.
+          unrelated_classes = true;
+        }
       }
       if (unrelated_classes) {
         // The oops classes are known to be unrelated. If the joined PTRs of

--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -76,11 +76,19 @@ const Type* SubTypeCheckNode::sub(const Type* sub_t, const Type* super_t) const 
       // type check is known to fail.
       unrelated_classes = true;
     }
-    // Ignore exactness of constant supertype (the type of the corresponding object may be non-exact).
-    const TypeKlassPtr* casted_sup = super_t->is_klassptr()->cast_to_exactness(false)->is_klassptr();
-    if (sub_t->is_ptr()->flat_array() && (!casted_sup->can_be_inline_type() || (superk->is_inlinetype() && !superk->flatten_array()))) {
-      // Subtype is flattened in arrays but supertype is not. Must be unrelated.
-      unrelated_classes = true;
+    if (!unrelated_classes) {
+      // Handle inline type arrays
+      if (sub_t->isa_aryptr() && sub_t->is_aryptr()->is_not_flat() && superk->is_flat_array_klass()) {
+        // Subtype is not a flat array but supertype is. Must be unrelated.
+        unrelated_classes = true;
+      } else if (sub_t->isa_aryptr() && sub_t->is_aryptr()->is_not_null_free() &&
+                 superk->is_obj_array_klass() && superk->as_obj_array_klass()->element_klass()->is_inlinetype()) {
+        // Subtype is not a null-free array but supertype is. Must be unrelated.
+        unrelated_classes = true;
+      } else if (sub_t->is_ptr()->flatten_array() && (!superk->can_be_inline_klass() || (superk->is_inlinetype() && !superk->flatten_array()))) {
+        // Subtype is flattened in arrays but supertype is not. Must be unrelated.
+        unrelated_classes = true;
+      }
     }
     if (unrelated_classes) {
       TypePtr::PTR jp = sub_t->is_ptr()->join_ptr(super_t->is_ptr()->_ptr);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -589,9 +589,9 @@ void Type::Initialize_shared(Compile* current) {
   TypeInstPtr::BOTTOM  = TypeInstPtr::make(TypePtr::BotPTR,  current->env()->Object_klass());
   TypeInstPtr::MIRROR  = TypeInstPtr::make(TypePtr::NotNull, current->env()->Class_klass());
   TypeInstPtr::MARK    = TypeInstPtr::make(TypePtr::BotPTR,  current->env()->Object_klass(),
-                                           false, 0, Offset(oopDesc::mark_offset_in_bytes()), false);
+                                           false, 0, Offset(oopDesc::mark_offset_in_bytes()));
   TypeInstPtr::KLASS   = TypeInstPtr::make(TypePtr::BotPTR,  current->env()->Object_klass(),
-                                           false, 0, Offset(oopDesc::klass_offset_in_bytes()), false);
+                                           false, 0, Offset(oopDesc::klass_offset_in_bytes()));
   TypeOopPtr::BOTTOM  = TypeOopPtr::make(TypePtr::BotPTR, Offset::bottom, TypeOopPtr::InstanceBot);
 
   TypeMetadataPtr::BOTTOM = TypeMetadataPtr::make(TypePtr::BotPTR, NULL, Offset::bottom);
@@ -650,8 +650,8 @@ void Type::Initialize_shared(Compile* current) {
   TypeAryPtr::_array_body_type[T_FLOAT]   = TypeAryPtr::FLOATS;
   TypeAryPtr::_array_body_type[T_DOUBLE]  = TypeAryPtr::DOUBLES;
 
-  TypeKlassPtr::OBJECT = TypeKlassPtr::make(TypePtr::NotNull, current->env()->Object_klass(), Offset(0), false);
-  TypeKlassPtr::OBJECT_OR_NULL = TypeKlassPtr::make(TypePtr::BotPTR, current->env()->Object_klass(), Offset(0), false);
+  TypeKlassPtr::OBJECT = TypeKlassPtr::make(TypePtr::NotNull, current->env()->Object_klass(), Offset(0));
+  TypeKlassPtr::OBJECT_OR_NULL = TypeKlassPtr::make(TypePtr::BotPTR, current->env()->Object_klass(), Offset(0));
 
   const Type **fi2c = TypeTuple::fields(2);
   fi2c[TypeFunc::Parms+0] = TypeInstPtr::BOTTOM; // Method*
@@ -3339,19 +3339,6 @@ const Type *TypeOopPtr::cast_to_exactness(bool klass_is_exact) const {
   return this;
 }
 
-
-//------------------------------as_klass_type----------------------------------
-// Return the klass type corresponding to this instance or array type.
-// It is the type that is loaded from an object of this type.
-const TypeKlassPtr* TypeOopPtr::as_klass_type() const {
-  ciKlass* k = klass();
-  bool    xk = klass_is_exact();
-  if (k == NULL)
-    return TypeKlassPtr::OBJECT;
-  else
-    return TypeKlassPtr::make(xk? Constant: NotNull, k, Offset(0), isa_instptr() && is_instptr()->flat_array());
-}
-
 //------------------------------meet-------------------------------------------
 // Compute the MEET of two types.  It returns a new Type object.
 const Type *TypeOopPtr::xmeet_helper(const Type *t) const {
@@ -3461,7 +3448,7 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
         klass_is_exact = true;
       }
     }
-    return TypeInstPtr::make(TypePtr::BotPTR, klass, klass_is_exact, NULL, Offset(0), klass->flatten_array());
+    return TypeInstPtr::make(TypePtr::BotPTR, klass, klass_is_exact, NULL, Offset(0));
   } else if (klass->is_obj_array_klass()) {
     // Element is an object or inline type array. Recursively call ourself.
     const TypeOopPtr* etype = TypeOopPtr::make_from_klass_common(klass->as_array_klass()->element_klass(), /* klass_change= */ false, try_for_exact);
@@ -3517,7 +3504,7 @@ const TypeOopPtr* TypeOopPtr::make_from_constant(ciObject* o, bool require_const
     if (make_constant) {
       return TypeInstPtr::make(o);
     } else {
-      return TypeInstPtr::make(TypePtr::NotNull, klass, true, NULL, Offset(0), klass->flatten_array());
+      return TypeInstPtr::make(TypePtr::NotNull, klass, true, NULL, Offset(0));
     }
   } else if (klass->is_obj_array_klass()) {
     // Element is an object array. Recursively call ourself.
@@ -3774,15 +3761,15 @@ const TypeInstPtr *TypeInstPtr::KLASS;
 
 //------------------------------TypeInstPtr-------------------------------------
 TypeInstPtr::TypeInstPtr(PTR ptr, ciKlass* k, bool xk, ciObject* o, Offset off,
-                         bool flat_array, int instance_id, const TypePtr* speculative,
+                         bool flatten_array, int instance_id, const TypePtr* speculative,
                          int inline_depth)
   : TypeOopPtr(InstPtr, ptr, k, xk, o, off, Offset::bottom, instance_id, speculative, inline_depth),
-    _name(k->name()), _flat_array(flat_array) {
-   assert(k != NULL &&
-          (k->is_loaded() || o == NULL),
-          "cannot have constants with non-loaded klass");
-   assert(!klass()->is_inlinetype() || !klass()->flatten_array() || flat_array, "incorrect flatten array bit");
-   assert(!flat_array || can_be_inline_type(), "incorrect flatten array bit");
+    _name(k->name()), _flatten_array(flatten_array) {
+  assert(k != NULL &&
+         (k->is_loaded() || o == NULL),
+         "cannot have constants with non-loaded klass");
+  assert(!klass()->flatten_array() || flatten_array, "Should be flat in array");
+  assert(!flatten_array || can_be_inline_type(), "Only inline types can be flat in array");
 };
 
 //------------------------------make-------------------------------------------
@@ -3791,7 +3778,7 @@ const TypeInstPtr *TypeInstPtr::make(PTR ptr,
                                      bool xk,
                                      ciObject* o,
                                      Offset offset,
-                                     bool flat_array,
+                                     bool flatten_array,
                                      int instance_id,
                                      const TypePtr* speculative,
                                      int inline_depth) {
@@ -3812,9 +3799,12 @@ const TypeInstPtr *TypeInstPtr::make(PTR ptr,
     if (xk && ik->is_interface())  xk = false;  // no exact interface
   }
 
+  // Check if this type is known to be flat in arrays
+  flatten_array = flatten_array || k->flatten_array();
+
   // Now hash this baby
   TypeInstPtr *result =
-    (TypeInstPtr*)(new TypeInstPtr(ptr, k, xk, o ,offset, flat_array, instance_id, speculative, inline_depth))->hashcons();
+    (TypeInstPtr*)(new TypeInstPtr(ptr, k, xk, o, offset, flatten_array, instance_id, speculative, inline_depth))->hashcons();
 
   return result;
 }
@@ -3847,7 +3837,7 @@ const Type *TypeInstPtr::cast_to_ptr_type(PTR ptr) const {
   if( ptr == _ptr ) return this;
   // Reconstruct _sig info here since not a problem with later lazy
   // construction, _sig will show up on demand.
-  return make(ptr, klass(), klass_is_exact(), const_oop(), _offset, _flat_array, _instance_id, _speculative, _inline_depth);
+  return make(ptr, klass(), klass_is_exact(), const_oop(), _offset, _flatten_array, _instance_id, _speculative, _inline_depth);
 }
 
 
@@ -3858,13 +3848,13 @@ const Type *TypeInstPtr::cast_to_exactness(bool klass_is_exact) const {
   ciInstanceKlass* ik = _klass->as_instance_klass();
   if( (ik->is_final() || _const_oop) )  return this;  // cannot clear xk
   if( ik->is_interface() )              return this;  // cannot set xk
-  return make(ptr(), klass(), klass_is_exact, const_oop(), _offset, _flat_array, _instance_id, _speculative, _inline_depth);
+  return make(ptr(), klass(), klass_is_exact, const_oop(), _offset, _flatten_array, _instance_id, _speculative, _inline_depth);
 }
 
 //-----------------------------cast_to_instance_id----------------------------
 const TypeOopPtr *TypeInstPtr::cast_to_instance_id(int instance_id) const {
   if( instance_id == _instance_id ) return this;
-  return make(_ptr, klass(), _klass_is_exact, const_oop(), _offset, _flat_array, instance_id, _speculative, _inline_depth);
+  return make(_ptr, klass(), _klass_is_exact, const_oop(), _offset, _flatten_array, instance_id, _speculative, _inline_depth);
 }
 
 //------------------------------xmeet_unloaded---------------------------------
@@ -3960,7 +3950,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
       // For instances when a subclass meets a superclass we fall
       // below the centerline when the superclass is exact. We need to
       // do the same here.
-      if (klass()->equals(ciEnv::current()->Object_klass()) && !klass_is_exact() && !flat_array()) {
+      if (klass()->equals(ciEnv::current()->Object_klass()) && !klass_is_exact() && !flatten_array()) {
         return TypeAryPtr::make(ptr, tp->ary(), tp->klass(), tp->klass_is_exact(), offset, tp->field_offset(), instance_id, speculative, depth);
       } else {
         // cannot subclass, so the meet has to fall badly below the centerline
@@ -3978,7 +3968,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
         // For instances when a subclass meets a superclass we fall
         // below the centerline when the superclass is exact. We need
         // to do the same here.
-        if (klass()->equals(ciEnv::current()->Object_klass()) && !klass_is_exact() && !flat_array()) {
+        if (klass()->equals(ciEnv::current()->Object_klass()) && !klass_is_exact() && !flatten_array()) {
           // that is, tp's array type is a subtype of my klass
           return TypeAryPtr::make(ptr, (ptr == Constant ? tp->const_oop() : NULL),
                                   tp->ary(), tp->klass(), tp->klass_is_exact(), offset, tp->field_offset(), instance_id, speculative, depth);
@@ -4006,7 +3996,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
       const TypePtr* speculative = xmeet_speculative(tp);
       int depth = meet_inline_depth(tp->inline_depth());
       return make(ptr, klass(), klass_is_exact(),
-                  (ptr == Constant ? const_oop() : NULL), offset, flat_array(), instance_id, speculative, depth);
+                  (ptr == Constant ? const_oop() : NULL), offset, flatten_array(), instance_id, speculative, depth);
     }
     case NotNull:
     case BotPTR: {
@@ -4034,7 +4024,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
     case TopPTR:
     case AnyNull: {
       return make(ptr, klass(), klass_is_exact(),
-                  (ptr == Constant ? const_oop() : NULL), offset, flat_array(), instance_id, speculative, depth);
+                  (ptr == Constant ? const_oop() : NULL), offset, flatten_array(), instance_id, speculative, depth);
     }
     case NotNull:
     case BotPTR:
@@ -4073,8 +4063,8 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
     // and we can handle the constants further down.  This case handles
     // both-not-loaded or both-loaded classes
     if (ptr != Constant && klass()->equals(tinst->klass()) && klass_is_exact() == tinst->klass_is_exact() &&
-        flat_array() == tinst->flat_array()) {
-      return make(ptr, klass(), klass_is_exact(), NULL, off, flat_array(), instance_id, speculative, depth);
+        flatten_array() == tinst->flatten_array()) {
+      return make(ptr, klass(), klass_is_exact(), NULL, off, flatten_array(), instance_id, speculative, depth);
     }
 
     // Classes require inspection in the Java klass hierarchy.  Must be loaded.
@@ -4082,8 +4072,8 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
     ciKlass* this_klass  = this->klass();
     bool tinst_xk = tinst->klass_is_exact();
     bool this_xk  = this->klass_is_exact();
-    bool tinst_flat_array = tinst->flat_array();
-    bool this_flat_array  = this->flat_array();
+    bool tinst_flatten_array = tinst->flatten_array();
+    bool this_flatten_array  = this->flatten_array();
     if (!tinst_klass->is_loaded() || !this_klass->is_loaded() ) {
       // One of these classes has not been loaded
       const TypeInstPtr *unloaded_meet = xmeet_unloaded(tinst);
@@ -4106,9 +4096,9 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
       bool tmp2 = tinst_xk;
       tinst_xk = this_xk;
       this_xk = tmp2;
-      tmp2 = tinst_flat_array;
-      tinst_flat_array = this_flat_array;
-      this_flat_array = tmp2;
+      tmp2 = tinst_flatten_array;
+      tinst_flatten_array = this_flatten_array;
+      this_flatten_array = tmp2;
     }
     if (tinst_klass->is_interface() &&
         !(this_klass->is_interface() ||
@@ -4129,14 +4119,14 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
         k  = below_centerline(ptr) ? tinst_klass : this_klass;
         // If we are keeping this_klass, keep its exactness too.
         xk = below_centerline(ptr) ? tinst_xk    : this_xk;
-        flat_array = below_centerline(ptr) ? tinst_flat_array    : this_flat_array;
+        flat_array = below_centerline(ptr) ? tinst_flatten_array    : this_flatten_array;
       } else {                  // Does not implement, fall to Object
         // Oop does not implement interface, so mixing falls to Object
         // just like the verifier does (if both are above the
         // centerline fall to interface)
         k = above_centerline(ptr) ? tinst_klass : ciEnv::current()->Object_klass();
         xk = above_centerline(ptr) ? tinst_xk : false;
-        flat_array = above_centerline(ptr) ? tinst_flat_array : false;
+        flat_array = above_centerline(ptr) ? tinst_flatten_array : false;
         // Watch out for Constant vs. AnyNull interface.
         if (ptr == Constant)  ptr = NotNull;   // forget it was a constant
         instance_id = InstanceBot;
@@ -4182,33 +4172,33 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
     if (tinst_klass->equals(this_klass)) {
       subtype = this_klass;
       subtype_exact = below_centerline(ptr) ? (this_xk && tinst_xk) : (this_xk || tinst_xk);
-      flat_array = below_centerline(ptr) ? (this_flat_array && tinst_flat_array) : (this_flat_array || tinst_flat_array);
-    } else if(!tinst_xk && this_klass->is_subtype_of(tinst_klass) && (!tinst_flat_array || this_flat_array)) {
+      flat_array = below_centerline(ptr) ? (this_flatten_array && tinst_flatten_array) : (this_flatten_array || tinst_flatten_array);
+    } else if(!tinst_xk && this_klass->is_subtype_of(tinst_klass) && (!tinst_flatten_array || this_flatten_array)) {
       subtype = this_klass;     // Pick subtyping class
       subtype_exact = this_xk;
-      flat_array = this_flat_array;
-    } else if(!this_xk && tinst_klass->is_subtype_of(this_klass) && (!this_flat_array || tinst_flat_array)) {
+      flat_array = this_flatten_array;
+    } else if(!this_xk && tinst_klass->is_subtype_of(this_klass) && (!this_flatten_array || tinst_flatten_array)) {
       subtype = tinst_klass;    // Pick subtyping class
       subtype_exact = tinst_xk;
-      flat_array = tinst_flat_array;
+      flat_array = tinst_flatten_array;
     }
 
     if (subtype) {
       if (above_centerline(ptr)) { // both are up?
         this_klass = tinst_klass = subtype;
         this_xk = tinst_xk = subtype_exact;
-        this_flat_array = tinst_flat_array = flat_array;
+        this_flatten_array = tinst_flatten_array = flat_array;
       } else if (above_centerline(this ->_ptr) && !above_centerline(tinst->_ptr)) {
         this_klass = tinst_klass; // tinst is down; keep down man
         this_xk = tinst_xk;
-        this_flat_array = tinst_flat_array;
+        this_flatten_array = tinst_flatten_array;
       } else if (above_centerline(tinst->_ptr) && !above_centerline(this ->_ptr)) {
         tinst_klass = this_klass; // this is down; keep down man
         tinst_xk = this_xk;
-        tinst_flat_array = this_flat_array;
+        tinst_flatten_array = this_flatten_array;
       } else {
         this_xk = subtype_exact;  // either they are equal, or we'll do an LCA
-        this_flat_array = flat_array;
+        this_flatten_array = flat_array;
       }
     }
 
@@ -4231,7 +4221,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
         else
           ptr = NotNull;
       }
-      return make(ptr, this_klass, this_xk, o, off, this_flat_array, instance_id, speculative, depth);
+      return make(ptr, this_klass, this_xk, o, off, this_flatten_array, instance_id, speculative, depth);
     } // Else classes are not equal
 
     // Since klasses are different, we require a LCA in the Java
@@ -4287,7 +4277,7 @@ ciType* TypeInstPtr::java_mirror_type() const {
 // Dual: do NOT dual on klasses.  This means I do NOT understand the Java
 // inheritance mechanism.
 const Type *TypeInstPtr::xdual() const {
-  return new TypeInstPtr(dual_ptr(), klass(), klass_is_exact(), const_oop(), dual_offset(), flat_array(), dual_instance_id(), dual_speculative(), dual_inline_depth());
+  return new TypeInstPtr(dual_ptr(), klass(), klass_is_exact(), const_oop(), dual_offset(), flatten_array(), dual_instance_id(), dual_speculative(), dual_inline_depth());
 }
 
 //------------------------------eq---------------------------------------------
@@ -4296,14 +4286,14 @@ bool TypeInstPtr::eq( const Type *t ) const {
   const TypeInstPtr *p = t->is_instptr();
   return
     klass()->equals(p->klass()) &&
-    flat_array() == p->flat_array() &&
+    flatten_array() == p->flatten_array() &&
     TypeOopPtr::eq(p);          // Check sub-type stuff
 }
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
 int TypeInstPtr::hash(void) const {
-  int hash = java_add(java_add((jint)klass()->hash(), (jint)TypeOopPtr::hash()), (jint)flat_array());
+  int hash = java_add(java_add((jint)klass()->hash(), (jint)TypeOopPtr::hash()), (jint)flatten_array());
   return hash;
 }
 
@@ -4339,7 +4329,7 @@ void TypeInstPtr::dump2( Dict &d, uint depth, outputStream *st ) const {
 
   st->print(" *");
 
-  if (flat_array() && !klass()->is_inlinetype()) {
+  if (flatten_array() && !klass()->is_inlinetype()) {
     st->print(" (flatten array)");
   }
 
@@ -4355,7 +4345,7 @@ void TypeInstPtr::dump2( Dict &d, uint depth, outputStream *st ) const {
 
 //------------------------------add_offset-------------------------------------
 const TypePtr *TypeInstPtr::add_offset(intptr_t offset) const {
-  return make(_ptr, klass(), klass_is_exact(), const_oop(), xadd_offset(offset), flat_array(),
+  return make(_ptr, klass(), klass_is_exact(), const_oop(), xadd_offset(offset), flatten_array(),
               _instance_id, add_offset_speculative(offset), _inline_depth);
 }
 
@@ -4364,7 +4354,7 @@ const Type *TypeInstPtr::remove_speculative() const {
     return this;
   }
   assert(_inline_depth == InlineDepthTop || _inline_depth == InlineDepthBottom, "non speculative type shouldn't have inline depth");
-  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flat_array(),
+  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flatten_array(),
               _instance_id, NULL, _inline_depth);
 }
 
@@ -4372,15 +4362,15 @@ const TypePtr *TypeInstPtr::with_inline_depth(int depth) const {
   if (!UseInlineDepthForSpeculativeTypes) {
     return this;
   }
-  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flat_array(), _instance_id, _speculative, depth);
+  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flatten_array(), _instance_id, _speculative, depth);
 }
 
 const TypePtr *TypeInstPtr::with_instance_id(int instance_id) const {
   assert(is_known_instance(), "should be known");
-  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flat_array(), instance_id, _speculative, _inline_depth);
+  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, flatten_array(), instance_id, _speculative, _inline_depth);
 }
 
-const TypeInstPtr *TypeInstPtr::cast_to_flat_array() const {
+const TypeInstPtr *TypeInstPtr::cast_to_flatten_array() const {
   return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, true, _instance_id, _speculative, _inline_depth);
 }
 
@@ -4521,6 +4511,21 @@ const TypeAryPtr* TypeAryPtr::cast_to_not_null_free(bool not_null_free) const {
   // Not null free implies not flat
   const TypeAry* new_ary = TypeAry::make(elem(), size(), is_stable(), not_null_free ? true : is_not_flat(), not_null_free);
   return make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset, _instance_id, _speculative, _inline_depth, _is_autobox_cache);
+}
+
+//---------------------------------update_properties---------------------------
+const TypeAryPtr* TypeAryPtr::update_properties(const TypeAryPtr* from) const {
+  if ((from->is_flat()          && is_not_flat()) ||
+      (from->is_not_flat()      && is_flat()) ||
+      (from->is_null_free()     && is_not_null_free()) ||
+      (from->is_not_null_free() && is_null_free())) {
+    return NULL; // Inconsistent properties
+  } else if (from->is_not_null_free()) {
+    return cast_to_not_null_free(); // Implies not flat
+  } else if (from->is_not_flat()) {
+    return cast_to_not_flat();
+  }
+  return this;
 }
 
 //------------------------------cast_to_stable---------------------------------
@@ -4701,8 +4706,8 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
       // Meeting flattened inline type array with non-flattened array. Adjust (field) offset accordingly.
       if (tary->_elem->isa_inlinetype()) {
         // Result is flattened
-        off = Offset(elem()->isa_inlinetype() ? offset() : tap->offset());
-        field_off = elem()->isa_inlinetype() ? field_offset() : tap->field_offset();
+        off = Offset(is_flat() ? offset() : tap->offset());
+        field_off = is_flat() ? field_offset() : tap->field_offset();
       } else if (tary->_elem->make_oopptr() != NULL && tary->_elem->make_oopptr()->isa_instptr() && below_centerline(ptr)) {
         // Result is non-flattened
         off = Offset(flattened_offset()).meet(Offset(tap->flattened_offset()));
@@ -4767,7 +4772,7 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
       // For instances when a subclass meets a superclass we fall
       // below the centerline when the superclass is exact. We need to
       // do the same here.
-      if (tp->klass()->equals(ciEnv::current()->Object_klass()) && !tp->klass_is_exact() && !tp->flat_array()) {
+      if (tp->klass()->equals(ciEnv::current()->Object_klass()) && !tp->klass_is_exact() && !tp->flatten_array()) {
         return TypeAryPtr::make(ptr, _ary, _klass, _klass_is_exact, offset, _field_offset, instance_id, speculative, depth);
       } else {
         // cannot subclass, so the meet has to fall badly below the centerline
@@ -4785,7 +4790,7 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
         // For instances when a subclass meets a superclass we fall
         // below the centerline when the superclass is exact. We need
         // to do the same here.
-        if (tp->klass()->equals(ciEnv::current()->Object_klass()) && !tp->klass_is_exact() && !tp->flat_array()) {
+        if (tp->klass()->equals(ciEnv::current()->Object_klass()) && !tp->klass_is_exact() && !tp->flatten_array()) {
           // that is, my array type is a subtype of 'tp' klass
           return make(ptr, (ptr == Constant ? const_oop() : NULL),
                       _ary, _klass, _klass_is_exact, offset, _field_offset, instance_id, speculative, depth);
@@ -4866,7 +4871,7 @@ void TypeAryPtr::dump2( Dict &d, uint depth, outputStream *st ) const {
     break;
   }
 
-  if (elem()->isa_inlinetype()) {
+  if (is_flat()) {
     st->print("(");
     _field_offset.dump2(st);
     st->print(")");
@@ -5337,30 +5342,32 @@ const TypeKlassPtr *TypeKlassPtr::OBJECT;
 const TypeKlassPtr *TypeKlassPtr::OBJECT_OR_NULL;
 
 //------------------------------TypeKlassPtr-----------------------------------
-TypeKlassPtr::TypeKlassPtr(PTR ptr, ciKlass* klass, Offset offset, bool flat_array)
-  : TypePtr(KlassPtr, ptr, offset), _klass(klass), _klass_is_exact(ptr == Constant), _flat_array(flat_array) {
-   assert(!klass->is_inlinetype() || !klass->flatten_array() || flat_array, "incorrect flatten array bit");
-   assert(!flat_array || can_be_inline_type(), "incorrect flatten array bit");
+TypeKlassPtr::TypeKlassPtr(PTR ptr, ciKlass* klass, Offset offset, bool flatten_array)
+  : TypePtr(KlassPtr, ptr, offset), _klass(klass), _klass_is_exact(ptr == Constant), _flatten_array(flatten_array) {
+  assert(!klass->flatten_array() || flatten_array, "Should be flat in array");
+  assert(!flatten_array || can_be_inline_type(), "Only inline types can be flat in array");
 }
 
 //------------------------------make-------------------------------------------
 // ptr to klass 'k', if Constant, or possibly to a sub-klass if not a Constant
-const TypeKlassPtr* TypeKlassPtr::make(PTR ptr, ciKlass* k, Offset offset, bool flat_array) {
+const TypeKlassPtr* TypeKlassPtr::make(PTR ptr, ciKlass* k, Offset offset, bool flatten_array) {
   assert(k == NULL || k->is_instance_klass() || k->is_array_klass(), "Incorrect type of klass oop");
-  return (TypeKlassPtr*)(new TypeKlassPtr(ptr, k, offset, flat_array))->hashcons();
+  // Check if this type is known to be flat in arrays
+  flatten_array = flatten_array || k->flatten_array();
+  return (TypeKlassPtr*)(new TypeKlassPtr(ptr, k, offset, flatten_array))->hashcons();
 }
 
 //------------------------------eq---------------------------------------------
 // Structural equality check for Type representations
 bool TypeKlassPtr::eq( const Type *t ) const {
   const TypeKlassPtr *p = t->is_klassptr();
-  return klass() == p->klass() && TypePtr::eq(p) && flat_array() == p->flat_array();
+  return klass() == p->klass() && TypePtr::eq(p) && flatten_array() == p->flatten_array();
 }
 
 //------------------------------hash-------------------------------------------
 // Type-specific hashing function.
 int TypeKlassPtr::hash(void) const {
-  return java_add(java_add(klass() != NULL ? klass()->hash() : (jint)0, (jint)TypePtr::hash()), (jint)flat_array());
+  return java_add(java_add(klass() != NULL ? klass()->hash() : (jint)0, (jint)TypePtr::hash()), (jint)flatten_array());
 }
 
 //------------------------------singleton--------------------------------------
@@ -5494,21 +5501,21 @@ ciKlass* TypeAryPtr::klass() const {
 //------------------------------add_offset-------------------------------------
 // Access internals of klass object
 const TypePtr *TypeKlassPtr::add_offset( intptr_t offset ) const {
-  return make(_ptr, klass(), xadd_offset(offset), flat_array());
+  return make(_ptr, klass(), xadd_offset(offset), flatten_array());
 }
 
 //------------------------------cast_to_ptr_type-------------------------------
 const Type *TypeKlassPtr::cast_to_ptr_type(PTR ptr) const {
   assert(_base == KlassPtr, "subclass must override cast_to_ptr_type");
   if( ptr == _ptr ) return this;
-  return make(ptr, _klass, _offset, _flat_array);
+  return make(ptr, _klass, _offset, _flatten_array);
 }
 
 
 //-----------------------------cast_to_exactness-------------------------------
 const Type *TypeKlassPtr::cast_to_exactness(bool klass_is_exact) const {
   if( klass_is_exact == _klass_is_exact ) return this;
-  return make(klass_is_exact ? Constant : NotNull, _klass, _offset, _flat_array);
+  return make(klass_is_exact ? Constant : NotNull, _klass, _offset, _flatten_array);
 }
 
 
@@ -5523,8 +5530,8 @@ const TypeOopPtr* TypeKlassPtr::as_instance_type() const {
   const TypeOopPtr* toop = TypeOopPtr::make_from_klass_raw(k);
   guarantee(toop != NULL, "need type for given klass");
   toop = toop->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
-  if (flat_array() && !klass()->is_inlinetype()) {
-    toop = toop->is_instptr()->cast_to_flat_array();
+  if (flatten_array() && !klass()->is_inlinetype()) {
+    toop = toop->is_instptr()->cast_to_flatten_array();
   }
   return toop->cast_to_exactness(xk)->is_oopptr();
 }
@@ -5568,7 +5575,7 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
     case Null:
       if( ptr == Null ) return TypePtr::make(AnyPtr, ptr, offset, tp->speculative(), tp->inline_depth());
     case AnyNull:
-      return make(ptr, klass(), offset, flat_array());
+      return make(ptr, klass(), offset, flatten_array());
     case BotPTR:
     case NotNull:
       return TypePtr::make(AnyPtr, ptr, offset, tp->speculative(), tp->inline_depth());
@@ -5609,15 +5616,15 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
       if (ptr == Constant) {
         k = (klass() == NULL) ? tkls->klass() : klass();
       }
-      return make(ptr, k, off, false);
+      return make(ptr, k, off);
     }
 
     // Check for easy case; klasses are equal (and perhaps not loaded!)
     // If we have constants, then we created oops so classes are loaded
     // and we can handle the constants further down.  This case handles
     // not-loaded classes
-    if (ptr != Constant && tkls->klass()->equals(klass()) && flat_array() == tkls->flat_array()) {
-      return make(ptr, klass(), off, flat_array());
+    if (ptr != Constant && tkls->klass()->equals(klass()) && flatten_array() == tkls->flatten_array()) {
+      return make(ptr, klass(), off, flatten_array());
     }
 
     // Classes require inspection in the Java klass hierarchy.  Must be loaded.
@@ -5625,9 +5632,9 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
     ciKlass* this_klass = this->klass();
     assert( tkls_klass->is_loaded(), "This class should have been loaded.");
     assert( this_klass->is_loaded(), "This class should have been loaded.");
-    bool tkls_flat_array = tkls->flat_array();
-    bool this_flat_array  = this->flat_array();
-    bool flat_array = below_centerline(ptr) ? (this_flat_array && tkls_flat_array) : (this_flat_array || tkls_flat_array);
+    bool tkls_flatten_array = tkls->flatten_array();
+    bool this_flatten_array  = this->flatten_array();
+    bool flatten_array = below_centerline(ptr) ? (this_flatten_array && tkls_flatten_array) : (this_flatten_array || tkls_flatten_array);
 
     // If 'this' type is above the centerline and is a superclass of the
     // other, we can treat 'this' as having the same type as the other.
@@ -5655,7 +5662,7 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
         else
           ptr = NotNull;
       }
-      return make(ptr, this_klass, off, flat_array);
+      return make(ptr, this_klass, off, flatten_array);
     } // Else classes are not equal
 
     // Since klasses are different, we require the LCA in the Java
@@ -5664,7 +5671,7 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
       ptr = NotNull;
     // Now we find the LCA of Java classes
     ciKlass* k = this_klass->least_common_ancestor(tkls_klass);
-    return   make(ptr, k, off, k->is_inlinetype() && k->flatten_array());
+    return   make(ptr, k, off);
   } // End of case KlassPtr
 
   } // End of switch
@@ -5674,7 +5681,7 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
 //------------------------------xdual------------------------------------------
 // Dual: compute field-by-field dual
 const Type    *TypeKlassPtr::xdual() const {
-  return new TypeKlassPtr(dual_ptr(), klass(), dual_offset(), flat_array());
+  return new TypeKlassPtr(dual_ptr(), klass(), dual_offset(), flatten_array());
 }
 
 //------------------------------get_con----------------------------------------

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -976,7 +976,7 @@ public:
   virtual bool maybe_null() const { return meet_ptr(Null) == ptr(); }
 
   virtual bool can_be_inline_type() const { return false; }
-  virtual bool flat_array() const { return false; }
+  virtual bool flatten_array() const { return false; }
 
   // Tests for relation to centerline of type lattice:
   static bool above_centerline(PTR ptr) { return (ptr <= AnyNull); }
@@ -1113,9 +1113,6 @@ public:
 
   virtual const TypeOopPtr *cast_to_instance_id(int instance_id) const;
 
-  // corresponding pointer to klass, for a given instance
-  const TypeKlassPtr* as_klass_type() const;
-
   virtual const TypePtr *add_offset( intptr_t offset ) const;
 
   // Speculative type helper methods.
@@ -1142,13 +1139,13 @@ public:
 // or to a Klass* (including array klasses).
 class TypeInstPtr : public TypeOopPtr {
   TypeInstPtr(PTR ptr, ciKlass* k, bool xk, ciObject* o, Offset offset,
-              bool is_value, int instance_id, const TypePtr* speculative,
+              bool flatten_array, int instance_id, const TypePtr* speculative,
               int inline_depth);
   virtual bool eq( const Type *t ) const;
   virtual int  hash() const;             // Type specific hashing
 
   ciSymbol*  _name;        // class name
-  bool _flat_array;
+  bool _flatten_array;     // Type is flat in arrays
 
  public:
   ciSymbol* name()         const { return _name; }
@@ -1157,31 +1154,31 @@ class TypeInstPtr : public TypeOopPtr {
 
   // Make a pointer to a constant oop.
   static const TypeInstPtr *make(ciObject* o) {
-    return make(TypePtr::Constant, o->klass(), true, o, Offset(0), o->klass()->is_inlinetype() && o->klass()->as_inline_klass()->flatten_array(), InstanceBot);
+    return make(TypePtr::Constant, o->klass(), true, o, Offset(0));
   }
   // Make a pointer to a constant oop with offset.
   static const TypeInstPtr* make(ciObject* o, Offset offset) {
-    return make(TypePtr::Constant, o->klass(), true, o, offset, o->klass()->is_inlinetype() && o->klass()->as_inline_klass()->flatten_array(), InstanceBot);
+    return make(TypePtr::Constant, o->klass(), true, o, offset);
   }
 
   // Make a pointer to some value of type klass.
   static const TypeInstPtr *make(PTR ptr, ciKlass* klass) {
-    return make(ptr, klass, false, NULL, Offset(0), klass->is_inlinetype() && klass->as_inline_klass()->flatten_array(), InstanceBot);
+    return make(ptr, klass, false, NULL, Offset(0));
   }
 
   // Make a pointer to some non-polymorphic value of exactly type klass.
   static const TypeInstPtr *make_exact(PTR ptr, ciKlass* klass) {
-    return make(ptr, klass, true, NULL, Offset(0), klass->is_inlinetype() && klass->as_inline_klass()->flatten_array(), InstanceBot);
+    return make(ptr, klass, true, NULL, Offset(0));
   }
 
   // Make a pointer to some value of type klass with offset.
   static const TypeInstPtr *make(PTR ptr, ciKlass* klass, Offset offset) {
-    return make(ptr, klass, false, NULL, offset, klass->is_inlinetype() && klass->as_inline_klass()->flatten_array(), InstanceBot);
+    return make(ptr, klass, false, NULL, offset);
   }
 
   // Make a pointer to an oop.
   static const TypeInstPtr* make(PTR ptr, ciKlass* k, bool xk, ciObject* o, Offset offset,
-                                 bool flat_array,
+                                 bool flatten_array = false,
                                  int instance_id = InstanceBot,
                                  const TypePtr* speculative = NULL,
                                  int inline_depth = InlineDepthBottom);
@@ -1207,12 +1204,8 @@ class TypeInstPtr : public TypeOopPtr {
   virtual const TypePtr* with_inline_depth(int depth) const;
   virtual const TypePtr* with_instance_id(int instance_id) const;
 
-  virtual const TypeInstPtr* cast_to_flat_array() const;
-  virtual bool flat_array() const {
-    assert(!klass()->is_inlinetype() || !klass()->as_inline_klass()->flatten_array() || _flat_array, "incorrect value bit");
-    assert(!_flat_array || can_be_inline_type(), "incorrect value bit");
-    return _flat_array;
-  }
+  virtual const TypeInstPtr* cast_to_flatten_array() const;
+  virtual bool flatten_array() const { return _flatten_array; }
 
   // the core of the computation of the meet of 2 types
   virtual const Type *xmeet_helper(const Type *t) const;
@@ -1280,7 +1273,9 @@ public:
   bool      is_stable() const { return _ary->_stable; }
 
   // Inline type array properties
+  bool is_flat()          const { return _ary->_elem->isa_inlinetype() != NULL; }
   bool is_not_flat()      const { return _ary->_not_flat; }
+  bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr()); }
   bool is_not_null_free() const { return _ary->_not_null_free; }
 
   bool is_autobox_cache() const { return _is_autobox_cache; }
@@ -1321,8 +1316,10 @@ public:
   virtual const Type *xmeet_helper(const Type *t) const;
   virtual const Type *xdual() const;    // Compute dual right now.
 
+  // Inline type array properties
   const TypeAryPtr* cast_to_not_flat(bool not_flat = true) const;
   const TypeAryPtr* cast_to_not_null_free(bool not_null_free = true) const;
+  const TypeAryPtr* update_properties(const TypeAryPtr* new_type) const;
 
   const TypeAryPtr* cast_to_stable(bool stable, int stable_dimension = 1) const;
   int stable_dimension() const;
@@ -1409,7 +1406,7 @@ public:
 //------------------------------TypeKlassPtr-----------------------------------
 // Class of Java Klass pointers
 class TypeKlassPtr : public TypePtr {
-  TypeKlassPtr(PTR ptr, ciKlass* klass, Offset offset, bool flat_array);
+  TypeKlassPtr(PTR ptr, ciKlass* klass, Offset offset, bool flatten_array);
 
 protected:
   virtual const Type *filter_helper(const Type *kills, bool include_speculative) const;
@@ -1422,28 +1419,24 @@ protected:
   ciKlass* _klass;
 
   // Does the type exclude subclasses of the klass?  (Inexact == polymorphic.)
-  bool          _klass_is_exact;
-  bool _flat_array;
+  bool _klass_is_exact;
+  bool _flatten_array; // Type is flat in arrays
 
 public:
   ciKlass* klass() const { return  _klass; }
   bool klass_is_exact()    const { return _klass_is_exact; }
 
   virtual bool can_be_inline_type() const { return EnableValhalla && (_klass == NULL || _klass->can_be_inline_klass(_klass_is_exact)); }
-  virtual bool flat_array() const {
-    assert(!klass()->is_inlinetype() || !klass()->as_inline_klass()->flatten_array() || _flat_array, "incorrect value bit");
-    assert(!_flat_array || can_be_inline_type(), "incorrect value bit");
-    return _flat_array;
-  }
+  virtual bool flatten_array() const { return _flatten_array; }
 
   bool  is_loaded() const { return klass() != NULL && klass()->is_loaded(); }
 
   // ptr to klass 'k'
-  static const TypeKlassPtr* make(ciKlass* k) { return make( TypePtr::Constant, k, Offset(0), k->is_inlinetype() && k->as_inline_klass()->flatten_array()); }
+  static const TypeKlassPtr* make(ciKlass* k) { return make( TypePtr::Constant, k, Offset(0)); }
   // ptr to klass 'k' with offset
-  static const TypeKlassPtr* make(ciKlass* k, Offset offset) { return make( TypePtr::Constant, k, offset, k->is_inlinetype() && k->as_inline_klass()->flatten_array()); }
+  static const TypeKlassPtr* make(ciKlass* k, Offset offset) { return make( TypePtr::Constant, k, offset); }
   // ptr to klass 'k' or sub-klass
-  static const TypeKlassPtr* make(PTR ptr, ciKlass* k, Offset offset, bool flat_array);
+  static const TypeKlassPtr* make(PTR ptr, ciKlass* k, Offset offset, bool flatten_array = false);
 
   virtual const Type *cast_to_ptr_type(PTR ptr) const;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2277,4 +2277,177 @@ public class TestArrays extends InlineTypeTest {
             Asserts.assertEQ(res, expected);
         }
     }
+
+    // Test propagation of not null-free/flat information
+    @Test(failOn = CHECKCAST_ARRAY)
+    public MyValue1[] test95(Object[] array) {
+        array[0] = null;
+        // Always throws a ClassCastException because we just successfully
+        // stored null and therefore the array can't be an inline type array.
+        return (MyValue1[])array;
+    }
+
+    @DontCompile
+    public void test95_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        Integer[] array2 = new Integer[1];
+        try {
+            test95(array1);
+            throw new RuntimeException("Should throw NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+        try {
+            test95(array2);
+            throw new RuntimeException("Should throw ClassCastException");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    // Same as test95 but with cmp user of cast result
+    @Test(failOn = CHECKCAST_ARRAY)
+    public boolean test96(Object[] array) {
+        array[0] = null;
+        // Always throws a ClassCastException because we just successfully
+        // stored null and therefore the array can't be an inline type array.
+        MyValue1[] casted = (MyValue1[])array;
+        return casted != null;
+    }
+
+    @DontCompile
+    public void test96_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        Integer[] array2 = new Integer[1];
+        try {
+            test96(array1);
+            throw new RuntimeException("Should throw NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+        try {
+            test96(array2);
+            throw new RuntimeException("Should throw ClassCastException");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    // Same as test95 but with instanceof instead of cast
+    @Test(failOn = CHECKCAST_ARRAY)
+    public boolean test97(Object[] array) {
+        array[0] = 42;
+        // Always throws a ClassCastException because we just successfully stored
+        // a non-inline value and therefore the array can't be an inline type array.
+        return array instanceof MyValue1[];
+    }
+
+    @DontCompile
+    public void test97_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        Integer[] array2 = new Integer[1];
+        try {
+            test97(array1);
+            throw new RuntimeException("Should throw ArrayStoreException");
+        } catch (ArrayStoreException e) {
+            // Expected
+        }
+        boolean res = test97(array2);
+        Asserts.assertFalse(res);
+    }
+
+    // Same as test95 but with non-flattenable store
+    @Test(valid = InlineTypeArrayFlattenOn, failOn = CHECKCAST_ARRAY)
+    @Test(valid = InlineTypeArrayFlattenOff)
+    public MyValue1[] test98(Object[] array) {
+        array[0] = NotFlattenable.default;
+        // Always throws a ClassCastException because we just successfully stored a
+        // non-flattenable value and therefore the array can't be a flat array.
+        return (MyValue1[])array;
+    }
+
+    @DontCompile
+    public void test98_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        NotFlattenable[] array2 = new NotFlattenable[1];
+        try {
+            test98(array1);
+            throw new RuntimeException("Should throw ArrayStoreException");
+        } catch (ArrayStoreException e) {
+            // Expected
+        }
+        try {
+            test98(array2);
+            throw new RuntimeException("Should throw ClassCastException");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    // Same as test98 but with cmp user of cast result
+    @Test(valid = InlineTypeArrayFlattenOn, failOn = CHECKCAST_ARRAY)
+    @Test(valid = InlineTypeArrayFlattenOff)
+    public boolean test99(Object[] array) {
+        array[0] = NotFlattenable.default;
+        // Always throws a ClassCastException because we just successfully stored a
+        // non-flattenable value and therefore the array can't be a flat array.
+        MyValue1[] casted = (MyValue1[])array;
+        return casted != null;
+    }
+
+    @DontCompile
+    public void test99_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        NotFlattenable[] array2 = new NotFlattenable[1];
+        try {
+            test99(array1);
+            throw new RuntimeException("Should throw ArrayStoreException");
+        } catch (ArrayStoreException e) {
+            // Expected
+        }
+        try {
+            test99(array2);
+            throw new RuntimeException("Should throw ClassCastException");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    // Same as test98 but with instanceof instead of cast
+    @Test(valid = InlineTypeArrayFlattenOn, failOn = CHECKCAST_ARRAY)
+    @Test(valid = InlineTypeArrayFlattenOff)
+    public boolean test100(Object[] array) {
+        array[0] = NotFlattenable.default;
+        // Always throws a ClassCastException because we just successfully stored a
+        // non-flattenable value and therefore the array can't be a flat array.
+        return array instanceof MyValue1[];
+    }
+
+    @DontCompile
+    public void test100_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        NotFlattenable[] array2 = new NotFlattenable[1];
+        try {
+            test100(array1);
+            throw new RuntimeException("Should throw ArrayStoreException");
+        } catch (ArrayStoreException e) {
+            // Expected
+        }
+        boolean res = test100(array2);
+        Asserts.assertFalse(res);
+    }
+
+    // Test that CHECKCAST_ARRAY matching works as expected
+    @Test(match = { CHECKCAST_ARRAY }, matchCount = { 1 })
+    public boolean test101(Object[] array) {
+        return array instanceof MyValue1[];
+    }
+
+    @DontCompile
+    public void test101_verifier(boolean warmup) {
+        MyValue1[] array1 = new MyValue1[1];
+        NotFlattenable[] array2 = new NotFlattenable[1];
+        Asserts.assertTrue(test101(array1));
+        Asserts.assertFalse(test101(array2));
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -2868,4 +2868,18 @@ public class TestNullableArrays extends InlineTypeTest {
     public void test110_verifier(boolean warmup) {
         test110();
     }
+
+    // Same as test109 but with Arrays.copyOf
+    @Test()
+    public static void test111() {
+        MyValue1[] src = new MyValue1[1];
+        src[0] = testValue1;
+        MyValue1.ref[] dst = Arrays.copyOf(src, src.length, MyValue1.ref[].class);
+        Asserts.assertEquals(src[0], dst[0]);
+    }
+
+    @DontCompile
+    public void test111_verifier(boolean warmup) {
+        test111();
+    }
 }


### PR DESCRIPTION
Similar to JDK-8242453 [1], the problem is that a load from a non-flat array can be pushed through an arraycopy from a flat array (see LoadNode::can_see_arraycopy_value) and end up with an inconsistent memory input (oop load from a flat array). The checks emitted by the arraycopy intrinsic will catch this and the load will be removed but other Ideal transformations can still be executed before that happens and encounter this inconsistent state.

The fix is to add CheckCastPPNodes to the arraycopy intrinsic that propagate the information that the src/dst array is not flat. This makes sure that the data path consistently dies if the input array is in fact a flat array. I've also removed the workaround from the JDK-8242453 [1] fix.

When updating the type of CheckCastPPNodes, we need to make sure that the not_null_free and not_flat properties of TypeAryPtr are propagated. This is done by TypeAryPtr::update_properties. A CheckCastPPNode that ends up with an inconsistent input is then simply replaced by TOP.

This change also includes:
- Optimize subtype checks based on not_null_free/not_flat properties of array types
- New tests to verify that checkcasts are folded if one array type is known to be not null-free/flat and the other type is null-free/flat
- Test suite should detect compilation bailouts and fail (currently, only completely missing compilations were detected)
- Renamed "flat_array" to "flatten_array" (which means "flattened in arrays") for consistency with runtime code. We should think about a better name.
- Lots of refactoring, removal of default arguments in calls and dead code

[1] https://bugs.openjdk.java.net/browse/JDK-8242453
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251442](https://bugs.openjdk.java.net/browse/JDK-8251442): [lworld] C2 compilation fails with assert(value->bottom_type()->higher_equal(_type))


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/151/head:pull/151`
`$ git checkout pull/151`
