### PR TITLE
8248220: [lworld] Optimize empty inline types

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5341,7 +5341,7 @@ bool MacroAssembler::move_helper(VMReg from, VMReg to, BasicType bt, RegState re
 }
 
 // Read all fields from an inline type oop and store the values in registers/stack slots
-bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, VMRegPair* regs_to,
+bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, int& from_index, VMRegPair* regs_to,
                                           int& to_index, RegState reg_state[], int ret_off, int extra_stack_offset) {
   Register fromReg = from->is_reg() ? from->as_Register() : noreg;
   assert(sig->at(sig_index)._bt == T_VOID, "should be at end delimiter");
@@ -5419,6 +5419,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     // This is okay because no one else will write to that slot
     reg_state[from->value()] = reg_writable;
   }
+  from_index--;
   return done;
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1659,7 +1659,7 @@ public:
   // Unpack all inline type arguments passed as oops
   void unpack_inline_args(Compile* C, bool receiver_only);
   bool move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[], int ret_off, int extra_stack_offset);
-  bool unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, VMRegPair* regs_to, int& to_index,
+  bool unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, int& from_index, VMRegPair* regs_to, int& to_index,
                             RegState reg_state[], int ret_off, int extra_stack_offset);
   bool pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                           VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -91,8 +91,10 @@ bool ciInlineKlass::can_be_returned_as_fields() const {
   GUARDED_VM_ENTRY(return to_InlineKlass()->can_be_returned_as_fields();)
 }
 
