### PR TITLE
8253511: [lworld] ClassFileParser does not handle field type mismatch

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6596,7 +6596,14 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
           Handle(THREAD, _loader_data->class_loader()),
           _protection_domain, true, CHECK);
       assert(klass != NULL, "Sanity check");
-      assert(klass->access_flags().is_inline_type(), "Inline type expected");
+      if (!klass->access_flags().is_inline_type()) {
+        assert(klass->is_instance_klass(), "Sanity check");
+        ResourceMark rm(THREAD);
+          THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
+                    err_msg("Class %s expect class %s to be an inline type, but it is not",
+                    _class_name->as_C_string(),
+                    InstanceKlass::cast(klass)->external_name()));
+      }
     }
   }
 

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6600,7 +6600,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         assert(klass->is_instance_klass(), "Sanity check");
         ResourceMark rm(THREAD);
           THROW_MSG(vmSymbols::java_lang_IncompatibleClassChangeError(),
-                    err_msg("Class %s expect class %s to be an inline type, but it is not",
+                    err_msg("Class %s expects class %s to be an inline type, but it is not",
                     _class_name->as_C_string(),
                     InstanceKlass::cast(klass)->external_name()));
       }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
@@ -45,6 +45,8 @@ public class TestFieldTypeMismatch {
           TestFieldTypeMismatchHelper t = new TestFieldTypeMismatchHelper();
         } catch(IncompatibleClassChangeError err) {
             exception = true;
+            Asserts.assertEquals(err.getMessage(),
+                "Class compiler/valhalla/inlinetypes/TestFieldTypeMismatchHelper expects class compiler.valhalla.inlinetypes.MyValue to be an inline type, but it is not");
         }
         Asserts.assertTrue(exception);
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @library /test/lib
+ * @compile TestFieldTypeMismatchHelper.jasm
+ * @compile TestFieldTypeMismatch.java
+ * @run main/othervm compiler.valhalla.inlinetypes.TestFieldTypeMismatch
+ */
+
+final class MyValue {
+    int foo = 42;
+}
+
+public class TestFieldTypeMismatch {
+
+    public static void main(String[] args) {
+        boolean exception = false;
+        try {
+          TestFieldTypeMismatchHelper t = new TestFieldTypeMismatchHelper();
+        } catch(IncompatibleClassChangeError err) {
+            exception = true;
+        }
+        Asserts.assertTrue(exception);
+    }
+}
+

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper.jasm
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper.jasm
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public class compiler/valhalla/inlinetypes/TestFieldTypeMismatchHelper version 60:0 {
+
+    Field field:"Qcompiler/valhalla/inlinetypes/MyValue;";
+
+    public Method "<init>":"()V"
+      stack 1 locals 1
+    {
+        aload_0;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    public Method test:"()V" stack 2 locals 1 {
+        aload_0;
+        aconst_null;
+        putfield Field field:"Qcompiler/valhalla/inlinetypes/MyValue;";
+        return;
+    }
+}
+


### PR DESCRIPTION
Please review this change with replaces an assert with the throwing of an IncompatibleClassChangeError when a pre-loaded class is not an inline type. This case was correctly handled for static fields, but not for non-static fields.

Tested with Mach5, tiers 1 to 3.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253511](https://bugs.openjdk.java.net/browse/JDK-8253511): [lworld] ClassFileParser does not handle field type mismatch


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/195/head:pull/195`
`$ git checkout pull/195`
