### PR TITLE
8252862: [lworld] Accidentally disabled fix for JDK-8252110

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2959,7 +2959,7 @@ Node* GraphKit::type_check_receiver(Node* receiver, ciKlass* klass,
                                     float prob, Node* *casted_receiver) {
   Node* fail = top();
   const Type* rec_t = _gvn.type(receiver);
-  if (false && rec_t->isa_inlinetype()) {
+  if (rec_t->isa_inlinetype()) {
     if (klass->equals(rec_t->inline_klass())) {
       (*casted_receiver) = receiver; // Always passes
     } else {


### PR DESCRIPTION
Removed "if (false)".
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252862](https://bugs.openjdk.java.net/browse/JDK-8252862): [lworld] Accidentally disabled fix for JDK-8252110


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/181/head:pull/181`
`$ git checkout pull/181`
