### PR TITLE
8252109: [lworld] C2 compilation fails with assert(!has_phi_inputs(region)) failed: already cloned with phis

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -34,7 +34,6 @@
 // Clones the inline type to handle control flow merges involving multiple inline types.
 // The inputs are replaced by PhiNodes to represent the merged values for the given region.
 InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* region) {
-  assert(!has_phi_inputs(region), "already cloned with phis");
   InlineTypeBaseNode* vt = clone()->as_InlineTypeBase();
 
   // Create a PhiNode for merging the oop values


### PR DESCRIPTION
Assert is too strong because during a PhiNode::Ideal transformation, some inputs of an InlineTypeNode might already be PhiNodes  of the same region.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252109](https://bugs.openjdk.java.net/browse/JDK-8252109): [lworld] C2 compilation fails with assert(!has_phi_inputs(region)) failed: already cloned with phis


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/161/head:pull/161`
`$ git checkout pull/161`
