### PR TITLE
8252040: [lworld] Execute compiler unit tests in random order

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -39,6 +39,8 @@ import java.lang.invoke.*;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -122,6 +124,7 @@ public abstract class InlineTypeTest {
     // Random test values
     public static final int  rI = Utils.getRandomInstance().nextInt() % 1000;
     public static final long rL = Utils.getRandomInstance().nextLong() % 1000;
+    public static final double rD = Utils.getRandomInstance().nextDouble() % 1000;
 
     // User defined settings
     protected static final boolean XCOMP = Platform.isComp();
@@ -177,7 +180,7 @@ public abstract class InlineTypeTest {
     protected static final int TypeProfileOn = 0x4000;
     protected static final int TypeProfileOff = 0x8000;
     protected static final boolean InlineTypePassFieldsAsArgs = (Boolean)WHITE_BOX.getVMFlag("InlineTypePassFieldsAsArgs");
-    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("FlatArrayElementMaxSize") == -1); // FIXME - fix this if default of FlatArrayElementMaxSize is changed
+    protected static final boolean InlineTypeArrayFlatten = (WHITE_BOX.getIntxVMFlag("FlatArrayElementMaxSize") == -1);
     protected static final boolean InlineTypeReturnedAsFields = (Boolean)WHITE_BOX.getVMFlag("InlineTypeReturnedAsFields");
     protected static final boolean AlwaysIncrementalInline = (Boolean)WHITE_BOX.getVMFlag("AlwaysIncrementalInline");
     protected static final boolean G1GC = (Boolean)WHITE_BOX.getVMFlag("UseG1GC");
@@ -657,9 +660,11 @@ public abstract class InlineTypeTest {
             setup(clazz);
         }
 
-        // Execute tests
+        // Execute tests in random order (execution sequence affects profiling)
         TreeMap<Long, String> durations = (PRINT_TIMES || VERBOSE) ? new TreeMap<Long, String>() : null;
-        for (Method test : tests.values()) {
+        List<Method> testList = new ArrayList<Method>(tests.values());
+        Collections.shuffle(testList, Utils.getRandomInstance());
+        for (Method test : testList) {
             if (VERBOSE) {
                 System.out.println("Starting " + test.getName());
             }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -143,6 +143,7 @@ public abstract class InlineTypeTest {
     private static final boolean GC_AFTER = Boolean.parseBoolean(System.getProperty("GCAfter", "false"));
     private static final int OSR_TEST_TIMEOUT = Integer.parseInt(System.getProperty("OSRTestTimeOut", "5000"));
     protected static final boolean STRESS_CC = Boolean.parseBoolean(System.getProperty("StressCC", "false"));
+    private static final boolean SHUFFLE_TESTS = Boolean.parseBoolean(System.getProperty("ShuffleTests", "false"));
 
     // "jtreg -DXcomp=true" runs all the scenarios with -Xcomp. This is faster than "jtreg -javaoptions:-Xcomp".
     protected static final boolean RUN_SCENARIOS_WITH_XCOMP = Boolean.parseBoolean(System.getProperty("Xcomp", "false"));
@@ -219,6 +220,7 @@ public abstract class InlineTypeTest {
     protected static final String LOAD_UNKNOWN_INLINE = "(.*call_leaf,runtime  load_unknown_inline.*" + END;
     protected static final String STORE_UNKNOWN_INLINE = "(.*call_leaf,runtime  store_unknown_inline.*" + END;
     protected static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static  wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
+    protected static final String INTRINSIC_SLOW_PATH = "(.*call,static  wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;
     protected static final String CLASS_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*class_check" + END;
     protected static final String NULL_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*null_check" + END;
     protected static final String RANGE_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*range_check" + END;
@@ -407,6 +409,13 @@ public abstract class InlineTypeTest {
             if (annos.length != 0 &&
                 ((list == null || list.contains(m.getName())) && (exclude == null || !exclude.contains(m.getName())))) {
                 tests.put(getClass().getSimpleName() + "::" + m.getName(), m);
+            } else if (annos.length == 0 && m.getName().startsWith("test")) {
+                try {
+                    getClass().getMethod(m.getName() + "_verifier", boolean.class);
+                    throw new RuntimeException(m.getName() + " has a verifier method but no @Test annotation");
+                } catch (NoSuchMethodException e) {
+                    // Expected
+                }
             }
         }
     }
@@ -579,7 +588,7 @@ public abstract class InlineTypeTest {
                     nodes += matcher.group() + "\n";
                 }
                 if (matchCount[i] < 0) {
-                    Asserts.assertLTE(Math.abs(matchCount[i]), count, "Graph for '" + testName + "' contains different number of match nodes (expected <= " + matchCount[i] + " but got " + count + "):\n" + nodes);
+                    Asserts.assertLTE(Math.abs(matchCount[i]), count, "Graph for '" + testName + "' contains different number of match nodes (expected >= " + Math.abs(matchCount[i]) + " but got " + count + "):\n" + nodes);
                 } else {
                     Asserts.assertEQ(matchCount[i], count, "Graph for '" + testName + "' contains different number of match nodes (expected " + matchCount[i] + " but got " + count + "):\n" + nodes);
                 }
@@ -660,10 +669,12 @@ public abstract class InlineTypeTest {
             setup(clazz);
         }
 
-        // Execute tests in random order (execution sequence affects profiling)
         TreeMap<Long, String> durations = (PRINT_TIMES || VERBOSE) ? new TreeMap<Long, String>() : null;
         List<Method> testList = new ArrayList<Method>(tests.values());
-        Collections.shuffle(testList, Utils.getRandomInstance());
+        if (SHUFFLE_TESTS) {
+            // Execute tests in random order (execution sequence affects profiling)
+            Collections.shuffle(testList, Utils.getRandomInstance());
+        }
         for (Method test : testList) {
             if (VERBOSE) {
                 System.out.println("Starting " + test.getName());

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue1.java
@@ -33,7 +33,7 @@ public final inline class MyValue1 extends MyAbstract {
     final int[] oa;
     final MyValue2 v1;
     final MyValue2 v2;
-    static final MyValue2 v3 = MyValue2.createWithFieldsInline(InlineTypeTest.rI, true);
+    static final MyValue2 v3 = MyValue2.createWithFieldsInline(InlineTypeTest.rI, InlineTypeTest.rD);
     final int c;
 
     @ForceInline
@@ -73,8 +73,8 @@ public final inline class MyValue1 extends MyAbstract {
         v = setO(v, new Integer(x));
         int[] oa = {x};
         v = setOA(v, oa);
-        v = setV1(v, MyValue2.createWithFieldsInline(x, y, true));
-        v = setV2(v, MyValue2.createWithFieldsInline(x, y, false));
+        v = setV1(v, MyValue2.createWithFieldsInline(x, y, InlineTypeTest.rD));
+        v = setV2(v, MyValue2.createWithFieldsInline(x, y, InlineTypeTest.rD+x));
         v = setC(v, (int)(x+y));
         return v;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue2.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue2.java
@@ -24,23 +24,23 @@
 package compiler.valhalla.inlinetypes;
 
 final inline class MyValue2Inline {
-    final boolean b;
-    final long c;
+    final double d;
+    final long l;
 
     @ForceInline
-    public MyValue2Inline(boolean b, long c) {
-        this.b = b;
-        this.c = c;
+    public MyValue2Inline(double d, long l) {
+        this.d = d;
+        this.l = l;
     }
 
     @ForceInline
-    static MyValue2Inline setB(MyValue2Inline v, boolean b) {
-        return new MyValue2Inline(b, v.c);
+    static MyValue2Inline setD(MyValue2Inline v, double d) {
+        return new MyValue2Inline(d, v.l);
     }
 
     @ForceInline
-    static MyValue2Inline setC(MyValue2Inline v, long c) {
-        return new MyValue2Inline(v.b, c);
+    static MyValue2Inline setL(MyValue2Inline v, long l) {
+        return new MyValue2Inline(v.d, l);
     }
 
     @ForceInline
@@ -49,10 +49,10 @@ final inline class MyValue2Inline {
     }
 
     @ForceInline
-    public static MyValue2Inline createWithFieldsInline(boolean b, long c) {
+    public static MyValue2Inline createWithFieldsInline(double d, long l) {
         MyValue2Inline v = MyValue2Inline.createDefault();
-        v = MyValue2Inline.setB(v, b);
-        v = MyValue2Inline.setC(v, c);
+        v = MyValue2Inline.setD(v, d);
+        v = MyValue2Inline.setL(v, l);
         return v;
     }
 }
@@ -60,13 +60,13 @@ final inline class MyValue2Inline {
 public final inline class MyValue2 extends MyAbstract {
     final int x;
     final byte y;
-    final MyValue2Inline v1;
+    final MyValue2Inline v;
 
     @ForceInline
-    public MyValue2(int x, byte y, MyValue2Inline v1) {
+    public MyValue2(int x, byte y, MyValue2Inline v) {
         this.x = x;
         this.y = y;
-        this.v1 = v1;
+        this.v = v;
     }
 
     @ForceInline
@@ -75,59 +75,59 @@ public final inline class MyValue2 extends MyAbstract {
     }
 
     @ForceInline
-    public static MyValue2 createWithFieldsInline(int x, long y, boolean b) {
+    public static MyValue2 createWithFieldsInline(int x, long y, double d) {
         MyValue2 v = createDefaultInline();
         v = setX(v, x);
         v = setY(v, (byte)x);
-        v = setV1(v, MyValue2Inline.createWithFieldsInline(b, y));
+        v = setV(v, MyValue2Inline.createWithFieldsInline(d, y));
         return v;
     }
 
     @ForceInline
-    public static MyValue2 createWithFieldsInline(int x, boolean b) {
+    public static MyValue2 createWithFieldsInline(int x, double d) {
         MyValue2 v = createDefaultInline();
         v = setX(v, x);
         v = setY(v, (byte)x);
-        v = setV1(v, MyValue2Inline.createWithFieldsInline(b, InlineTypeTest.rL));
+        v = setV(v, MyValue2Inline.createWithFieldsInline(d, InlineTypeTest.rL));
         return v;
     }
 
     @DontInline
-    public static MyValue2 createWithFieldsDontInline(int x, boolean b) {
+    public static MyValue2 createWithFieldsDontInline(int x, double d) {
         MyValue2 v = createDefaultInline();
         v = setX(v, x);
         v = setY(v, (byte)x);
-        v = setV1(v, MyValue2Inline.createWithFieldsInline(b, InlineTypeTest.rL));
+        v = setV(v, MyValue2Inline.createWithFieldsInline(d, InlineTypeTest.rL));
         return v;
     }
 
     @ForceInline
     public long hash() {
-        return x + y + (v1.b ? 0 : 1) + v1.c;
+        return x + y + (long)v.d + v.l;
     }
 
     @DontInline
     public long hashInterpreted() {
-        return x + y + (v1.b ? 0 : 1) + v1.c;
+        return x + y + (long)v.d + v.l;
     }
 
     @ForceInline
     public void print() {
-        System.out.print("x=" + x + ", y=" + y + ", b=" + v1.b + ", c=" + v1.c);
+        System.out.print("x=" + x + ", y=" + y + ", d=" + v.d + ", l=" + v.l);
     }
 
     @ForceInline
     static MyValue2 setX(MyValue2 v, int x) {
-        return new MyValue2(x, v.y, v.v1);
+        return new MyValue2(x, v.y, v.v);
     }
 
     @ForceInline
     static MyValue2 setY(MyValue2 v, byte y) {
-        return new MyValue2(v.x, y, v.v1);
+        return new MyValue2(v.x, y, v.v);
     }
 
     @ForceInline
-    static MyValue2 setV1(MyValue2 v, MyValue2Inline v1) {
-        return new MyValue2(v.x, v.y, v1);
+    static MyValue2 setV(MyValue2 v, MyValue2Inline vi) {
+        return new MyValue2(v.x, v.y, vi);
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,7 @@ public class TestArrayAccessDeopt {
                 test6(va, vt);
                 try {
                     test6(va, null);
+                    throw new RuntimeException("NullPointerException expected");
                 } catch (NullPointerException npe) {
                     // Expected
                 }
@@ -122,6 +123,7 @@ public class TestArrayAccessDeopt {
                 test9(va, vt);
                 try {
                     test9(va, null);
+                    throw new RuntimeException("NullPointerException expected");
                 } catch (NullPointerException npe) {
                     // Expected
                 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -186,8 +186,8 @@ public class TestBasicFunctionality extends InlineTypeTest {
     }
 
     // Merge inline types created from two branches
-    @Test(valid = InlineTypePassFieldsAsArgsOn, match = {LOAD}, matchCount = {12}, failOn = TRAP + ALLOC + STORE)
-    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC, STORE}, matchCount = {1, 12}, failOn = LOAD + TRAP)
+    @Test(valid = InlineTypePassFieldsAsArgsOn, match = {LOAD}, matchCount = {14}, failOn = TRAP + ALLOC + STORE)
+    @Test(valid = InlineTypePassFieldsAsArgsOff, match = {ALLOC, STORE}, matchCount = {1, 13}, failOn = LOAD + TRAP)
     public MyValue1 test9(boolean b, int localrI, long localrL) {
         MyValue1 v;
         if (b) {
@@ -315,7 +315,7 @@ public class TestBasicFunctionality extends InlineTypeTest {
 
     // Create an inline type in a non-inlined method and then call a
     // non-inlined method on that inline type.
-    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = (ALLOC + STORE + TRAP), match = {LOAD}, matchCount = {12})
+    @Test(valid = InlineTypePassFieldsAsArgsOn, failOn = (ALLOC + STORE + TRAP), match = {LOAD}, matchCount = {14})
     @Test(valid = InlineTypePassFieldsAsArgsOff, failOn = (ALLOC + LOAD + STORE + TRAP))
     public long test14() {
         MyValue1 v = MyValue1.createWithFieldsDontInline(rI, rL);
@@ -447,7 +447,7 @@ public class TestBasicFunctionality extends InlineTypeTest {
         long result = val1.hash() + val2.hash() + val3.hash() + val4.hash() + val5.hash();
         // Update fields
         val1 = MyValue1.createWithFieldsInline(x, y);
-        val2 = MyValue2.createWithFieldsInline(x, true);
+        val2 = MyValue2.createWithFieldsInline(x, rD);
         val4 = MyValue1.createWithFieldsInline(x, y);
         return result;
     }
@@ -465,7 +465,7 @@ public class TestBasicFunctionality extends InlineTypeTest {
         Asserts.assertEQ(result, hash);
         // Check if inline type fields were updated
         Asserts.assertEQ(val1.hash(), hash(rI + 1, rL + 1));
-        Asserts.assertEQ(val2.hash(), MyValue2.createWithFieldsInline(rI + 1, true).hash());
+        Asserts.assertEQ(val2.hash(), MyValue2.createWithFieldsInline(rI + 1, rD).hash());
         Asserts.assertEQ(val4.hash(), hash(rI + 1, rL + 1));
     }
 
@@ -512,14 +512,14 @@ public class TestBasicFunctionality extends InlineTypeTest {
     // Test withfield
     @Test(failOn = ALLOC + LOAD + STORE + LOOP + TRAP)
     public long test25() {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         return v.hash();
     }
 
     @DontCompile
     public void test25_verifier(boolean warmup) {
         long result = test25();
-        Asserts.assertEQ(result, MyValue2.createWithFieldsInline(rI, true).hash());
+        Asserts.assertEQ(result, MyValue2.createWithFieldsInline(rI, rD).hash());
     }
 
     // Test withfield

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -85,7 +85,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test1_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test1(v);
         Asserts.assertEQ(result, v.hashInterpreted());
     }
@@ -97,7 +97,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test2_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test2(rI, v, 2*rI);
         Asserts.assertEQ(result, v.hashInterpreted() - rI);
     }
@@ -109,7 +109,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test3_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test3(rL, v, 2*rL);
         Asserts.assertEQ(result, v.hashInterpreted() - rL);
     }
@@ -121,7 +121,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test4_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test4(rI, v, rL);
         Asserts.assertEQ(result, v.hashInterpreted() + rL + rI);
     }
@@ -133,7 +133,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test5_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test5(rL, v, rI);
         Asserts.assertEQ(result, v.hashInterpreted() + rL + rI);
     }
@@ -146,7 +146,7 @@ public class TestCallingConvention extends InlineTypeTest {
     @DontCompile
     public void test6_verifier(boolean warmup) {
         MyValue1 v1 = MyValue1.createWithFieldsDontInline(rI, rL);
-        MyValue2 v2 = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v2 = MyValue2.createWithFieldsInline(rI, rD);
         long result = test6(rL, v1, rI, v2);
         Asserts.assertEQ(result, v1.hashInterpreted() + rL + rI + v2.hashInterpreted());
     }
@@ -164,7 +164,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test7_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test7(v);
         Asserts.assertEQ(result, v.hashInterpreted());
     }
@@ -181,7 +181,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test8_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test8(rI, v, 2*rI);
         Asserts.assertEQ(result, v.hashInterpreted() - rI);
     }
@@ -198,7 +198,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test9_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test9(rL, v, 2*rL);
         Asserts.assertEQ(result, v.hashInterpreted() - rL);
     }
@@ -215,7 +215,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test10_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test10(rI, v, rL);
         Asserts.assertEQ(result, v.hashInterpreted() + rL + rI);
     }
@@ -232,7 +232,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test11_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         long result = test11(rL, v, rI);
         Asserts.assertEQ(result, v.hashInterpreted() + rL + rI);
     }
@@ -250,7 +250,7 @@ public class TestCallingConvention extends InlineTypeTest {
     @DontCompile
     public void test12_verifier(boolean warmup) {
         MyValue1 v1 = MyValue1.createWithFieldsDontInline(rI, rL);
-        MyValue2 v2 = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v2 = MyValue2.createWithFieldsInline(rI, rD);
         long result = test12(rL, v1, rI, v2);
         Asserts.assertEQ(result, v1.hashInterpreted() + rL + rI + v2.hashInterpreted());
     }
@@ -272,7 +272,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test13_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         MyValue1[] va = new MyValue1[2];
         va[0] = MyValue1.createWithFieldsDontInline(rI, rL);
         va[1] = MyValue1.createWithFieldsDontInline(rI, rL);
@@ -287,7 +287,7 @@ public class TestCallingConvention extends InlineTypeTest {
             // uncommon trap
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test14"));
         }
-        return MyValue2.createWithFieldsInline(rI, true);
+        return MyValue2.createWithFieldsInline(rI, rD);
     }
 
     @Test()
@@ -298,7 +298,7 @@ public class TestCallingConvention extends InlineTypeTest {
     @DontCompile
     public void test14_verifier(boolean warmup) {
         MyValue2 result = test14(!warmup);
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         Asserts.assertEQ(result.hash(), v.hash());
     }
 
@@ -509,7 +509,7 @@ public class TestCallingConvention extends InlineTypeTest {
         if (b) {
             return null;
         } else {
-            return MyValue2.createWithFieldsInline(rI, true);
+            return MyValue2.createWithFieldsInline(rI, rD);
         }
     }
 
@@ -523,7 +523,7 @@ public class TestCallingConvention extends InlineTypeTest {
         MyValue2.ref vt = test26(true);
         Asserts.assertEQ(vt, null);
         vt = test26(false);
-        Asserts.assertEQ(vt.hash(), MyValue2.createWithFieldsInline(rI, true).hash());
+        Asserts.assertEQ(vt.hash(), MyValue2.createWithFieldsInline(rI, rD).hash());
     }
 
     // Test calling convention with deep hierarchy of flattened fields
@@ -646,7 +646,7 @@ public class TestCallingConvention extends InlineTypeTest {
             // uncommon trap
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test32"));
         }
-        return MyValue2.createWithFieldsInline(rI+32, true);
+        return MyValue2.createWithFieldsInline(rI+32, rD);
     }
 
     @Test()
@@ -657,7 +657,7 @@ public class TestCallingConvention extends InlineTypeTest {
     @DontCompile
     public void test32_verifier(boolean warmup) throws Throwable {
         MyValue2 result = test32(!warmup);
-        MyValue2 v = MyValue2.createWithFieldsInline(rI+32, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI+32, rD);
         Asserts.assertEQ(result.hash(), v.hash());
     }
 
@@ -670,7 +670,7 @@ public class TestCallingConvention extends InlineTypeTest {
             // uncommon trap
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test33"));
         }
-        return MyValue2.createWithFieldsInline(rI+33, true);
+        return MyValue2.createWithFieldsInline(rI+33, rD);
     }
 
     @Test()
@@ -682,7 +682,7 @@ public class TestCallingConvention extends InlineTypeTest {
     @DontCompile
     public void test33_verifier(boolean warmup) throws Throwable {
         MyValue2 result = test33(!warmup);
-        MyValue2 v = MyValue2.createWithFieldsInline(rI+33, true);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI+33, rD);
         Asserts.assertEQ(result.hash(), v.hash());
     }
 
@@ -715,7 +715,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test34_verifier(boolean warmup) {
-        MyValue2 vt = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 vt = MyValue2.createWithFieldsInline(rI, rD);
         long result = test34(vt, rI, rI, rI, rI);
         Asserts.assertEQ(result, vt.hash()+4*rI);
         if (!warmup) {
@@ -740,7 +740,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     @DontCompile
     public void test35_verifier(boolean warmup) {
-        MyValue2 vt = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 vt = MyValue2.createWithFieldsInline(rI, rD);
         long result = test35(vt, rI, rI, rI, rI);
         Asserts.assertEQ(result, vt.hash()+10004*rI);
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -117,9 +117,9 @@ public class TestIntrinsics extends InlineTypeTest {
     @Test(failOn = LOADK)
     public boolean test4() {
         boolean check1 = Object.class.getSuperclass() == null;
-        // TODO Remove cast as workaround once javac is fixed
+        // TODO 8244562: Remove cast as workaround once javac is fixed
         boolean check2 = (Class<?>)MyValue1.ref.class.getSuperclass() == MyAbstract.class;
-        // TODO Remove cast as workaround once javac is fixed
+        // TODO 8244562: Remove cast as workaround once javac is fixed
         boolean check3 = (Class<?>)MyValue1.val.class.getSuperclass() == MyValue1.ref.class;
         boolean check4 = Class.class.getSuperclass() == Object.class;
         return check1 && check2 && check3 && check4;
@@ -437,7 +437,7 @@ public class TestIntrinsics extends InlineTypeTest {
 
     @Test
     public Test25Value[] test25(Test25Value element) {
-        // TODO Remove cast as workaround once javac is fixed
+        // TODO 8244562: Remove cast as workaround once javac is fixed
         Test25Value[] newArray = (Test25Value[])Arrays.copyOf(test25Array, test25Array.length + 1);
         newArray[test25Array.length] = element;
         return newArray;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -437,10 +437,9 @@ public class TestIntrinsics extends InlineTypeTest {
 
     @Test
     public Test25Value[] test25(Test25Value element) {
-        // TODO 8244562: Remove cast as workaround once javac is fixed
-        Test25Value[] newArray = (Test25Value[])Arrays.copyOf(test25Array, test25Array.length + 1);
+        Object[] newArray = Arrays.copyOf(test25Array, test25Array.length + 1);
         newArray[test25Array.length] = element;
-        return newArray;
+        return (Test25Value[]) newArray;
     }
 
     @DontCompile

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -66,7 +66,7 @@ public class TestLWorld extends InlineTypeTest {
     // Helper methods
 
     private static final MyValue1 testValue1 = MyValue1.createWithFieldsInline(rI, rL);
-    private static final MyValue2 testValue2 = MyValue2.createWithFieldsInline(rI, true);
+    private static final MyValue2 testValue2 = MyValue2.createWithFieldsInline(rI, rD);
 
     protected long hash() {
         return testValue1.hash();
@@ -186,7 +186,7 @@ public class TestLWorld extends InlineTypeTest {
         } else if (state == 5) {
             res = null;
         } else if (state == 6) {
-            res = MyValue2.createWithFieldsInline(rI, true);
+            res = MyValue2.createWithFieldsInline(rI, rD);
         } else if (state == 7) {
             res = testValue2;
         }
@@ -1628,7 +1628,7 @@ public class TestLWorld extends InlineTypeTest {
     @Test()
     public Object test55(boolean b) {
         MyValue1 vt1 = MyValue1.createWithFieldsInline(rI, rL);
-        MyValue2 vt2 = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 vt2 = MyValue2.createWithFieldsInline(rI, rD);
         return b ? vt1 : vt2;
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class TestLWorldProfiling extends InlineTypeTest {
     }
 
     private static final MyValue1 testValue1 = MyValue1.createWithFieldsInline(rI, rL);
-    private static final MyValue2 testValue2 = MyValue2.createWithFieldsInline(rI, true);
+    private static final MyValue2 testValue2 = MyValue2.createWithFieldsInline(rI, rD);
     private static final MyValue1[] testValue1Array = new MyValue1[] {testValue1};
     private static final MyValue2[] testValue2Array = new MyValue2[] {testValue2};
     private static final Integer[] testIntegerArray = new Integer[] {42};
@@ -389,7 +389,10 @@ public class TestLWorldProfiling extends InlineTypeTest {
         test15(testNotFlattenableArray, notFlattenable);
         try {
             test15(testNotFlattenableArray, null);
-        } catch (NullPointerException npe) {  }
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // Expected
+        }
     }
 
     @Warmup(10000)
@@ -404,7 +407,10 @@ public class TestLWorldProfiling extends InlineTypeTest {
         test16(testNotFlattenableArray, notFlattenable);
         try {
             test16(testNotFlattenableArray, null);
-        } catch (NullPointerException npe) {  }
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException npe) {
+            // Expected
+        }
         test16(testIntegerArray, 42);
     }
 
@@ -418,9 +424,8 @@ public class TestLWorldProfiling extends InlineTypeTest {
     @DontCompile
     public void test17_verifier(boolean warmup) {
         test17(testIntegerArray, 42);
-        try {
-            test17(testIntegerArray, null);
-        } catch (NullPointerException npe) {  }
+        test17(testIntegerArray, null);
+        testIntegerArray[0] = 42;
         test17(testLongArray, 42L);
     }
 
@@ -441,9 +446,8 @@ public class TestLWorldProfiling extends InlineTypeTest {
     public void test18_verifier(boolean warmup) {
         test18_helper(testValue1Array, testValue1); // pollute profile
         test18(testIntegerArray, 42);
-        try {
-            test18(testIntegerArray, null);
-        } catch (NullPointerException npe) {  }
+        test18(testIntegerArray, null);
+        testIntegerArray[0] = 42;
         test18(testLongArray, 42L);
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
@@ -292,12 +292,12 @@ public class TestMethodHandles extends InlineTypeTest {
     // constant. Shouldn't cause any allocation.
     @ForceInline
     static MyValue2 test7_target1() {
-        return MyValue2.createWithFieldsInline(rI, true);
+        return MyValue2.createWithFieldsInline(rI, rD);
     }
 
     @ForceInline
     static MyValue2 test7_target2() {
-        return MyValue2.createWithFieldsInline(rI+1, false);
+        return MyValue2.createWithFieldsInline(rI+1, rD+1);
     }
 
     static boolean test7_bool = true;
@@ -318,19 +318,19 @@ public class TestMethodHandles extends InlineTypeTest {
     public void test7_verifier(boolean warmup) throws Throwable {
         test7_bool = !test7_bool;
         long hash = test7();
-        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+(test7_bool ? 0 : 1), test7_bool).hash());
+        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+(test7_bool ? 0 : 1), rD+(test7_bool ? 0 : 1)).hash());
     }
 
     // Same as above but with the method handle for target2 not
     // constant. Shouldn't cause any allocation.
     @ForceInline
     static MyValue2 test8_target1() {
-        return MyValue2.createWithFieldsInline(rI, true);
+        return MyValue2.createWithFieldsInline(rI, rD);
     }
 
     @ForceInline
     static MyValue2 test8_target2() {
-        return MyValue2.createWithFieldsInline(rI+1, false);
+        return MyValue2.createWithFieldsInline(rI+1, rD+1);
     }
 
     static boolean test8_bool = true;
@@ -351,7 +351,7 @@ public class TestMethodHandles extends InlineTypeTest {
     public void test8_verifier(boolean warmup) throws Throwable {
         test8_bool = !test8_bool;
         long hash = test8();
-        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+(test8_bool ? 0 : 1), test8_bool).hash());
+        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+(test8_bool ? 0 : 1), rD+(test8_bool ? 0 : 1)).hash());
     }
 
     // Return of target1, target2 and target3 merged in Lambda Forms
@@ -407,17 +407,17 @@ public class TestMethodHandles extends InlineTypeTest {
     // Same as above but with non constant target2 and target3
     @ForceInline
     static MyValue2 test10_target1() {
-        return MyValue2.createWithFieldsInline(rI, true);
+        return MyValue2.createWithFieldsInline(rI, rD);
     }
 
     @ForceInline
     static MyValue2 test10_target2() {
-        return MyValue2.createWithFieldsInline(rI+1, false);
+        return MyValue2.createWithFieldsInline(rI+1, rD+1);
     }
 
     @ForceInline
     static MyValue2 test10_target3() {
-        return MyValue2.createWithFieldsInline(rI+2, true);
+        return MyValue2.createWithFieldsInline(rI+2, rD+2);
     }
 
     static boolean test10_bool1 = true;
@@ -449,21 +449,21 @@ public class TestMethodHandles extends InlineTypeTest {
         test10_bool1 = (test10_i % 2) == 0;
         test10_bool2 = (test10_i % 3) == 0;
         long hash = test10();
-        int i = rI+(test10_bool1 ? 0 : (test10_bool2 ? 1 : 2));
-        boolean b = test10_bool1 ? true : (test10_bool2 ? false : true);
-        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(i, b).hash());
+        int i = rI + (test10_bool1 ? 0 : (test10_bool2 ? 1 : 2));
+        double d = rD + (test10_bool1 ? 0 : (test10_bool2 ? 1 : 2));
+        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(i, d).hash());
     }
 
     static int test11_i = 0;
 
     @ForceInline
     static MyValue2 test11_target1() {
-        return MyValue2.createWithFieldsInline(rI+test11_i, true);
+        return MyValue2.createWithFieldsInline(rI+test11_i, rD+test11_i);
     }
 
     @ForceInline
     static MyValue2 test11_target2() {
-        return MyValue2.createWithFieldsInline(rI-test11_i, false);
+        return MyValue2.createWithFieldsInline(rI-test11_i, rD-test11_i);
     }
 
     @ForceInline
@@ -487,6 +487,6 @@ public class TestMethodHandles extends InlineTypeTest {
         test11_i++;
         long hash = test11();
         boolean b = (test11_i % 100) == 0;
-        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+test11_i * (b ? 1 : -1), b).hash());
+        Asserts.assertEQ(hash, MyValue2.createWithFieldsInline(rI+test11_i * (b ? 1 : -1), rD+test11_i * (b ? 1 : -1)).hash());
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -105,9 +105,7 @@ public class TestNullableArrays extends InlineTypeTest {
     }
 
     // Test creation of an inline type array and element access
-    @Test
-    // TODO 8227588
-    // @Test(failOn = ALLOC + ALLOCA + LOOP + LOAD + STORE + TRAP)
+    @Test(failOn = ALLOC + ALLOCA + LOOP + LOAD + STORE + TRAP)
     public long test2() {
         MyValue1.ref[] va = new MyValue1.ref[1];
         va[0] = MyValue1.createWithFieldsInline(rI, rL);
@@ -609,13 +607,13 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] dst3 = new MyValue2.ref[len];
         MyValue2[]  dst4 = new MyValue2[len];
         if (len > 0) {
-            src2[0] = MyValue2.createWithFieldsInline(rI, true);
+            src2[0] = MyValue2.createWithFieldsInline(rI, rD);
         }
         for (int i = 1; i < len; ++i) {
-            src1[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src2[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src3[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src4[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src1[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src2[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src3[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src4[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test21(src1, dst1);
         test21(src2, dst2);
@@ -755,12 +753,12 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2[]  dst2 = new MyValue2[8];
         MyValue2.ref[] dst3 = new MyValue2.ref[8];
         MyValue2[]  dst4 = new MyValue2[8];
-        src2[0] = MyValue2.createWithFieldsInline(rI, true);
+        src2[0] = MyValue2.createWithFieldsInline(rI, rD);
         for (int i = 1; i < 8; ++i) {
-            src1[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src2[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src3[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src4[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src1[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src2[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src3[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src4[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test25(src1, dst1);
         test25(src2, dst2);
@@ -858,7 +856,7 @@ public class TestNullableArrays extends InlineTypeTest {
     }
 
     // non escaping allocations
-    // TODO ZGC does not support the clone intrinsic, remove this once JDK-8232896 is fixed
+    // TODO 8252027: Make sure this is optimized with ZGC
     @Test(valid = ZGCOff, failOn = ALLOC + ALLOCA + LOOP + LOAD + STORE + TRAP)
     @Test(valid = ZGCOn)
     public MyValue2.ref test28() {
@@ -870,7 +868,7 @@ public class TestNullableArrays extends InlineTypeTest {
 
     @DontCompile
     public void test28_verifier(boolean warmup) {
-        MyValue2 v = MyValue2.createWithFieldsInline(rI, false);
+        MyValue2 v = MyValue2.createWithFieldsInline(rI, rD);
         MyValue2.ref result = test28();
         Asserts.assertEQ(result, null);
     }
@@ -889,8 +887,8 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src1 = new MyValue2.ref[10];
         MyValue2.val[] src2 = new MyValue2.val[10];
         for (int i = 0; i < 10; ++i) {
-            src1[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src2[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src1[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src2[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         MyValue2.ref v = test29(src1);
         Asserts.assertEQ(src1[0].hash(), v.hash());
@@ -916,8 +914,8 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src1 = new MyValue2.ref[10];
         MyValue2.val[] src2 = new MyValue2.val[10];
         for (int i = 0; i < 10; ++i) {
-            src1[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
-            src2[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src1[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            src2[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         MyValue2.ref v = test30(src1, !warmup);
         Asserts.assertEQ(src1[0].hash(), v.hash());
@@ -934,9 +932,9 @@ public class TestNullableArrays extends InlineTypeTest {
     public long test31(boolean b, boolean deopt) {
         MyValue2.ref[] src = new MyValue2.ref[1];
         if (b) {
-            src[0] = MyValue2.createWithFieldsInline(rI, true);
+            src[0] = MyValue2.createWithFieldsInline(rI, rD);
         } else {
-            src[0] = MyValue2.createWithFieldsInline(rI, false);
+            src[0] = MyValue2.createWithFieldsInline(rI+1, rD+1);
         }
         if (deopt) {
             // uncommon trap
@@ -947,10 +945,10 @@ public class TestNullableArrays extends InlineTypeTest {
 
     @DontCompile
     public void test31_verifier(boolean warmup) {
-        MyValue2 v1 = MyValue2.createWithFieldsInline(rI, true);
+        MyValue2 v1 = MyValue2.createWithFieldsInline(rI, rD);
         long result1 = test31(true, !warmup);
         Asserts.assertEQ(result1, v1.hash());
-        MyValue2 v2 = MyValue2.createWithFieldsInline(rI, false);
+        MyValue2 v2 = MyValue2.createWithFieldsInline(rI+1, rD+1);
         long result2 = test31(false, !warmup);
         Asserts.assertEQ(result2, v2.hash());
     }
@@ -1135,7 +1133,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[len];
         MyValue2.ref[] dst = new MyValue2.ref[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test36(src, dst);
         verify(src, dst);
@@ -1156,7 +1154,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[len];
         MyValue2.ref[] dst = new MyValue2.ref[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test37(src, dst);
         verify(src, dst);
@@ -1178,7 +1176,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[len];
         MyValue2.ref[] dst = new MyValue2.ref[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test38(src, dst);
         verify(dst, src);
@@ -1205,7 +1203,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[len];
         Object[] dst = new Object[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test39(src, dst);
         verify(src, dst);
@@ -1227,7 +1225,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[len];
         MyValue2.ref[] dst = new MyValue2.ref[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test40(src, dst);
         verify(dst, src);
@@ -1254,7 +1252,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[len];
         Object[] dst = new Object[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test41(src, dst);
         verify(src, dst);
@@ -1275,7 +1273,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[len];
         Object[] dst = new Object[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test42(src, dst);
         verify(src, dst);
@@ -1318,7 +1316,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[8];
         MyValue2.ref[] dst = new MyValue2.ref[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test44(src, dst);
         verify(src, dst);
@@ -1338,7 +1336,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[8];
         MyValue2.ref[] dst = new MyValue2.ref[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test45(src, dst);
         verify(src, dst);
@@ -1359,7 +1357,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[8];
         MyValue2.ref[] dst = new MyValue2.ref[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test46(src, dst);
         verify(dst, src);
@@ -1385,7 +1383,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[8];
         Object[] dst = new Object[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test47(src, dst);
         verify(src, dst);
@@ -1406,7 +1404,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[8];
         MyValue2.ref[] dst = new MyValue2.ref[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test48(src, dst);
         verify(dst, src);
@@ -1432,7 +1430,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[8];
         Object[] dst = new Object[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test49(src, dst);
         verify(src, dst);
@@ -1452,7 +1450,7 @@ public class TestNullableArrays extends InlineTypeTest {
         Object[] src = new Object[8];
         Object[] dst = new Object[8];
         for (int i = 1; i < 8; ++i) {
-            src[i] = MyValue2.createWithFieldsInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
         }
         test50(src, dst);
         verify(src, dst);
@@ -1848,7 +1846,7 @@ public class TestNullableArrays extends InlineTypeTest {
         MyValue2.ref[] src = new MyValue2.ref[len];
         MyValue2.ref[] dst = new MyValue2.ref[len];
         for (int i = 1; i < len; ++i) {
-            src[i] = MyValue2.createWithFieldsDontInline(rI, (i % 2) == 0);
+            src[i] = MyValue2.createWithFieldsDontInline(rI+i, rD+i);
         }
         System.arraycopy(src, 0, dst, 0, src.length);
         for (int i = 0; i < len; ++i) {


### PR DESCRIPTION
- Profiling of callee methods depends on execution order of unit tests. Execute tests in random order to increase coverage.
- At double field to test inline type
- Verify that expected NPEs are always thrown
- Fixed a test bug in TestLWorldProfiling.java (array element is not re-initialized and therefore NULL)
- Refactoring and removal of old, non-applicable TODOs
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252040](https://bugs.openjdk.java.net/browse/JDK-8252040): [lworld] Execute compiler unit tests in random order


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/154/head:pull/154`
`$ git checkout pull/154`
