### PR TITLE
8252112: [lworld] Deoptimization fails when trying to re-assign empty inline type elements of a flattened array

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1388,6 +1388,9 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
 void Deoptimization::reassign_flat_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, flatArrayOop obj, FlatArrayKlass* vak, TRAPS) {
   InlineKlass* vk = vak->element_klass();
   assert(vk->flatten_array(), "should only be used for flattened inline type arrays");
+  if (vk->is_empty_inline_type()) {
+    return; // No fields to re-assign
+  }
   // Adjust offset to omit oop header
   int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - InlineKlass::cast(vk)->first_field_offset();
   // Initialize all elements of the flattened inline type array

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3289,4 +3289,20 @@ public class TestLWorld extends InlineTypeTest {
         boolean res = test118(MyValueEmpty.default, MyValueEmpty.default, new MyValueEmpty());
         Asserts.assertTrue(res);
     }
+
+    // Test re-allocation of empty inline type array during deoptimization
+    @Test
+    public void test119(boolean deopt) {
+        MyValueEmpty[] arr = new MyValueEmpty[]{MyValueEmpty.default};
+        if (deopt) {
+            // uncommon trap
+            WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test119"));
+        }
+        Asserts.assertEquals(arr[0], MyValueEmpty.default);
+    }
+
+    @DontCompile
+    public void test119_verifier(boolean warmup) {
+        test119(!warmup);
+    }
 }


### PR DESCRIPTION
Deoptimization::reassign_flat_array_elements needs to handle flat arrays with empty inline type elements.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252112](https://bugs.openjdk.java.net/browse/JDK-8252112): [lworld] Deoptimization fails when trying to re-assign empty inline type elements of a flattened array


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/158/head:pull/158`
`$ git checkout pull/158`
