### PR TITLE
8253006: [lworld] Incorrect debug information for fields of scalarized flat array

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -335,6 +335,10 @@ Node* PhaseMacroExpand::make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, 
       Node* base = ac->in(ArrayCopyNode::Src);
       const TypePtr* adr_type = _igvn.type(base)->is_ptr();
       assert(adr_type->isa_aryptr(), "only arrays here");
+      if (adr_type->is_aryptr()->is_flat()) {
+        ciFlatArrayKlass* vak = adr_type->is_aryptr()->klass()->as_flat_array_klass();
+        shift = vak->log2_element_size();
+      }
       if (src_pos_t->is_con() && dest_pos_t->is_con()) {
         intptr_t off = ((src_pos_t->get_con() - dest_pos_t->get_con()) << shift) + offset;
         adr = _igvn.transform(new AddPNode(base, base, MakeConX(off)));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2248,6 +2248,7 @@ public class TestArrays extends InlineTypeTest {
 
     // Same as test30 but accessing all elements of the non-escaping array
     @Test
+    @Warmup(10000)
     public long test93(MyValue2[] src, boolean flag) {
         MyValue2[] dst = new MyValue2[10];
         System.arraycopy(src, 0, dst, 0, 10);
@@ -2272,6 +2273,7 @@ public class TestArrays extends InlineTypeTest {
 
     // Same as test93 but with variable source array offset
     @Test
+    @Warmup(10000)
     public long test94(MyValue2[] src, int i, boolean flag) {
         MyValue2[] dst = new MyValue2[10];
         System.arraycopy(src, i, dst, 0, 1);


### PR DESCRIPTION
Loads from a scalarized, flat array generated by PhaseMacroExpand::make_arraycopy_load use a wrong offset because the shift value is not adjusted to the inline klass element size. Not sure how this slipped through testing that long but existing tests catch it when increasing the number of warmup iterations.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253006](https://bugs.openjdk.java.net/browse/JDK-8253006): [lworld] Incorrect debug information for fields of scalarized flat array


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/184/head:pull/184`
`$ git checkout pull/184`
