### PR TITLE
8253873: jdi, jvmti, and jdwp tests fail because of unexpected number of interfaces

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,8 +181,8 @@ public class allinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface0list.size() != 0) {
-                            log3("ERROR : iface0list.size() != 0 in case: Class0ForCheck");
+                        if (iface0list.size() != 1) {
+                            log3("ERROR : iface0list.size() != 1 in case: Class0ForCheck");
                             expresult = 1;
                             break;
                         }
@@ -198,8 +198,8 @@ public class allinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface1list.size() != 2) {
-                            log3("ERROR : iface1list.size() != 2 in case: Class1forCheck   :"  + iface1list.size());
+                        if (iface1list.size() != 3) {
+                            log3("ERROR : iface1list.size() != 3 in case: Class1forCheck   :"  + iface1list.size());
                             expresult = 1;
                             break;
                         }
@@ -208,7 +208,7 @@ public class allinterfaces001 {
                         name = reftype.name();
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
-                                log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2') in Class1forCheck");
+                                log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2') in Class1forCheck, name: " + name);
                                 expresult = 1;
                                 break;
                             }
@@ -217,9 +217,11 @@ public class allinterfaces001 {
                         name = reftype.name();
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
-                                log3("ERROR :name2: !name.equals('.Iface1' or '.Iface2') in Class1forCheck");
-                                expresult = 1;
-                                break;
+                                if (!name.equals("java.lang.IdentityObject")) {
+                                    log3("ERROR :name2: !name.equals('.Iface1' or '.Iface2 or 'java.lang.IdentityObject') in Class1forCheck, name: " + name);
+                                    expresult = 1;
+                                    break;
+                                }
                             }
                         }
                         break;
@@ -233,8 +235,8 @@ public class allinterfaces001 {
                         List iface2list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface2list.size() != 3) {
-                            log3("ERROR : iface2list.size() != 3 in case: Class2forCheck");
+                        if (iface2list.size() != 4) {
+                            log3("ERROR : iface2list.size() != 4 in case: Class2forCheck");
                             expresult = 1;
                             break;
                         }
@@ -244,7 +246,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class2forCheck, name: " + name);
                                     expresult = 1;
                                     break;
                                 }
@@ -255,9 +257,11 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
-                                    expresult = 1;
-                                    break;
+                                    if (!name.equals("java.lang.IdentityObject")) {
+                                        log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3' or 'java.lang.IdentityObject') in Class2forCheck, name: " + name);
+                                        expresult = 1;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -266,7 +270,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck, name: " + name);
                                     expresult = 1;
                                     break;
                                 }
@@ -283,8 +287,8 @@ public class allinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface3list.size() != 3) {
-                            log3("ERROR : iface3list.size() != 3 in case: Class3forCheck");
+                        if (iface3list.size() != 4) {
+                            log3("ERROR : iface3list.size() != 4 in case: Class3forCheck");
                             expresult = 1;
                             break;
                         }
@@ -294,7 +298,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class3forCheck, name: " + name);
                                     expresult = 1;
                                     break;
                                 }
