### PR TITLE
8253745: [lworld] C1: Flat inline type array store may write out of bounds

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1676,20 +1676,22 @@ void LIRGenerator::access_flattened_array(bool is_load, LIRItem& array, LIRItem&
     assert(!inner_field->is_flattened(), "flattened fields must have been expanded");
     int obj_offset = inner_field->offset();
     int elm_offset = obj_offset - elem_klass->first_field_offset() + sub_offset; // object header is not stored in array.
-
     BasicType field_type = inner_field->type()->basic_type();
-    switch (field_type) {
+
+    // Types which are smaller than int are still passed in an int register.
+    BasicType reg_type = field_type;
+    switch (reg_type) {
     case T_BYTE:
     case T_BOOLEAN:
     case T_SHORT:
     case T_CHAR:
-     field_type = T_INT;
+      reg_type = T_INT;
       break;
     default:
       break;
     }
 
-    LIR_Opr temp = new_register(field_type);
+    LIR_Opr temp = new_register(reg_type);
     TempResolvedAddress* elm_resolved_addr = new TempResolvedAddress(as_ValueType(field_type), elm_op);
     LIRItem elm_item(elm_resolved_addr, this);
 


### PR DESCRIPTION
When storing to a flat inline type array, C1 emits code for a field-wise copy from the source buffer to the destination array element. The field contents are stored in a temp register. If the field type is smaller than T_INT, we increase it to T_INT because smaller registers are not supported. However, the type of the load/store should not be updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253745](https://bugs.openjdk.java.net/browse/JDK-8253745): [lworld] C1: Flat inline type array store may write out of bounds


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/208/head:pull/208`
`$ git checkout pull/208`
