### PR TITLE
8252651: [lworld] Clear the instance klass mirror for inline type

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1196,7 +1196,7 @@ oop java_lang_Class::archive_mirror(Klass* k, TRAPS) {
 
   if (k->is_inline_klass()) {
     // Inline types have a val type mirror and a ref type mirror. Don't handle this for now. TODO:CDS
-    k->set_java_mirror(Handle());
+    k->clear_java_mirror_handle();
     return NULL;
   }
 


### PR DESCRIPTION
clear the mirror, don't set empty handle
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252651](https://bugs.openjdk.java.net/browse/JDK-8252651): [lworld] Clear the instance klass mirror for inline type


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/171/head:pull/171`
`$ git checkout pull/171`
