### PR TITLE
8252650: [lworld] Merge of jdk-16+8 breaks debug build GC gc/TestObjectAlignment.java

### DIFF
--- a/src/hotspot/share/runtime/biasedLocking.cpp
+++ b/src/hotspot/share/runtime/biasedLocking.cpp
@@ -910,7 +910,6 @@ void BiasedLocking::preserve_marks() {
 
   Thread* cur = Thread::current();
   ResourceMark rm(cur);
-  HandleMark hm(cur);
 
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thread = jtiwh.next(); ) {
     if (thread->has_last_Java_frame()) {


### PR DESCRIPTION
Apply in advance: 8251118: BiasedLocking::preserve_marks should not have a HandleMark
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252650](https://bugs.openjdk.java.net/browse/JDK-8252650): [lworld]  Merge of jdk-16+8 breaks debug build GC gc/TestObjectAlignment.java


### Reviewers
 * Harold Seigel ([hseigel](@hseigel) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/172/head:pull/172`
`$ git checkout pull/172`
