### PR TITLE
8254022: [lworld] [type-restrictions] Initial support for RestrictedField

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3365,6 +3365,22 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   // volatile_barrier(Assembler::Membar_mask_bits(Assembler::LoadStore |
   //                                              Assembler::StoreStore));
 
+
+  Label notRestricted;
+  __ movl(rdx, flags);
+  __ shrl(rdx, ConstantPoolCacheEntry::has_restricted_type);
+  __ andl(rdx, 0x1);
+  __ testl(rdx, rdx);
+  __ jcc(Assembler::zero, notRestricted);
+
+  __ bind(notRestricted); // Added for testing
+
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::check_restricted_type));
+  __ get_cache_and_index_at_bcp(cache, index, 1);
+  load_field_cp_cache_entry(obj, cache, index, off, flags, is_static);
+
+  // __ bind(notRestricted);  // Commented for testing
+
   Label notVolatile, Done;
   __ movl(rdx, flags);
   __ shrl(rdx, ConstantPoolCacheEntry::is_volatile_shift);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3368,18 +3368,17 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
 
   Label notRestricted;
   __ movl(rdx, flags);
-  __ shrl(rdx, ConstantPoolCacheEntry::has_restricted_type);
+  // __ shrl(rdx, ConstantPoolCacheEntry::has_restricted_type_shift);
+  __ shrl(rdx, ConstantPoolCacheEntry::is_inline_type_shift);         // For testing purposes, apply to all inline fields
   __ andl(rdx, 0x1);
   __ testl(rdx, rdx);
   __ jcc(Assembler::zero, notRestricted);
-
-  __ bind(notRestricted); // Added for testing
 
   __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::check_restricted_type));
   __ get_cache_and_index_at_bcp(cache, index, 1);
   load_field_cp_cache_entry(obj, cache, index, off, flags, is_static);
 
-  // __ bind(notRestricted);  // Commented for testing
+  __ bind(notRestricted);
 
   Label notVolatile, Done;
   __ movl(rdx, flags);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3368,8 +3368,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
 
   Label notRestricted;
   __ movl(rdx, flags);
