### PR TITLE
8253724: [lworld] C1 compilation hits assert: Empty inline type access should be removed

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2076,7 +2076,9 @@ void GraphBuilder::withfield(int field_index)
       if (field->offset() != offset) {
         if (field->is_flattened()) {
           ciInlineKlass* vk = field->type()->as_inline_klass();
-          copy_inline_content(vk, obj, off, new_instance, vk->first_field_offset(), state_before, needs_patching);
+          if (!vk->is_empty()) {
+            copy_inline_content(vk, obj, off, new_instance, vk->first_field_offset(), state_before, needs_patching);
+          }
         } else {
           // Only load those fields who are not modified
           LoadField* load = new LoadField(obj, off, field, false, state_before, needs_patching);
@@ -2095,7 +2097,9 @@ void GraphBuilder::withfield(int field_index)
   }
   if (field_modify->is_flattened()) {
     ciInlineKlass* vk = field_modify->type()->as_inline_klass();
-    copy_inline_content(vk, val, vk->first_field_offset(), new_instance, field_modify->offset(), state_before, needs_patching);
+    if (!vk->is_empty()) {
+      copy_inline_content(vk, val, vk->first_field_offset(), new_instance, field_modify->offset(), state_before, needs_patching);
+    }
   } else {
     StoreField* store = new StoreField(new_instance, offset, field_modify, val, false, state_before, needs_patching);
     append(store);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1964,7 +1964,14 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             ciInlineKlass* inline_klass = field->type()->as_inline_klass();
             scope()->set_wrote_final();
             scope()->set_wrote_fields();
-            if (has_pending_load_indexed()) {
+            if (inline_klass->is_empty()) {
+              apush(append(new Constant(new InstanceConstant(inline_klass->default_instance()))));
+              if (has_pending_field_access()) {
+                set_pending_field_access(NULL);
+              } else if (has_pending_load_indexed()) {
+                set_pending_load_indexed(NULL);
+              }
+            } else if (has_pending_load_indexed()) {
               assert(!needs_patching, "Can't patch delayed field access");
               pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
               NewInlineTypeInstance* vt = new NewInlineTypeInstance(inline_klass, pending_load_indexed()->state_before());

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
@@ -182,4 +182,38 @@ public class TestGetfieldChains extends InlineTypeTest {
         Asserts.assertEQ(st.getLineNumber(), 31);       // line number depends on jcod file generated from NamedRectangle.java
         Asserts.assertEQ(nsfe.getMessage(), "x");
     }
+
+    static inline class EmptyType { }
+    static inline class EmptyContainer {
+        int i = 0;
+        EmptyType et = new EmptyType();
+    }
+    static inline class Container {
+        EmptyContainer container0 = new EmptyContainer();
+        EmptyContainer container1 = new EmptyContainer();
+    }
+
+    @Test(compLevel=C1)
+    public EmptyType test6() {
+        Container c = new Container();
+        return c.container1.et;
+    }
+
+    @DontCompile
+    public void test6_verifier(boolean warmup) {
+        EmptyType et = test6();
+        Asserts.assertEQ(et, EmptyType.default);
+    }
+
+    @Test(compLevel=C1)
+    public EmptyType test7() {
+        Container[] ca = new Container[10];
+        return ca[3].container0.et;
+    }
+
+    @DontCompile
+    public void test7_verifier(boolean warmup) {
+        EmptyType et = test7();
+        Asserts.assertEQ(et, EmptyType.default);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
@@ -183,37 +183,37 @@ public class TestGetfieldChains extends InlineTypeTest {
         Asserts.assertEQ(nsfe.getMessage(), "x");
     }
 
-    static inline class EmptyType { }
-    static inline class EmptyContainer {
-        int i = 0;
-        EmptyType et = new EmptyType();
-    }
-    static inline class Container {
-        EmptyContainer container0 = new EmptyContainer();
-        EmptyContainer container1 = new EmptyContainer();
-    }
+    // static inline class EmptyType { }
+    // static inline class EmptyContainer {
+    //     int i = 0;
+    //     EmptyType et = new EmptyType();
+    // }
+    // static inline class Container {
+    //     EmptyContainer container0 = new EmptyContainer();
+    //     EmptyContainer container1 = new EmptyContainer();
+    // }
 
-    @Test(compLevel=C1)
-    public EmptyType test6() {
-        Container c = new Container();
-        return c.container1.et;
-    }
+    // @Test(compLevel=C1)
+    // public EmptyType test6() {
+    //     Container c = new Container();
+    //     return c.container1.et;
+    // }
 
-    @DontCompile
-    public void test6_verifier(boolean warmup) {
-        EmptyType et = test6();
-        Asserts.assertEQ(et, EmptyType.default);
-    }
+    // @DontCompile
+    // public void test6_verifier(boolean warmup) {
+    //     EmptyType et = test6();
+    //     Asserts.assertEQ(et, EmptyType.default);
+    // }
 
-    @Test(compLevel=C1)
-    public EmptyType test7() {
-        Container[] ca = new Container[10];
-        return ca[3].container0.et;
-    }
+    // @Test(compLevel=C1)
+    // public EmptyType test7() {
+    //     Container[] ca = new Container[10];
+    //     return ca[3].container0.et;
+    // }
 
-    @DontCompile
-    public void test7_verifier(boolean warmup) {
-        EmptyType et = test7();
-        Asserts.assertEQ(et, EmptyType.default);
-    }
+    // @DontCompile
+    // public void test7_verifier(boolean warmup) {
+    //     EmptyType et = test7();
+    //     Asserts.assertEQ(et, EmptyType.default);
+    // }
 }


### PR DESCRIPTION
Please review these changes fixing handling the handling of empty inline types in C1.
The changeset includes two new unit tests, but they are currently disabled because they are causing failures with C2 which has issues with empty inline types too (C2 will be fixed with a different patch).

Tested with Mach5, tiers 1 to 3.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253724](https://bugs.openjdk.java.net/browse/JDK-8253724): [lworld] C1 compilation hits assert: Empty inline type access should be removed


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/203/head:pull/203`
`$ git checkout pull/203`
