### PR TITLE
8253416: [lworld] C1: incorrect nestmate access to flattened field if nest-host is not loaded

### DIFF
--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -238,6 +238,7 @@ NewInstanceStub::NewInstanceStub(LIR_Opr klass_reg, LIR_Opr result, ciInstanceKl
   _klass_reg = klass_reg;
   _info = new CodeEmitInfo(info);
   assert(stub_id == Runtime1::new_instance_id                 ||
+         stub_id == Runtime1::new_instance_no_inline_id       ||
          stub_id == Runtime1::fast_new_instance_id            ||
          stub_id == Runtime1::fast_new_instance_init_check_id,
          "need new_instance id");

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1288,11 +1288,12 @@ void LIRGenerator::do_NewInstance(NewInstance* x) {
   CodeEmitInfo* info = state_for(x, x->state());
   LIR_Opr reg = result_register_for(x->type());
   new_instance(reg, x->klass(), x->is_unresolved(),
-                       FrameMap::rcx_oop_opr,
-                       FrameMap::rdi_oop_opr,
-                       FrameMap::rsi_oop_opr,
-                       LIR_OprFact::illegalOpr,
-                       FrameMap::rdx_metadata_opr, info);
+               /* allow_inline */ false,
+               FrameMap::rcx_oop_opr,
+               FrameMap::rdi_oop_opr,
+               FrameMap::rsi_oop_opr,
+               LIR_OprFact::illegalOpr,
+               FrameMap::rdx_metadata_opr, info);
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);
 }
@@ -1302,15 +1303,15 @@ void LIRGenerator::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
   CodeEmitInfo* info = state_for(x, x->state_before());
   x->set_to_object_type();
   LIR_Opr reg = result_register_for(x->type());
