### PR TITLE
8252110: [lworld] C2 compilation crashes with SIGSEGV in AddPNode::Value

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2955,11 +2955,22 @@ Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
 
 // Profile-driven exact type check:
 Node* GraphKit::type_check_receiver(Node* receiver, ciKlass* klass,
-                                    float prob,
-                                    Node* *casted_receiver) {
+                                    float prob, Node* *casted_receiver) {
+  Node* fail = top();
+  const Type* rec_t = _gvn.type(receiver);
+  if (false && rec_t->isa_inlinetype()) {
+    if (klass->equals(rec_t->inline_klass())) {
+      (*casted_receiver) = receiver; // Always passes
+    } else {
+      (*casted_receiver) = top();    // Always fails
+      fail = control();
+      set_control(top());
+    }
+    return fail;
+  }
   const TypeKlassPtr* tklass = TypeKlassPtr::make(klass);
   Node* recv_klass = load_object_klass(receiver);
-  Node* fail = type_check(recv_klass, tklass, prob);
+  fail = type_check(recv_klass, tklass, prob);
   const TypeOopPtr* recv_xtype = tklass->as_instance_type();
   assert(recv_xtype->klass_is_exact(), "");
 


### PR DESCRIPTION
The receiver type check emitted by the PredictedCallGenerator needs to handle InlineTypeNodes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252110](https://bugs.openjdk.java.net/browse/JDK-8252110): [lworld] C2 compilation crashes with SIGSEGV in AddPNode::Value


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/160/head:pull/160`
`$ git checkout pull/160`
