### PR TITLE
8253592: [lworld] C2: Additional fixes for handling empty inline types

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -780,7 +780,7 @@ void ciTypeFlow::StateVector::do_multianewarray(ciBytecodeStream* str) {
 void ciTypeFlow::StateVector::do_new(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
-  if (!will_link || str->is_unresolved_klass()) {
+  if (!will_link || str->is_unresolved_klass() || klass->is_inlinetype()) {
     trap(str, klass, str->get_klass_index());
   } else {
     push_object(klass);
@@ -792,10 +792,9 @@ void ciTypeFlow::StateVector::do_new(ciBytecodeStream* str) {
 void ciTypeFlow::StateVector::do_defaultvalue(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
-  if (!will_link) {
+  if (!will_link || !klass->is_inlinetype()) {
     trap(str, klass, str->get_klass_index());
   } else {
-    assert(klass->is_inlinetype(), "should be inline type");
     push_object(klass);
   }
 }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -868,7 +868,7 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
   for (uint i = 0; i < (uint)arg_size; i++) {
     const Type* t = tf->domain_sig()->field_at(i);
     Node* parm = NULL;
-    if (has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null()) {
+    if (has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null() && t->inline_klass()->can_be_passed_as_fields()) {
       // Inline type arguments are not passed by reference: we get an argument per
       // field of the inline type. Build InlineTypeNodes from the inline type arguments.
       GraphKit kit(jvms, &gvn);

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -281,6 +281,7 @@ void Parse::do_new() {
   bool will_link;
   ciInstanceKlass* klass = iter().get_klass(will_link)->as_instance_klass();
   assert(will_link, "_new: typeflow responsibility");
+  assert(!klass->is_inlinetype(), "unexpected inline type");
 
   // Should throw an InstantiationError?
   if (klass->is_abstract() || klass->is_interface() ||

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -231,6 +231,7 @@ public abstract class InlineTypeTest {
     protected static final String CHECKCAST_ARRAY = "(cmp.*precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue.*" + END;
     protected static final String CHECKCAST_ARRAYCOPY = "(.*call_leaf_nofp,runtime  checkcast_arraycopy.*" + END;
     protected static final String JLONG_ARRAYCOPY = "(.*call_leaf_nofp,runtime  jlong_disjoint_arraycopy.*" + END;
+    protected static final String FIELD_ACCESS = "(.*Field: *" + END;
 
     public static String[] concat(String prefix[], String... extra) {
         ArrayList<String> list = new ArrayList<String>();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -340,6 +340,7 @@ public class TestArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test12_verifier(boolean warmup) {
         Asserts.assertEQ(test12(), rI);
     }
@@ -361,6 +362,7 @@ public class TestArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test13_verifier(boolean warmup) {
         Asserts.assertEQ(test13(), rI);
     }
@@ -371,6 +373,7 @@ public class TestArrays extends InlineTypeTest {
         return va[index].x;
     }
 
+    @DontCompile
     public void test14_verifier(boolean warmup) {
         int arraySize = Math.abs(rI) % 10;
         MyValue1[] va = new MyValue1[arraySize];
@@ -406,6 +409,7 @@ public class TestArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test15_verifier(boolean warmup) {
         Asserts.assertEQ(test15(), rI);
     }
@@ -426,6 +430,7 @@ public class TestArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test16_verifier(boolean warmup) {
         Asserts.assertEQ(test16(), rI);
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -901,4 +901,17 @@ public class TestCallingConvention extends InlineTypeTest {
         LargeValueWithoutOops res = test40(vt);
         Asserts.assertEQ(res, vt);
     }
+
+    // Test passing/returning an empty inline type together with non-empty
+    // inline types such that only some inline type arguments are scalarized.
+    @Test(failOn = ALLOC + LOAD + STORE + TRAP)
+    public MyValueEmpty test41(MyValue1 vt1, MyValueEmpty vt2, MyValue1 vt3) {
+        return vt2.copy(vt2);
+    }
+
+    @DontCompile
+    public void test41_verifier(boolean warmup) {
+        MyValueEmpty res = test41(MyValue1.default, MyValueEmpty.default, MyValue1.default);
+        Asserts.assertEQ(res, MyValueEmpty.default);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -67,6 +67,7 @@ public class TestIntrinsics extends InlineTypeTest {
         return supercls.isAssignableFrom(subcls);
     }
 
+    @DontCompile
     public void test1_verifier(boolean warmup) {
         Asserts.assertTrue(test1(java.util.AbstractList.class, java.util.ArrayList.class), "test1_1 failed");
         Asserts.assertTrue(test1(MyValue1.ref.class, MyValue1.ref.class), "test1_2 failed");
@@ -96,6 +97,7 @@ public class TestIntrinsics extends InlineTypeTest {
         return check1 && check2 && check3 && check4 && check5 && check6 && check7 && check8 && check9 && check10;
     }
 
+    @DontCompile
     public void test2_verifier(boolean warmup) {
         Asserts.assertTrue(test2(), "test2 failed");
     }
@@ -106,6 +108,7 @@ public class TestIntrinsics extends InlineTypeTest {
         return cls.getSuperclass();
     }
 
+    @DontCompile
     public void test3_verifier(boolean warmup) {
         Asserts.assertTrue(test3(Object.class) == null, "test3_1 failed");
         Asserts.assertTrue(test3(MyValue1.ref.class) == MyAbstract.class, "test3_2 failed");
@@ -125,6 +128,7 @@ public class TestIntrinsics extends InlineTypeTest {
         return check1 && check2 && check3 && check4;
     }
 
+    @DontCompile
     public void test4_verifier(boolean warmup) {
         Asserts.assertTrue(test4(), "test4 failed");
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3334,6 +3334,8 @@ public class TestLWorld extends InlineTypeTest {
         Asserts.assertTrue(res);
     }
 
+    // TODO Disabled until JDK-8253416 is fixed
+    /*
     // Verify that empty inline type field loads check for null holder
     @Test()
     public MyValueEmpty test122(TestLWorld t) {
@@ -3369,4 +3371,5 @@ public class TestLWorld extends InlineTypeTest {
             // Expected
         }
     }
+    */
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3305,4 +3305,68 @@ public class TestLWorld extends InlineTypeTest {
     public void test119_verifier(boolean warmup) {
         test119(!warmup);
     }
+
+    // Test removal of empty inline type field stores
+    @Test(failOn = ALLOC + ALLOC_G + LOAD + STORE + FIELD_ACCESS + NULL_CHECK_TRAP + TRAP)
+    public void test120(MyValueEmpty empty) {
+        fEmpty1 = empty;
+        fEmpty3 = empty;
+        // fEmpty2 and fEmpty4 could be null, store can't be removed
+    }
+
+    @DontCompile
+    public void test120_verifier(boolean warmup) {
+        test120(MyValueEmpty.default);
+        Asserts.assertEquals(fEmpty1, MyValueEmpty.default);
+        Asserts.assertEquals(fEmpty2, MyValueEmpty.default);
+    }
+
+    // Test removal of empty inline type field loads
+    @Test(failOn = ALLOC + ALLOC_G + LOAD + STORE + FIELD_ACCESS + NULL_CHECK_TRAP + TRAP)
+    public boolean test121() {
+        return fEmpty1.equals(fEmpty3);
+        // fEmpty2 and fEmpty4 could be null, load can't be removed
+    }
+
+    @DontCompile
+    public void test121_verifier(boolean warmup) {
+        boolean res = test121();
+        Asserts.assertTrue(res);
+    }
+
+    // Verify that empty inline type field loads check for null holder
+    @Test()
+    public MyValueEmpty test122(TestLWorld t) {
+        return t.fEmpty3;
+    }
+
+    @DontCompile
+    public void test122_verifier(boolean warmup) {
+        MyValueEmpty res = test122(this);
+        Asserts.assertEquals(res, MyValueEmpty.default);
+        try {
+            test122(null);
+            throw new RuntimeException("No NPE thrown");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
+
+    // Verify that empty inline type field stores check for null holder
+    @Test()
+    public void test123(TestLWorld t) {
+        t.fEmpty3 = MyValueEmpty.default;
+    }
+
+    @DontCompile
+    public void test123_verifier(boolean warmup) {
+        test123(this);
+        Asserts.assertEquals(fEmpty3, MyValueEmpty.default);
+        try {
+            test123(null);
+            throw new RuntimeException("No NPE thrown");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -361,6 +361,7 @@ public class TestNullableArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test12_verifier(boolean warmup) {
         Asserts.assertEQ(test12(), rI);
     }
@@ -382,6 +383,7 @@ public class TestNullableArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test13_verifier(boolean warmup) {
         Asserts.assertEQ(test13(), rI);
     }
@@ -392,6 +394,7 @@ public class TestNullableArrays extends InlineTypeTest {
         return va[index].x;
     }
 
+    @DontCompile
     public void test14_verifier(boolean warmup) {
         int arraySize = Math.abs(rI) % 10;
         MyValue1.ref[] va = new MyValue1.ref[arraySize];
@@ -427,6 +430,7 @@ public class TestNullableArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test15_verifier(boolean warmup) {
         Asserts.assertEQ(test15(), rI);
     }
@@ -447,6 +451,7 @@ public class TestNullableArrays extends InlineTypeTest {
         }
     }
 
+    @DontCompile
     public void test16_verifier(boolean warmup) {
         Asserts.assertEQ(test16(), rI);
     }


### PR DESCRIPTION
While working on JDK-8253416, I found more issues with handling of empty inline types in C2:
- Compile::build_start_state assumes that all inline type arguments are scalarized if has_scalarized_args() is true but one of the arguments could be non-scalarized (for example, if it's an empty inline type).
- Loads/stores from/to inline type fields should be removed. Refactoring the related code also fixes an issue where alias analysis gets confused when looking at flattened fields of empty inline types.

Unrelated fixes:
- Handling of unexpected inline/non-inline klasses in _new/_defaultvalue.
- Missing @DontCompile statements in some tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253592](https://bugs.openjdk.java.net/browse/JDK-8253592): [lworld] C2: Additional fixes for handling empty inline types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/197/head:pull/197`
`$ git checkout pull/197`