-  new_instance(reg, x->klass(), x->is_unresolved(),
-             FrameMap::rcx_oop_opr,
-             FrameMap::rdi_oop_opr,
-             FrameMap::rsi_oop_opr,
-             LIR_OprFact::illegalOpr,
-             FrameMap::rdx_metadata_opr, info);
+  new_instance(reg, x->klass(), false,
+               /* allow_inline */ true,
+               FrameMap::rcx_oop_opr,
+               FrameMap::rdi_oop_opr,
+               FrameMap::rsi_oop_opr,
+               LIR_OprFact::illegalOpr,
+               FrameMap::rdx_metadata_opr, info);
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);
-
 }
 
 void LIRGenerator::do_NewTypeArray(NewTypeArray* x) {

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1016,6 +1016,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
       break;
 
     case new_instance_id:
+    case new_instance_no_inline_id:
     case fast_new_instance_id:
     case fast_new_instance_init_check_id:
       {
@@ -1024,6 +1025,8 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
         if (id == new_instance_id) {
           __ set_info("new_instance", dont_gc_arguments);
+        } else if (id == new_instance_no_inline_id) {
+          __ set_info("new_instance_no_inline", dont_gc_arguments);
         } else if (id == fast_new_instance_id) {
           __ set_info("fast new_instance", dont_gc_arguments);
         } else {
@@ -1088,7 +1091,12 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
         __ enter();
         OopMap* map = save_live_registers(sasm, 2);
-        int call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
+        int call_offset;
+        if (id == new_instance_no_inline_id) {
+          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance_no_inline), klass);
+        } else {
+          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
+        }
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_rax(sasm);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1042,7 +1042,7 @@ void GraphBuilder::load_indexed(BasicType type) {
       set_pending_load_indexed(dli);
       return; // Nothing else to do for now
     } else {
-      NewInlineTypeInstance* new_instance = new NewInlineTypeInstance(elem_klass, state_before, false);
+      NewInlineTypeInstance* new_instance = new NewInlineTypeInstance(elem_klass, state_before);
       _memory->new_instance(new_instance);
       apush(append_split(new_instance));
       load_indexed = new LoadIndexed(array, index, length, type, state_before);
@@ -1754,6 +1754,8 @@ Value GraphBuilder::make_constant(ciConstant field_value, ciField* field) {
 
 void GraphBuilder::copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off,
                                        ValueStack* state_before, bool needs_patching) {
+  assert(!needs_patching, "Can't patch flattened inline type field access");
+  assert(vk->nof_nonstatic_fields() > 0, "Empty inline type access should be removed");
   src->set_escaped();
   for (int i = 0; i < vk->nof_nonstatic_fields(); i++) {
     ciField* inner_field = vk->nonstatic_field_at(i);
@@ -1776,7 +1778,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
   // call will_link again to determine if the field is valid.
   const bool needs_patching = !holder->is_loaded() ||
                               !field->will_link(method(), code) ||
-                              PatchALot;
+                              (!field->is_flattened() && PatchALot);
 
   ValueStack* state_before = NULL;
   if (!holder->is_initialized() || needs_patching) {
@@ -1795,11 +1797,11 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     }
   }
 
-  if (field->is_final() && (code == Bytecodes::_putfield || code == Bytecodes::_withfield)) {
+  if (field->is_final() && code == Bytecodes::_putfield) {
     scope()->set_wrote_final();
   }
 
-  if (code == Bytecodes::_putfield || code == Bytecodes::_withfield) {
+  if (code == Bytecodes::_putfield) {
     scope()->set_wrote_fields();
     if (field->is_volatile()) {
       scope()->set_wrote_volatile();
@@ -1816,6 +1818,9 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         assert(!field->is_stable() || !field_value.is_null_or_zero(),
                "stable static w/ default value shouldn't be a constant");
         constant = make_constant(field_value, field);
+      } else if (field_type == T_INLINE_TYPE && field->type()->as_inline_klass()->is_empty()) {
+        // Loading from a field of an empty inline type. Just return the default instance.
+        constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
       }
       if (constant != NULL) {
         push(type, append(constant));
@@ -1839,6 +1844,10 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
+      if (field_type == T_INLINE_TYPE && field->type()->as_inline_klass()->is_empty()) {
+        // Storing to a field of an empty inline type. Ignore.
+        break;
+      }
       append(new StoreField(append(obj), offset, field, val, true, state_before, needs_patching));
       break;
     }
@@ -1853,7 +1862,11 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (!has_pending_field_access() && !has_pending_load_indexed()) {
         obj = apop();
         ObjectType* obj_type = obj->type()->as_ObjectType();
-        if (field->is_constant() && !field->is_flattened() && obj_type->is_constant() && !PatchALot) {
+        if (field_type == T_INLINE_TYPE && field->type()->as_inline_klass()->is_empty()) {
+          // Loading from a field of an empty inline type. Just return the default instance.
+          null_check(obj);
+          constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
+        } else if (field->is_constant() && !field->is_flattened() && obj_type->is_constant() && !PatchALot) {
           ciObject* const_oop = obj_type->constant_value();
           if (!const_oop->is_null_object() && const_oop->is_loaded()) {
             ciConstant field_value = field->constant_value_of(const_oop);
@@ -1885,11 +1898,13 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         if (!field->is_flattened()) {
           LoadField* load;
           if (has_pending_field_access()) {
+            assert(!needs_patching, "Can't patch delayed field access");
             load = new LoadField(pending_field_access()->obj(),
                                  pending_field_access()->offset() + offset - field->holder()->as_inline_klass()->first_field_offset(),
                                  field, false, state_before, needs_patching);
             set_pending_field_access(NULL);
           } else if (has_pending_load_indexed()) {
+            assert(!needs_patching, "Can't patch delayed field access");
             pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
             LoadIndexed* li = pending_load_indexed()->load_instr();
             li->set_type(type);
@@ -1904,17 +1919,16 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             assert(replacement->is_linked() || !replacement->can_be_linked(), "should already by linked");
             // Writing an (integer) value to a boolean, byte, char or short field includes an implicit narrowing
             // conversion. Emit an explicit conversion here to get the correct field value after the write.
-            BasicType bt = field->type()->basic_type();
-            switch (bt) {
+            switch (field_type) {
             case T_BOOLEAN:
             case T_BYTE:
-              replacement = append(new Convert(Bytecodes::_i2b, replacement, as_ValueType(bt)));
+              replacement = append(new Convert(Bytecodes::_i2b, replacement, type));
               break;
             case T_CHAR:
-              replacement = append(new Convert(Bytecodes::_i2c, replacement, as_ValueType(bt)));
+              replacement = append(new Convert(Bytecodes::_i2c, replacement, type));
               break;
             case T_SHORT:
-              replacement = append(new Convert(Bytecodes::_i2s, replacement, as_ValueType(bt)));
+              replacement = append(new Convert(Bytecodes::_i2s, replacement, type));
               break;
             default:
               break;
@@ -1924,10 +1938,19 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             push(type, append(load));
           }
         } else {
+          // Look at the next bytecode to check if we can delay the field access
+          bool can_delay_access = false;
           ciBytecodeStream s(method());
           s.force_bci(bci());
           s.next();
           if (s.cur_bc() == Bytecodes::_getfield && !needs_patching) {
+            ciField* next_field = s.get_field(will_link);
+            bool next_needs_patching = !next_field->holder()->is_loaded() ||
+                                       !next_field->will_link(method(), code) ||
+                                       PatchALot;
+            can_delay_access = !next_needs_patching;
+          }
+          if (can_delay_access) {
             if (has_pending_load_indexed()) {
               pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
             } else if (has_pending_field_access()) {
@@ -1938,22 +1961,20 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               set_pending_field_access(dfa);
             }
           } else {
-            assert(field->type()->is_inlinetype(), "Sanity check");
             ciInlineKlass* inline_klass = field->type()->as_inline_klass();
-            assert(field->type()->is_inlinetype(), "Sanity check");
             scope()->set_wrote_final();
             scope()->set_wrote_fields();
             if (has_pending_load_indexed()) {
+              assert(!needs_patching, "Can't patch delayed field access");
               pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
-              NewInlineTypeInstance* vt = new NewInlineTypeInstance(field->type()->as_inline_klass(),
-                                                                    pending_load_indexed()->state_before(), false);
+              NewInlineTypeInstance* vt = new NewInlineTypeInstance(inline_klass, pending_load_indexed()->state_before());
               _memory->new_instance(vt);
               pending_load_indexed()->load_instr()->set_vt(vt);
               apush(append_split(vt));
               append(pending_load_indexed()->load_instr());
               set_pending_load_indexed(NULL);
             } else {
-              NewInlineTypeInstance* new_instance = new NewInlineTypeInstance(inline_klass, state_before, false);
+              NewInlineTypeInstance* new_instance = new NewInlineTypeInstance(inline_klass, state_before);
               _memory->new_instance(new_instance);
               apush(append_split(new_instance));
               if (has_pending_field_access()) {
@@ -1964,7 +1985,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
                 set_pending_field_access(NULL);
               } else {
                 copy_inline_content(inline_klass, obj, field->offset(), new_instance, inline_klass->first_field_offset(),
-                            state_before, needs_patching);
+                                    state_before, needs_patching);
               }
             }
           }
@@ -1972,7 +1993,6 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       }
       break;
     }
-    case Bytecodes::_withfield:
     case Bytecodes::_putfield: {
       Value val = pop(type);
       val->set_escaped();
@@ -1980,23 +2000,22 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (state_before == NULL) {
         state_before = copy_state_for_exception();
       }
-      if (field->type()->basic_type() == T_BOOLEAN) {
+      if (field_type == T_BOOLEAN) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
-
-      if (!field->is_flattened()) {
+      if (field_type == T_INLINE_TYPE && field->type()->as_inline_klass()->is_empty()) {
+        // Storing to a field of an empty inline type. Ignore.
+        null_check(obj);
+      } else if (!field->is_flattened()) {
         StoreField* store = new StoreField(obj, offset, field, val, false, state_before, needs_patching);
         if (!needs_patching) store = _memory->store(store);
         if (store != NULL) {
           append(store);
         }
       } else {
-        assert(field->type()->is_inlinetype(), "Sanity check");
         ciInlineKlass* inline_klass = field->type()->as_inline_klass();
-        int flattening_offset = field->offset() - inline_klass->first_field_offset();
-        copy_inline_content(inline_klass, val, inline_klass->first_field_offset(), obj, field->offset(),
-                   state_before, needs_patching);
+        copy_inline_content(inline_klass, val, inline_klass->first_field_offset(), obj, offset, state_before, needs_patching);
       }
       break;
     }
@@ -2020,22 +2039,20 @@ void GraphBuilder::withfield(int field_index)
                               !field_modify->will_link(method(), Bytecodes::_withfield) ||
                               PatchALot;
 
-
   scope()->set_wrote_final();
   scope()->set_wrote_fields();
 
   const int offset = !needs_patching ? field_modify->offset() : -1;
 
+  ValueStack* state_before = copy_state_before();
   if (!holder->is_loaded()
       || needs_patching /* FIXME: 8228634 - field_modify->will_link() may incorrectly return false */
       ) {
-    ValueStack* state_before = copy_state_before();
     Value val = pop(type);
     Value obj = apop();
     apush(append_split(new WithField(state_before)));
     return;
   }
-  ValueStack* state_before = copy_state_before();
 
   Value val = pop(type);
   Value obj = apop();
@@ -2048,7 +2065,7 @@ void GraphBuilder::withfield(int field_index)
     new_instance = obj->as_NewInlineTypeInstance();
     apush(append_split(new_instance));
   } else {
-    new_instance = new NewInlineTypeInstance(holder->as_inline_klass(), state_before, false);
+    new_instance = new NewInlineTypeInstance(holder->as_inline_klass(), state_before);
     _memory->new_instance(new_instance);
     apush(append_split(new_instance));
 
@@ -2058,8 +2075,6 @@ void GraphBuilder::withfield(int field_index)
 
       if (field->offset() != offset) {
         if (field->is_flattened()) {
-          assert(field->type()->is_inlinetype(), "Sanity check");
-          assert(field->type()->is_inlinetype(), "Only inline types can be flattened");
           ciInlineKlass* vk = field->type()->as_inline_klass();
           copy_inline_content(vk, obj, off, new_instance, vk->first_field_offset(), state_before, needs_patching);
         } else {
@@ -2079,7 +2094,6 @@ void GraphBuilder::withfield(int field_index)
     val = append(new LogicOp(Bytecodes::_iand, val, mask));
   }
   if (field_modify->is_flattened()) {
-    assert(field_modify->type()->is_inlinetype(), "Only inline types can be flattened");
     ciInlineKlass* vk = field_modify->type()->as_inline_klass();
     copy_inline_content(vk, val, vk->first_field_offset(), new_instance, field_modify->offset(), state_before, needs_patching);
   } else {
@@ -2457,7 +2471,6 @@ void GraphBuilder::new_instance(int klass_index) {
   bool will_link;
   ciKlass* klass = stream()->get_klass(will_link);
   assert(klass->is_instance_klass(), "must be an instance klass");
-  assert(!klass->is_inlinetype(), "must not be an inline klass");
   NewInstance* new_instance = new NewInstance(klass->as_instance_klass(), state_before, stream()->is_unresolved_klass());
   _memory->new_instance(new_instance);
   apush(append_split(new_instance));
@@ -2465,8 +2478,9 @@ void GraphBuilder::new_instance(int klass_index) {
 
 void GraphBuilder::default_value(int klass_index) {
   bool will_link;
-  if (!stream()->is_unresolved_klass()) {
-    ciInlineKlass* vk = stream()->get_klass(will_link)->as_inline_klass();
+  ciKlass* klass = stream()->get_klass(will_link);
+  if (!stream()->is_unresolved_klass() && klass->is_inlinetype()) {
+    ciInlineKlass* vk = klass->as_inline_klass();
     apush(append(new Constant(new InstanceConstant(vk->default_instance()))));
   } else {
     ValueStack* state_before = copy_state_before();

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -307,15 +307,6 @@ ciType* NewInstance::declared_type() const {
   return exact_type();
 }
 
-Value NewInlineTypeInstance::depends_on() {
-  if (_depends_on != this) {
-    if (_depends_on->as_NewInlineTypeInstance() != NULL) {
-      return _depends_on->as_NewInlineTypeInstance()->depends_on();
-    }
-  }
-  return _depends_on;
-}
-
 ciType* NewInlineTypeInstance::exact_type() const {
   return klass();
 }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1386,39 +1386,25 @@ LEAF(NewInstance, StateSplit)
 };
 
 LEAF(NewInlineTypeInstance, StateSplit)
-  bool _is_unresolved;
   ciInlineKlass* _klass;
-  Value _depends_on;      // Link to instance on with withfield was called on
-  bool _is_optimizable_for_withfield;
   bool _in_larval_state;
   int _first_local_index;
   int _on_stack_count;
 public:
 
   // Default creation, always allocated for now
-  NewInlineTypeInstance(ciInlineKlass* klass, ValueStack* state_before, bool is_unresolved, Value depends_on = NULL, bool from_default_value = false)
+  NewInlineTypeInstance(ciInlineKlass* klass, ValueStack* state_before)
   : StateSplit(instanceType, state_before)
-   , _is_unresolved(is_unresolved)
    , _klass(klass)
-   , _is_optimizable_for_withfield(from_default_value)
    , _in_larval_state(true)
    , _first_local_index(-1)
    , _on_stack_count(1)
   {
-    if (depends_on == NULL) {
-      _depends_on = this;
-    } else {
-      _depends_on = depends_on;
-    }
     set_null_free(true);
   }
 
   // accessors
-  bool is_unresolved() const                     { return _is_unresolved; }
-  Value depends_on();
-
   ciInlineKlass* klass() const { return _klass; }
-
   virtual bool needs_exception_state() const     { return false; }
 
   // generic
@@ -1429,10 +1415,6 @@ public:
   // Only done in LIR Generator -> map everything to object
   void set_to_object_type() { set_type(instanceType); }
 
-  // withfield optimization
-  virtual void set_escaped() {
-    _is_optimizable_for_withfield = false;
-  }
   virtual void set_local_index(int index) {
     if (_first_local_index != index) {
       if (_first_local_index == -1) {
@@ -1459,7 +1441,6 @@ public:
       decrement_on_stack_count();
     }
   }
-
 };
 
 BASE(NewArray, StateSplit)

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -673,10 +673,15 @@ void LIRGenerator::print_if_not_loaded(const NewInstance* new_instance) {
 }
 #endif
 
-void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unresolved, LIR_Opr scratch1, LIR_Opr scratch2, LIR_Opr scratch3, LIR_Opr scratch4, LIR_Opr klass_reg, CodeEmitInfo* info) {
-  klass2reg_with_patching(klass_reg, klass, info, is_unresolved);
-  // If klass is not loaded we do not know if the klass has finalizers:
-  if (UseFastNewInstance && klass->is_loaded()
+void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unresolved, bool allow_inline, LIR_Opr scratch1, LIR_Opr scratch2, LIR_Opr scratch3, LIR_Opr scratch4, LIR_Opr klass_reg, CodeEmitInfo* info) {
+  if (allow_inline) {
+    assert(!is_unresolved && klass->is_loaded(), "inline type klass should be resolved");
+    __ metadata2reg(klass->constant_encoding(), klass_reg);
+  } else {
+    klass2reg_with_patching(klass_reg, klass, info, is_unresolved);
+  }
+  // If klass is not loaded we do not know if the klass has finalizers or is an unexpected inline klass
+  if (UseFastNewInstance && klass->is_loaded() && (allow_inline || !klass->is_inlinetype())
       && !Klass::layout_helper_needs_slow_path(klass->layout_helper())) {
 
     Runtime1::StubID stub_id = klass->is_initialized() ? Runtime1::fast_new_instance_id : Runtime1::fast_new_instance_init_check_id;
@@ -690,8 +695,8 @@ void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unr
     __ allocate_object(dst, scratch1, scratch2, scratch3, scratch4,
                        oopDesc::header_size(), instance_size, klass_reg, !klass->is_initialized(), slow_path);
   } else {
-    CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, Runtime1::new_instance_id);
-    __ branch(lir_cond_always, slow_path);
+    CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, allow_inline ? Runtime1::new_instance_id : Runtime1::new_instance_no_inline_id);
+    __ jump(slow_path);
     __ branch_destination(slow_path->continuation());
   }
 }
@@ -1551,25 +1556,18 @@ void LIRGenerator::do_StoreField(StoreField* x) {
   }
 #endif
 
+  if (!inline_type_field_access_prolog(x, info)) {
+    // Field store will always deopt due to unloaded field or holder klass
+    return;
+  }
+
   if (x->needs_null_check() &&
       (needs_patching ||
        MacroAssembler::needs_explicit_null_check(x->offset()))) {
-    if (needs_patching && x->field()->signature()->is_Q_signature()) {
-      // We are storing a field of type "QT;" into holder class H, but H is not yet
-      // loaded. (If H had been loaded, then T must also have already been loaded
-      // due to the "Q" signature, and needs_patching would be false).
-      assert(!x->field()->holder()->is_loaded(), "must be");
-      // We don't know the offset of this field. Let's deopt and recompile.
-      CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
-                                          Deoptimization::Reason_unloaded,
-                                          Deoptimization::Action_make_not_entrant);
-      __ branch(lir_cond_always, stub);
-    } else {
-      // Emit an explicit null check because the offset is too large.
-      // If the class is not loaded and the object is NULL, we need to deoptimize to throw a
-      // NoClassDefFoundError in the interpreter instead of an implicit NPE from compiled code.
-      __ null_check(object.result(), new CodeEmitInfo(info), /* deoptimize */ needs_patching);
-    }
+    // Emit an explicit null check because the offset is too large.
+    // If the class is not loaded and the object is NULL, we need to deoptimize to throw a
+    // NoClassDefFoundError in the interpreter instead of an implicit NPE from compiled code.
+    __ null_check(object.result(), new CodeEmitInfo(info), /* deoptimize */ needs_patching);
   }
 
   DecoratorSet decorators = IN_HEAP;
@@ -1647,16 +1645,13 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
                      elm_item, LIR_OprFact::intConst(sub_offset), result,
                      NULL, NULL);
 
-  Constant* default_value = NULL;
   if (field->signature()->is_Q_signature()) {
     assert(field->type()->as_inline_klass()->is_loaded(), "Must be");
-    default_value = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
-  }
-  if (default_value != NULL) {
     LabelObj* L_end = new LabelObj();
     __ cmp(lir_cond_notEqual, result, LIR_OprFact::oopConst(NULL));
     __ branch(lir_cond_notEqual, L_end->label());
     set_in_conditional_code(true);
+    Constant* default_value = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
     __ move(load_constant(default_value), result);
     __ branch_destination(L_end->label());
     set_in_conditional_code(false);
@@ -1944,78 +1939,29 @@ LIR_Opr LIRGenerator::access_resolve(DecoratorSet decorators, LIR_Opr obj) {
   return _barrier_set->resolve(this, decorators, obj);
 }
 
-Constant* LIRGenerator::flattened_field_load_prolog(LoadField* x, CodeEmitInfo* info) {
+bool LIRGenerator::inline_type_field_access_prolog(AccessField* x, CodeEmitInfo* info) {
   ciField* field = x->field();
-  ciInstanceKlass* holder = field->holder();
-  Constant* default_value = NULL;
-
-  // Unloaded "QV;" klasses are represented by a ciInstanceKlass
-  bool field_type_unloaded = field->type()->is_instance_klass() && !field->type()->as_instance_klass()->is_loaded();
-
-  // Check for edge cases (1), (2) and (3) for getstatic and getfield
-  bool deopt = false;
-  bool need_default = false;
-  if (field->is_static()) {
-      // (1) holder is unloaded -- no problem: it will be loaded by patching, and field offset will be determined.
-      // No check needed here.
-
-    if (field_type_unloaded) {
-      // (2) field type is unloaded -- problem: we don't know what the default value is. Let's deopt.
-      //                               FIXME: consider getting the default value in patching code.
-      deopt = true;
-    } else {
-      need_default = true;
-    }
-
-      // (3) field is not flattened -- we don't care: static fields are never flattened.
-      // No check needed here.
-  } else {
-    if (!holder->is_loaded()) {
-      // (1) holder is unloaded -- problem: we needed the field offset back in GraphBuilder::access_field()
-      //                           FIXME: consider getting field offset in patching code (but only if the field
-      //                           type was loaded at compilation time).
-      deopt = true;
-    } else if (field_type_unloaded) {
-      // (2) field type is unloaded -- problem: we don't know whether it's flattened or not. Let's deopt
-      deopt = true;
-    } else if (!field->is_flattened()) {
-      // (3) field is not flattened -- need default value in cases of uninitialized field
-      need_default = true;
-    }
+  assert(!field->is_flattened(), "Flattened field access should have been expanded");
+  if (!field->signature()->is_Q_signature()) {
+    return true; // Not an inline type field
   }
-
-  if (deopt) {
-    assert(!need_default, "deopt and need_default cannot both be true");
-    assert(x->needs_patching(), "must be");
-    assert(info != NULL, "must be");
+  // Deoptimize if the access is non-static and requires patching (holder not loaded
+  // or not accessible) because then we only have partial field information and the
+  // field could be flattened (see ciField constructor).
+  bool could_be_flat = !x->is_static() && x->needs_patching();
+  // Deoptimize if we load from a static field with an unloaded type because we need
+  // the default value if the field is null.
+  bool could_be_null = x->is_static() && x->as_LoadField() != NULL && !field->type()->is_loaded();
+  assert(!could_be_null || !field->holder()->is_loaded(), "inline type field should be loaded");
+  if (could_be_flat || could_be_null) {
+    assert(x->needs_patching(), "no deopt required");
     CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                         Deoptimization::Reason_unloaded,
                                         Deoptimization::Action_make_not_entrant);
-    __ branch(lir_cond_always, stub);
-  } else if (need_default) {
-    assert(!field_type_unloaded, "must be");
-    assert(field->type()->is_inlinetype(), "must be");
-    ciInlineKlass* inline_klass = field->type()->as_inline_klass();
-    assert(inline_klass->is_loaded(), "must be");
-
-    if (field->is_static() && holder->is_loaded()) {
-      ciInstance* mirror = field->holder()->java_mirror();
-      ciObject* val = mirror->field_value(field).as_object();
-      if (val->is_null_object()) {
-        // This is a non-nullable static field, but it's not initialized.
-        // We need to do a null check, and replace it with the default value.
-      } else {
-        // No need to perform null check on this static field
-        need_default = false;
-      }
-    }
-
-    if (need_default) {
-      default_value = new Constant(new InstanceConstant(inline_klass->default_instance()));
-    }
+    __ jump(stub);
+    return false;
   }
-
-  return default_value;
+  return true;
 }
 
 void LIRGenerator::do_LoadField(LoadField* x) {
@@ -2047,9 +1993,11 @@ void LIRGenerator::do_LoadField(LoadField* x) {
   }
 #endif
 
-  Constant* default_value = NULL;
-  if (x->field()->signature()->is_Q_signature()) {
-    default_value = flattened_field_load_prolog(x, info);
+  if (!inline_type_field_access_prolog(x, info)) {
+    // Field load will always deopt due to unloaded field or holder klass
+    LIR_Opr result = rlock_result(x, field_type);
+    __ move(LIR_OprFact::oopConst(NULL), result);
+    return;
   }
 
   bool stress_deopt = StressLoopInvariantCodeMotion && info && info->deoptimize_on_exception();
@@ -2081,11 +2029,26 @@ void LIRGenerator::do_LoadField(LoadField* x) {
                  object, LIR_OprFact::intConst(x->offset()), result,
                  info ? new CodeEmitInfo(info) : NULL, info);
 
-  if (default_value != NULL) {
+  ciField* field = x->field();
+  if (field->signature()->is_Q_signature()) {
+    // Load from non-flattened inline type field requires
+    // a null check to replace null with the default value.
+    ciInlineKlass* inline_klass = field->type()->as_inline_klass();
+    assert(inline_klass->is_loaded(), "field klass must be loaded");
+
+    ciInstanceKlass* holder = field->holder();
+    if (field->is_static() && holder->is_loaded()) {
+      ciObject* val = holder->java_mirror()->field_value(field).as_object();
+      if (!val->is_null_object()) {
+        // Static field is initialized, we don need to perform a null check.
+        return;
+      }
+    }
     LabelObj* L_end = new LabelObj();
     __ cmp(lir_cond_notEqual, result, LIR_OprFact::oopConst(NULL));
     __ branch(lir_cond_notEqual, L_end->label());
     set_in_conditional_code(true);
+    Constant* default_value = new Constant(new InstanceConstant(inline_klass->default_instance()));
     __ move(load_constant(default_value), result);
     __ branch_destination(L_end->label());
     set_in_conditional_code(false);
@@ -2277,7 +2240,7 @@ void LIRGenerator::do_WithField(WithField* x) {
   CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                       Deoptimization::Reason_unloaded,
                                       Deoptimization::Action_make_not_entrant);
-  __ branch(lir_cond_always, stub);
+  __ jump(stub);
   LIR_Opr reg = rlock_result(x, T_OBJECT);
   __ move(LIR_OprFact::oopConst(NULL), reg);
 }
@@ -2288,7 +2251,7 @@ void LIRGenerator::do_DefaultValue(DefaultValue* x) {
   CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                       Deoptimization::Reason_unloaded,
                                       Deoptimization::Action_make_not_entrant);
-  __ branch(lir_cond_always, stub);
+  __ jump(stub);
   LIR_Opr reg = rlock_result(x, T_OBJECT);
   __ move(LIR_OprFact::oopConst(NULL), reg);
 }

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -268,7 +268,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_update_CRC32C(Intrinsic* x);
   void do_vectorizedMismatch(Intrinsic* x);
 
-  Constant* flattened_field_load_prolog(LoadField* x, CodeEmitInfo* info);
+  bool inline_type_field_access_prolog(AccessField* x, CodeEmitInfo* info);
   void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);
@@ -379,7 +379,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void monitor_enter (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info, CodeStub* throw_imse_stub);
   void monitor_exit  (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no);
 
-  void new_instance    (LIR_Opr  dst, ciInstanceKlass* klass, bool is_unresolved, LIR_Opr  scratch1, LIR_Opr  scratch2, LIR_Opr  scratch3,  LIR_Opr scratch4, LIR_Opr  klass_reg, CodeEmitInfo* info);
+  void new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unresolved, bool allow_inline, LIR_Opr scratch1, LIR_Opr scratch2, LIR_Opr scratch3, LIR_Opr scratch4, LIR_Opr klass_reg, CodeEmitInfo* info);
 
   // machine dependent
   void cmp_mem_int(LIR_Condition condition, LIR_Opr base, int disp, int c, CodeEmitInfo* info);

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -47,6 +47,7 @@ class StubAssembler;
   stub(throw_null_pointer_exception) \
   stub(register_finalizer)           \
   stub(new_instance)                 \
+  stub(new_instance_no_inline)       \
   stub(fast_new_instance)            \
   stub(fast_new_instance_init_check) \
   stub(new_type_array)               \
@@ -154,6 +155,7 @@ class Runtime1: public AllStatic {
 
   // runtime entry points
   static void new_instance    (JavaThread* thread, Klass* klass);
+  static void new_instance_no_inline(JavaThread* thread, Klass* klass);
   static void new_type_array  (JavaThread* thread, Klass* klass, jint length);
   static void new_object_array(JavaThread* thread, Klass* klass, jint length);
   static void new_flat_array (JavaThread* thread, Klass* klass, jint length);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
@@ -96,19 +96,19 @@ public class TestGetfieldChains extends InlineTypeTest {
     // Simple chain of getfields ending with primitive field
     @Test(compLevel=C1)
     public int test1() {
-            return NamedRectangle.getP1X(new NamedRectangle());
+        return NamedRectangle.getP1X(new NamedRectangle());
     }
 
     @DontCompile
     public void test1_verifier(boolean warmup) {
-            int res = test1();
-            Asserts.assertEQ(res, 4);
+        int res = test1();
+        Asserts.assertEQ(res, 4);
     }
 
     // Simple chain of getfields ending with a flattened field
     @Test(compLevel=C1)
     public Point test2() {
-            return NamedRectangle.getP1(new NamedRectangle());
+        return NamedRectangle.getP1(new NamedRectangle());
     }
 
     @DontCompile

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3334,8 +3334,6 @@ public class TestLWorld extends InlineTypeTest {
         Asserts.assertTrue(res);
     }
 
-    // TODO Disabled until JDK-8253416 is fixed
-    /*
     // Verify that empty inline type field loads check for null holder
     @Test()
     public MyValueEmpty test122(TestLWorld t) {
@@ -3371,5 +3369,4 @@ public class TestLWorld extends InlineTypeTest {
             // Expected
         }
     }
-    */
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNestmateAccess.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNestmateAccess.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+import jdk.test.lib.Asserts;
+
+/**
+ * @test
+ * @bug 8253416
+ * @summary Test nestmate access to flattened field if nest-host is not loaded.
+ * @library /test/lib
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.Test*::<init>
+ *                   compiler.valhalla.inlinetypes.TestNestmateAccess
+ * @run main/othervm -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.Test*::<init>
+ *                   compiler.valhalla.inlinetypes.TestNestmateAccess
+ */
+
+interface MyInterface {
+    int hash();
+}
+
+inline class MyValue implements MyInterface {
+    int x = 42;
+    int y = 43;
+
+    @Override
+    public int hash() { return x + y; }
+}
+
+// Test load from flattened field in nestmate when nest-host is not loaded.
+class Test1 {
+    private MyValue vt;
+
+    public Test1(final MyValue vt) {
+        this.vt = vt;
+    }
+
+    public MyInterface test() {
+        return new MyInterface() {
+            // The vt field load does not link.
+            private int x = (Test1.this).vt.hash();
+
+            @Override
+            public int hash() { return x; }
+        };
+    }
+}
+
+// Same as Test1 but outer class is an inline type
+inline class Test2 {
+    private MyValue vt;
+
+    public Test2(final MyValue vt) {
+        this.vt = vt;
+    }
+
+    public MyInterface test() {
+        return new MyInterface() {
+            // Delayed flattened load of Test2.this.
+            // The vt field load does not link.
+            private int x = (Test2.this).vt.hash();
+
+            @Override
+            public int hash() { return x; }
+        };
+    }
+}
+
+// Test store to flattened field in nestmate when nest-host is not loaded.
+class Test3 {
+    private MyValue vt;
+
+    public MyInterface test(MyValue init) {
+        return new MyInterface() {
+            // Store to the vt field does not link.
+            private MyValue tmp = (vt = init);
+
+            @Override
+            public int hash() { return tmp.hash() + vt.hash(); }
+        };
+    }
+}
+
+// Same as Test1 but with static field
+class Test4 {
+    private static MyValue vt;
+
+    public Test4(final MyValue vt) {
+        this.vt = vt;
+    }
+
+    public MyInterface test() {
+        return new MyInterface() {
+            // The vt field load does not link.
+            private int x = (Test4.this).vt.hash();
+
+            @Override
+            public int hash() { return x; }
+        };
+    }
+}
+
+// Same as Test2 but with static field
+inline class Test5 {
+    private static MyValue vt;
+
+    public Test5(final MyValue vt) {
+        this.vt = vt;
+    }
+
+    public MyInterface test() {
+        return new MyInterface() {
+            // Delayed flattened load of Test5.this.
+            // The vt field load does not link.
+            private int x = (Test5.this).vt.hash();
+
+            @Override
+            public int hash() { return x; }
+        };
+    }
+}
+
+// Same as Test3 but with static field
+class Test6 {
+    private static MyValue vt;
+
+    public MyInterface test(MyValue init) {
+        return new MyInterface() {
+            // Store to the vt field does not link.
+            private MyValue tmp = (vt = init);
+
+            @Override
+            public int hash() { return tmp.hash() + vt.hash(); }
+        };
+    }
+}
+
+// Same as Test6 but outer class is an inline type
+inline class Test7 {
+    private static MyValue vt;
+
+    public MyInterface test(MyValue init) {
+        return new MyInterface() {
+            // Store to the vt field does not link.
+            private MyValue tmp = (vt = init);
+
+            @Override
+            public int hash() { return tmp.hash() + vt.hash(); }
+        };
+    }
+}
+
+public class TestNestmateAccess {
+
+    public static void main(String[] args) {
+        Test1 t1 = new Test1(new MyValue());
+        int res = t1.test().hash();
+        Asserts.assertEQ(res, 85);
+
+        Test2 t2 = new Test2(new MyValue());
+        res = t2.test().hash();
+        Asserts.assertEQ(res, 85);
+
+        Test3 t3 = new Test3();
+        res = t3.test(new MyValue()).hash();
+        Asserts.assertEQ(res, 170);
+
+        Test4 t4 = new Test4(new MyValue());
+        res = t4.test().hash();
+        Asserts.assertEQ(res, 85);
+
+        Test5 t5 = new Test5(new MyValue());
+        res = t5.test().hash();
+        Asserts.assertEQ(res, 85);
+
+        Test6 t6 = new Test6();
+        res = t6.test(new MyValue()).hash();
+        Asserts.assertEQ(res, 170);
+
+        Test7 t7 = new Test7();
+        res = t7.test(new MyValue()).hash();
+        Asserts.assertEQ(res, 170);
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/hack/GetUnresolvedInlineFieldWrongSignature.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/hack/GetUnresolvedInlineFieldWrongSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,100 @@ class TestUnloadedInlineTypeField {
     static class MyValue3Holder {
         MyValue3 v;
     }
+
+    static class MyValue10 {
+        int foo;
+    }
+
+    static class MyValue10Holder {
+        MyValue10 v1;
+        MyValue10 v2;
+    }
+
+    static class MyValue13 {
+        int foo;
+    }
+
+    static class MyValue13Holder {
+        MyValue13 v;
+    }
+
+    static class MyValue14 {
+        int foo;
+    }
+
+    static class MyValue14Holder {
+        MyValue14 v;
+    }
+
+    static class MyValue15 {
+        int foo;
+    }
+
+    static class MyValue15Holder {
+        MyValue15 v;
+    }
+
+    static inline class MyValue16 {
+        int foo = 42;
+    }
+
+    static inline class MyValue17 {
+        int foo = 42;
+    }
 }
 
 class GetUnresolvedInlineFieldWrongSignature {
-    static int test3(TestUnloadedInlineTypeField.MyValue3Holder holder3) {
-        if (holder3 != null) {
-            return holder3.v.foo + 3;
+    static int test3(Object holder) {
+        if (holder != null) {
+            // Don't use MyValue3Holder in the signature, it might trigger class loading
+            return ((TestUnloadedInlineTypeField.MyValue3Holder)holder).v.foo + 3;
         } else {
             return 0;
+        }
+    }
+
+    static void test10(Object holder) {
+        if (holder != null) {
+            // Don't use MyValue10Holder in the signature, it might trigger class loading
+            ((TestUnloadedInlineTypeField.MyValue10Holder)holder).v1 = ((TestUnloadedInlineTypeField.MyValue10Holder)holder).v2;
+        }
+    }
+
+    static void test13(Object holder) {
+        if (holder != null) {
+            // Don't use MyValue13Holder in the signature, it might trigger class loading
+            ((TestUnloadedInlineTypeField.MyValue13Holder)holder).v = new TestUnloadedInlineTypeField.MyValue13();
+        }
+    }
+
+    static void test14(Object holder) {
+        if (holder != null) {
+            // Don't use MyValue14Holder in the signature, it might trigger class loading
+            ((TestUnloadedInlineTypeField.MyValue14Holder)holder).v = null;
+        }
+    }
+
+    static void test15(Object holder) {
+        if (holder != null) {
+            // Don't use MyValue15Holder in the signature, it might trigger class loading
+            ((TestUnloadedInlineTypeField.MyValue15Holder)holder).v = new TestUnloadedInlineTypeField.MyValue15();
+        }
+    }
+
+    static Object test16(boolean warmup) {
+        if (!warmup) {
+            return TestUnloadedInlineTypeField.MyValue16.default;
+        } else {
+            return null;
+        }
+    }
+
+    static Object test17(boolean warmup) {
+        if (!warmup) {
+            return TestUnloadedInlineTypeField.MyValue17.default;
+        } else {
+            return null;
         }
     }
 }


### PR DESCRIPTION
C1 incorrectly assumes that a nestmate field access is not flat if the nest-host is not loaded.

We are creating the ciField instance for a field in the nest-host via:
`ciField::ciField -> Reflection::verify_member_access -> InstanceKlass::has_nestmate_access_to -> InstanceKlass::nest_host`
Resolving the nest host then requires class loading which is not possible from the C1 compiler thread and as a result we end up with partial field information (is_flattened is always false). The code in LIRGenerator::flattened_field_load_prolog then assumes that if !field->is_flattened(), the field is indeed not flattened. However, we can only rely on that information if !needs_patching.

I've completely re-wrote and simplified the complex logic in LIRGenerator::flattened_field_load_prolog and added asserts/checks to make sure we are not attempting to patch flattened inline type field accesses (that functionality could be added though but it's not easy).

This patch also includes the following unrelated changes:
- The "new" bytecode needs to throw an exception on inline klasses (the klass might be unloaded). The fix makes sure we always take the slow path to "new_instance_no_inline" in that case.
- The "defaultvalue" bytecode needs to throw an exception on non-inline klasses. We simply deoptimize in that case.
- Load/stores from/to fields of an empty inline type should be removed.
- Some refactoring and new asserts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253416](https://bugs.openjdk.java.net/browse/JDK-8253416): [lworld] C1: incorrect nestmate access to flattened field if nest-host is not loaded


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/198/head:pull/198`
`$ git checkout pull/198`
