### PR TITLE
8252633: [lworld] Multiple compiler test failures after merging jdk-16+7

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1207,8 +1207,8 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   // Scalarized c2i adapter with non-scalarized receiver (i.e., don't pack receiver)
   address c2i_inline_ro_entry = __ pc();
   if (regs_cc != regs_cc_ro) {
-    Label inline_ro_skip_fixup;
-    gen_c2i_adapter(masm, sig_cc_ro, regs_cc_ro, inline_ro_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
+    gen_c2i_adapter(masm, sig_cc_ro, regs_cc_ro, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
+    skip_fixup.reset();
   }
 
   // Scalarized c2i adapter


### PR DESCRIPTION
Fixed incorrect merge (skip_fixup label is not bound anymore to code in gen_c2i_adapter).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252633](https://bugs.openjdk.java.net/browse/JDK-8252633): [lworld] Multiple compiler test failures after merging jdk-16+7


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/170/head:pull/170`
`$ git checkout pull/170`
