### PR TITLE
8252030: [lworld] Enable UseArrayLoadStoreProfile by default

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -773,7 +773,7 @@
   product(bool, UseProfiledLoopPredicate, true,                             \
           "Move predicates out of loops based on profiling data")           \
                                                                             \
-  product(bool, UseArrayLoadStoreProfile, false,                            \
+  product(bool, UseArrayLoadStoreProfile, true,                             \
           "Take advantage of profiling at array load/store")                \
                                                                             \
   product(bool, ExpandSubTypeCheckAtParseTime, false, DIAGNOSTIC,           \

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -131,7 +131,7 @@ public abstract class InlineTypeTest {
     private static final boolean PRINT_GRAPH = true;
     private static final boolean VERBOSE = Boolean.parseBoolean(System.getProperty("Verbose", "false"));
     private static final boolean PRINT_TIMES = Boolean.parseBoolean(System.getProperty("PrintTimes", "false"));
-    private static final boolean COMPILE_COMMANDS = Boolean.parseBoolean(System.getProperty("CompileCommands", "true"));
+    private static final boolean COMPILE_COMMANDS = Boolean.parseBoolean(System.getProperty("CompileCommands", "true")) && !XCOMP;
     private static       boolean VERIFY_IR = Boolean.parseBoolean(System.getProperty("VerifyIR", "true")) && !XCOMP && !TEST_C1 && COMPILE_COMMANDS;
     private static final boolean VERIFY_VM = Boolean.parseBoolean(System.getProperty("VerifyVM", "false"));
     private static final String SCENARIOS = System.getProperty("Scenarios", "");
@@ -264,32 +264,31 @@ public abstract class InlineTypeTest {
     public String[] getVMParameters(int scenario) {
         switch (scenario) {
         case 0: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:FlatArrayElementMaxOops=5",
                 "-XX:FlatArrayElementMaxSize=-1",
+                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 1: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
                 "-XX:FlatArrayElementMaxOops=5",
                 "-XX:FlatArrayElementMaxSize=-1",
+                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};
         case 2: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:-UseCompressedOops",
                 "-XX:FlatArrayElementMaxOops=0",
                 "-XX:FlatArrayElementMaxSize=0",
+                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields",
                 "-XX:+StressInlineTypeReturnedAsFields"};
         case 3: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:FlatArrayElementMaxOops=0",
@@ -298,7 +297,6 @@ public abstract class InlineTypeTest {
                 "-XX:+InlineTypePassFieldsAsArgs",
                 "-XX:+InlineTypeReturnedAsFields"};
         case 4: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-DVerifyIR=false",
                 "-XX:FlatArrayElementMaxOops=-1",
                 "-XX:FlatArrayElementMaxSize=-1",
@@ -307,10 +305,10 @@ public abstract class InlineTypeTest {
                 "-XX:-InlineTypeReturnedAsFields",
                 "-XX:-ReduceInitialCardMarks"};
         case 5: return new String[] {
-                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:+AlwaysIncrementalInline",
                 "-XX:FlatArrayElementMaxOops=5",
                 "-XX:FlatArrayElementMaxSize=-1",
+                "-XX:-UseArrayLoadStoreProfile",
                 "-XX:InlineFieldMaxFlatSize=-1",
                 "-XX:-InlineTypePassFieldsAsArgs",
                 "-XX:-InlineTypeReturnedAsFields"};


### PR DESCRIPTION
Profiling at array loads/stores should be enabled by default and only be disabled by test scenarios that do IR verification (to make sure the IR shape does not vary depending on profiling).

This patch also disables compile commands if we are running with -Xcomp to make sure more code is inlined/compiled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252030](https://bugs.openjdk.java.net/browse/JDK-8252030): [lworld] Enable UseArrayLoadStoreProfile by default


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/212/head:pull/212`
`$ git checkout pull/212`
