### PR TITLE
8254174: [lworld] [lw3] C1 should optimize access to array of empty types

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1031,7 +1031,6 @@ void GraphBuilder::load_indexed(BasicType type) {
     ciType* array_type = array->declared_type();
     ciInlineKlass* elem_klass = array_type->as_flat_array_klass()->element_klass()->as_inline_klass();
 
-
     ciBytecodeStream s(method());
     s.force_bci(bci());
     s.next();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -287,7 +287,7 @@ public class TestC1 extends InlineTypeTest {
 
 
     // Test optimizations for arrays of empty types
-    // (ead/write are not performed, pre-allocated instance is used for reads)
+    // (read/write are not performed, pre-allocated instance is used for reads)
     // Most tests check that error conditions are still correctly handled
     // (OOB, null pointer)
     static inline class EmptyType {}
@@ -326,21 +326,21 @@ public class TestC1 extends InlineTypeTest {
         Exception e = null;
         EmptyType[] array = new EmptyType[10];
         try {
-            EmptyType et  = test11(array, 11);
+            EmptyType et = test11(array, 11);
         } catch (ArrayIndexOutOfBoundsException ex) {
             e = ex;
         }
         Asserts.assertNotNull(e);
         e = null;
         try {
-            EmptyType et  = test11(array, -1);
+            EmptyType et = test11(array, -1);
         } catch (ArrayIndexOutOfBoundsException ex) {
             e = ex;
         }
         Asserts.assertNotNull(e);
         e = null;
         try {
-            EmptyType et  = test11(null, 1);
+            EmptyType et = test11(null, 1);
         } catch (NullPointerException ex) {
             e = ex;
         }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -285,4 +285,98 @@ public class TestC1 extends InlineTypeTest {
         Asserts.assertEQ(b, (byte)11);
     }
 
+
+    // Test optimizations for arrays of empty types
+    // (ead/write are not performed, pre-allocated instance is used for reads)
+    // Most tests check that error conditions are still correctly handled
+    // (OOB, null pointer)
+    static inline class EmptyType {}
+
+    @Test(compLevel=C1)
+    public EmptyType test9() {
+        EmptyType[] array = new EmptyType[10];
+        return array[4];
+    }
+
+    @DontCompile
+    public void test9_verifier(boolean warmup) {
+        EmptyType et = test9();
+        Asserts.assertEQ(et, EmptyType.default);
+    }
+
+    @Test(compLevel=C1)
+    public EmptyType test10(EmptyType[] array) {
+        return array[0];
+    }
+
+    @DontCompile
+    public void test10_verifier(boolean warmup) {
+        EmptyType[] array = new EmptyType[16];
+        EmptyType et = test10(array);
+        Asserts.assertEQ(et, EmptyType.default);
+    }
+
+    @Test(compLevel=C1)
+    public EmptyType test11(EmptyType[] array, int index) {
+        return array[index];
+    }
+
+    @DontCompile
+    public void test11_verifier(boolean warmup) {
+        Exception e = null;
+        EmptyType[] array = new EmptyType[10];
+        try {
+            EmptyType et  = test11(array, 11);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+        e = null;
+        try {
+            EmptyType et  = test11(array, -1);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+        e = null;
+        try {
+            EmptyType et  = test11(null, 1);
+        } catch (NullPointerException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+    }
+
+    @Test(compLevel=C1)
+    public void test12(EmptyType[] array, int index, EmptyType value) {
+        array[index] = value;
+    }
+
+    @DontCompile
+    public void test12_verifier(boolean warmup) {
+        EmptyType[] array = new EmptyType[16];
+        test12(array, 2, EmptyType.default);
+        Exception e = null;
+        try {
+            test12(null, 2, EmptyType.default);
+        } catch(NullPointerException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+        e = null;
+        try {
+            test12(array, 17, EmptyType.default);
+        } catch(ArrayIndexOutOfBoundsException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+        e = null;
+        try {
+            test12(array, -8, EmptyType.default);
+        } catch(ArrayIndexOutOfBoundsException ex) {
+            e = ex;
+        }
+        Asserts.assertNotNull(e);
+    }
+
 }


### PR DESCRIPTION
Please review these changes adding more optimizations related to empty inline types when accessing flattened arrays.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (2/3 running) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Build / test |    |  ⏳ (1/1 running) |    | 
| Test (tier1) |    |     |  ⏳ (9/9 running) |

**Failed test tasks**
- [Windows x64 (build debug)](https://github.com/fparain/valhalla/runs/1225763108)
- [Windows x64 (build release)](https://github.com/fparain/valhalla/runs/1225763086)

### Issue
 * [JDK-8254174](https://bugs.openjdk.java.net/browse/JDK-8254174): [lworld] [lw3] C1 should optimize access to array of empty types


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/213/head:pull/213`
`$ git checkout pull/213`
