### PR TITLE
8254026: [lworld] Execute compiler unit tests in random order by default

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -143,7 +143,7 @@ public abstract class InlineTypeTest {
     private static final boolean GC_AFTER = Boolean.parseBoolean(System.getProperty("GCAfter", "false"));
     private static final int OSR_TEST_TIMEOUT = Integer.parseInt(System.getProperty("OSRTestTimeOut", "5000"));
     protected static final boolean STRESS_CC = Boolean.parseBoolean(System.getProperty("StressCC", "false"));
-    private static final boolean SHUFFLE_TESTS = Boolean.parseBoolean(System.getProperty("ShuffleTests", "false"));
+    private static final boolean SHUFFLE_TESTS = Boolean.parseBoolean(System.getProperty("ShuffleTests", "true"));
 
     // "jtreg -DXcomp=true" runs all the scenarios with -Xcomp. This is faster than "jtreg -javaoptions:-Xcomp".
     protected static final boolean RUN_SCENARIOS_WITH_XCOMP = Boolean.parseBoolean(System.getProperty("Xcomp", "false"));


### PR DESCRIPTION
Execute compiler unit tests in random order because the order affects profiling. Functionality was added by JDK-8252040. Now enabling by default after all bugs that were triggered have been fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8254026](https://bugs.openjdk.java.net/browse/JDK-8254026): [lworld] Execute compiler unit tests in random order by default


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/211/head:pull/211`
`$ git checkout pull/211`