@@ -305,9 +309,11 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
-                                    expresult = 1;
-                                    break;
+                                    if (!name.equals("java.lang.IdentityObject")) {
+                                        log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3' or 'java.lang.IdentityObject') in Class3forCheck, name: " + name);
+                                        expresult = 1;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -316,7 +322,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class3forCheck, name: " + name);
                                     expresult = 1;
                                     break;
                                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
@@ -172,7 +172,7 @@ public class allinterfaces001 {
 
                 switch (i2) {
 
-                case 0:         // Class0ForCheck - 0 interfaces
+                case 0:         // Class0ForCheck - 1 injected interface (java.lang.IdentityObject)
 
                         List list0 = vm.classesByName(mName + ".Class0ForCheck");
 
@@ -189,7 +189,7 @@ public class allinterfaces001 {
 
                         break ;
 
-                case 1:         // Class1forCheck - 1 direct and 1 indirect interfaces
+                case 1:         // Class1forCheck - 1 direct, 1 indirect, and 1 injected (java.lang.IdentityObject) interfaces
 
                         List list1 = vm.classesByName(mName + ".Class1ForCheck");
 
@@ -226,7 +226,7 @@ public class allinterfaces001 {
                         }
                         break;
 
-                case 2:         // Class2ForCheck - 1 direct and 2 indirect interfaces
+                case 2:         // Class2ForCheck - 1 direct, 2 indirect, and 1 injected (java.lang.IdentityObject) interfaces
 
                         List list2 = vm.classesByName(mName + ".Class2ForCheck");
 
@@ -278,7 +278,7 @@ public class allinterfaces001 {
                         }
                         break;
 
-                case 3:         // Class3ForCheck - 1 direct and 2 indirect interfaces
+                case 3:         // Class3ForCheck - 1 direct, 2 indirect, and 1 injected (java.lang.IdentityObject) interfaces
 
                         List list3 = vm.classesByName(mName + ".Class3ForCheck");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,8 +176,8 @@ public class interfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 0) {
-                            log3("ERROR : iface0list.size() != 0 in case: Class0ForCheck");
+                        if (iface0list.size() != 1) {
+                            log3("ERROR : iface0list.size() != 1 in case: Class0ForCheck");
                             expresult = 1;
                             break;
                         }
@@ -193,8 +193,8 @@ public class interfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 1) {
-                            log3("ERROR : iface1list.size() != 1 in case: Class1forCheck");
+                        if (iface1list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2 in case: Class1forCheck");
                             expresult = 1;
                             break;
                         }
@@ -218,8 +218,8 @@ public class interfaces001 {
                         List iface2list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface2list.size() != 2) {
-                            log3("ERROR : iface1list.size() != 2 in case: Class2forCheck");
+                        if (iface2list.size() != 3) {
+                            log3("ERROR : iface1list.size() != 3 in case: Class2forCheck");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
@@ -167,7 +167,7 @@ public class interfaces001 {
 
                 switch (i2) {
 
-                case 0:         // Class0ForCheck - 0 interfaces
+                case 0:         // Class0ForCheck - 1 interface (injected java.lang.IdentityObject)
 
                         List list0 = vm.classesByName(mName + ".Class0ForCheck");
 
@@ -184,7 +184,7 @@ public class interfaces001 {
 
                         break;
 
-                case 1:         // Class1forCheck - 1 interface
+                case 1:         // Class1forCheck - 2 interfaces (includes injected java.lang.IdentityObject)
 
                         List list1 = vm.classesByName(mName + ".Class1ForCheck");
 
@@ -209,7 +209,7 @@ public class interfaces001 {
 
                         break;
 
-                case 2:         // Class2ForCheck - 2 interfaces
+                case 2:         // Class2ForCheck - 3 interfaces (includes injected java.lang.IdentityObject)
 
                         List list2 = vm.classesByName(mName + ".Class2ForCheck");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,8 +178,8 @@ public class implementors001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 1) {
-                            log3("ERROR : iface0list.size() != 1  in case: Iface1");
+                        if (iface0list.size() != 2) {
+                            log3("ERROR : iface0list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;
                         }
@@ -222,8 +222,8 @@ public class implementors001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 1) {
-                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
+                        if (iface1list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -255,8 +255,8 @@ public class implementors001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 1) {
-                            log3("ERROR : iface3list.size() != 1  in case: Iface3");
+                        if (iface3list.size() != 2) {
+                            log3("ERROR : iface3list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
@@ -178,7 +178,7 @@ public class implementors001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) {
+                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface0list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;
@@ -255,7 +255,7 @@ public class implementors001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) {
+                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface3list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,8 +177,8 @@ public class subinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 1) {
-                            log3("ERROR : iface0list.size() != 1  in case: Iface3");
+                        if (iface0list.size() != 2) {
+                            log3("ERROR : iface0list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;
                         }
@@ -201,8 +201,8 @@ public class subinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 1) {
-                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
+                        if (iface1list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -234,8 +234,8 @@ public class subinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 1) {
-                            log3("ERROR : iface3list.size() != 1  in case: Iface1");
+                        if (iface3list.size() != 2) {
+                            log3("ERROR : iface3list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
@@ -177,7 +177,7 @@ public class subinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) {
+                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface0list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;
@@ -201,7 +201,7 @@ public class subinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) {
+                        if (iface1list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface1list.size() != 2  in case: Iface2");
                             expresult = 1;
                             break;
@@ -234,7 +234,7 @@ public class subinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) {
+                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface3list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,8 +180,8 @@ public class superinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 1) {
-                            log3("ERROR : iface0list.size() != 1  in case: Iface1");
+                        if (iface0list.size() != 2) {
+                            log3("ERROR : iface0list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;
                         }
@@ -204,8 +204,8 @@ public class superinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 1) {
-                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
+                        if (iface1list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -237,8 +237,8 @@ public class superinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 1) {
-                            log3("ERROR : iface3list.size() != 1  in case: Iface3");
+                        if (iface3list.size() != 2) {
+                            log3("ERROR : iface3list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;
                         }
@@ -262,8 +262,8 @@ public class superinterfaces001 {
                         List iface4list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface4list.size() != 1) {
-                            log3("ERROR : iface4list.size() != 1  in case: Iface4");
+                        if (iface4list.size() != 2) {
+                            log3("ERROR : iface4list.size() != 2  in case: Iface4");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
@@ -180,7 +180,7 @@ public class superinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) {
+                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface0list.size() != 2  in case: Iface1");
                             expresult = 1;
                             break;
@@ -204,7 +204,7 @@ public class superinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) {
+                        if (iface1list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface1list.size() != 2  in case: Iface2");
                             expresult = 1;
                             break;
@@ -237,7 +237,7 @@ public class superinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) {
+                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface3list.size() != 2  in case: Iface3");
                             expresult = 1;
                             break;
@@ -262,7 +262,7 @@ public class superinterfaces001 {
                         List iface4list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface4list.size() != 2) {
+                        if (iface4list.size() != 2) { // includes injected java.lang.IdentityObject
                             log3("ERROR : iface4list.size() != 2  in case: Iface4");
                             expresult = 1;
                             break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
@@ -46,7 +46,8 @@ public class interfaces001 {
 
     static final String class_interfaces [][] = {
                     { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface1", "" },
-                    { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface2", "" }
+                    { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface2", "" },
+                    { "java.lang.IdentityObject", ""}
                 };
     static final int DECLARED_INTERFACES = class_interfaces.length;
     static final long interfaceIDs[] = new long[DECLARED_INTERFACES];

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
@@ -60,7 +60,7 @@ static size_t eventsCount = 0;
 static size_t eventsExpected = 0;
 static class_info classes[] = {
     { "Lnsk/jvmti/ClassPrepare/classprep001$TestInterface;", EXP_STATUS, 2, 1, 0 },
-    { "Lnsk/jvmti/ClassPrepare/classprep001$TestClass;", EXP_STATUS, 3, 2, 1 }
+    { "Lnsk/jvmti/ClassPrepare/classprep001$TestClass;", EXP_STATUS, 3, 2, 2 }
 };
 
 void printStatus(jint status) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/getintrf007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/getintrf007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,15 +67,19 @@ static iface_info i9[] = {
     { "Lnsk/jvmti/GetImplementedInterfaces/OuterInterface2;" }
 };
 
+static iface_info jlio[] = {
+    { "Ljava/lang/IdentityObject;" }
+};
+
 static class_info classes[] = {
-    { "InnerClass1", 0, NULL },
+    { "InnerClass1", 1, jlio },
     { "InnerInterface1", 0, NULL },
     { "InnerInterface2", 1, i2 },
-    { "InnerClass2", 1, i3 },
-    { "OuterClass1", 0, NULL },
+    { "InnerClass2", 2, i3 },
+    { "OuterClass1", 1, jlio },
     { "OuterClass2", 0, NULL },
     { "OuterInterface1", 0, NULL },
-    { "OuterClass3", 1, i7 },
+    { "OuterClass3", 2, i7 },
     { "OuterInterface2", 1, i8 },
     { "OuterClass4", 1, i9 },
     { "OuterClass5", 0, NULL }
@@ -155,9 +159,11 @@ Java_nsk_jvmti_GetImplementedInterfaces_getintrf007_check(JNIEnv *env, jclass cl
                 }
                 if ((j < classes[i].icount) && (sig == NULL ||
                         strcmp(sig, classes[i].ifaces[j].sig) != 0)) {
-                    printf("(%d:%d) wrong interface: \"%s\"", i, j, sig);
-                    printf(", expected: \"%s\"\n", classes[i].ifaces[j].sig);
-                    result = STATUS_FAILED;
+                    if (strcmp(sig, "Ljava/lang/IdentityObject;") != 0) {
+                        printf("(%d:%d) wrong interface: \"%s\"", i, j, sig);
+                        printf(", expected: \"%s\"\n", classes[i].ifaces[j].sig);
+                        result = STATUS_FAILED;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Please review these changes to fix tier4 and tier5 tests that started failing because injected interface IdentityObject is no longer hidden.  Tiers 4 and 5 were run on linux X64, Macosx, and Windows to check that the tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253873](https://bugs.openjdk.java.net/browse/JDK-8253873): jdi, jvmti, and jdwp tests fail because of unexpected number of interfaces


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/206/head:pull/206`
`$ git checkout pull/206`
