### PR TITLE
8253113: [lworld] [lw3] C1 should avoid copying element of flattened arrays when reading a sub-element

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -35,13 +35,13 @@
 
 class MemoryBuffer;
 
-class DelayedFlattenedFieldAccess : public CompilationResourceObj {
+class DelayedFieldAccess : public CompilationResourceObj {
 private:
   Value _obj;
   ciField* _field;
   int _offset;
 public:
-  DelayedFlattenedFieldAccess(Value obj, ciField* field, int offset)
+  DelayedFieldAccess(Value obj, ciField* field, int offset)
   : _obj(obj)
   , _field(field)
   , _offset(offset) { }
@@ -211,9 +211,9 @@ class GraphBuilder {
   Instruction*      _last;                       // the last instruction added
   bool              _skip_block;                 // skip processing of the rest of this block
 
-  DelayedFlattenedFieldAccess* _delayed_flattened_field_access;
-  bool              has_delayed_flattened_field_access() { return _delayed_flattened_field_access != NULL; }
-
+  // support for optimization of accesses to flattened fields and arrays
+  DelayedFieldAccess* _delayed_field_access;
+  DelayedLoadIndexed* _delayed_load_indexed;
 
   // accessors
   ScopeData*        scope_data() const           { return _scope_data; }
@@ -232,6 +232,12 @@ class GraphBuilder {
   Bytecodes::Code   code() const                 { return stream()->cur_bc(); }
   int               bci() const                  { return stream()->cur_bci(); }
   int               next_bci() const             { return stream()->next_bci(); }
+  bool              has_delayed_field_access()   { return _delayed_field_access != NULL; }
+  DelayedFieldAccess* delayed_field_access()     { return _delayed_field_access; }
+  void              set_delayed_field_access(DelayedFieldAccess* delayed) { _delayed_field_access = delayed; }
+  bool              has_delayed_load_indexed()   { return _delayed_load_indexed != NULL; }
+  DelayedLoadIndexed* delayed_load_indexed()     { return _delayed_load_indexed; }
+  void              set_delayed_load_indexed(DelayedLoadIndexed* delayed) { _delayed_load_indexed = delayed; }
 
   // unified bailout support
   void bailout(const char* msg) const            { compilation()->bailout(msg); }

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -212,8 +212,8 @@ class GraphBuilder {
   bool              _skip_block;                 // skip processing of the rest of this block
 
   // support for optimization of accesses to flattened fields and arrays
-  DelayedFieldAccess* _delayed_field_access;
-  DelayedLoadIndexed* _delayed_load_indexed;
+  DelayedFieldAccess* _pending_field_access;
+  DelayedLoadIndexed* _pending_load_indexed;
 
   // accessors
   ScopeData*        scope_data() const           { return _scope_data; }
@@ -232,12 +232,12 @@ class GraphBuilder {
   Bytecodes::Code   code() const                 { return stream()->cur_bc(); }
   int               bci() const                  { return stream()->cur_bci(); }
   int               next_bci() const             { return stream()->next_bci(); }
-  bool              has_delayed_field_access()   { return _delayed_field_access != NULL; }
-  DelayedFieldAccess* delayed_field_access()     { return _delayed_field_access; }
-  void              set_delayed_field_access(DelayedFieldAccess* delayed) { _delayed_field_access = delayed; }
-  bool              has_delayed_load_indexed()   { return _delayed_load_indexed != NULL; }
-  DelayedLoadIndexed* delayed_load_indexed()     { return _delayed_load_indexed; }
-  void              set_delayed_load_indexed(DelayedLoadIndexed* delayed) { _delayed_load_indexed = delayed; }
+  bool              has_pending_field_access()   { return _pending_field_access != NULL; }
+  DelayedFieldAccess* pending_field_access()     { return _pending_field_access; }
+  void              set_pending_field_access(DelayedFieldAccess* delayed) { _pending_field_access = delayed; }
+  bool              has_pending_load_indexed()   { return _pending_load_indexed != NULL; }
+  DelayedLoadIndexed* pending_load_indexed()     { return _pending_load_indexed; }
+  void              set_pending_load_indexed(DelayedLoadIndexed* delayed) { _pending_load_indexed = delayed; }
 
   // unified bailout support
   void bailout(const char* msg) const            { compilation()->bailout(msg); }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1029,13 +1029,13 @@ LEAF(LoadIndexed, AccessIndexed)
 class DelayedLoadIndexed : public CompilationResourceObj {
 private:
   LoadIndexed* _load_instr;
-  NewInlineTypeInstance* _vt;
+  ValueStack* _state_before;
   ciField* _field;
   int _offset;
  public:
-  DelayedLoadIndexed(LoadIndexed* load, NewInlineTypeInstance* vt)
+  DelayedLoadIndexed(LoadIndexed* load, ValueStack* state_before)
   : _load_instr(load)
-  , _vt(vt)
+  , _state_before(state_before)
   , _field(NULL)
   , _offset(0) { }
 
@@ -1045,7 +1045,7 @@ private:
   }
 
   LoadIndexed* load_instr() { return _load_instr; }
-  NewInlineTypeInstance* vt() { return _vt; }
+  ValueStack* state_before() { return _state_before; }
   ciField* field() { return _field; }
   int offset() { return _offset; }
 };

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1041,10 +1041,6 @@ private:
 
   void update(ciField* field, int offset) {
     _field = field;
-    {
-      ResourceMark rm;
-      tty->print_cr("Updating offset from %d to %d", _offset, _offset + offset);
-    }
     _offset += offset;
   }
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -398,7 +398,7 @@ void InstructionPrinter::do_ArrayLength(ArrayLength* x) {
 void InstructionPrinter::do_LoadIndexed(LoadIndexed* x) {
   print_indexed(x);
   if (x->delayed() != NULL) {
-    output()->print(" +%d ", x->delayed()->offset());
+    output()->print(" +%d", x->delayed()->offset());
     output()->print(" (%c)", type2char(x->delayed()->field()->type()->basic_type()));
   } else {
     output()->print(" (%c)", type2char(x->elt_type()));

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -397,7 +397,12 @@ void InstructionPrinter::do_ArrayLength(ArrayLength* x) {
 
 void InstructionPrinter::do_LoadIndexed(LoadIndexed* x) {
   print_indexed(x);
-  output()->print(" (%c)", type2char(x->elt_type()));
+  if (x->delayed() != NULL) {
+    output()->print(" +%d ", x->delayed()->offset());
+    output()->print(" (%c)", type2char(x->delayed()->field()->type()->basic_type()));
+  } else {
+    output()->print(" (%c)", type2char(x->elt_type()));
+  }
   if (x->check_flag(Instruction::NeedsRangeCheckFlag)) {
     output()->print(" [rc]");
   }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1637,8 +1637,6 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
   TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(subelt_type), elm_op);
   LIRItem elm_item(elm_resolved_addr, this);
 
-  // should the case of uninitialized unflattened inline type field be handled here? Yes!
-
   DecoratorSet decorators = IN_HEAP;
   access_load_at(decorators, subelt_type,
                      elm_item, LIR_OprFact::intConst(sub_offset), result,

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1635,7 +1635,7 @@ LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& inde
 void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset) {
   assert(field != NULL, "Need a subelement type specified");
 
-// Find the starting address of the source (inside the array)
+  // Find the starting address of the source (inside the array)
   LIR_Opr elm_op = get_and_load_element_address(array, index);
 
   BasicType subelt_type = field->type()->basic_type();
@@ -1667,7 +1667,7 @@ void LIRGenerator::access_flattened_array(bool is_load, LIRItem& array, LIRItem&
                                           ciField* field, int sub_offset) {
   assert(sub_offset == 0 || field != NULL, "Sanity check");
 
-// Find the starting address of the source (inside the array)
+  // Find the starting address of the source (inside the array)
   LIR_Opr elm_op = get_and_load_element_address(array, index);
 
   ciInlineKlass* elem_klass = NULL;

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2270,7 +2270,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
     }
 
     if (x->elt_type() == T_OBJECT && x->array()->maybe_flattened_array()) {
-      // assert(x->delayed() == NULL, "Delayed LoadIndexed only apply to load_flattened_arrays");
+      assert(x->delayed() == NULL, "Delayed LoadIndexed only apply to loaded_flattened_arrays");
       index.load_item();
       // if we are loading from flattened array, load it using a runtime call
       slow_path = new LoadFlattenedArrayStub(array.result(), index.result(), result, state_for(x, x->state_before()));

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -271,6 +271,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   Constant* flattened_field_load_prolog(LoadField* x, CodeEmitInfo* info);
   void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
+  LIR_Opr get_index_in_register(LIRItem& index, int shift);
   bool needs_flattened_array_store_check(StoreIndexed* x);
   void check_flattened_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path);
   bool needs_null_free_array_store_check(StoreIndexed* x);

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -271,7 +271,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   Constant* flattened_field_load_prolog(LoadField* x, CodeEmitInfo* info);
   void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
-  LIR_Opr get_index_in_register(LIRItem& index, int shift);
+  LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);
   bool needs_flattened_array_store_check(StoreIndexed* x);
   void check_flattened_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path);
   bool needs_null_free_array_store_check(StoreIndexed* x);

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -269,7 +269,8 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_vectorizedMismatch(Intrinsic* x);
 
   Constant* flattened_field_load_prolog(LoadField* x, CodeEmitInfo* info);
-  void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item);
+  void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
+  void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
   bool needs_flattened_array_store_check(StoreIndexed* x);
   void check_flattened_array(LIR_Opr array, LIR_Opr value, CodeStub* slow_path);
   bool needs_null_free_array_store_check(StoreIndexed* x);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -205,8 +205,6 @@ public class TestC1 extends InlineTypeTest {
         MyValue2 v = new MyValue2(1,(byte)2, vi);
         array[0] = v;
         MyValue2Inline vi2 = test6(array, 0);
-        System.out.println("vi.d=" + vi.d + " vi.l=" + vi.l);
-        System.out.println("vi2.d=" + vi2.d + " vi2.l=" + vi2.l);
         Asserts.assertEQ(vi, vi2);
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import jdk.test.lib.Asserts;
  * @compile -XDallowWithFieldOperator TestC1.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI -XX:+PrintCFGToFile
+ *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI
  *                               compiler.valhalla.inlinetypes.InlineTypeTest
  *                               compiler.valhalla.inlinetypes.TestC1
  */

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -41,7 +41,7 @@ import jdk.test.lib.Asserts;
  * @compile -XDallowWithFieldOperator TestC1.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI
+ *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI -XX:+PrintCFGToFile
  *                               compiler.valhalla.inlinetypes.InlineTypeTest
  *                               compiler.valhalla.inlinetypes.TestC1
  */
@@ -130,4 +130,161 @@ public class TestC1 extends InlineTypeTest {
         int result = test2(array);
         Asserts.assertEQ(result, 2*rI);
     }
+
+
+    // Tests below (3 to 8) check the behavior of the C1 optimization to access
+    // sub-elements of a flattened array without copying the element first
+
+    // Test access to a null array
+    @Test(compLevel=C1)
+    public int test3(MyValue2[] array, int index) {
+        return array[index].x;
+    }
+
+    @DontCompile
+    public void test3_verifier(boolean warmup) {
+        NullPointerException npe = null;
+        try {
+            test3(null, 0);
+        } catch(NullPointerException e) {
+            npe = e;
+        }
+        Asserts.assertNE(npe, null);
+    }
+
+    // Test out of bound accesses
+    @Test(compLevel=C1)
+    public int test4(MyValue2[] array, int index) {
+        return array[index].x;
+    }
+
+    @DontCompile
+    public void test4_verifier(boolean warmup) {
+        MyValue2[] array = new MyValue2[2];
+        ArrayIndexOutOfBoundsException aioob = null;
+        try {
+            test3(array, -1);
+        } catch(ArrayIndexOutOfBoundsException e) {
+            aioob = e;
+        }
+        Asserts.assertNE(aioob, null);
+        aioob = null;
+        try {
+            test3(array, 2);
+        } catch(ArrayIndexOutOfBoundsException e) {
+            aioob = e;
+        }
+        Asserts.assertNE(aioob, null);
+    }
+
+    // Test 1st level sub-element access to primitive field
+    @Test(compLevel=C1)
+    public int test5(MyValue2[] array, int index) {
+        return array[index].x;
+    }
+
+    @DontCompile
+    public void test5_verifier(boolean warmup) {
+        MyValue2[] array = new MyValue2[2];
+        MyValue2 v = new MyValue2(1,(byte)2, new MyValue2Inline(5.0d, 345L));
+        array[1] = v;
+        int x = test5(array, 1);
+        Asserts.assertEQ(x, 1);
+    }
+
+    // Test 1st level sub-element access to flattened field
+    @Test(compLevel=C1)
+    public MyValue2Inline test6(MyValue2[] array, int index) {
+        return array[index].v;
+    }
+
+    @DontCompile
+    public void test6_verifier(boolean warmup) {
+        MyValue2[] array = new MyValue2[2];
+        MyValue2Inline vi = new MyValue2Inline(3.5d, 678L);
+        MyValue2 v = new MyValue2(1,(byte)2, vi);
+        array[0] = v;
+        MyValue2Inline vi2 = test6(array, 0);
+        System.out.println("vi.d=" + vi.d + " vi.l=" + vi.l);
+        System.out.println("vi2.d=" + vi2.d + " vi2.l=" + vi2.l);
+        Asserts.assertEQ(vi, vi2);
+    }
+
+    // Test 1st level sub-element access to non-flattened field
+    static inline class Big {
+        long l0,l1,l2,l3,l4,l5,l6,l7,l8,l9,l10,l11,l12,l13,l14,l15,l16,l17,l18,l19 ;
+
+        Big(long n) {
+            l0 = n++; l1 = n++; l2 = n++; l3 = n++; l4 = n++; l5 = n++; l6 = n++; l7 = n++; l8 = n++;
+            l9 = n++; l10 = n++; l11 = n++; l12 = n++; l13 = n++; l14 = n++; l15 = n++; l16= n++;
+            l17 = n++; l18 = n++; l19 = n++;
+        }
+
+        void check(long n, int i) {
+            Asserts.assertEQ(l0, n); n += i;
+            Asserts.assertEQ(l1, n); n += i;
+            Asserts.assertEQ(l2, n); n += i;
+            Asserts.assertEQ(l3, n); n += i;
+            Asserts.assertEQ(l4, n); n += i;
+            Asserts.assertEQ(l5, n); n += i;
+            Asserts.assertEQ(l6, n); n += i;
+            Asserts.assertEQ(l7, n); n += i;
+            Asserts.assertEQ(l8, n); n += i;
+            Asserts.assertEQ(l9, n); n += i;
+            Asserts.assertEQ(l10, n); n += i;
+            Asserts.assertEQ(l11, n); n += i;
+            Asserts.assertEQ(l12, n); n += i;
+            Asserts.assertEQ(l13, n); n += i;
+            Asserts.assertEQ(l14, n); n += i;
+            Asserts.assertEQ(l15, n); n += i;
+            Asserts.assertEQ(l16, n); n += i;
+            Asserts.assertEQ(l17, n); n += i;
+            Asserts.assertEQ(l18, n); n += i;
+            Asserts.assertEQ(l19, n);
+        }
+    }
+
+    static inline class TestValue {
+        int i;
+        Big big;
+
+        TestValue(int n) {
+            i = n;
+            big = new Big(n);
+        }
+    }
+
+    @Test(compLevel=C1)
+    public Big test7(TestValue[] array, int index) {
+        return array[index].big;
+    }
+
+    @DontCompile
+    public void test7_verifier(boolean warmup) {
+        TestValue[] array = new TestValue[7];
+        Big b0 = test7(array, 3);
+        b0.check(0, 0);
+        TestValue tv = new TestValue(9);
+        array[5] = tv;
+        Big b1 = test7(array, 5);
+        b1.check(9, 1);
+    }
+
+    // Test 2nd level sub-element access to primitive field
+    @Test(compLevel=C1)
+    public byte test8(MyValue1[] array, int index) {
+        return array[index].v2.y;
+    }
+
+    @DontCompile
+    public void test8_verifier(boolean warmup) {
+        MyValue1[] array = new MyValue1[23];
+        MyValue2 mv2a = MyValue2.createWithFieldsInline(7, 63L, 8.9d);
+        MyValue2 mv2b = MyValue2.createWithFieldsInline(11, 69L, 17.3d);
+        MyValue1 mv1 = new MyValue1(1, 2L, (short)3, 4, null, mv2a, mv2b, 'z');
+        array[19] = mv1;
+        byte b = test8(array, 19);
+        Asserts.assertEQ(b, (byte)11);
+    }
+
 }


### PR DESCRIPTION
Please review these changes optimizing access to flattened arrays in C1.

The optimization avoids unnecessary copies of intermediate values when the code accesses a sub-element of a flattened array.

For instance, with the following code:

inline class Point { int x = 0, y = 0; }
void foo() {
    Point[] array = new Point[10];
    int i = array[1].x;
}

C1 used to create a new instance of Point, copy the content from the array, then reads the x field from this new instance.
With the optimization, C1 directly accesses the x field from the flattened array, and makes no heap allocation.

A simple benchmark on the "int i = array[1].x;" line gives these results:

baseline:
Benchmark                          Mode  Samples  Score  Score error  Units
o.s.MyBenchmark.testArrayReads     avgt      200  4.250        0.011  ns/op

optimized:
Benchmark                          Mode  Samples  Score  Score error  Units
o.s.MyBenchmark.testArrayReads     avgt      200  2.228        0.004  ns/op

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253113](https://bugs.openjdk.java.net/browse/JDK-8253113): [lworld] [lw3] C1 should avoid copying element of flattened arrays when reading a sub-element


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/187/head:pull/187`
`$ git checkout pull/187`
