### PR TITLE
8252227: [lworld] Merge of jdk-16+5 broke compiler/arraycopy/TestEliminateArrayCopy.java

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4647,6 +4647,7 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
 
       BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
       if (bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, BarrierSetC2::Parsing) &&
+          UseFlatArray && obj_type->klass()->can_be_inline_array_klass() &&
           (!obj_type->isa_aryptr() || !obj_type->is_aryptr()->is_not_flat())) {
         // Flattened inline type array may have object field that would require a
         // write barrier. Conservatively, go to slow path.


### PR DESCRIPTION
Clone intrinsic should not emit flat array guard if src object can't be an array or flattening is completely disabled.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252227](https://bugs.openjdk.java.net/browse/JDK-8252227): [lworld] Merge of jdk-16+5 broke compiler/arraycopy/TestEliminateArrayCopy.java


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/163/head:pull/163`
`$ git checkout pull/163`