-bool ciInlineKlass::is_empty() const {
-  GUARDED_VM_ENTRY(return to_InlineKlass()->is_empty_inline_type();)
+bool ciInlineKlass::is_empty() {
+  // Do not use InlineKlass::is_empty_inline_type here because it does
+  // not recursively account for flattened fields of empty inline types.
+  return nof_nonstatic_fields() == 0;
 }
 
 // When passing an inline type's fields as arguments, count the number

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -81,7 +81,7 @@ public:
   bool is_scalarizable() const;
   bool can_be_passed_as_fields() const;
   bool can_be_returned_as_fields() const;
-  bool is_empty() const;
+  bool is_empty();
   int inline_arg_slots();
   int default_value_offset() const;
   ciInstance* default_instance() const;

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -275,7 +275,7 @@ Klass* InlineKlass::array_klass_impl(bool or_null, TRAPS) {
 int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
   int count = 0;
   SigEntry::add_entry(sig, T_INLINE_TYPE, base_off);
-  for (AllFieldStream fs(this); !fs.done(); fs.next()) {
+  for (JavaFieldStream fs(this); !fs.done(); fs.next()) {
     if (fs.access_flags().is_static()) continue;
     int offset = base_off + fs.offset() - (base_off > 0 ? first_field_offset() : 0);
     if (fs.is_inlined()) {
@@ -376,12 +376,12 @@ bool InlineKlass::is_scalarizable() const {
 
 // Can this inline type be passed as multiple values?
 bool InlineKlass::can_be_passed_as_fields() const {
-  return InlineTypePassFieldsAsArgs && is_scalarizable() && !is_empty_inline_type();
+  return InlineTypePassFieldsAsArgs && is_scalarizable();
 }
 
 // Can this inline type be returned as multiple values?
 bool InlineKlass::can_be_returned_as_fields(bool init) const {
-  return InlineTypeReturnedAsFields && is_scalarizable() && !is_empty_inline_type() && (init || return_regs() != NULL);
+  return InlineTypeReturnedAsFields && is_scalarizable() && (init || return_regs() != NULL);
 }
 
 // Create handles for all oop fields returned in registers that are going to be live across a safepoint

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -462,7 +462,7 @@ void LateInlineCallGenerator::do_late_inline() {
     uint j = TypeFunc::Parms;
     for (uint i1 = 0; i1 < nargs; i1++) {
       const Type* t = domain_sig->field_at(TypeFunc::Parms + i1);
-      if (method()->has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null()) {
+      if (method()->has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null() && t->inline_klass()->can_be_passed_as_fields()) {
         // Inline type arguments are not passed by reference: we get an argument per
         // field of the inline type. Build InlineTypeNodes from the inline type arguments.
         GraphKit arg_kit(jvms, &gvn);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1812,7 +1812,7 @@ void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inli
   for (uint i = TypeFunc::Parms, idx = TypeFunc::Parms; i < nargs; i++) {
     Node* arg = argument(i-TypeFunc::Parms);
     const Type* t = domain->field_at(i);
-    if (call->method()->has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null()) {
+    if (call->method()->has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null() && t->inline_klass()->can_be_passed_as_fields()) {
       // We don't pass inline type arguments by reference but instead pass each field of the inline type
       InlineTypeNode* vt = arg->as_InlineType();
       vt->pass_fields(this, call, sig_cc, idx);

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -223,14 +223,14 @@ int InlineTypeBaseNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node
   return sfpt->replace_edges_in_range(this, sobj, start, end);
 }
 
-void InlineTypeBaseNode::make_scalar_in_safepoints(PhaseIterGVN* igvn) {
+void InlineTypeBaseNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop) {
   // Process all safepoint uses and scalarize inline type
   Unique_Node_List worklist;
   for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
     SafePointNode* sfpt = fast_out(i)->isa_SafePoint();
     if (sfpt != NULL && !sfpt->is_CallLeaf() && (!sfpt->is_Call() || sfpt->as_Call()->has_debug_use(this))) {
       int nb = 0;
-      if (is_allocated(igvn) && get_oop()->is_Con()) {
+      if (allow_oop && is_allocated(igvn) && get_oop()->is_Con()) {
         // Inline type is allocated with a constant oop, link it directly
         nb = sfpt->replace_edges_in_range(this, get_oop(), sfpt->jvms()->debug_start(), sfpt->jvms()->debug_end());
         igvn->rehash_node_delayed(sfpt);
@@ -273,8 +273,12 @@ void InlineTypeBaseNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKl
     Node* value = NULL;
     ciType* ft = field_type(i);
     if (field_is_flattened(i)) {
-      // Recursively load the flattened inline type field
-      value = InlineTypeNode::make_from_flattened(kit, ft->as_inline_klass(), base, ptr, holder, offset, decorators);
+      if (ft->as_inline_klass()->is_empty()) {
+        value = InlineTypeNode::make_default(kit->gvn(), ft->as_inline_klass());
+      } else {
+        // Recursively load the flattened inline type field
+        value = InlineTypeNode::make_from_flattened(kit, ft->as_inline_klass(), base, ptr, holder, offset, decorators);
+      }
     } else {
       const TypeOopPtr* oop_ptr = kit->gvn().type(base)->isa_oopptr();
       bool is_array = (oop_ptr->isa_aryptr() != NULL);
@@ -510,7 +514,7 @@ InlineTypeNode* InlineTypeNode::make_default(PhaseGVN& gvn, ciInlineKlass* vk) {
     if (field_type->is_inlinetype()) {
       ciInlineKlass* field_klass = field_type->as_inline_klass();
       if (field_klass->is_scalarizable()) {
-        value = InlineTypeNode::make_default(gvn, field_klass);
+        value = make_default(gvn, field_klass);
       } else {
         value = default_oop(gvn, field_klass);
       }
@@ -538,7 +542,9 @@ bool InlineTypeNode::is_default(PhaseGVN* gvn) const {
 
 InlineTypeNode* InlineTypeNode::make_from_oop(GraphKit* kit, Node* oop, ciInlineKlass* vk) {
   PhaseGVN& gvn = kit->gvn();
-
+  if (vk->is_empty()) {
+    return make_default(gvn, vk);
+  }
   // Create and initialize an InlineTypeNode by loading all field
   // values from a heap-allocated version and also save the oop.
   InlineTypeNode* vt = new InlineTypeNode(vk, oop);
@@ -577,7 +583,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop(GraphKit* kit, Node* oop, ciInline
     // Oop can never be null
     Node* init_ctl = kit->control();
     vt->load(kit, oop, oop, vk, /* holder_offset */ 0);
-    assert(init_ctl != kit->control() || !gvn.type(oop)->is_inlinetypeptr() || oop->is_Con() || oop->Opcode() == Op_InlineTypePtr ||
+    assert(vt->is_default(&gvn) || init_ctl != kit->control() || !gvn.type(oop)->is_inlinetypeptr() || oop->is_Con() || oop->Opcode() == Op_InlineTypePtr ||
            AllocateNode::Ideal_allocation(oop, &gvn) != NULL || vt->is_loaded(&gvn) == oop, "inline type should be loaded");
   }
 
@@ -599,8 +605,8 @@ InlineTypeNode* InlineTypeNode::make_from_flattened(GraphKit* kit, ciInlineKlass
 }
 
 InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, ciInlineKlass* vk, uint& base_input, bool in) {
-  InlineTypeNode* vt = InlineTypeNode::make_uninitialized(kit->gvn(), vk);
-  vt->initialize_fields(kit, multi, sig, base_input, 0, in);
+  InlineTypeNode* vt = make_uninitialized(kit->gvn(), vk);
+  vt->initialize_fields(kit, multi, sig, base_input, in);
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
@@ -659,10 +665,12 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
     if (value->is_InlineType()) {
       InlineTypeNode* vt = value->as_InlineType();
       if (field_is_flattened(i)) {
-        // Check inline type field load recursively
-        base = vt->is_loaded(phase, vk, base, offset - vt->inline_klass()->first_field_offset());
-        if (base == NULL) {
-          return NULL;
+        if (!vt->inline_klass()->is_empty()) {
+          // Check inline type field load recursively
+          base = vt->is_loaded(phase, vk, base, offset - vt->inline_klass()->first_field_offset());
+          if (base == NULL) {
+            return NULL;
+          }
         }
         continue;
       } else {
@@ -705,16 +713,16 @@ Node* InlineTypeNode::tagged_klass(ciInlineKlass* vk, PhaseGVN& gvn) {
   return gvn.makecon(TypeRawPtr::make((address)bits));
 }
 
-void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input, int base_offset) {
+void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input) {
   for (uint i = 0; i < field_count(); i++) {
-    int sig_offset = (*sig)._offset;
-    uint idx = field_index(sig_offset - base_offset);
-    Node* arg = field_value(idx);
+    int offset = field_offset(i);
+    ciType* type = field_type(i);
+    Node* arg = field_value(i);
 
-    if (field_is_flattened(idx)) {
+    if (field_is_flattened(i)) {
       // Flattened inline type field
       InlineTypeNode* vt = arg->as_InlineType();
-      vt->pass_fields(kit, n, sig, base_input, sig_offset - vt->inline_klass()->first_field_offset());
+      vt->pass_fields(kit, n, sig, base_input);
     } else {
       if (arg->is_InlineType()) {
         // Non-flattened inline type field
@@ -739,18 +747,15 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig,
   }
 }
 
-void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, int base_offset, bool in) {
+void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, bool in) {
   PhaseGVN& gvn = kit->gvn();
-  for (uint i = 0; i < field_count(); i++) {
-    int sig_offset = (*sig)._offset;
-    uint idx = field_index(sig_offset - base_offset);
-    ciType* type = field_type(idx);
-
+  for (uint i = 0; i < field_count(); ++i) {
+    ciType* type = field_type(i);
     Node* parm = NULL;
-    if (field_is_flattened(idx)) {
+    if (field_is_flattened(i)) {
       // Flattened inline type field
-      InlineTypeNode* vt = InlineTypeNode::make_uninitialized(gvn, type->as_inline_klass());
-      vt->initialize_fields(kit, multi, sig, base_input, sig_offset - type->as_inline_klass()->first_field_offset(), in);
+      InlineTypeNode* vt = make_uninitialized(gvn, type->as_inline_klass());
+      vt->initialize_fields(kit, multi, sig, base_input, in);
       parm = gvn.transform(vt);
     } else {
       if (multi->is_Start()) {
@@ -764,20 +769,21 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, Extended
       if (type->is_inlinetype()) {
         // Non-flattened inline type field
         if (type->as_inline_klass()->is_scalarizable()) {
-          parm = InlineTypeNode::make_from_oop(kit, parm, type->as_inline_klass());
+          parm = make_from_oop(kit, parm, type->as_inline_klass());
         } else {
           parm = kit->null2default(parm, type->as_inline_klass());
         }
       }
-      base_input += type2size[type->basic_type()];
-      // Skip reserved arguments
       BasicType bt = type->basic_type();
+      base_input += type2size[bt];
+      // Skip reserved arguments
       while (SigEntry::next_is_reserved(sig, bt)) {
         base_input += type2size[bt];
       }
     }
     assert(parm != NULL, "should never be null");
-    set_field_value(idx, parm);
+    assert(field_value(i) == NULL, "already set");
+    set_field_value(i, parm);
     gvn.record_for_igvn(parm);
   }
 }

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -76,7 +76,7 @@ public:
   bool          field_is_flattened(uint index) const;
 
   // Replace InlineTypeNodes in debug info at safepoints with SafePointScalarObjectNodes
-  void make_scalar_in_safepoints(PhaseIterGVN* igvn);
+  void make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop = true);
 
   // Store the inline type as a flattened (headerless) representation
   void store_flattened(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass* holder = NULL, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED) const;
@@ -139,9 +139,9 @@ public:
   }
   static Node* tagged_klass(ciInlineKlass* vk, PhaseGVN& gvn);
   // Pass inline type as fields at a call or return
-  void pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input, int base_offset = 0);
+  void pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input);
   // Initialize the inline type fields with the inputs or outputs of a MultiNode
-  void initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, int base_offset, bool in);
+  void initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, bool in);
 
   // Allocation optimizations
   void remove_redundant_allocations(PhaseIterGVN* igvn, PhaseIdealLoop* phase);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -614,8 +614,6 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
   for (int i = 0; i < vk->nof_declared_nonstatic_fields(); ++i) {
     ciType* field_type = vt->field_type(i);
     int field_offset = offset + vt->field_offset(i);
-    // Each inline type field has its own memory slice
-    adr_type = adr_type->with_field_offset(field_offset);
     Node* value = NULL;
     if (vt->field_is_flattened(i)) {
       value = inline_type_from_mem(mem, ctl, field_type->as_inline_klass(), adr_type, field_offset, alloc);
@@ -626,6 +624,8 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
         ft = ft->make_narrowoop();
         bt = T_NARROWOOP;
       }
+      // Each inline type field has its own memory slice
+      adr_type = adr_type->with_field_offset(field_offset);
       value = value_from_mem(mem, ctl, bt, ft, adr_type, alloc);
       if (value != NULL && ft->isa_narrowoop()) {
         assert(UseCompressedOops, "unexpected narrow oop");
@@ -969,10 +969,13 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
     _igvn._worklist.push(sfpt);
     safepoints_done.append_if_missing(sfpt); // keep it for rollback
   }
-  // Scalarize inline types that were added to the safepoint
+  // Scalarize inline types that were added to the safepoint.
+  // Don't allow linking a constant oop (if available) for flat array elements
+  // because Deoptimization::reassign_flat_array_elements needs field values.
+  bool allow_oop = (klass == NULL) || !klass->is_flat_array_klass();
   for (uint i = 0; i < value_worklist.size(); ++i) {
     Node* vt = value_worklist.at(i);
-    vt->as_InlineType()->make_scalar_in_safepoints(&_igvn);
+    vt->as_InlineType()->make_scalar_in_safepoints(&_igvn, allow_oop);
   }
   return true;
 }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -863,9 +863,9 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
     set_default_node_notes(entry_nn);
   }
   PhaseGVN& gvn = *initial_gvn();
-  uint j = 0;
+  uint i = 0;
   ExtendedSignature sig_cc = ExtendedSignature(method()->get_sig_cc(), SigEntryFilter());
-  for (uint i = 0; i < (uint)arg_size; i++) {
+  for (uint j = 0; i < (uint)arg_size; i++) {
     const Type* t = tf->domain_sig()->field_at(i);
     Node* parm = NULL;
     if (has_scalarized_args() && t->is_inlinetypeptr() && !t->maybe_null() && t->inline_klass()->can_be_passed_as_fields()) {
@@ -890,8 +890,8 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
     // Record all these guys for later GVN.
     record_for_igvn(parm);
   }
-  for (; j < map->req(); j++) {
-    map->init_req(j, top());
+  for (; i < map->req(); i++) {
+    map->init_req(i, top());
   }
   assert(jvms->argoff() == TypeFunc::Parms, "parser gets arguments here");
   set_default_node_notes(old_nn);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -295,6 +295,10 @@ void Parse::array_store(BasicType bt) {
         if (stopped()) return;
         dec_sp(3);
       }
+      if (elemtype->inline_klass()->is_empty()) {
+        // Ignore empty inline stores, array is already initialized.
+        return;
+      }
     } else if (!ary_t->is_not_flat() && tval != TypePtr::NULL_PTR) {
       // Array might be flattened, emit runtime checks (for NULL, a simple inline_array_null_guard is sufficient).
       assert(UseFlatArray && !not_flattened && elemtype->is_oopptr()->can_be_inline_type() &&

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -173,7 +173,7 @@ class Deoptimization : AllStatic {
   static bool realloc_inline_type_result(InlineKlass* vk, const RegisterMap& map, GrowableArray<Handle>& return_oops, TRAPS);
   static void reassign_type_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, typeArrayOop obj, BasicType type);
   static void reassign_object_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, objArrayOop obj);
-  static void reassign_flat_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, flatArrayOop obj, FlatArrayKlass* vak, TRAPS);
+  static void reassign_flat_array_elements(frame* fr, RegisterMap* reg_map, ObjectValue* sv, flatArrayOop obj, FlatArrayKlass* vak, bool skip_internal, TRAPS);
   static void reassign_fields(frame* fr, RegisterMap* reg_map, GrowableArray<ScopeValue*>* objects, bool realloc_failures, bool skip_internal, TRAPS);
   static void relock_objects(GrowableArray<MonitorInfo*>* monitors, JavaThread* thread, bool realloc_failures);
   static void pop_frames_failed_reallocs(JavaThread* thread, vframeArray* array);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3013,4 +3013,96 @@ public class TestArrays extends InlineTypeTest {
             // expected
         }
     }
+
+    // Empty inline type array access
+    @Test(failOn = ALLOC + ALLOCA + LOAD + STORE)
+    public MyValueEmpty test130(MyValueEmpty[] array) {
+        array[0] = new MyValueEmpty();
+        return array[1];
+    }
+
+    @DontCompile
+    public void test130_verifier(boolean warmup) {
+        MyValueEmpty[] array = new MyValueEmpty[2];
+        MyValueEmpty empty = test130(array);
+        Asserts.assertEquals(array[0], MyValueEmpty.default);
+        Asserts.assertEquals(empty, MyValueEmpty.default);
+    }
+
+    static inline class EmptyContainer {
+        MyValueEmpty empty = MyValueEmpty.default;
+    }
+
+    // TODO disabled until JDK-8253893 is fixed
+/*
+    // Empty inline type container array access
+    @Test(failOn = ALLOC + ALLOCA + LOAD + STORE)
+    public MyValueEmpty test131(EmptyContainer[] array) {
+        array[0] = new EmptyContainer();
+        return array[1].empty;
+    }
+
+    @DontCompile
+    public void test131_verifier(boolean warmup) {
+        EmptyContainer[] array = new EmptyContainer[2];
+        MyValueEmpty empty = test131(array);
+        Asserts.assertEquals(array[0], EmptyContainer.default);
+        Asserts.assertEquals(empty, MyValueEmpty.default);
+    }
+*/
+
+    // Empty inline type array access with unknown array type
+    @Test()
+    public Object test132(Object[] array) {
+        array[0] = new MyValueEmpty();
+        return array[1];
+    }
+
+    @DontCompile
+    public void test132_verifier(boolean warmup) {
+        Object[] array = new MyValueEmpty[2];
+        Object empty = test132(array);
+        Asserts.assertEquals(array[0], MyValueEmpty.default);
+        Asserts.assertEquals(empty, MyValueEmpty.default);
+        array = new Object[2];
+        empty = test132(array);
+        Asserts.assertEquals(array[0], MyValueEmpty.default);
+        Asserts.assertEquals(empty, null);
+    }
+
+    // TODO disabled until JDK-8253893 is fixed
+/*
+    // Empty inline type container array access with unknown array type
+    @Test()
+    public Object test133(Object[] array) {
+        array[0] = new EmptyContainer();
+        return array[1];
+    }
+
+    @DontCompile
+    public void test133_verifier(boolean warmup) {
+        Object[] array = new EmptyContainer[2];
+        Object empty = test133(array);
+        Asserts.assertEquals(array[0], EmptyContainer.default);
+        Asserts.assertEquals(empty, EmptyContainer.default);
+        array = new Object[2];
+        empty = test133(array);
+        Asserts.assertEquals(array[0], EmptyContainer.default);
+        Asserts.assertEquals(empty, null);
+    }
+*/
+
+    // Non-escaping empty inline type array access
+    @Test(failOn = ALLOC + ALLOCA + LOAD + STORE)
+    public static MyValueEmpty test134(MyValueEmpty val) {
+        MyValueEmpty[] array = new MyValueEmpty[1];
+        array[0] = val;
+        return array[0];
+    }
+
+    @DontCompile
+    public void test134_verifier(boolean warmup) {
+        MyValueEmpty empty = test134(MyValueEmpty.default);
+        Asserts.assertEquals(empty, MyValueEmpty.default);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
@@ -183,37 +183,37 @@ public class TestGetfieldChains extends InlineTypeTest {
         Asserts.assertEQ(nsfe.getMessage(), "x");
     }
 
-    // static inline class EmptyType { }
-    // static inline class EmptyContainer {
-    //     int i = 0;
-    //     EmptyType et = new EmptyType();
-    // }
-    // static inline class Container {
-    //     EmptyContainer container0 = new EmptyContainer();
-    //     EmptyContainer container1 = new EmptyContainer();
-    // }
+    static inline class EmptyType { }
+    static inline class EmptyContainer {
+        int i = 0;
+        EmptyType et = new EmptyType();
+    }
+    static inline class Container {
+        EmptyContainer container0 = new EmptyContainer();
+        EmptyContainer container1 = new EmptyContainer();
+    }
 
-    // @Test(compLevel=C1)
-    // public EmptyType test6() {
-    //     Container c = new Container();
-    //     return c.container1.et;
-    // }
+    @Test(compLevel=C1)
+    public EmptyType test6() {
+        Container c = new Container();
+        return c.container1.et;
+    }
 
-    // @DontCompile
-    // public void test6_verifier(boolean warmup) {
-    //     EmptyType et = test6();
-    //     Asserts.assertEQ(et, EmptyType.default);
-    // }
+    @DontCompile
+    public void test6_verifier(boolean warmup) {
+        EmptyType et = test6();
+        Asserts.assertEQ(et, EmptyType.default);
+    }
 
-    // @Test(compLevel=C1)
-    // public EmptyType test7() {
-    //     Container[] ca = new Container[10];
-    //     return ca[3].container0.et;
-    // }
+    @Test(compLevel=C1)
+    public EmptyType test7() {
+        Container[] ca = new Container[10];
+        return ca[3].container0.et;
+    }
 
-    // @DontCompile
-    // public void test7_verifier(boolean warmup) {
-    //     EmptyType et = test7();
-    //     Asserts.assertEQ(et, EmptyType.default);
-    // }
+    @DontCompile
+    public void test7_verifier(boolean warmup) {
+        EmptyType et = test7();
+        Asserts.assertEQ(et, EmptyType.default);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3289,11 +3289,11 @@ public class TestLWorld extends InlineTypeTest {
         boolean res = test118(MyValueEmpty.default, MyValueEmpty.default, new MyValueEmpty());
         Asserts.assertTrue(res);
     }
-    
+
     static inline class EmptyContainer {
         private MyValueEmpty empty = MyValueEmpty.default;
     }
-    
+
     static inline class MixedContainer {
         public int val = rI;
         private EmptyContainer empty = EmptyContainer.default;
@@ -3311,7 +3311,7 @@ public class TestLWorld extends InlineTypeTest {
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test119"));
         }
         Asserts.assertEquals(array1[0], MyValueEmpty.default);
-// TODO disabled until JDK-8253893 is fixed        
+// TODO disabled until JDK-8253893 is fixed
 //        Asserts.assertEquals(array2[0], EmptyContainer.default);
 //        Asserts.assertEquals(array3[0], MixedContainer.default);
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3289,16 +3289,31 @@ public class TestLWorld extends InlineTypeTest {
         boolean res = test118(MyValueEmpty.default, MyValueEmpty.default, new MyValueEmpty());
         Asserts.assertTrue(res);
     }
+    
+    static inline class EmptyContainer {
+        private MyValueEmpty empty = MyValueEmpty.default;
+    }
+    
+    static inline class MixedContainer {
+        public int val = rI;
+        private EmptyContainer empty = EmptyContainer.default;
+    }
 
     // Test re-allocation of empty inline type array during deoptimization
     @Test
     public void test119(boolean deopt) {
-        MyValueEmpty[] arr = new MyValueEmpty[]{MyValueEmpty.default};
+        MyValueEmpty[]   array1 = new MyValueEmpty[]{MyValueEmpty.default};
+// TODO disabled until JDK-8253893 is fixed
+//        EmptyContainer[] array2 = new EmptyContainer[]{EmptyContainer.default};
+//        MixedContainer[] array3 = new MixedContainer[]{MixedContainer.default};
         if (deopt) {
             // uncommon trap
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test119"));
         }
-        Asserts.assertEquals(arr[0], MyValueEmpty.default);
+        Asserts.assertEquals(array1[0], MyValueEmpty.default);
+// TODO disabled until JDK-8253893 is fixed        
+//        Asserts.assertEquals(array2[0], EmptyContainer.default);
+//        Asserts.assertEquals(array3[0], MixedContainer.default);
     }
 
     @DontCompile


### PR DESCRIPTION
The change includes the following optimizations for empty inline types and several bug fixes:
- All uses ((array) loads, stores, allocations, ...) are replaced by the default oop or removed
- Calling convention should not pass/return anything

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8248220](https://bugs.openjdk.java.net/browse/JDK-8248220): [lworld] Optimize empty inline types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/207/head:pull/207`
`$ git checkout pull/207`
