### PR TITLE
8252506: [lworld] Multiple issues with C2's arraycopy intrinsic

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3302,14 +3302,6 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     return;
   }
 
-  if (flags & LIR_OpArrayCopy::src_inlinetype_check) {
-    arraycopy_inlinetype_check(src, tmp, stub, false, (flags & LIR_OpArrayCopy::src_null_check));
-  }
-
-  if (flags & LIR_OpArrayCopy::dst_inlinetype_check) {
-    arraycopy_inlinetype_check(dst, tmp, stub, true, (flags & LIR_OpArrayCopy::dst_null_check));
-  }
-
   // if we don't know anything, just go through the generic arraycopy
   if (default_type == NULL) {
     // save outgoing arguments on stack in case call to System.arraycopy is needed
@@ -3401,6 +3393,14 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
     __ bind(*stub->continuation());
     return;
+  }
+
+  // Handle inline type arrays
+  if (flags & LIR_OpArrayCopy::src_inlinetype_check) {
+    arraycopy_inlinetype_check(src, tmp, stub, false, (flags & LIR_OpArrayCopy::src_null_check));
+  }
+  if (flags & LIR_OpArrayCopy::dst_inlinetype_check) {
+    arraycopy_inlinetype_check(dst, tmp, stub, true, (flags & LIR_OpArrayCopy::dst_null_check));
   }
 
   assert(default_type != NULL && default_type->is_array_klass() && default_type->is_loaded(), "must be true at this point");

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -2641,10 +2641,10 @@ class StubGenerator: public StubCodeGenerator {
 
     const int lh_offset = in_bytes(Klass::layout_helper_offset());
 
-    // Handle objArrays completely differently...
+    // Handle objArrays (including non-flat, null-free inline type arrays) completely differently...
     const jint objArray_lh = Klass::array_layout_helper(T_OBJECT);
     __ cmpl(Address(r10_src_klass, lh_offset), objArray_lh);
-    __ jcc(Assembler::equal, L_objArray);
+    __ jcc(Assembler::greaterEqual, L_objArray);
 
     //  if (src->klass() != dst->klass()) return -1;
     __ load_klass(rax, dst, rklass_tmp);
@@ -2653,6 +2653,10 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register rax_lh = rax;  // layout helper
     __ movl(rax_lh, Address(r10_src_klass, lh_offset));
+
+    // Check for flat inline type array
+    __ testl(rax_lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ jcc(Assembler::notZero, L_failed);
 
     //  if (!src->is_Array()) return -1;
     __ cmpl(rax_lh, Klass::_lh_neutral_value);
@@ -2663,8 +2667,10 @@ class StubGenerator: public StubCodeGenerator {
     {
       BLOCK_COMMENT("assert primitive array {");
       Label L;
-      __ cmpl(rax_lh, (Klass::_lh_array_tag_type_value << Klass::_lh_array_tag_shift));
-      __ jcc(Assembler::greaterEqual, L);
+      __ movl(rklass_tmp, rax_lh);
+      __ sarl(rklass_tmp, Klass::_lh_array_tag_shift);
+      __ cmpl(rklass_tmp, Klass::_lh_array_tag_type_value);
+      __ jcc(Assembler::equal, L);
       __ stop("must be a primitive array");
       __ bind(L);
       BLOCK_COMMENT("} assert primitive array done");
@@ -2766,8 +2772,22 @@ class StubGenerator: public StubCodeGenerator {
     // live at this point:  r10_src_klass, r11_length, rax (dst_klass)
     {
       // Before looking at dst.length, make sure dst is also an objArray.
+      // This check also fails for flat/null-free arrays which are not supported.
       __ cmpl(Address(rax, lh_offset), objArray_lh);
       __ jcc(Assembler::notEqual, L_failed);
+
+#ifdef ASSERT
+      {
+        BLOCK_COMMENT("assert not null-free array {");
+        Label L;
+        __ movl(rklass_tmp, Address(rax, lh_offset));
+        __ testl(rklass_tmp, Klass::_lh_null_free_bit_inplace);
+        __ jcc(Assembler::zero, L);
+        __ stop("unexpected null-free array");
+        __ bind(L);
+        BLOCK_COMMENT("} assert not null-free array");
+      }
+#endif
 
       // It is safe to examine both src.length and dst.length.
       arraycopy_range_checks(src, src_pos, dst, dst_pos, r11_length,

--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -270,12 +270,10 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     BasicType src_elem  = ary_src->klass()->as_array_klass()->element_type()->basic_type();
     BasicType dest_elem = ary_dest->klass()->as_array_klass()->element_type()->basic_type();
-    if (src_elem  == T_ARRAY ||
-        (src_elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
+    if (src_elem == T_ARRAY || (src_elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
       src_elem  = T_OBJECT;
     }
-    if (dest_elem == T_ARRAY ||
-        (dest_elem == T_INLINE_TYPE && ary_dest->klass()->is_obj_array_klass())) {
+    if (dest_elem == T_ARRAY || (dest_elem == T_INLINE_TYPE && ary_dest->klass()->is_obj_array_klass())) {
       dest_elem = T_OBJECT;
     }
 
@@ -333,8 +331,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     adr_dest = phase->transform(new AddPNode(base_dest, base_dest, dest_offset));
 
     BasicType elem = ary_src->klass()->as_array_klass()->element_type()->basic_type();
-    if (elem == T_ARRAY ||
-        (elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
+    if (elem == T_ARRAY || (elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
       elem = T_OBJECT;
     }
 
@@ -342,6 +339,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
     if (bs->array_copy_requires_gc_barriers(true, elem, true, BarrierSetC2::Optimization) ||
         (elem == T_INLINE_TYPE && ary_src->elem()->inline_klass()->contains_oops() &&
          bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, BarrierSetC2::Optimization))) {
+      // It's an object array copy but we can't emit the card marking that is needed
       return false;
     }
 

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -855,6 +855,7 @@ class GraphKit : public Phase {
 
   Node* is_inline_type(Node* obj);
   Node* is_non_flattened_array(Node* ary);
+  Node* check_null_free_bit(Node* klass, bool null_free);
   Node* is_nullable_array(Node* ary);
   Node* gen_inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace = false);
   Node* load_lh_array_tag(Node* kls);

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -134,7 +134,8 @@ private:
 
   // More helper methods for array copy
   Node* generate_nonpositive_guard(Node** ctrl, Node* index, bool never_negative);
-  Node* generate_flattened_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
+  Node* generate_flat_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
+  Node* generate_null_free_array_guard(Node** ctrl, Node* array, RegionNode* region);
   Node* generate_object_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
   Node* generate_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region, jint lh_con);
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -221,6 +221,7 @@ public abstract class InlineTypeTest {
     protected static final String STORE_UNKNOWN_INLINE = "(.*call_leaf,runtime  store_unknown_inline.*" + END;
     protected static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static  wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
     protected static final String INTRINSIC_SLOW_PATH = "(.*call,static  wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;
+    protected static final String CLONE_INTRINSIC_SLOW_PATH = "(.*call,static.*java.lang.Object::clone.*" + END;
     protected static final String CLASS_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*class_check" + END;
     protected static final String NULL_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*null_check" + END;
     protected static final String RANGE_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*range_check" + END;
@@ -228,6 +229,8 @@ public abstract class InlineTypeTest {
     protected static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
     protected static final String MEMBAR = START + "MemBar" + MID + END;
     protected static final String CHECKCAST_ARRAY = "(cmp.*precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue.*" + END;
+    protected static final String CHECKCAST_ARRAYCOPY = "(.*call_leaf_nofp,runtime  checkcast_arraycopy.*" + END;
+    protected static final String JLONG_ARRAYCOPY = "(.*call_leaf_nofp,runtime  jlong_disjoint_arraycopy.*" + END;
 
     public static String[] concat(String prefix[], String... extra) {
         ArrayList<String> list = new ArrayList<String>();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8252506
+ * @summary Verify that arraycopy intrinsics properly handle flat inline type arrays with oop fields.
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
+ *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::create*
+ *                   -Xbatch
+ *                   compiler.valhalla.inlinetypes.TestArrayCopyWithOops
+ * @run main/othervm -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
+ *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::create*
+ *                   -Xbatch -XX:FlatArrayElementMaxSize=0
+ *                   compiler.valhalla.inlinetypes.TestArrayCopyWithOops
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.util.Arrays;
+
+import jdk.test.lib.Asserts;
+
+public class TestArrayCopyWithOops {
+    static final int LEN = 200;
+
+    static class MyObject {
+        long val = Integer.MAX_VALUE;
+    }
+
+    static inline class ManyOops {
+        MyObject o1 = new MyObject();
+        MyObject o2 = new MyObject();
+        MyObject o3 = new MyObject();
+        MyObject o4 = new MyObject();
+
+        long hash() {
+            return o1.val + o2.val + o3.val + o4.val;
+        }
+    }
+
+    static ManyOops[] createArrayInline() {
+        ManyOops[] array = new ManyOops[LEN];
+        for (int i = 0; i < LEN; ++i) {
+            array[i] = new ManyOops();
+        }
+        return array;
+    }
+
+    static Object[] createArrayObject() {
+        return createArrayInline();
+    }
+
+    static Object createObject() {
+        return createArrayInline();
+    }
+
+    // System.arraycopy tests
+
+    static void test1(ManyOops[] dst) {
+        System.arraycopy(createArrayInline(), 0, dst, 0, LEN);
+    }
+
+    static void test2(Object[] dst) {
+        System.arraycopy(createArrayObject(), 0, dst, 0, LEN);
+    }
+
+    static void test3(ManyOops[] dst) {
+        System.arraycopy(createArrayObject(), 0, dst, 0, LEN);
+    }
+
+    static void test4(Object[] dst) {
+        System.arraycopy(createArrayInline(), 0, dst, 0, LEN);
+    }
+
+    // System.arraycopy tests (tightly coupled with allocation of dst array)
+
+    static Object[] test5() {
+        ManyOops[] dst = new ManyOops[LEN];
+        System.arraycopy(createArrayInline(), 0, dst, 0, LEN);
+        return dst;
+    }
+
+    static Object[] test6() {
+        Object[] dst = new Object[LEN];
+        System.arraycopy(createArrayObject(), 0, dst, 0, LEN);
+        return dst;
+    }
+
+    static Object[] test7() {
+        ManyOops[] dst = new ManyOops[LEN];
+        System.arraycopy(createArrayObject(), 0, dst, 0, LEN);
+        return dst;
+    }
+
+    static Object[] test8() {
+        Object[] dst = new Object[LEN];
+        System.arraycopy(createArrayInline(), 0, dst, 0, LEN);
+        return dst;
+    }
+
+    // Arrays.copyOf tests
+
+    static Object[] test9() {
+        return Arrays.copyOf(createArrayInline(), LEN, ManyOops[].class);
+    }
+
+    static Object[] test10() {
+        return Arrays.copyOf(createArrayObject(), LEN, Object[].class);
+    }
+
+    static Object[] test11() {
+        return Arrays.copyOf(createArrayInline(), LEN, ManyOops[].class);
+    }
+
+    static Object[] test12() {
+        return Arrays.copyOf(createArrayObject(), LEN, Object[].class);
+    }
+
+    // System.arraycopy test using generic_copy stub
+
+    static void test13(Object dst) {
+        System.arraycopy(createObject(), 0, dst, 0, LEN);
+    }
+
+    static void produceGarbage() {
+        for (int i = 0; i < 100; ++i) {
+            Object[] arrays = new Object[1024];
+            for (int j = 0; j < arrays.length; j++) {
+                arrays[i] = new int[1024];
+            }
+        }
+        System.gc();
+    }
+
+    public static void main(String[] args) {
+        ManyOops[] dst1 = createArrayInline();
+        ManyOops[] dst2 = createArrayInline();
+        ManyOops[] dst3 = createArrayInline();
+        ManyOops[] dst4 = createArrayInline();
+        ManyOops[] dst13 = createArrayInline();
+
+        // Warmup runs to trigger compilation
+        for (int i = 0; i < 50_000; ++i) {
+            test1(dst1);
+            test2(dst2);
+            test3(dst3);
+            test4(dst4);
+            test5();
+            test6();
+            test7();
+            test8();
+            test9();
+            test10();
+            test11();
+            test12();
+            test13(dst13);
+        }
+
+        // Trigger GC to make sure dst arrays are moved to old gen
+        produceGarbage();
+
+        // Move data from flat src to flat dest
+        test1(dst1);
+        test2(dst2);
+        test3(dst3);
+        test4(dst4);
+        Object[] dst5 = test5();
+        Object[] dst6 = test6();
+        Object[] dst7 = test7();
+        Object[] dst8 = test8();
+        Object[] dst9 = test9();
+        Object[] dst10 = test10();
+        Object[] dst11 = test11();
+        Object[] dst12 = test12();
+        test13(dst13);
+
+        // Trigger GC again to make sure that the now dead src arrays are collected.
+        // MyObjects should be kept alive via oop references from the dst array.
+        produceGarbage();
+
+        // Verify content
+        long expected = 4L*Integer.MAX_VALUE;
+        for (int i = 0; i < LEN; ++i) {
+            Asserts.assertEquals(dst1[i].hash(), expected);
+            Asserts.assertEquals(dst2[i].hash(), expected);
+            Asserts.assertEquals(dst3[i].hash(), expected);
+            Asserts.assertEquals(dst4[i].hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst5[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst7[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst8[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst8[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst9[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst10[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst11[i]).hash(), expected);
+            Asserts.assertEquals(((ManyOops)dst12[i]).hash(), expected);
+            Asserts.assertEquals(dst13[i].hash(), expected);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -597,13 +597,18 @@ public class TestArrays extends InlineTypeTest {
     public void test24_verifier(boolean warmup) {
         int len = Math.abs(rI) % 10;
         MyValue1[] src = new MyValue1[len];
-        MyValue1[] dst = new MyValue1[len];
+        MyValue1[] dst1 = new MyValue1[len];
+        Object[] dst2 = new Object[len];
         for (int i = 0; i < len; ++i) {
             src[i] = MyValue1.createWithFieldsInline(rI, rL);
         }
-        test24(src, dst);
+        test24(src, dst1);
         for (int i = 0; i < len; ++i) {
-            Asserts.assertEQ(src[i].hash(), dst[i].hash());
+            Asserts.assertEQ(src[i].hash(), dst1[i].hash());
+        }
+        test24(src, dst2);
+        for (int i = 0; i < len; ++i) {
+            Asserts.assertEQ(src[i].hash(), ((MyValue1)dst2[i]).hash());
         }
     }
 
@@ -842,8 +847,14 @@ public class TestArrays extends InlineTypeTest {
     }
 
     static void verify(Object[] src, Object[] dst) {
-        for (int i = 0; i < src.length; ++i) {
-            Asserts.assertEQ(((MyInterface)src[i]).hash(), ((MyInterface)dst[i]).hash());
+        if (src instanceof MyInterface[] && dst instanceof MyInterface[]) {
+            for (int i = 0; i < src.length; ++i) {
+                Asserts.assertEQ(((MyInterface)src[i]).hash(), ((MyInterface)dst[i]).hash());
+            }
+        } else {
+            for (int i = 0; i < src.length; ++i) {
+                Asserts.assertEQ(src[i], dst[i]);
+            }
         }
     }
 
@@ -895,15 +906,18 @@ public class TestArrays extends InlineTypeTest {
     public void test35_verifier(boolean warmup) {
         int len = Math.abs(rI) % 10;
         MyValue1[] src = new MyValue1[len];
-        MyValue1[] dst = new MyValue1[len];
+        MyValue1[] dst1 = new MyValue1[len];
+        Object[] dst2 = new Object[len];
         for (int i = 0; i < len; ++i) {
             src[i] = MyValue1.createWithFieldsInline(rI, rL);
         }
-        test35(src, dst, src.length);
-        verify(src, dst);
+        test35(src, dst1, src.length);
+        verify(src, dst1);
+        test35(src, dst2, src.length);
+        verify(src, dst2);
         if (compile_and_run_again_if_deoptimized(warmup, "TestArrays::test35")) {
-            test35(src, dst, src.length);
-            verify(src, dst);
+            test35(src, dst1, src.length);
+            verify(src, dst1);
         }
     }
 
@@ -1250,7 +1264,8 @@ public class TestArrays extends InlineTypeTest {
     @Test
     public MyValue1[] test51(MyValue1[] va) {
         // TODO 8244562: Remove cast as workaround once javac is fixed
-        return (MyValue1[])Arrays.copyOf(va, va.length, MyValue1[].class);
+        Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
+        return (MyValue1[]) res;
     }
 
     @DontCompile
@@ -1269,7 +1284,8 @@ public class TestArrays extends InlineTypeTest {
     @Test
     public MyValue1[] test52() {
         // TODO 8244562: Remove cast as workaround once javac is fixed
-        return (MyValue1[])Arrays.copyOf(test52_va, 8, MyValue1[].class);
+        Object[] res = Arrays.copyOf(test52_va, 8, MyValue1[].class);
+        return (MyValue1[]) res;
     }
 
     @DontCompile
@@ -1284,7 +1300,8 @@ public class TestArrays extends InlineTypeTest {
     @Test
     public MyValue1[] test53(Object[] va) {
         // TODO 8244562: Remove cast as workaround once javac is fixed
-        return (MyValue1[])Arrays.copyOf(va, va.length, MyValue1[].class);
+        Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
+        return (MyValue1[]) res;
     }
 
     @DontCompile
@@ -1333,7 +1350,8 @@ public class TestArrays extends InlineTypeTest {
     @Test
     public MyValue1[] test56(Object[] va) {
         // TODO 8244562: Remove cast as workaround once javac is fixed
-        return (MyValue1[])Arrays.copyOf(va, va.length, MyValue1[].class);
+        Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
+        return (MyValue1[]) res;
     }
 
     @DontCompile
@@ -1690,7 +1708,7 @@ public class TestArrays extends InlineTypeTest {
         try {
             test73(arr, v0, v1);
             throw new RuntimeException("ArrayStoreException expected");
-        } catch (ArrayStoreException t) {
+        } catch (ArrayStoreException e) {
             // expected
         }
         Asserts.assertEQ(arr[0].hash(), v0.hash());
@@ -2446,5 +2464,524 @@ public class TestArrays extends InlineTypeTest {
         NotFlattenable[] array2 = new NotFlattenable[1];
         Asserts.assertTrue(test101(array1));
         Asserts.assertFalse(test101(array2));
+    }
+
+    static final MyValue2[] val_src = new MyValue2[8];
+    static final MyValue2[] val_dst = new MyValue2[8];
+    static final Object[]   obj_src = new Object[8];
+    static final Object[]   obj_null_src = new Object[8];
+    static final Object[]   obj_dst = new Object[8];
+
+    static Object get_val_src() { return val_src; }
+    static Object get_val_dst() { return val_dst; }
+    static Class get_val_class() { return MyValue2[].class; }
+    static Class get_int_class() { return Integer[].class; }
+    static Object get_obj_src() { return obj_src; }
+    static Object get_obj_null_src() { return obj_null_src; }
+    static Object get_obj_dst() { return obj_dst; }
+    static Class get_obj_class() { return Object[].class; }
+
+    static {
+        for (int i = 0; i < 8; ++i) {
+            val_src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            obj_src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+            obj_null_src[i] = MyValue2.createWithFieldsInline(rI+i, rD+i);
+        }
+        obj_null_src[0] = null;
+    }
+
+    // Arraycopy with constant source and destination arrays
+    @Test(valid = InlineTypeArrayFlattenOn, match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH)
+    public void test102() {
+        System.arraycopy(val_src, 0, obj_dst, 0, 8);
+    }
+
+    @DontCompile
+    public void test102_verifier(boolean warmup) {
+        test102();
+        verify(val_src, obj_dst);
+    }
+
+    // Same as test102 but with MyValue2[] dst
+    @Test(failOn = INTRINSIC_SLOW_PATH)
+    public void test103() {
+        System.arraycopy(val_src, 0, val_dst, 0, 8);
+    }
+
+    @DontCompile
+    public void test103_verifier(boolean warmup) {
+        test103();
+        verify(val_src, val_dst);
+    }
+
+    // Same as test102 but with Object[] src
+    @Test(failOn = INTRINSIC_SLOW_PATH)
+    public void test104() {
+        System.arraycopy(obj_src, 0, obj_dst, 0, 8);
+    }
+
+    @DontCompile
+    public void test104_verifier(boolean warmup) {
+        test104();
+        verify(obj_src, obj_dst);
+    }
+
+    // Same as test103 but with Object[] src
+    @Test(match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    public void test105() {
+        System.arraycopy(obj_src, 0, val_dst, 0, 8);
+    }
+
+    @DontCompile
+    public void test105_verifier(boolean warmup) {
+        test105();
+        verify(obj_src, val_dst);
+    }
+
+    // Same as test103 but with Object[] src containing null
+    @Test(match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    public void test105_null() {
+        System.arraycopy(obj_null_src, 0, val_dst, 0, 8);
+    }
+
+    @DontCompile
+    public void test105_null_verifier(boolean warmup) {
+        try {
+            test105_null();
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    // Below tests are equal to test102-test105 but hide the src/dst types until
+    // after the arraycopy intrinsic is emitted (with incremental inlining).
+
+    @Test(valid = InlineTypeArrayFlattenOn, match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH)
+    public void test106() {
+        System.arraycopy(get_val_src(), 0, get_obj_dst(), 0, 8);
+    }
+
+    @DontCompile
+    public void test106_verifier(boolean warmup) {
+        test106();
+        verify(val_src, obj_dst);
+    }
+
+    // TODO 8251971: Should be optimized but we are bailing out because
+    // at parse time it looks as if src could be flat and dst could be not flat.
+    @Test(valid = InlineTypeArrayFlattenOn)
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH)
+    public void test107() {
+        System.arraycopy(get_val_src(), 0, get_val_dst(), 0, 8);
+    }
+
+    @DontCompile
+    public void test107_verifier(boolean warmup) {
+        test107();
+        verify(val_src, val_dst);
+    }
+
+    @Test(failOn = INTRINSIC_SLOW_PATH)
+    public void test108() {
+        System.arraycopy(get_obj_src(), 0, get_obj_dst(), 0, 8);
+    }
+
+    @DontCompile
+    public void test108_verifier(boolean warmup) {
+        test108();
+        verify(obj_src, obj_dst);
+    }
+
+    @Test(match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    public void test109() {
+        System.arraycopy(get_obj_src(), 0, get_val_dst(), 0, 8);
+    }
+
+    @DontCompile
+    public void test109_verifier(boolean warmup) {
+        test109();
+        verify(obj_src, val_dst);
+    }
+
+    @Test(match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    public void test109_null() {
+        System.arraycopy(get_obj_null_src(), 0, get_val_dst(), 0, 8);
+    }
+
+    @DontCompile
+    public void test109_null_verifier(boolean warmup) {
+        try {
+            test109_null();
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    // Arrays.copyOf with constant source and destination arrays
+    @Test(valid = InlineTypeArrayFlattenOn, match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test110() {
+        return Arrays.copyOf(val_src, 8, Object[].class);
+    }
+
+    @DontCompile
+    public void test110_verifier(boolean warmup) {
+        Object[] res = test110();
+        verify(val_src, res);
+    }
+
+    // Same as test110 but with MyValue2[] dst
+    @Test(failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test111() {
+        return Arrays.copyOf(val_src, 8, MyValue2[].class);
+    }
+
+    @DontCompile
+    public void test111_verifier(boolean warmup) {
+        Object[] res = test111();
+        verify(val_src, res);
+    }
+
+    // Same as test110 but with Object[] src
+    @Test(failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test112() {
+        return Arrays.copyOf(obj_src, 8, Object[].class);
+    }
+
+    @DontCompile
+    public void test112_verifier(boolean warmup) {
+        Object[] res = test112();
+        verify(obj_src, res);
+    }
+
+    // Same as test111 but with Object[] src
+    @Test(match = { INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP }, matchCount = { 1 })
+    public Object[] test113() {
+        return Arrays.copyOf(obj_src, 8, MyValue2[].class);
+    }
+
+    @DontCompile
+    public void test113_verifier(boolean warmup) {
+        Object[] res = test113();
+        verify(obj_src, res);
+    }
+
+    // Same as test111 but with Object[] src containing null
+    @Test(match = { INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP }, matchCount = { 1 })
+    public Object[] test113_null() {
+        return Arrays.copyOf(obj_null_src, 8, MyValue2[].class);
+    }
+
+    @DontCompile
+    public void test113_null_verifier(boolean warmup) {
+        try {
+            test113_null();
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    // Below tests are equal to test110-test113 but hide the src/dst types until
+    // after the arraycopy intrinsic is emitted (with incremental inlining).
+
+    @Test(valid = InlineTypeArrayFlattenOn, match = { INTRINSIC_SLOW_PATH }, matchCount = { 1 })
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test114() {
+        return Arrays.copyOf((Object[])get_val_src(), 8, get_obj_class());
+    }
+
+    @DontCompile
+    public void test114_verifier(boolean warmup) {
+        Object[] res = test114();
+        verify(val_src, res);
+    }
+
+    // TODO 8251971: Should be optimized but we are bailing out because
+    // at parse time it looks as if src could be flat and dst could be not flat
+    @Test(valid = InlineTypeArrayFlattenOn)
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test115() {
+        return Arrays.copyOf((Object[])get_val_src(), 8, get_val_class());
+    }
+
+    @DontCompile
+    public void test115_verifier(boolean warmup) {
+        Object[] res = test115();
+        verify(val_src, res);
+    }
+
+    @Test(failOn = INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP)
+    public Object[] test116() {
+        return Arrays.copyOf((Object[])get_obj_src(), 8, get_obj_class());
+    }
+
+    @DontCompile
+    public void test116_verifier(boolean warmup) {
+        Object[] res = test116();
+        verify(obj_src, res);
+    }
+
+    @Test(match = { INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP }, matchCount = { 1 })
+    public Object[] test117() {
+        return Arrays.copyOf((Object[])get_obj_src(), 8, get_val_class());
+    }
+
+    @DontCompile
+    public void test117_verifier(boolean warmup) {
+        Object[] res = test117();
+        verify(obj_src, res);
+    }
+
+    @Test(match = { INTRINSIC_SLOW_PATH + CLASS_CHECK_TRAP }, matchCount = { 1 })
+    public Object[] test117_null() {
+        return Arrays.copyOf((Object[])get_obj_null_src(), 8, get_val_class());
+    }
+
+    @DontCompile
+    public void test117_null_verifier(boolean warmup) {
+        try {
+            test117_null();
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    // Some more Arrays.copyOf tests with only constant class
+
+    @Test(match = { CLASS_CHECK_TRAP }, matchCount = { 1 }, failOn = INTRINSIC_SLOW_PATH)
+    public Object[] test118(Object[] src) {
+        return Arrays.copyOf(src, 8, MyValue2[].class);
+    }
+
+    @DontCompile
+    public void test118_verifier(boolean warmup) {
+        Object[] res = test118(obj_src);
+        verify(obj_src, res);
+        res = test118(val_src);
+        verify(val_src, res);
+        try {
+            test118(obj_null_src);
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public Object[] test119(Object[] src) {
+        return Arrays.copyOf(src, 8, Object[].class);
+    }
+
+    @DontCompile
+    public void test119_verifier(boolean warmup) {
+        Object[] res = test119(obj_src);
+        verify(obj_src, res);
+        res = test119(val_src);
+        verify(val_src, res);
+    }
+
+    @Test(match = { CLASS_CHECK_TRAP }, matchCount = { 1 }, failOn = INTRINSIC_SLOW_PATH)
+    public Object[] test120(Object[] src) {
+        return Arrays.copyOf(src, 8, Integer[].class);
+    }
+
+    @DontCompile
+    public void test120_verifier(boolean warmup) {
+        Integer[] arr = new Integer[8];
+        for (int i = 0; i < 8; ++i) {
+            arr[i] = rI + i;
+        }
+        Object[] res = test120(arr);
+        verify(arr, res);
+        try {
+            test120(val_src);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+    }
+
+    @Test
+    @Warmup(10000) // Make sure we hit too_many_traps for the src <: dst check
+    public Object[] test121(Object[] src) {
+        return Arrays.copyOf(src, 8, MyValue2[].class);
+    }
+
+    @DontCompile
+    public void test121_verifier(boolean warmup) {
+        Object[] res = test121(obj_src);
+        verify(obj_src, res);
+        res = test121(val_src);
+        verify(val_src, res);
+        try {
+            test121(obj_null_src);
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    @Test
+    @Warmup(10000) // Make sure we hit too_many_traps for the src <: dst check
+    public Object[] test122(Object[] src) {
+        return Arrays.copyOf(src, 8, get_val_class());
+    }
+
+    @DontCompile
+    public void test122_verifier(boolean warmup) {
+        Object[] res = test122(obj_src);
+        verify(obj_src, res);
+        res = test122(val_src);
+        verify(val_src, res);
+        try {
+            test122(obj_null_src);
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    @Test
+    @Warmup(10000) // Make sure we hit too_many_traps for the src <: dst check
+    public Object[] test123(Object[] src) {
+        return Arrays.copyOf(src, 8, Integer[].class);
+    }
+
+    @DontCompile
+    public void test123_verifier(boolean warmup) {
+        Integer[] arr = new Integer[8];
+        for (int i = 0; i < 8; ++i) {
+            arr[i] = rI + i;
+        }
+        Object[] res = test123(arr);
+        verify(arr, res);
+        try {
+            test123(val_src);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+    }
+
+    @Test
+    @Warmup(10000) // Make sure we hit too_many_traps for the src <: dst check
+    public Object[] test124(Object[] src) {
+        return Arrays.copyOf(src, 8, get_int_class());
+    }
+
+    @DontCompile
+    public void test124_verifier(boolean warmup) {
+        Integer[] arr = new Integer[8];
+        for (int i = 0; i < 8; ++i) {
+            arr[i] = rI + i;
+        }
+        Object[] res = test124(arr);
+        verify(arr, res);
+        try {
+            test124(val_src);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+    }
+
+    @Test
+    @Warmup(10000) // Make sure we hit too_many_traps for the src <: dst check
+    public Object[] test125(Object[] src, Class klass) {
+        return Arrays.copyOf(src, 8, klass);
+    }
+
+    @DontCompile
+    public void test125_verifier(boolean warmup) {
+        Integer[] arr = new Integer[8];
+        for (int i = 0; i < 8; ++i) {
+            arr[i] = rI + i;
+        }
+        Object[] res = test125(arr, Integer[].class);
+        verify((Object[])arr, res);
+        res = test125(val_src, MyValue2[].class);
+        verify(val_src, res);
+        res = test125(obj_src, MyValue2[].class);
+        verify(val_src, res);
+        try {
+            test125(obj_null_src, MyValue2[].class);
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+        try {
+            test125(arr, MyValue2[].class);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+        try {
+            test125(val_src, MyValue1[].class);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+    }
+
+    // Verify that clone from (flat) inline type array not containing oops is always optimized.
+    @Test(valid = InlineTypeArrayFlattenOn, match = { JLONG_ARRAYCOPY }, matchCount = { 1 }, failOn = CHECKCAST_ARRAYCOPY + CLONE_INTRINSIC_SLOW_PATH)
+    @Test(valid = InlineTypeArrayFlattenOff, failOn = CLONE_INTRINSIC_SLOW_PATH)
+    public Object[] test126(MyValue2[] src) {
+        return src.clone();
+    }
+
+    @DontCompile
+    public void test126_verifier(boolean warmup) {
+        Object[] res = test126(val_src);
+        verify(val_src, res);
+    }
+
+    // Verify correctness of generic_copy stub
+    @Test
+    public void test127(Object src, Object dst, int len) {
+        System.arraycopy(src, 0, dst, 0, len);
+    }
+
+    @DontCompile
+    public void test127_verifier(boolean warmup) {
+        test127(val_src, obj_dst, 8);
+        verify(val_src, obj_dst);
+        test127(val_src, val_dst, 8);
+        verify(val_src, val_dst);
+        test127(obj_src, val_dst, 8);
+        verify(obj_src, val_dst);
+        try {
+            test127(obj_null_src, val_dst, 8);
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
+    // Verify that copyOf with known source and unknown destination class is optimized
+    @Test(valid = InlineTypeArrayFlattenOn, match = { JLONG_ARRAYCOPY }, matchCount = { 1 }, failOn = CHECKCAST_ARRAYCOPY)
+    @Test(valid = InlineTypeArrayFlattenOff)
+    public Object[] test128(MyValue2[] src, Class klass) {
+        return Arrays.copyOf(src, 8, klass);
+    }
+
+    @DontCompile
+    public void test128_verifier(boolean warmup) {
+        Object[] res = test128(val_src, MyValue2[].class);
+        verify(val_src, res);
+        res = test128(val_src, Object[].class);
+        verify(val_src, res);
+        try {
+            test128(val_src, MyValue1[].class);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2984,4 +2984,26 @@ public class TestArrays extends InlineTypeTest {
             // expected
         }
     }
+
+    // Arraycopy with non-array src/dst
+    @Test
+    public void test129(Object src, Object dst, int len) {
+        System.arraycopy(src, 0, dst, 0, len);
+    }
+
+    @DontCompile
+    public void test129_verifier(boolean warmup) {
+        try {
+            test129(new Object(), new Object[0], 0);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+        try {
+            test129(new Object[0], new Object(), 0);
+            throw new RuntimeException("ArrayStoreException expected");
+        } catch (ArrayStoreException e) {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
This patch fixes multiple issues in C2's arraycopy/copyof/clone intrinsics:
- Flat inline type arrays containing oops might be copied without GC barriers.
- Missing membarrier in copyOf code at macro expansion
- We can often avoid flat/null-free checks by relying on the src <: dst subtype check
- We often know at parse time that a flat array does not contain oops and should make use of that information
- And more.. Hopefully the comments in the code are self-explanatory

Other changes:
- generic_arraycopy stub needs to handle flat/null-free inline type arrays
  - Bail if src is flat or dst is flat/null-free
  - Primitive array verification code is broken because array tag contains more bits
  - The "Load layout helper" comment needs adjustment as well but I'll wait with that until we've moved bits to the mark word
- C1 arraycopy intrinsic does not need to check arguments to generic_arraycopy stub (moved checks below)
- Added asserts and runtime verification code to catch issues earlier
- Added lots of test for all issues I've found and new IR matching rules to verify that all arraycopy optimizations work as expected
- Some refactoring

I've identified some remaining optimization opportunities and marked them with "TODO 8251971" in code and tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252506](https://bugs.openjdk.java.net/browse/JDK-8252506): [lworld] Multiple issues with C2's arraycopy intrinsic


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/178/head:pull/178`
`$ git checkout pull/178`
