### PR TITLE
8253312: Enable JVM experiments in specialization under an opt-in mode

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -386,6 +386,9 @@ public class ClassFinder {
                 throw cf;
             } finally {
                 currentClassFile = previousClassFile;
+                if (c.isValue() && c.projection != null) {
+                    c.projection.flags_field = (c.flags_field & ~(VALUE | UNATTRIBUTED | FINAL)) | SEALED;
+                }
             }
         } else {
             throw classFileNotFound(c);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -143,6 +143,10 @@ public class Flags {
      */
     public static final int VALUEBASED       = 1<<19;
 
+    /** Flag is set for a type restricted field.
+     */
+    public static final int RESTRICTED_FIELD       = 1<<19;
+
     /** Flag is set for compiler-generated anonymous method symbols
      *  that `own' an initializer block.
      */
@@ -518,6 +522,7 @@ public class Flags {
         CLASH(Flags.CLASH),
         AUXILIARY(Flags.AUXILIARY),
         NOT_IN_PROFILE(Flags.NOT_IN_PROFILE),
+        RESTRICTED_FIELD(Flags.RESTRICTED_FIELD),
         BAD_OVERRIDE(Flags.BAD_OVERRIDE),
         SIGNATURE_POLYMORPHIC(Flags.SIGNATURE_POLYMORPHIC),
         THROWS(Flags.THROWS),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -101,6 +101,9 @@ public class Types {
     List<Warner> warnStack = List.nil();
     final Name capturedName;
 
+    /** enable alternate code generation to faciliate specialization experiments using type restrictions */
+    public boolean flattenWithTypeRestrictions;
+
     public final Warner noWarnings;
 
     // <editor-fold defaultstate="collapsed" desc="Instantiating">
@@ -126,6 +129,7 @@ public class Types {
         noWarnings = new Warner(null);
         Options options = Options.instance(context);
         allowValueBasedClasses = options.isSet("allowValueBasedClasses");
+        flattenWithTypeRestrictions = options.isSet("flattenWithTypeRestrictions");
     }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -973,12 +973,25 @@ public class ClassWriter extends ClassFile {
             pw.println("---" + flagNames(v.flags()));
         }
         databuf.appendChar(poolWriter.putName(v.name));
-        databuf.appendChar(poolWriter.putDescriptor(v));
+        boolean emitRestrictedField = false;
+        if (types.flattenWithTypeRestrictions && v.type.isValue()) {
+            emitRestrictedField = true;
+            databuf.appendChar(poolWriter.putDescriptor(v.type.referenceProjection()));
+        } else {
+            databuf.appendChar(poolWriter.putDescriptor(v));
+        }
+
         int acountIdx = beginAttrs();
         int acount = 0;
         if (v.getConstValue() != null) {
             int alenIdx = writeAttr(names.ConstantValue);
             databuf.appendChar(poolWriter.putConstant(v.getConstValue()));
+            endAttr(alenIdx);
+            acount++;
+        }
+        if (emitRestrictedField) {
+            int alenIdx = writeAttr(names.RestrictedField);
+            databuf.appendChar(poolWriter.putDescriptor(v));
             endAttr(alenIdx);
             acount++;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -151,6 +151,7 @@ public class Names {
     public final Name NestHost;
     public final Name NestMembers;
     public final Name Record;
+    public final Name RestrictedField;
     public final Name RuntimeInvisibleAnnotations;
     public final Name RuntimeInvisibleParameterAnnotations;
     public final Name RuntimeInvisibleTypeAnnotations;
@@ -337,6 +338,7 @@ public class Names {
         NestHost = fromString("NestHost");
         NestMembers = fromString("NestMembers");
         Record = fromString("Record");
+        RestrictedField = fromString("RestrictedField");
         RuntimeInvisibleAnnotations = fromString("RuntimeInvisibleAnnotations");
         RuntimeInvisibleParameterAnnotations = fromString("RuntimeInvisibleParameterAnnotations");
         RuntimeInvisibleTypeAnnotations = fromString("RuntimeInvisibleTypeAnnotations");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -61,6 +61,7 @@ public abstract class Attribute {
     public static final String NestHost                 = "NestHost";
     public static final String NestMembers              = "NestMembers";
     public static final String Record                   = "Record";
+    public static final String RestrictedField          = "RestrictedField";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
     public static final String RuntimeInvisibleAnnotations = "RuntimeInvisibleAnnotations";
     public static final String RuntimeVisibleParameterAnnotations = "RuntimeVisibleParameterAnnotations";
@@ -137,6 +138,7 @@ public abstract class Attribute {
             standardAttributes.put(NestHost, NestHost_attribute.class);
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
+            standardAttributes.put(RestrictedField, RestrictedField_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
             standardAttributes.put(RuntimeInvisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations_attribute.class);
             standardAttributes.put(RuntimeVisibleAnnotations, RuntimeVisibleAnnotations_attribute.class);
@@ -204,6 +206,7 @@ public abstract class Attribute {
         R visitNestHost(NestHost_attribute attr, P p);
         R visitNestMembers(NestMembers_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
+        R visitRestrictedField(RestrictedField_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);
         R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p);
         R visitRuntimeVisibleParameterAnnotations(RuntimeVisibleParameterAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -656,6 +656,12 @@ public class ClassWriter {
         }
 
         @Override
+        public Void visitRestrictedField(RestrictedField_attribute attr, ClassOutputStream out) {
+            out.writeShort(attr.restricted_type_index);
+            return null;
+        }
+
+        @Override
         public Void visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, ClassOutputStream out) {
             annotationWriter.write(attr.annotations, out);
             return null;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedField_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedField_attribute.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+
+/**
+ * See JVMS, section 4.8.9.
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+
+public class RestrictedField_attribute extends Attribute {
+    RestrictedField_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        restricted_type_index = cr.readUnsignedShort();
+    }
+    public RestrictedField_attribute(ConstantPool constant_pool, int restricted_type_index)
+            throws ConstantPoolException {
+        this(constant_pool.getUTF8Index(Attribute.RestrictedField), restricted_type_index);
+    }
+    public RestrictedField_attribute(int name_index, int restricted_type_index) {
+        super(name_index, 2);
+        this.restricted_type_index = restricted_type_index;
+    }
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitRestrictedField(this, data);
+    }
+
+    public String getRestrictedType(ConstantPool constant_pool) throws ConstantPoolException {
+        return constant_pool.getUTF8Value(restricted_type_index);
+    }
+
+    public final int restricted_type_index;
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -61,6 +61,7 @@ import com.sun.tools.classfile.ModuleTarget_attribute;
 import com.sun.tools.classfile.NestHost_attribute;
 import com.sun.tools.classfile.NestMembers_attribute;
 import com.sun.tools.classfile.Record_attribute;
+import com.sun.tools.classfile.RestrictedField_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleParameterAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleTypeAnnotations_attribute;
@@ -763,6 +764,22 @@ public class AttributeWriter extends BasicWriter
         }
         indent(-1);
         return null;
+    }
+
+    @Override
+    public Void visitRestrictedField(RestrictedField_attribute attr, Void p) {
+        print("RestrictedField: #" + attr.restricted_type_index);
+        tab();
+        println("// " + getRestrictedType(attr));
+        return null;
+    }
+
+    String getRestrictedType(RestrictedField_attribute info) {
+        try {
+            return info.getRestrictedType(constant_pool);
+        } catch (ConstantPoolException e) {
+            return report(e);
+        }
     }
 
     String getValue(Descriptor d) {

--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1371,6 +1371,11 @@ public class ClassfileInspector {
         public Void visitRecord(Record_attribute attr, T p) {
             return null;
         }
+
+        @Override
+        public Void visitRestrictedField(RestrictedField_attribute attr, T p) {
+            return null;
+        }
     }
 
     private static final Attribute.Visitor<Void, ExpectedTypeAnnotation> typeAnnoMatcher

--- a/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
+++ b/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
@@ -66,4 +66,5 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitSynthetic(Synthetic_attribute attr, P p) { return null; }
     public R visitPermittedSubclasses(PermittedSubclasses_attribute attr, P p) { return null; }
     public R visitRecord(Record_attribute attr, P p) { return null; }
+    public R visitRestrictedField(RestrictedField_attribute attr, P p) { return null; }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldCodegenTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldCodegenTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8253312
+ * @summary Enable JVM experiments in specialization under an opt-in mode
+ * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
+ * @compile -XDflattenWithTypeRestrictions RestrictedFieldCodegenTest.java
+ * @run main/othervm -Xverify:none RestrictedFieldCodegenTest
+ * @modules jdk.compiler
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Paths;
+
+class PointBox {
+
+    static inline class Point {
+        public double x;
+        public double y;
+        public Point(double x, double y) { this.x = x; this.y = y; }
+    }
+
+    public Point p;
+
+    public static void main(String... args) {
+        PointBox b = new PointBox();
+        if (b.p != new Point(0,0)) throw new RuntimeException();
+        b.p = new Point(1.0, 2.0);
+        if (b.p != new Point(1.0, 2.0)) throw new RuntimeException();
+    }
+}
+
+public class RestrictedFieldCodegenTest {
+
+    public static void main(String [] args) {
+        new RestrictedFieldCodegenTest().run();
+    }
+
+    void run() {
+        String [] params = new String [] { "-v",
+                                            Paths.get(System.getProperty("test.classes"),
+                                                "PointBox.class").toString() };
+        runCheck(params, new String [] {
+
+         "public PointBox$Point$ref p;",
+         "descriptor: LPointBox$Point$ref;",
+         "RestrictedField: #25                    // QPointBox$Point;",
+         " 9: getfield      #10                 // Field p:LPointBox$Point$ref;",
+         "36: putfield      #10                 // Field p:LPointBox$Point$ref;",
+         "40: getfield      #10                 // Field p:LPointBox$Point$ref;",
+         });
+
+     }
+
+     void runCheck(String [] params, String [] expectedOut) {
+        StringWriter s;
+        String out;
+
+        System.out.println("Checking javap");
+        try (PrintWriter pw = new PrintWriter(s = new StringWriter())) {
+            com.sun.tools.javap.Main.run(params, pw);
+            out = s.toString();
+        }
+        System.out.println("Javap = " + out);
+        int errors = 0;
+        for (String eo: expectedOut) {
+            if (!out.contains(eo)) {
+                System.err.println("Match not found for string: " + eo);
+                errors++;
+            }
+        }
+         if (errors > 0) {
+             throw new AssertionError("Unexpected javap output: " + out);
+         }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.java
@@ -1,0 +1,15 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8253312
+ * @summary Enable JVM experiments in specialization under an opt-in mode
+ * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
+ * @compile -XDflattenWithTypeRestrictions -XDrawDiagnostics RestrictedFieldCodegenTest.java
+ * @compile/fail/ref=RestrictedFieldTypeTest.out -XDflattenWithTypeRestrictions -XDrawDiagnostics RestrictedFieldTypeTest.java
+ */
+
+public class RestrictedFieldTypeTest {
+    PointBox rft = new PointBox();
+    void foo() {
+        rft.p = null;
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.out
@@ -1,0 +1,2 @@
+RestrictedFieldTypeTest.java:13:17: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, PointBox.Point)
+1 error


### PR DESCRIPTION
Early support for specialization experiements via type restrictions on fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253312](https://bugs.openjdk.java.net/browse/JDK-8253312): Enable JVM experiments in specialization under an opt-in mode


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/199/head:pull/199`
`$ git checkout pull/199`
