### PR TITLE
8253161: [lworld] C1's substitutability check should use andptr instead of andl for mark word

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -2036,13 +2036,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   // (1) Null check -- if one of the operands is null, the other must not be null (because
   //     the two references are not equal), so they are not substitutable,
   //     FIXME: do null check only if the operand is nullable
-  {
-    __ cmpptr(left, (int32_t)NULL_WORD);
-    __ jcc(Assembler::equal, L_oops_not_equal);
-
-    __ cmpptr(right, (int32_t)NULL_WORD);
-    __ jcc(Assembler::equal, L_oops_not_equal);
-  }
+  __ testptr(left, right);
+  __ jcc(Assembler::zero, L_oops_not_equal);
 
   ciKlass* left_klass = op->left_klass();
   ciKlass* right_klass = op->right_klass();
@@ -2054,8 +2049,8 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
       !left_klass->is_inlinetype() || !right_klass->is_inlinetype()) {
     Register tmp1  = op->tmp1()->as_register();
     __ movptr(tmp1, (intptr_t)markWord::always_locked_pattern);
-    __ andl(tmp1, Address(left, oopDesc::mark_offset_in_bytes()));
-    __ andl(tmp1, Address(right, oopDesc::mark_offset_in_bytes()));
+    __ andptr(tmp1, Address(left, oopDesc::mark_offset_in_bytes()));
+    __ andptr(tmp1, Address(right, oopDesc::mark_offset_in_bytes()));
     __ cmpptr(tmp1, (intptr_t)markWord::always_locked_pattern);
     __ jcc(Assembler::notEqual, L_oops_not_equal);
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -742,7 +742,8 @@ class MacroAssembler: public Assembler {
   }
 
   void andptr(Register dst, int32_t src);
-  void andptr(Register src1, Register src2) { LP64_ONLY(andq(src1, src2)) NOT_LP64(andl(src1, src2)) ; }
+  void andptr(Register dst, Register src) { LP64_ONLY(andq(dst, src)) NOT_LP64(andl(dst, src)) ; }
+  void andptr(Register dst, Address src) { LP64_ONLY(andq(dst, src)) NOT_LP64(andl(dst, src)) ; }
 
   void cmp8(AddressLiteral src1, int imm);
 


### PR DESCRIPTION
C1's substitutability check should use andptr instead of andl for mark word. I've also optimized the null check.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253161](https://bugs.openjdk.java.net/browse/JDK-8253161): [lworld] C1's substitutability check should use andptr instead of andl for mark word


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/189/head:pull/189`
`$ git checkout pull/189`
