### PR TITLE
8249887: [lworld] [lw3] Inline types should have a single set of array klasses

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -100,21 +100,6 @@ class InlineKlass: public InstanceKlass {
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(default_value_offset_offset());
   }
 
-  address adr_flat_array_klass() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
-    return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _flat_array_klass));
-  }
-
-  Klass* get_flat_array_klass() const {
-    return *(Klass**)adr_flat_array_klass();
-  }
-
-  Klass* acquire_flat_array_klass() const {
-    return Atomic::load_acquire((Klass**)adr_flat_array_klass());
-  }
-
-  Klass* allocate_flat_array_klass(TRAPS);
-
   address adr_alignment() const {
     assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _alignment));
@@ -176,9 +161,6 @@ class InlineKlass: public InstanceKlass {
   // Returns the array class with this class as element type
   Klass* array_klass_impl(bool or_null, TRAPS);
 
-  // Specifically flat array klass
-  Klass* flat_array_klass(bool or_null, int rank, TRAPS);
-
  public:
   // Type testing
   bool is_inline_klass_slow() const        { return true; }
@@ -191,10 +173,6 @@ class InlineKlass: public InstanceKlass {
   virtual int size_helper() const {
     return layout_helper_to_size_helper(layout_helper());
   }
-
-  // Metadata iterators
-  void array_klasses_do(void f(Klass* k));
-  void array_klasses_do(void f(Klass* k, TRAPS), TRAPS);
 
   // allocate_instance() allocates a stand alone value in the Java heap
   // initialized to default value (cleared memory)

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1592,7 +1592,7 @@ Klass* InstanceKlass::array_klass_impl(bool or_null, int n, TRAPS) {
     }
   }
   // _this will always be set at this point
-  ObjArrayKlass* oak = array_klasses();
+  ArrayKlass* oak = array_klasses();
   if (or_null) {
     return oak->array_klass_or_null(n);
   }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -145,7 +145,6 @@ class InlineKlassFixedBlock {
   address* _pack_handler_jobject;
   address* _unpack_handler;
   int* _default_value_offset;
-  Klass** _flat_array_klass;
   int _alignment;
   int _first_field_offset;
   int _exact_size_in_bytes;
@@ -192,7 +191,7 @@ class InstanceKlass: public Klass {
   // Package this class is defined in
   PackageEntry*   _package_entry;
   // Array classes holding elements of this class.
-  ObjArrayKlass* volatile _array_klasses;
+  ArrayKlass* volatile _array_klasses;
   // Constant pool for this class.
   ConstantPool* _constants;
   // The InnerClasses attribute and EnclosingMethod attribute. The
@@ -494,10 +493,10 @@ class InstanceKlass: public Klass {
   void set_itable_length(int len)          { _itable_len = len; }
 
   // array klasses
-  ObjArrayKlass* array_klasses() const     { return _array_klasses; }
-  inline ObjArrayKlass* array_klasses_acquire() const; // load with acquire semantics
-  void set_array_klasses(ObjArrayKlass* k) { _array_klasses = k; }
-  inline void release_set_array_klasses(ObjArrayKlass* k); // store with release semantics
+  ArrayKlass* array_klasses() const     { return _array_klasses; }
+  inline ArrayKlass* array_klasses_acquire() const; // load with acquire semantics
+  void set_array_klasses(ArrayKlass* k) { _array_klasses = k; }
+  inline void release_set_array_klasses(ArrayKlass* k); // store with release semantics
 
   // methods
   Array<Method*>* methods() const          { return _methods; }

--- a/src/hotspot/share/oops/instanceKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceKlass.inline.hpp
@@ -35,11 +35,11 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
-inline ObjArrayKlass* InstanceKlass::array_klasses_acquire() const {
+inline ArrayKlass* InstanceKlass::array_klasses_acquire() const {
   return Atomic::load_acquire(&_array_klasses);
 }
 
-inline void InstanceKlass::release_set_array_klasses(ObjArrayKlass* k) {
+inline void InstanceKlass::release_set_array_klasses(ArrayKlass* k) {
   Atomic::release_store(&_array_klasses, k);
 }
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -218,7 +218,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(ConstantPoolCache,           _reference_map,                                Array<u2>*)                            \
   nonstatic_field(ConstantPoolCache,           _length,                                       int)                                   \
   nonstatic_field(ConstantPoolCache,           _constant_pool,                                ConstantPool*)                         \
-  volatile_nonstatic_field(InstanceKlass,      _array_klasses,                                ObjArrayKlass*)                        \
+  volatile_nonstatic_field(InstanceKlass,      _array_klasses,                                ArrayKlass*)                        \
   nonstatic_field(InstanceKlass,               _methods,                                      Array<Method*>*)                       \
   nonstatic_field(InstanceKlass,               _default_methods,                              Array<Method*>*)                       \
   nonstatic_field(InstanceKlass,               _local_interfaces,                             Array<InstanceKlass*>*)                \


### PR DESCRIPTION
Please review these changes simplifying the handling of meta-data for array classes of inline types.

Tested with Mach5, tiers 1 to 3.

Thank you,

Fred
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8249887](https://bugs.openjdk.java.net/browse/JDK-8249887): [lworld] [lw3] Inline types should have a single set of array klasses


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/190/head:pull/190`
`$ git checkout pull/190`
