### PR TITLE
8252111: [lworld] C2 intrinsic needs to handle unsafe access to non-flattened field of constant inline type holder

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2490,7 +2490,6 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
 
   if (base->is_InlineType()) {
     InlineTypeNode* vt = base->as_InlineType();
-
     if (is_store) {
       if (!vt->is_allocated(&_gvn) || !_gvn.type(vt)->is_inlinetype()->larval()) {
         return false;
@@ -2504,18 +2503,15 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
           return false;
         }
 
-        ciField* f = vk->get_non_flattened_field_by_offset((int)off);
-
-        if (f != NULL) {
-          BasicType bt = f->layout_type();
-          if (bt == T_ARRAY || bt == T_NARROWOOP) {
+        ciField* field = vk->get_non_flattened_field_by_offset(off);
+        if (field != NULL) {
+          BasicType bt = field->layout_type();
+          if (bt == T_ARRAY || bt == T_NARROWOOP || (bt == T_INLINE_TYPE && !field->is_flattened())) {
             bt = T_OBJECT;
           }
-          if (bt == type) {
-            if (bt != T_INLINE_TYPE || f->type() == inline_klass) {
-              set_result(vt->field_value_by_offset((int)off, false));
-              return true;
-            }
+          if (bt == type && (bt != T_INLINE_TYPE || field->type() == inline_klass)) {
+            set_result(vt->field_value_by_offset(off, false));
+            return true;
           }
         }
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1027,4 +1027,21 @@ public class TestIntrinsics extends InlineTypeTest {
         MyValue1 res = test54(v.setX(v, 0));
         Asserts.assertEQ(res.hash(), v.hash());
     }
+
+    static final MyValue1 test55_vt = MyValue1.createWithFieldsInline(rI, rL);
+
+    // Same as test30 but with constant field holder
+    @Test(failOn=CALL_Unsafe)
+    public MyValue2 test55() {
+        if (V1_FLATTENED) {
+            return U.getValue(test55_vt, V1_OFFSET, MyValue2.val.class);
+        }
+        return (MyValue2)U.getReference(test55_vt, V1_OFFSET);
+    }
+
+    @DontCompile
+    public void test55_verifier(boolean warmup) {
+        MyValue2 res = test55();
+        Asserts.assertEQ(res.hash(), vfinal.v1.hash());
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1042,6 +1042,6 @@ public class TestIntrinsics extends InlineTypeTest {
     @DontCompile
     public void test55_verifier(boolean warmup) {
         MyValue2 res = test55();
-        Asserts.assertEQ(res.hash(), vfinal.v1.hash());
+        Asserts.assertEQ(res.hash(), test55_vt.v1.hash());
     }
 }


### PR DESCRIPTION
The C2 intrinsic for unsafe accesses fails to determine the field value when accessing a non-flattened field of a constant inline type holder.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252111](https://bugs.openjdk.java.net/browse/JDK-8252111): [lworld] C2 intrinsic needs to handle unsafe access to non-flattened field of constant inline type holder


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/159/head:pull/159`
`$ git checkout pull/159`