-  // __ shrl(rdx, ConstantPoolCacheEntry::has_restricted_type_shift);
-  __ shrl(rdx, ConstantPoolCacheEntry::is_inline_type_shift);         // For testing purposes, apply to all inline fields
+  __ shrl(rdx, ConstantPoolCacheEntry::has_restricted_type_shift);
   __ andl(rdx, 0x1);
   __ testl(rdx, rdx);
   __ jcc(Assembler::zero, notRestricted);

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -146,7 +146,7 @@ class ClassFileParser {
   Array<AnnotationArray*>* _fields_type_annotations;
   InstanceKlass* _klass;  // InstanceKlass* once created.
   InstanceKlass* _klass_to_deallocate; // an InstanceKlass* to be destroyed
-  GrowableArray<RestrictedFieldInfo>* _restricted_field_info;
+  GrowableArray<u2>* _restricted_field_info;
 
   ClassAnnotationCollector* _parsed_annotations;
   FieldAllocationCount* _fac;
@@ -284,7 +284,8 @@ class ClassFileParser {
                               bool* const is_synthetic_addr,
                               u2* const generic_signature_index_addr,
                               FieldAnnotationCollector* parsed_annotations,
-                              RestrictedFieldInfo* restricted_field_info,
+                              u2* restricted_field_info,
+                              bool* has_restricted_type,
                               TRAPS);
 
   void parse_fields(const ClassFileStream* const cfs,

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -146,6 +146,7 @@ class ClassFileParser {
   Array<AnnotationArray*>* _fields_type_annotations;
   InstanceKlass* _klass;  // InstanceKlass* once created.
   InstanceKlass* _klass_to_deallocate; // an InstanceKlass* to be destroyed
+  GrowableArray<RestrictedFieldInfo>* _restricted_field_info;
 
   ClassAnnotationCollector* _parsed_annotations;
   FieldAllocationCount* _fac;
@@ -213,6 +214,7 @@ class ClassFileParser {
   bool _invalid_identity_super; // if true, invalid super type for an identity type.
   bool _implements_identityObject;
   bool _has_injected_identityObject;
+  bool _has_restricted_fields;
 
   // precomputed flags
   bool _has_finalizer;
@@ -282,6 +284,7 @@ class ClassFileParser {
                               bool* const is_synthetic_addr,
                               u2* const generic_signature_index_addr,
                               FieldAnnotationCollector* parsed_annotations,
+                              RestrictedFieldInfo* restricted_field_info,
                               TRAPS);
 
   void parse_fields(const ClassFileStream* const cfs,
@@ -605,6 +608,8 @@ class ClassFileParser {
   bool invalid_identity_super() const { return _invalid_identity_super; }
   void set_invalid_identity_super() { _invalid_identity_super = true; }
   bool is_invalid_super_for_inline_type();
+  void set_has_restricted_fields() { _has_restricted_fields = true; }
+  bool has_restricted_fields() const { return _has_restricted_fields; }
 
   u2 java_fields_count() const { return _java_fields_count; }
 

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -518,12 +518,14 @@ void FieldLayout::print(outputStream* output, bool is_static, const InstanceKlas
 }
 
 FieldLayoutBuilder::FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-                                       Array<u2>* fields, bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
+                                       Array<u2>* fields, GrowableArray<RestrictedFieldInfo>* restricted_field_info,
+                                       bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
                                        Handle protection_domain, FieldLayoutInfo* info) :
   _classname(classname),
   _super_klass(super_klass),
   _constant_pool(constant_pool),
   _fields(fields),
+  _restricted_field_info(restricted_field_info),
   _info(info),
   _root_group(NULL),
   _contended_groups(GrowableArray<FieldGroup*>(8)),
@@ -598,6 +600,11 @@ void FieldLayoutBuilder::regular_field_sorting() {
     }
     assert(group != NULL, "invariant");
     BasicType type = Signature::basic_type(fs.signature());
+    if (fs.has_restricted_type()) {
+      tty->print_cr("Restricted type detected, switching from %s to %s",
+                    fs.signature()->as_C_string(),
+                    _restricted_field_info->at(fs.index()).name()->as_C_string());
+    }
     switch(type) {
     case T_BYTE:
     case T_CHAR:

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -518,14 +518,12 @@ void FieldLayout::print(outputStream* output, bool is_static, const InstanceKlas
 }
 
 FieldLayoutBuilder::FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-                                       Array<u2>* fields, GrowableArray<RestrictedFieldInfo>* restricted_field_info,
-                                       bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
+                                       Array<u2>* fields,  bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
                                        Handle protection_domain, FieldLayoutInfo* info) :
   _classname(classname),
   _super_klass(super_klass),
   _constant_pool(constant_pool),
   _fields(fields),
-  _restricted_field_info(restricted_field_info),
   _info(info),
   _root_group(NULL),
   _contended_groups(GrowableArray<FieldGroup*>(8)),
@@ -600,11 +598,6 @@ void FieldLayoutBuilder::regular_field_sorting() {
     }
     assert(group != NULL, "invariant");
     BasicType type = Signature::basic_type(fs.signature());
-    if (fs.has_restricted_type()) {
-      tty->print_cr("Restricted type detected, switching from %s to %s",
-                    fs.signature()->as_C_string(),
-                    _restricted_field_info->at(fs.index()).name()->as_C_string());
-    }
     switch(type) {
     case T_BYTE:
     case T_CHAR:

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -240,7 +240,6 @@ class FieldLayoutBuilder : public ResourceObj {
   const InstanceKlass* _super_klass;
   ConstantPool* _constant_pool;
   Array<u2>* _fields;
-  GrowableArray<RestrictedFieldInfo>* _restricted_field_info;
   FieldLayoutInfo* _info;
   FieldGroup* _root_group;
   GrowableArray<FieldGroup*> _contended_groups;
@@ -265,8 +264,8 @@ class FieldLayoutBuilder : public ResourceObj {
 
  public:
   FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-      Array<u2>* fields, GrowableArray<RestrictedFieldInfo>* restricted_field_info, bool is_contended, bool is_inline_type,
-      ClassLoaderData* class_loader_data, Handle protection_domain, FieldLayoutInfo* info);
+      Array<u2>* fields, bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
+      Handle protection_domain, FieldLayoutInfo* info);
 
   int get_alignment() {
     assert(_alignment != -1, "Uninitialized");

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -240,6 +240,7 @@ class FieldLayoutBuilder : public ResourceObj {
   const InstanceKlass* _super_klass;
   ConstantPool* _constant_pool;
   Array<u2>* _fields;
+  GrowableArray<RestrictedFieldInfo>* _restricted_field_info;
   FieldLayoutInfo* _info;
   FieldGroup* _root_group;
   GrowableArray<FieldGroup*> _contended_groups;
@@ -264,8 +265,8 @@ class FieldLayoutBuilder : public ResourceObj {
 
  public:
   FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-      Array<u2>* fields, bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
-      Handle protection_domain, FieldLayoutInfo* info);
+      Array<u2>* fields, GrowableArray<RestrictedFieldInfo>* restricted_field_info, bool is_contended, bool is_inline_type,
+      ClassLoaderData* class_loader_data, Handle protection_domain, FieldLayoutInfo* info);
 
   int get_alignment() {
     assert(_alignment != -1, "Uninitialized");

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -177,6 +177,7 @@
   template(tag_enclosing_method,                      "EnclosingMethod")                          \
   template(tag_bootstrap_methods,                     "BootstrapMethods")                         \
   template(tag_permitted_subclasses,                  "PermittedSubclasses")                      \
+  template(tag_restricted_field,                      "RestrictedField")                          \
                                                                                                   \
   /* exception klasses: at least all exceptions thrown by the VM have entries here */             \
   template(java_lang_ArithmeticException,             "java/lang/ArithmeticException")            \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -968,6 +968,7 @@ void InterpreterRuntime::resolve_get_put(JavaThread* thread, Bytecodes::Code byt
     info.access_flags().is_volatile(),
     info.is_inlined(),
     info.is_inline_type(),
+    info.has_restricted_type(),
     pool->pool_holder()
   );
 }

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -71,6 +71,7 @@ class InterpreterRuntime: AllStatic {
   static void value_array_store(JavaThread* thread, void* val, arrayOopDesc* array, int index);
 
   static jboolean is_substitutable(JavaThread* thread, oopDesc* aobj, oopDesc* bobj);
+  static void check_restricted_type(JavaThread* thread);
 
   // Quicken instance-of and check-cast bytecodes
   static void    quicken_io_cc(JavaThread* thread);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -136,6 +136,7 @@ void ConstantPoolCacheEntry::set_field(Bytecodes::Code get_code,
                                        bool is_volatile,
                                        bool is_inlined,
                                        bool is_inline_type,
+                                       bool has_restricted_type,
                                        Klass* root_klass) {
   set_f1(field_holder);
   set_f2(field_offset);
@@ -146,7 +147,8 @@ void ConstantPoolCacheEntry::set_field(Bytecodes::Code get_code,
                   ((is_volatile ? 1 : 0) << is_volatile_shift) |
                   ((is_final    ? 1 : 0) << is_final_shift) |
                   ((is_inlined  ? 1 : 0) << is_inlined_shift) |
-                  ((is_inline_type ? 1 : 0) << is_inline_type_shift),
+                  ((is_inline_type ? 1 : 0) << is_inline_type_shift) |
+                  ((has_restricted_type ? 1 : 0) << has_restricted_type_shift),
                   field_index);
   set_bytecode_1(get_code);
   set_bytecode_2(put_code);

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -231,6 +231,7 @@ class ConstantPoolCacheEntry {
     bool            is_volatile,                 // the field is volatile
     bool            is_inlined,                  // the field is inlined
     bool            is_inline_type,              // the field is an inline type (must never be null)
+    bool            has_restricted_type,         // field has a restricted type
     Klass*          root_klass                   // needed by the GC to dirty the klass
   );
 

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -51,7 +51,7 @@ class PSPromotionManager;
 // _indices   [ b2 | b1 |  index  ]  index = constant_pool_index
 // _f1        [  entry specific   ]  metadata ptr (method or klass)
 // _f2        [  entry specific   ]  vtable or res_ref index, or vfinal method ptr
-// _flags     [tos|0|F=1|0|I|i|f|v|0 |0000|field_index] (for field entries)
+// _flags     [tos|0|F=1|R|I|i|f|v|0 |0000|field_index] (for field entries)
 // bit length [ 4 |1| 1 |1|1|1|1|1|1 |1     |-3-|----16-----]
 // _flags     [tos|0|F=0|S|A|I|f|0|vf|indy_rf|000|00000|psize] (for method entries)
 // bit length [ 4 |1| 1 |1|1|1|1|1|1 |-4--|--8--|--8--]
@@ -185,6 +185,7 @@ class ConstantPoolCacheEntry {
     // misc. option bits; can be any bit position in [16..27]
     is_field_entry_shift       = 26,  // (F) is it a field or a method?
     has_local_signature_shift  = 25,  // (S) does the call site have a per-site signature (sig-poly methods)?
+    has_restricted_type        = 25,  // (R) does the field have a restricted type?
     has_appendix_shift         = 24,  // (A) does the call site have an appendix argument?
     is_inline_type_shift       = 24,  // (I) is the type of the field an inline type (must never be null)
     is_forced_virtual_shift    = 23,  // (I) is the interface reference forced to virtual mode?

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -185,7 +185,7 @@ class ConstantPoolCacheEntry {
     // misc. option bits; can be any bit position in [16..27]
     is_field_entry_shift       = 26,  // (F) is it a field or a method?
     has_local_signature_shift  = 25,  // (S) does the call site have a per-site signature (sig-poly methods)?
-    has_restricted_type        = 25,  // (R) does the field have a restricted type?
+    has_restricted_type_shift  = 25,  // (R) does the field have a restricted type?
     has_appendix_shift         = 24,  // (A) does the call site have an appendix argument?
     is_inline_type_shift       = 24,  // (I) is the type of the field an inline type (must never be null)
     is_forced_virtual_shift    = 23,  // (I) is the interface reference forced to virtual mode?

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -45,24 +45,25 @@ class FieldInfo {
   // Field info extracted from the class file and stored
   // as an array of 6 shorts.
 
-#define FIELDINFO_TAG_SIZE             3
-#define FIELDINFO_TAG_BLANK            0
-#define FIELDINFO_TAG_OFFSET           1
-#define FIELDINFO_TAG_TYPE_PLAIN       2
-#define FIELDINFO_TAG_TYPE_CONTENDED   3
-#define FIELDINFO_TAG_TYPE_MASK        3
-#define FIELDINFO_TAG_MASK             7
-#define FIELDINFO_TAG_INLINED          4
+#define FIELDINFO_TAG_SIZE             4
+#define FIELDINFO_TAG_OFFSET           1 << 0
+#define FIELDINFO_TAG_CONTENDED        1 << 1
+#define FIELDINFO_TAG_INLINED          1 << 2
+#define FIELDINFO_TAG_RESTRICTED       1 << 3
 
   // Packed field has the tag, and can be either of:
   //    hi bits <--------------------------- lo bits
   //   |---------high---------|---------low---------|
-  //    ..........................................00  - blank
-  //    [------------------offset---------------]I01  - real field offset
-  //    ......................[-------type------]I10  - plain field with type
-  //    [--contention_group--][-------type------]I11  - contended field with type and contention group
-  //
-  // Bit I indicates if the field has been inlined  (I=1) or nor (I=0)
+  //    ........................................RICO
+  //    ........................................RI00  - non-contended field
+  //    [--contention_group--]..................RI10  - contended field with type and contention group
+  //    [------------------offset--------------]RI01  - real field offset
+
+  // Bit O indicates if the packed field contains an offset (O=1) or not (O=1)
+  // Bit C indicates if the field is contended (C=1) or not (C=1)
+  //       (if it is contended, the high packed field contains the contention group)
+  // Bit I indicates if the field has been inlined  (I=1) or not (I=0)
+  // Bit R indicates if the field has a type restriction (R=1) ot not (R=0)
 
   enum FieldOffset {
     access_flags_offset      = 0,
@@ -107,78 +108,22 @@ class FieldInfo {
 
   u2 access_flags() const                        { return _shorts[access_flags_offset];            }
   u4 offset() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_OFFSET:
-        return build_int_from_shorts(_shorts[low_packed_offset], _shorts[high_packed_offset]) >> FIELDINFO_TAG_SIZE;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        fatal("Asking offset for the plain type field");
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        fatal("Asking offset for the contended type field");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking offset for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) != 0, "Offset must have been set");
+    return build_int_from_shorts(_shorts[low_packed_offset], _shorts[high_packed_offset]) >> FIELDINFO_TAG_SIZE;
   }
 
   bool is_contended() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        return false;
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return true;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking contended flag for the field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking contended flag for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return false;
+    return (_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) != 0;
   }
 
   u2 contended_group() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        return 0;
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return _shorts[high_packed_offset];
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking the contended group for the field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking the contended group for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) == 0, "Offset must not have been set");
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) != 0, "Field must be contended");
+    return _shorts[high_packed_offset];
  }
 
-  u2 allocation_type() const {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        return (lo >> FIELDINFO_TAG_SIZE);
-#ifndef PRODUCT
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Asking the field type for field with offset");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Asking the field type for the blank field");
-#endif
-    }
-    ShouldNotReachHere();
-    return 0;
-  }
-
   bool is_offset_set() const {
-    return (_shorts[low_packed_offset] & FIELDINFO_TAG_TYPE_MASK) == FIELDINFO_TAG_OFFSET;
+    return (_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET)!= 0;
   }
 
   Symbol* name(ConstantPool* cp) const {
@@ -198,33 +143,13 @@ class FieldInfo {
   }
 
   void set_access_flags(u2 val)                  { _shorts[access_flags_offset] = val;             }
+
   void set_offset(u4 val)                        {
     val = val << FIELDINFO_TAG_SIZE; // make room for tag
-    bool inlined = is_inlined();
-    _shorts[low_packed_offset] = extract_low_short_from_int(val) | FIELDINFO_TAG_OFFSET;
-    if (inlined) set_inlined(true);
+    int inline_tag = is_inlined() ? FIELDINFO_TAG_INLINED : 0;
+    int restricted_tag = has_restricted_type() ? FIELDINFO_TAG_RESTRICTED : 0;
+    _shorts[low_packed_offset] = extract_low_short_from_int(val) | restricted_tag | inline_tag | FIELDINFO_TAG_OFFSET;
     _shorts[high_packed_offset] = extract_high_short_from_int(val);
-    assert(is_inlined() || !inlined, "just checking");
-  }
-
-  void set_allocation_type(int type) {
-    bool b = is_inlined();
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_BLANK:
-        _shorts[low_packed_offset] |= ((type << FIELDINFO_TAG_SIZE)) & 0xFFFF;
-        _shorts[low_packed_offset] &= ~FIELDINFO_TAG_TYPE_MASK;
-        _shorts[low_packed_offset] |= FIELDINFO_TAG_TYPE_PLAIN;
-        assert(is_inlined() || !b, "Just checking");
-        return;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_PLAIN:
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Setting the field type with overwriting");
-#endif
-    }
-    ShouldNotReachHere();
   }
 
   void set_inlined(bool b) {
@@ -235,27 +160,27 @@ class FieldInfo {
     }
   }
 
-  bool is_inlined() {
+  bool is_inlined() const {
     return (_shorts[low_packed_offset] & FIELDINFO_TAG_INLINED) != 0;
   }
 
-  void set_contended_group(u2 val) {
-    u2 lo = _shorts[low_packed_offset];
-    switch(lo & FIELDINFO_TAG_TYPE_MASK) {
-      case FIELDINFO_TAG_TYPE_PLAIN:
-        _shorts[low_packed_offset] |= FIELDINFO_TAG_TYPE_CONTENDED;
-        _shorts[high_packed_offset] = val;
-        return;
-#ifndef PRODUCT
-      case FIELDINFO_TAG_TYPE_CONTENDED:
-        fatal("Overwriting contended group");
-      case FIELDINFO_TAG_BLANK:
-        fatal("Setting contended group for the blank field");
-      case FIELDINFO_TAG_OFFSET:
-        fatal("Setting contended group for field with offset");
-#endif
+  void set_has_rectricted_type(bool b) {
+    if (b) {
+      _shorts[low_packed_offset] |= FIELDINFO_TAG_RESTRICTED;
+    } else {
+      _shorts[low_packed_offset] &= ~FIELDINFO_TAG_RESTRICTED;
     }
-    ShouldNotReachHere();
+  }
+
+  bool has_restricted_type() const {
+    return (_shorts[low_packed_offset] & FIELDINFO_TAG_RESTRICTED) != 0;
+  }
+
+  void set_contended_group(u2 val) {
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_OFFSET) == 0, "Offset must not have been set");
+    assert((_shorts[low_packed_offset] & FIELDINFO_TAG_CONTENDED) == 0, "Overwritting contended group");
+    _shorts[low_packed_offset] |= FIELDINFO_TAG_CONTENDED;
+    _shorts[high_packed_offset] = val;
   }
 
   bool is_internal() const {

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -121,6 +121,16 @@ class FieldStreamBase : public StackObj {
     return field()->signature(_constants());
   }
 
+  Symbol* secondary_signature() const {
+    assert(field()->has_restricted_type(), "Must have");
+    int sig_index = field_holder()->fields_erased_type()[index()];
+    if (access_flags().is_internal()) {
+      return vmSymbols::symbol_at((vmSymbols::SID)sig_index);
+    } else {
+      return _constants->symbol_at(sig_index);
+    }
+  }
+
   Symbol* generic_signature() const {
     if (access_flags().field_has_generic_signature()) {
       assert(_generic_signature_slot < _fields->length(), "out of bounds");

--- a/src/hotspot/share/oops/fieldStreams.hpp
+++ b/src/hotspot/share/oops/fieldStreams.hpp
@@ -135,10 +135,6 @@ class FieldStreamBase : public StackObj {
     return field()->offset();
   }
 
-  int allocation_type() const {
-    return field()->allocation_type();
-  }
-
   bool is_inlined() {
     return field()->is_inlined();
   }
@@ -161,6 +157,14 @@ class FieldStreamBase : public StackObj {
 
   int contended_group() const {
     return field()->contended_group();
+  }
+
+  bool has_restricted_type() const {
+    return field()->has_restricted_type();
+  }
+
+  void set_has_restricted_type(bool b) {
+    field()->set_has_rectricted_type(b);
   }
 
   // bridge to a heavier API:

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1659,10 +1659,19 @@ void InstanceKlass::mask_for(const methodHandle& method, int bci,
 bool InstanceKlass::find_local_field(Symbol* name, Symbol* sig, fieldDescriptor* fd) const {
   for (JavaFieldStream fs(this); !fs.done(); fs.next()) {
     Symbol* f_name = fs.name();
-    Symbol* f_sig  = fs.signature();
-    if (f_name == name && f_sig == sig) {
-      fd->reinitialize(const_cast<InstanceKlass*>(this), fs.index());
-      return true;
+    if (f_name == name) {
+      Symbol* f_sig  = fs.signature();
+      if (f_sig == sig) {
+        fd->reinitialize(const_cast<InstanceKlass*>(this), fs.index());
+        return true;
+      }
+      if (fs.has_restricted_type()) {
+        Symbol* f_sig2 = fs.secondary_signature();
+        if (f_name == name && f_sig2 == sig) {
+          fd->reinitialize(const_cast<InstanceKlass*>(this), fs.index());
+          return true;
+        }
+      }
     }
   }
   return false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -481,7 +481,8 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
                                        parser.is_unsafe_anonymous(),
                                        should_store_fingerprint(is_hidden_or_anonymous),
                                        parser.has_inline_fields() ? parser.java_fields_count() : 0,
-                                       parser.is_inline_type());
+                                       parser.is_inline_type(),
+                                       parser.has_restricted_fields());
 
   const Symbol* const class_name = parser.class_name();
   assert(class_name != NULL, "invariant");

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -153,61 +153,6 @@ class InlineKlassFixedBlock {
   friend class InlineKlass;
 };
 
-class RestrictedFieldInfo {
-  friend class InstanceKlass;
-  friend class ClassFileParser;
-
- public:
-  enum class RFState { NONE, UNRESOLVED, RESOLVED};
-
- private:
-  RFState _flag;
-  Symbol* _name;
-  Klass* _klass;
-
- public:
-  RestrictedFieldInfo() {
-    _flag = RFState::NONE;
-    _name = NULL;
-    _klass = NULL;
-  }
-
-  Symbol* name() const { return _name; }
-  Klass* klass() const { return _klass; }
-
-  void set_unresolved(Symbol* name) {
-    assert(name != NULL, "Sanity check");
-    _name = name;
-    _flag = RFState::UNRESOLVED;
-  }
-
-  void set_resolved(Klass* klass) {
-    assert(klass != NULL, "Sanity check");
-    _klass = klass;
-    _flag = RFState::RESOLVED;
-  }
-
-  void clear() {
-    _flag = RFState::NONE;
-    _name = NULL;
-    _klass = NULL;
-  }
-
-  bool has_restricted_type() { return _flag != RFState::NONE; }
-  bool is_resolved() { return _flag == RFState::RESOLVED; }
-
-  void print() {
-    switch(_flag) {
-      case RFState::NONE: tty->print("NONE: "); break;
-      case RFState::UNRESOLVED: tty->print("UNRESOLVED: "); break;
-      case RFState::RESOLVED: tty->print("RESOLVED: "); break;
-      default: tty->print("UNKNOWN STATE: ");
-    }
-    tty->print("symbol = %s ", _name == NULL ? " NULL" : _name->as_C_string());
-    tty->print("klass = %s ", _klass == NULL ? " NULL" :_klass->name()->as_C_string());
-  }
-};
-
 class InstanceKlass: public Klass {
   friend class VMStructs;
   friend class JVMCIVMStructs;
@@ -1267,7 +1212,7 @@ public:
            (has_stored_fingerprint ? (int)sizeof(uint64_t*)/wordSize : 0) +
            (java_fields * (int)sizeof(Klass*)/wordSize) +
            (is_inline_type ? (int)sizeof(InlineKlassFixedBlock) : 0) +
-           (has_restricted_fields ? java_fields * (int)sizeof(RestrictedFieldInfo)/wordSize : 0));
+           (has_restricted_fields ? java_fields * (int)sizeof(u2)/wordSize : 0));
   }
   int size() const                    { return size(vtable_length(),
                                                itable_length(),
@@ -1337,7 +1282,7 @@ public:
     }
   }
 
-  RestrictedFieldInfo* restricted_fields_info();
+  u2* fields_erased_type();
 
   address adr_inline_type_field_klasses() const {
     if (has_inline_type_fields()) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -57,6 +57,7 @@ class RecordComponent;
 //    [EMBEDDED fingerprint       ] only if should_store_fingerprint()==true
 //    [EMBEDDED inline_type_field_klasses] only if has_inline_fields() == true
 //    [EMBEDDED InlineKlassFixedBlock] only if is an InlineKlass instance
+//    [EMBEDDED restricted_fields_info] only if has_restricted_fields() == true
 
 
 // forward declaration for class -- see below for definition
@@ -150,6 +151,61 @@ class InlineKlassFixedBlock {
   int _exact_size_in_bytes;
 
   friend class InlineKlass;
+};
+
+class RestrictedFieldInfo {
+  friend class InstanceKlass;
+  friend class ClassFileParser;
+
+ public:
+  enum class RFState { NONE, UNRESOLVED, RESOLVED};
+
+ private:
+  RFState _flag;
+  Symbol* _name;
+  Klass* _klass;
+
+ public:
+  RestrictedFieldInfo() {
+    _flag = RFState::NONE;
+    _name = NULL;
+    _klass = NULL;
+  }
+
+  Symbol* name() const { return _name; }
+  Klass* klass() const { return _klass; }
+
+  void set_unresolved(Symbol* name) {
+    assert(name != NULL, "Sanity check");
+    _name = name;
+    _flag = RFState::UNRESOLVED;
+  }
+
+  void set_resolved(Klass* klass) {
+    assert(klass != NULL, "Sanity check");
+    _klass = klass;
+    _flag = RFState::RESOLVED;
+  }
+
+  void clear() {
+    _flag = RFState::NONE;
+    _name = NULL;
+    _klass = NULL;
+  }
+
+  bool has_restricted_type() { return _flag != RFState::NONE; }
+  bool is_resolved() { return _flag == RFState::RESOLVED; }
+
+  void print() {
+    switch(_flag) {
+      case RFState::NONE: tty->print("NONE: "); break;
+      case RFState::UNRESOLVED: tty->print("UNRESOLVED: "); break;
+      case RFState::RESOLVED: tty->print("RESOLVED: "); break;
+      default: tty->print("UNKNOWN STATE: ");
+    }
+    tty->print("symbol = %s ", _name == NULL ? " NULL" : _name->as_C_string());
+    tty->print("klass = %s ", _klass == NULL ? " NULL" :_klass->name()->as_C_string());
+  }
 };
 
 class InstanceKlass: public Klass {
@@ -293,7 +349,8 @@ class InstanceKlass: public Klass {
     _misc_is_declared_atomic                  = 1 << 19, // implements jl.NonTearable
     _misc_invalid_inline_super                = 1 << 20, // invalid super type for an inline type
     _misc_invalid_identity_super              = 1 << 21, // invalid super type for an identity type
-    _misc_has_injected_identityObject         = 1 << 22  // IdentityObject has been injected by the JVM
+    _misc_has_injected_identityObject         = 1 << 22, // IdentityObject has been injected by the JVM
+    _misc_has_restricted_fields               = 1 << 23  // class has fields with type restrictions
   };
   u2 shared_loader_type_bits() const {
     return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
@@ -476,6 +533,14 @@ class InstanceKlass: public Klass {
 
   void set_has_injected_identityObject() {
     _misc_flags |= _misc_has_injected_identityObject;
+  }
+
+  bool has_restricted_fields() const {
+    return (_misc_flags & _misc_has_restricted_fields);
+  }
+
+  void set_has_restricted_fields() {
+    _misc_flags |= _misc_has_restricted_fields;
   }
 
   // field sizes
@@ -1192,7 +1257,7 @@ public:
   static int size(int vtable_length, int itable_length,
                   int nonstatic_oop_map_size,
                   bool is_interface, bool is_unsafe_anonymous, bool has_stored_fingerprint,
-                  int java_fields, bool is_inline_type) {
+                  int java_fields, bool is_inline_type, bool has_restricted_fields) {
     return align_metadata_size(header_size() +
            vtable_length +
            itable_length +
@@ -1201,7 +1266,8 @@ public:
            (is_unsafe_anonymous ? (int)sizeof(Klass*)/wordSize : 0) +
            (has_stored_fingerprint ? (int)sizeof(uint64_t*)/wordSize : 0) +
            (java_fields * (int)sizeof(Klass*)/wordSize) +
-           (is_inline_type ? (int)sizeof(InlineKlassFixedBlock) : 0));
+           (is_inline_type ? (int)sizeof(InlineKlassFixedBlock) : 0) +
+           (has_restricted_fields ? java_fields * (int)sizeof(RestrictedFieldInfo)/wordSize : 0));
   }
   int size() const                    { return size(vtable_length(),
                                                itable_length(),
@@ -1210,7 +1276,8 @@ public:
                                                is_unsafe_anonymous(),
                                                has_stored_fingerprint(),
                                                has_inline_type_fields() ? java_fields_count() : 0,
-                                               is_inline_klass());
+                                               is_inline_klass(),
+                                               has_restricted_fields());
   }
 
   intptr_t* start_of_itable()   const { return (intptr_t*)start_of_vtable() + vtable_length(); }
@@ -1269,6 +1336,8 @@ public:
       return NULL;
     }
   }
+
+  RestrictedFieldInfo* restricted_fields_info();
 
   address adr_inline_type_field_klasses() const {
     if (has_inline_type_fields()) {

--- a/src/hotspot/share/oops/instanceKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceKlass.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/iterator.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/inlineKlass.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.hpp"
 #include "oops/oop.inline.hpp"
@@ -169,5 +170,34 @@ inline instanceOop InstanceKlass::allocate_instance(oop java_class, TRAPS) {
   ik->initialize(CHECK_NULL);
   return ik->allocate_instance(THREAD);
 }
+
+inline RestrictedFieldInfo* InstanceKlass::restricted_fields_info() {
+    assert(has_restricted_fields(), "Should not be called otherwise");
+    if (is_inline_klass()) {
+      return (RestrictedFieldInfo*)((address)(InlineKlass::cast(this)->inlineklass_static_block()) + sizeof(InlineKlassFixedBlock));
+    }
+
+    address adr_jf = adr_inline_type_field_klasses();
+    if (adr_jf != NULL) {
+      return (RestrictedFieldInfo*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
+    }
+
+    address adr_fing = adr_fingerprint();
+    if (adr_fing != NULL) {
+      return (RestrictedFieldInfo*)(adr_fingerprint() + sizeof(u8));
+    }
+
+    InstanceKlass** adr_host = adr_unsafe_anonymous_host();
+    if (adr_host != NULL) {
+      return (RestrictedFieldInfo*)(adr_host + 1);
+    }
+
+    Klass* volatile* adr_impl = adr_implementor();
+    if (adr_impl != NULL) {
+      return (RestrictedFieldInfo*)(adr_impl + 1);
+    }
+
+    return (RestrictedFieldInfo*)end_of_nonstatic_oop_maps();
+  }
 
 #endif // SHARE_OOPS_INSTANCEKLASS_INLINE_HPP

--- a/src/hotspot/share/oops/instanceKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceKlass.inline.hpp
@@ -171,33 +171,33 @@ inline instanceOop InstanceKlass::allocate_instance(oop java_class, TRAPS) {
   return ik->allocate_instance(THREAD);
 }
 
-inline RestrictedFieldInfo* InstanceKlass::restricted_fields_info() {
+inline u2* InstanceKlass::fields_erased_type() {
     assert(has_restricted_fields(), "Should not be called otherwise");
     if (is_inline_klass()) {
-      return (RestrictedFieldInfo*)((address)(InlineKlass::cast(this)->inlineklass_static_block()) + sizeof(InlineKlassFixedBlock));
+      return (u2*)((address)(InlineKlass::cast(this)->inlineklass_static_block()) + sizeof(InlineKlassFixedBlock));
     }
 
     address adr_jf = adr_inline_type_field_klasses();
     if (adr_jf != NULL) {
-      return (RestrictedFieldInfo*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
+      return (u2*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
     }
 
     address adr_fing = adr_fingerprint();
     if (adr_fing != NULL) {
-      return (RestrictedFieldInfo*)(adr_fingerprint() + sizeof(u8));
+      return (u2*)(adr_fingerprint() + sizeof(u8));
     }
 
     InstanceKlass** adr_host = adr_unsafe_anonymous_host();
     if (adr_host != NULL) {
-      return (RestrictedFieldInfo*)(adr_host + 1);
+      return (u2*)(adr_host + 1);
     }
 
     Klass* volatile* adr_impl = adr_implementor();
     if (adr_impl != NULL) {
-      return (RestrictedFieldInfo*)(adr_impl + 1);
+      return (u2*)(adr_impl + 1);
     }
 
-    return (RestrictedFieldInfo*)end_of_nonstatic_oop_maps();
+    return (u2*)end_of_nonstatic_oop_maps();
   }
 
 #endif // SHARE_OOPS_INSTANCEKLASS_INLINE_HPP

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -93,8 +93,9 @@ class fieldDescriptor {
   bool is_stable()                const    { return access_flags().is_stable(); }
   bool is_volatile()              const    { return access_flags().is_volatile(); }
   bool is_transient()             const    { return access_flags().is_transient(); }
-  inline bool is_inlined() const;
+  inline bool is_inlined()        const;
   inline bool is_inline_type()    const;
+  inline bool has_restricted_type() const;
 
   bool is_synthetic()             const    { return access_flags().is_synthetic(); }
 

--- a/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
@@ -82,5 +82,6 @@ inline BasicType fieldDescriptor::field_type() const {
 
 inline bool fieldDescriptor::is_inlined()  const  { return field()->is_inlined(); }
 inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_INLINE_TYPE; }
+inline bool fieldDescriptor::has_restricted_type() const { return field()->has_restricted_type(); }
 
 #endif // SHARE_RUNTIME_FIELDDESCRIPTOR_INLINE_HPP

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2232,8 +2232,10 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   /*************************************/                                 \
                                                                           \
   declare_preprocessor_constant("FIELDINFO_TAG_SIZE", FIELDINFO_TAG_SIZE) \
-  declare_preprocessor_constant("FIELDINFO_TAG_MASK", FIELDINFO_TAG_MASK) \
   declare_preprocessor_constant("FIELDINFO_TAG_OFFSET", FIELDINFO_TAG_OFFSET) \
+  declare_preprocessor_constant("FIELDINFO_TAG_CONTENDED", FIELDINFO_TAG_CONTENDED) \
+  declare_preprocessor_constant("FIELDINFO_TAG_INLINED", FIELDINFO_TAG_INLINED) \
+  declare_preprocessor_constant("FIELDINFO_TAG_RESTRICTED", FIELDINFO_TAG_RESTRICTED) \
                                                                           \
   /************************************************/                      \
   /* InstanceKlass InnerClassAttributeOffset enum */                      \

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -386,6 +386,9 @@ public class ClassFinder {
                 throw cf;
             } finally {
                 currentClassFile = previousClassFile;
+                if (c.isValue() && c.projection != null) {
+                    c.projection.flags_field = (c.flags_field & ~(VALUE | UNATTRIBUTED | FINAL)) | SEALED;
+                }
             }
         } else {
             throw classFileNotFound(c);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -143,6 +143,10 @@ public class Flags {
      */
     public static final int VALUEBASED       = 1<<19;
 
+    /** Flag is set for a type restricted field.
+     */
+    public static final int RESTRICTED_FIELD       = 1<<19;
+
     /** Flag is set for compiler-generated anonymous method symbols
      *  that `own' an initializer block.
      */
@@ -518,6 +522,7 @@ public class Flags {
         CLASH(Flags.CLASH),
         AUXILIARY(Flags.AUXILIARY),
         NOT_IN_PROFILE(Flags.NOT_IN_PROFILE),
+        RESTRICTED_FIELD(Flags.RESTRICTED_FIELD),
         BAD_OVERRIDE(Flags.BAD_OVERRIDE),
         SIGNATURE_POLYMORPHIC(Flags.SIGNATURE_POLYMORPHIC),
         THROWS(Flags.THROWS),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -101,6 +101,9 @@ public class Types {
     List<Warner> warnStack = List.nil();
     final Name capturedName;
 
+    /** enable alternate code generation to faciliate specialization experiments using type restrictions */
+    public boolean flattenWithTypeRestrictions;
+
     public final Warner noWarnings;
 
     // <editor-fold defaultstate="collapsed" desc="Instantiating">
@@ -126,6 +129,7 @@ public class Types {
         noWarnings = new Warner(null);
         Options options = Options.instance(context);
         allowValueBasedClasses = options.isSet("allowValueBasedClasses");
+        flattenWithTypeRestrictions = options.isSet("flattenWithTypeRestrictions");
     }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -973,12 +973,25 @@ public class ClassWriter extends ClassFile {
             pw.println("---" + flagNames(v.flags()));
         }
         databuf.appendChar(poolWriter.putName(v.name));
-        databuf.appendChar(poolWriter.putDescriptor(v));
+        boolean emitRestrictedField = false;
+        if (types.flattenWithTypeRestrictions && v.type.isValue()) {
+            emitRestrictedField = true;
+            databuf.appendChar(poolWriter.putDescriptor(v.type.referenceProjection()));
+        } else {
+            databuf.appendChar(poolWriter.putDescriptor(v));
+        }
+
         int acountIdx = beginAttrs();
         int acount = 0;
         if (v.getConstValue() != null) {
             int alenIdx = writeAttr(names.ConstantValue);
             databuf.appendChar(poolWriter.putConstant(v.getConstValue()));
+            endAttr(alenIdx);
+            acount++;
+        }
+        if (emitRestrictedField) {
+            int alenIdx = writeAttr(names.RestrictedField);
+            databuf.appendChar(poolWriter.putDescriptor(v));
             endAttr(alenIdx);
             acount++;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -151,6 +151,7 @@ public class Names {
     public final Name NestHost;
     public final Name NestMembers;
     public final Name Record;
+    public final Name RestrictedField;
     public final Name RuntimeInvisibleAnnotations;
     public final Name RuntimeInvisibleParameterAnnotations;
     public final Name RuntimeInvisibleTypeAnnotations;
@@ -337,6 +338,7 @@ public class Names {
         NestHost = fromString("NestHost");
         NestMembers = fromString("NestMembers");
         Record = fromString("Record");
+        RestrictedField = fromString("RestrictedField");
         RuntimeInvisibleAnnotations = fromString("RuntimeInvisibleAnnotations");
         RuntimeInvisibleParameterAnnotations = fromString("RuntimeInvisibleParameterAnnotations");
         RuntimeInvisibleTypeAnnotations = fromString("RuntimeInvisibleTypeAnnotations");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -61,6 +61,7 @@ public abstract class Attribute {
     public static final String NestHost                 = "NestHost";
     public static final String NestMembers              = "NestMembers";
     public static final String Record                   = "Record";
+    public static final String RestrictedField          = "RestrictedField";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
     public static final String RuntimeInvisibleAnnotations = "RuntimeInvisibleAnnotations";
     public static final String RuntimeVisibleParameterAnnotations = "RuntimeVisibleParameterAnnotations";
@@ -137,6 +138,7 @@ public abstract class Attribute {
             standardAttributes.put(NestHost, NestHost_attribute.class);
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
+            standardAttributes.put(RestrictedField, RestrictedField_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
             standardAttributes.put(RuntimeInvisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations_attribute.class);
             standardAttributes.put(RuntimeVisibleAnnotations, RuntimeVisibleAnnotations_attribute.class);
@@ -204,6 +206,7 @@ public abstract class Attribute {
         R visitNestHost(NestHost_attribute attr, P p);
         R visitNestMembers(NestMembers_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
+        R visitRestrictedField(RestrictedField_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);
         R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p);
         R visitRuntimeVisibleParameterAnnotations(RuntimeVisibleParameterAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -656,6 +656,12 @@ public class ClassWriter {
         }
 
         @Override
+        public Void visitRestrictedField(RestrictedField_attribute attr, ClassOutputStream out) {
+            out.writeShort(attr.restricted_type_index);
+            return null;
+        }
+
+        @Override
         public Void visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, ClassOutputStream out) {
             annotationWriter.write(attr.annotations, out);
             return null;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedField_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedField_attribute.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+
+/**
+ * See JVMS, section 4.8.9.
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+
+public class RestrictedField_attribute extends Attribute {
+    RestrictedField_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        restricted_type_index = cr.readUnsignedShort();
+    }
+    public RestrictedField_attribute(ConstantPool constant_pool, int restricted_type_index)
+            throws ConstantPoolException {
+        this(constant_pool.getUTF8Index(Attribute.RestrictedField), restricted_type_index);
+    }
+    public RestrictedField_attribute(int name_index, int restricted_type_index) {
+        super(name_index, 2);
+        this.restricted_type_index = restricted_type_index;
+    }
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitRestrictedField(this, data);
+    }
+
+    public String getRestrictedType(ConstantPool constant_pool) throws ConstantPoolException {
+        return constant_pool.getUTF8Value(restricted_type_index);
+    }
+
+    public final int restricted_type_index;
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -61,6 +61,7 @@ import com.sun.tools.classfile.ModuleTarget_attribute;
 import com.sun.tools.classfile.NestHost_attribute;
 import com.sun.tools.classfile.NestMembers_attribute;
 import com.sun.tools.classfile.Record_attribute;
+import com.sun.tools.classfile.RestrictedField_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleParameterAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleTypeAnnotations_attribute;
@@ -763,6 +764,22 @@ public class AttributeWriter extends BasicWriter
         }
         indent(-1);
         return null;
+    }
+
+    @Override
+    public Void visitRestrictedField(RestrictedField_attribute attr, Void p) {
+        print("RestrictedField: #" + attr.restricted_type_index);
+        tab();
+        println("// " + getRestrictedType(attr));
+        return null;
+    }
+
+    String getRestrictedType(RestrictedField_attribute info) {
+        try {
+            return info.getRestrictedType(constant_pool);
+        } catch (ConstantPoolException e) {
+            return report(e);
+        }
     }
 
     String getValue(Descriptor d) {

--- a/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/SimpleTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/SimpleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.typerestrictions;
+
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @summary Simple test about type restrictions
+ * @library /test/lib
+ * @compile  -XDflattenWithTypeRestrictions SimpleTest.java
+ * @run main/othervm -Xint runtime.valhalla.typerestrictions.SimpleTest
+ */
+public class SimpleTest {
+
+    static inline class Point {
+        public double x;
+        public double y;
+        public Point(double x, double y) { this.x = x; this.y = y; }
+    }
+
+    public Point p;
+
+    public static void main(String... args) {
+        SimpleTest b = new SimpleTest();
+        if (b.p != new Point(0,0)) throw new RuntimeException();
+        b.p = new Point(1.0, 2.0);
+        if (b.p != new Point(1.0, 2.0)) throw new RuntimeException();
+    }
+}

--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1371,6 +1371,11 @@ public class ClassfileInspector {
         public Void visitRecord(Record_attribute attr, T p) {
             return null;
         }
+
+        @Override
+        public Void visitRestrictedField(RestrictedField_attribute attr, T p) {
+            return null;
+        }
     }
 
     private static final Attribute.Visitor<Void, ExpectedTypeAnnotation> typeAnnoMatcher

--- a/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
+++ b/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
@@ -66,4 +66,5 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitSynthetic(Synthetic_attribute attr, P p) { return null; }
     public R visitPermittedSubclasses(PermittedSubclasses_attribute attr, P p) { return null; }
     public R visitRecord(Record_attribute attr, P p) { return null; }
+    public R visitRestrictedField(RestrictedField_attribute attr, P p) { return null; }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldCodegenTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldCodegenTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8253312
+ * @summary Enable JVM experiments in specialization under an opt-in mode
+ * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
+ * @compile -XDflattenWithTypeRestrictions RestrictedFieldCodegenTest.java
+ * @run main/othervm -Xverify:none RestrictedFieldCodegenTest
+ * @modules jdk.compiler
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Paths;
+
+class PointBox {
+
+    static inline class Point {
+        public double x;
+        public double y;
+        public Point(double x, double y) { this.x = x; this.y = y; }
+    }
+
+    public Point p;
+
+    public static void main(String... args) {
+        PointBox b = new PointBox();
+        if (b.p != new Point(0,0)) throw new RuntimeException();
+        b.p = new Point(1.0, 2.0);
+        if (b.p != new Point(1.0, 2.0)) throw new RuntimeException();
+    }
+}
+
+public class RestrictedFieldCodegenTest {
+
+    public static void main(String [] args) {
+        new RestrictedFieldCodegenTest().run();
+    }
+
+    void run() {
+        String [] params = new String [] { "-v",
+                                            Paths.get(System.getProperty("test.classes"),
+                                                "PointBox.class").toString() };
+        runCheck(params, new String [] {
+
+         "public PointBox$Point$ref p;",
+         "descriptor: LPointBox$Point$ref;",
+         "RestrictedField: #25                    // QPointBox$Point;",
+         " 9: getfield      #10                 // Field p:LPointBox$Point$ref;",
+         "36: putfield      #10                 // Field p:LPointBox$Point$ref;",
+         "40: getfield      #10                 // Field p:LPointBox$Point$ref;",
+         });
+
+     }
+
+     void runCheck(String [] params, String [] expectedOut) {
+        StringWriter s;
+        String out;
+
+        System.out.println("Checking javap");
+        try (PrintWriter pw = new PrintWriter(s = new StringWriter())) {
+            com.sun.tools.javap.Main.run(params, pw);
+            out = s.toString();
+        }
+        System.out.println("Javap = " + out);
+        int errors = 0;
+        for (String eo: expectedOut) {
+            if (!out.contains(eo)) {
+                System.err.println("Match not found for string: " + eo);
+                errors++;
+            }
+        }
+         if (errors > 0) {
+             throw new AssertionError("Unexpected javap output: " + out);
+         }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.java
@@ -1,0 +1,15 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8253312
+ * @summary Enable JVM experiments in specialization under an opt-in mode
+ * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
+ * @compile -XDflattenWithTypeRestrictions -XDrawDiagnostics RestrictedFieldCodegenTest.java
+ * @compile/fail/ref=RestrictedFieldTypeTest.out -XDflattenWithTypeRestrictions -XDrawDiagnostics RestrictedFieldTypeTest.java
+ */
+
+public class RestrictedFieldTypeTest {
+    PointBox rft = new PointBox();
+    void foo() {
+        rft.p = null;
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedFieldTypeTest.out
@@ -1,0 +1,2 @@
+RestrictedFieldTypeTest.java:13:17: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, PointBox.Point)
+1 error


### PR DESCRIPTION
Please review these changes adding an initial support for RestrictedField.

The patch includes:
  - recognizing and processing the new attribute during class file parsing
  - creating new meta-data to store both the erased type and the restricted type
  - fixing all intermediate method dealing with field types (FieldInfo, FieldStream, etc)
  - fixing field resolution to take into the two possible signatures of the fields
  - adding checkcast against the restricted type in the interpreter implementation of putfield

The patch doesn't include:
  - propagating new meta-data to CI
  - adding new type checks in JIT generated code

The main take away of this first patch is that the VM mostly cares about the sharp type (from the
RestrictedField attribute), and the only place where it needs knowledge of the erased type is for
field resolution. This is why the implementation of the RestrictedField in the VM is inverted compared
to the content of the class file: the traditional FieldInfo is filled with the sharp type from the RestrictedField
attribute, while the original erased type is moved to a new variable section of InstanceKlass.

Note: the patch includes a serious clean up of the FieldInfo data structure. It used to store the allocation
type of the field, but this information is not used anymore after the replacement of the old field layout
code by the field layout builder. Removing the allocation type from the data structure simplifies it a lot.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8254022](https://bugs.openjdk.java.net/browse/JDK-8254022): [lworld] [type-restrictions] Initial support for RestrictedField


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/209/head:pull/209`
`$ git checkout pull/209`
