### PR TITLE
8251527: CTW: C2 (Shenandoah) compilation fails with SEGV due to unhandled catchproj == NULL

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1267,14 +1267,14 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
   Node* phi = PhiNode::make_blank(region, n->in(1));
   for (uint i = 1; i < region->req(); i++) {
     Node* in = obj->in(i);
-    Node* ctrl = get_ctrl(in);
+    Node* ctrl = region->in(i);
     if (addr->in(AddPNode::Base) != obj) {
       Node* cast = addr->in(AddPNode::Base);
       assert(cast->Opcode() == Op_CastPP && cast->in(0) != NULL, "inconsistent subgraph");
       Node* cast_clone = cast->clone();
-      cast_clone->set_req(0, region->in(i));
+      cast_clone->set_req(0, ctrl);
       cast_clone->set_req(1, in);
-      register_new_node(cast_clone, region->in(i));
+      register_new_node(cast_clone, ctrl);
       _igvn.set_type(cast_clone, cast_clone->Value(&_igvn));
       in = cast_clone;
     }


### PR DESCRIPTION
In PhaseIdealLoop::flatten_array_element_type_check(), when pushing:

(LoadKlass (AddP (CastPP ...

through a Phi, the control of CastPP clone is set to region->in(i) but
the AddP clone control is set to get_ctrl(phi->in(i)) which can be
above region->in(i) while the AddP is below the CastPP. Fix is to use
region->in(i) for all clones.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251527](https://bugs.openjdk.java.net/browse/JDK-8251527): CTW: C2 (Shenandoah) compilation fails with SEGV due to unhandled catchproj == NULL


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/156/head:pull/156`
`$ git checkout pull/156`
