### PR TITLE
8254219: [lworld] Remove reserved entries from the calling convention

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1928,12 +1928,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   }
 }
 
-uint MachPrologNode::size(PhaseRegAlloc* ra_) const
-{
-  return MachNode::size(ra_); // too many variables; just compute it
-                              // the hard way
-}
-
 int MachPrologNode::reloc() const
 {
   return 0;
@@ -1981,11 +1975,6 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   if (do_polling() && C->is_method_compilation()) {
     __ fetch_and_read_polling_page(rscratch1, relocInfo::poll_return_type);
   }
-}
-
-uint MachEpilogNode::size(PhaseRegAlloc *ra_) const {
-  // Variable size. Determine dynamically.
-  return MachNode::size(ra_);
 }
 
 int MachEpilogNode::reloc() const {
@@ -2297,17 +2286,12 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   } else {
     // Unpack inline type args passed as oop and then jump to
     // the verified entry point (skipping the unverified entry).
-    __ unpack_inline_args(ra_->C, _receiver_only);
+    int sp_inc = __ unpack_inline_args(ra_->C, _receiver_only);
+    // Emit code for verified entry and save increment for stack repair on return
+    __ verified_entry(ra_->C, sp_inc);
     __ b(*_verified_entry);
   }
 }
-
-
-uint MachVEPNode::size(PhaseRegAlloc* ra_) const
-{
-  return MachNode::size(ra_); // too many variables; just compute it the hard way
-}
-
 
 //=============================================================================
 #ifndef PRODUCT
@@ -2341,11 +2325,6 @@ void MachUEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   __ br(Assembler::EQ, skip);
   __ far_jump(RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
   __ bind(skip);
-}
-
-uint MachUEPNode::size(PhaseRegAlloc* ra_) const
-{
-  return MachNode::size(ra_);
 }
 
 // REQUIRED EMIT CODE

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -418,8 +418,6 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   int args_passed = sig->length();
   int args_passed_cc = SigEntry::fill_sig_bt(sig_cc, sig_bt);
 
-  int extra_stack_offset = wordSize; // tos is return address.
-
   // Create a temp frame so we can call into runtime. It must be properly set up to accomodate GC.
   int sp_inc = (args_on_stack - args_on_stack_cc) * VMRegImpl::stack_slot_size;
   if (sp_inc > 0) {
@@ -451,9 +449,9 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   // Remove the temp frame
   add(sp, sp, frame_size_in_bytes);
 
-  int n = shuffle_inline_args(true, is_inline_ro_entry, extra_stack_offset, sig_bt, sig_cc,
-                              args_passed_cc, args_on_stack_cc, regs_cc, // from
-                              args_passed, args_on_stack, regs);         // to
+  int n = shuffle_inline_args(true, is_inline_ro_entry, sig_cc,
+                              args_passed_cc, regs_cc,            // from
+                              args_passed, args_on_stack, regs);  // to
   assert(sp_inc == n, "must be");
 
   if (sp_inc != 0) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1191,36 +1191,19 @@ public:
 
   void adrp(Register reg1, const Address &dest, uint64_t &byte_offset);
 
-
-  enum RegState {
-     reg_readonly,
-     reg_writable,
-     reg_written
-  };
-
   void verified_entry(Compile* C, int sp_inc);
 
+  // Inline type specific methods
+  #include "asm/macroAssembler_common.hpp"
+
   int store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from_interpreter = true);
-
-// Unpack all inline type arguments passed as oops
-  void unpack_inline_args(Compile* C, bool receiver_only);
-  bool move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[], int ret_off, int extra_stack_offset);
+  bool move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[]);
   bool unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, VMRegPair* regs_to, int& to_index,
-                            RegState reg_state[], int ret_off, int extra_stack_offset);
+                            RegState reg_state[]);
   bool pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
-                          VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
-                          int ret_off, int extra_stack_offset);
+                          VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[]);
   void restore_stack(Compile* C);
-
-  int shuffle_inline_args(bool is_packing, bool receiver_only, int extra_stack_offset,
-                          BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                          int args_passed, int args_on_stack, VMRegPair* regs,
-                          int args_passed_to, int args_on_stack_to, VMRegPair* regs_to);
-  bool shuffle_inline_args_spill(bool is_packing,  const GrowableArray<SigEntry>* sig_cc, int sig_cc_index,
-                                 VMRegPair* regs_from, int from_index, int regs_from_count,
-                                 RegState* reg_state, int sp_inc, int extra_stack_offset);
   VMReg spill_reg_for(VMReg reg);
-
 
   void tableswitch(Register index, jint lowbound, jint highbound,
                    Label &jumptable, Label &jumptable_end, int stride = 1) {
@@ -1425,9 +1408,6 @@ public:
   }
   void cache_wb(Address line);
   void cache_wbsync(bool is_pre);
-
-  #include "asm/macroAssembler_common.hpp"
-
 };
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -476,9 +476,7 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
   if (InlineTypePassFieldsAsArgs) {
      for (int i = 0; i < sig_extended->length(); i++) {
        BasicType bt = sig_extended->at(i)._bt;
-       if (SigEntry::is_reserved_entry(sig_extended, i)) {
-         // Ignore reserved entry
-       } else if (bt == T_INLINE_TYPE) {
+       if (bt == T_INLINE_TYPE) {
          // In sig_extended, an inline type argument starts with:
          // T_INLINE_TYPE, followed by the types of the fields of the
          // inline type and T_VOID to mark the end of the value
@@ -660,22 +658,17 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     int st_off   = (total_args_passed - next_arg_int - 1) * Interpreter::stackElementSize;
 
     if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
+      if (bt == T_VOID) {
+         assert(next_arg_comp > 0 && (sig_extended->at(next_arg_comp - 1)._bt == T_LONG || sig_extended->at(next_arg_comp - 1)._bt == T_DOUBLE), "missing half");
+         next_arg_int ++;
+         continue;
+       }
 
-            if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
-               continue; // Ignore reserved entry
-            }
+       int next_off = st_off - Interpreter::stackElementSize;
+       int offset = (bt == T_LONG || bt == T_DOUBLE) ? next_off : st_off;
 
-            if (bt == T_VOID) {
-               assert(next_arg_comp > 0 && (sig_extended->at(next_arg_comp - 1)._bt == T_LONG || sig_extended->at(next_arg_comp - 1)._bt == T_DOUBLE), "missing half");
-               next_arg_int ++;
-               continue;
-             }
-
-             int next_off = st_off - Interpreter::stackElementSize;
-             int offset = (bt == T_LONG || bt == T_DOUBLE) ? next_off : st_off;
-
-             gen_c2i_adapter_helper(masm, bt, regs[next_arg_comp], extraspace, Address(sp, offset));
-             next_arg_int ++;
+       gen_c2i_adapter_helper(masm, bt, regs[next_arg_comp], extraspace, Address(sp, offset));
+       next_arg_int ++;
    } else {
        ignored++;
       // get the buffer from the just allocated pool of buffers
@@ -700,8 +693,6 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         } else if (bt == T_VOID && prev_bt != T_LONG && prev_bt != T_DOUBLE) {
           vt--;
           ignored++;
-        } else if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
-          // Ignore reserved entry
         } else {
           int off = sig_extended->at(next_arg_comp)._offset;
           assert(off > 0, "offset in object should be positive");

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1648,31 +1648,18 @@ public:
   // C2 compiled method's prolog code.
   void verified_entry(Compile* C, int sp_inc = 0);
 
-  enum RegState {
-    reg_readonly,
-    reg_writable,
-    reg_written
-  };
+  // Inline type specific methods
+  #include "asm/macroAssembler_common.hpp"
 
   int store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from_interpreter = true);
-
-  // Unpack all inline type arguments passed as oops
-  void unpack_inline_args(Compile* C, bool receiver_only);
-  bool move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[], int ret_off, int extra_stack_offset);
-  bool unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, int& from_index, VMRegPair* regs_to, int& to_index,
-                            RegState reg_state[], int ret_off, int extra_stack_offset);
+  bool move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[]);
+  bool unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index,
+                            VMReg from, int& from_index, VMRegPair* to, int to_count, int& to_index,
+                            RegState reg_state[]);
   bool pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
-                          VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[],
-                          int ret_off, int extra_stack_offset);
+                          VMRegPair* from, int from_count, int& from_index, VMReg to,
+                          RegState reg_state[]);
   void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
-
-  void shuffle_inline_args(bool is_packing, bool receiver_only, int extra_stack_offset,
-                           BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                           int args_passed, int args_on_stack, VMRegPair* regs,
-                           int args_passed_to, int args_on_stack_to, VMRegPair* regs_to, int sp_inc);
-  bool shuffle_inline_args_spill(bool is_packing,  const GrowableArray<SigEntry>* sig_cc, int sig_cc_index,
-                                 VMRegPair* regs_from, int from_index, int regs_from_count,
-                                 RegState* reg_state, int sp_inc, int extra_stack_offset);
   VMReg spill_reg_for(VMReg reg);
 
   // clear memory of size 'cnt' qwords, starting at 'base';
@@ -1810,8 +1797,6 @@ public:
 #endif // _LP64
 
   void vallones(XMMRegister dst, int vector_len);
-
-  #include "asm/macroAssembler_common.hpp"
 };
 
 /**

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -661,9 +661,7 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
   if (InlineTypePassFieldsAsArgs) {
     for (int i = 0; i < sig_extended->length(); i++) {
       BasicType bt = sig_extended->at(i)._bt;
-      if (SigEntry::is_reserved_entry(sig_extended, i)) {
-        // Ignore reserved entry
-      } else if (bt == T_INLINE_TYPE) {
+      if (bt == T_INLINE_TYPE) {
         // In sig_extended, an inline type argument starts with:
         // T_INLINE_TYPE, followed by the types of the fields of the
         // inline type and T_VOID to mark the end of the value
@@ -861,9 +859,6 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     BasicType bt = sig_extended->at(next_arg_comp)._bt;
     int st_off = (total_args_passed - next_arg_int) * Interpreter::stackElementSize;
     if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
-      if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
-        continue; // Ignore reserved entry
-      }
       int next_off = st_off - Interpreter::stackElementSize;
       const int offset = (bt == T_LONG || bt == T_DOUBLE) ? next_off : st_off;
       const VMRegPair reg_pair = regs[next_arg_comp-ignored];
@@ -903,8 +898,6 @@ static void gen_c2i_adapter(MacroAssembler *masm,
                    prev_bt != T_DOUBLE) {
           vt--;
           ignored++;
-        } else if (SigEntry::is_reserved_entry(sig_extended, next_arg_comp)) {
-          // Ignore reserved entry
         } else {
           int off = sig_extended->at(next_arg_comp)._offset;
           assert(off > 0, "offset in object should be positive");

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1508,21 +1508,23 @@ void MachVEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 
 void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
 {
-  MacroAssembler masm(&cbuf);
+  MacroAssembler _masm(&cbuf);
   if (!_verified) {  
     uint insts_size = cbuf.insts_size();
     if (UseCompressedClassPointers) {
-      masm.load_klass(rscratch1, j_rarg0, rscratch2);
-      masm.cmpptr(rax, rscratch1);
+      __ load_klass(rscratch1, j_rarg0, rscratch2);
+      __ cmpptr(rax, rscratch1);
     } else {
-      masm.cmpptr(rax, Address(j_rarg0, oopDesc::klass_offset_in_bytes()));
+      __ cmpptr(rax, Address(j_rarg0, oopDesc::klass_offset_in_bytes()));
     }
-    masm.jump_cc(Assembler::notEqual, RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
+    __ jump_cc(Assembler::notEqual, RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
   } else {
     // Unpack inline type args passed as oop and then jump to
     // the verified entry point (skipping the unverified entry).
-    masm.unpack_inline_args(ra_->C, _receiver_only);
-    masm.jmp(*_verified_entry);
+    int sp_inc = __ unpack_inline_args(ra_->C, _receiver_only);
+    // Emit code for verified entry and save increment for stack repair on return
+    __ verified_entry(ra_->C, sp_inc);
+    __ jmp(*_verified_entry);
   }
 }
 

--- a/src/hotspot/share/asm/macroAssembler_common.hpp
+++ b/src/hotspot/share/asm/macroAssembler_common.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,27 +25,30 @@
 #ifndef SHARE_ASM_MACROASSEMBLER_COMMON_HPP
 #define SHARE_ASM_MACROASSEMBLER_COMMON_HPP
 
-// These are part of the MacroAssembler class that are common for
-// all CPUs
+// These are part of the MacroAssembler class that are common for all CPUs
 
 // class MacroAssembler ... {
-private:
+
+  enum RegState {
+    reg_readonly,
+    reg_writable,
+    reg_written
+  };
+
   void skip_unpacked_fields(const GrowableArray<SigEntry>* sig, int& sig_index, VMRegPair* regs_from,
                             int regs_from_count, int& from_index);
   bool is_reg_in_unpacked_fields(const GrowableArray<SigEntry>* sig, int sig_index, VMReg to, VMRegPair* regs_from,
                                  int regs_from_count, int from_index);
   void mark_reg_writable(const VMRegPair* regs, int num_regs, int reg_index, RegState* reg_state);
-  void mark_reserved_entries_writable(const GrowableArray<SigEntry>* sig_cc, const VMRegPair* regs, int num_regs, RegState* reg_state);
-  RegState* init_reg_state(bool is_packing, const GrowableArray<SigEntry>* sig_cc,
-                           VMRegPair* regs, int num_regs, int sp_inc, int max_stack);
-
-  int unpack_inline_args_common(Compile* C, bool receiver_only);
-  void shuffle_inline_args_common(bool is_packing, bool receiver_only, int extra_stack_offset,
-                                  BasicType* sig_bt, const GrowableArray<SigEntry>* sig_cc,
-                                  int args_passed, int args_on_stack, VMRegPair* regs,
-                                  int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,
-                                  int sp_inc, int ret_off);
-
+  RegState* init_reg_state(VMRegPair* regs, int num_regs, int sp_inc, int max_stack);
+  int unpack_inline_args(Compile* C, bool receiver_only);
+  void shuffle_inline_args(bool is_packing, bool receiver_only,
+                           const GrowableArray<SigEntry>* sig,
+                           int args_passed, int args_on_stack, VMRegPair* regs,
+                           int args_passed_to, int args_on_stack_to, VMRegPair* regs_to,
+                           int sp_inc);
+  bool shuffle_inline_args_spill(bool is_packing, const GrowableArray<SigEntry>* sig, int sig_index,
+                                 VMRegPair* regs_from, int from_index, int regs_from_count, RegState* reg_state);
 // };
 
 #endif // SHARE_ASM_MACROASSEMBLER_COMMON_HPP

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3170,7 +3170,6 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
     ResourceMark rm;
     int sizeargs = 0;
     BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, 256);
-    bool has_scalarized_args = ces->has_scalarized_args();
     TempNewSymbol sig = SigEntry::create_symbol(sig_cc);
     for (SignatureStream ss(sig); !ss.at_return_type(); ss.next()) {
       BasicType t = ss.type();
@@ -3190,7 +3189,6 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
     int stack_slot_offset = this->frame_size() * wordSize;
     int tab1 = 14, tab2 = 24;
     int sig_index = 0;
-    int sig_index_cc = 0;
     int arg_index = has_this ? -1 : 0;
     bool did_old_sp = false;
     for (SignatureStream ss(sig); !ss.at_return_type(); ) {
@@ -3232,15 +3230,6 @@ void nmethod::print_nmethod_labels(outputStream* stream, address block_begin, bo
         }
         if (!did_name)
           stream->print("%s", type2name(t));
-      }
-      if (has_scalarized_args) {
-        while (!SigEntry::skip_value_delimiters(sig_cc, sig_index_cc)) {
-          sig_index_cc++;
-        }
-        if (SigEntry::is_reserved_entry(sig_cc, sig_index_cc)) {
-          stream->print(" [RESERVED]");
-        }
-        sig_index_cc += type2size[t];
       }
       if (at_old_sp) {
         stream->print("  (%s of caller)", spname);

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -369,19 +369,8 @@ void LateInlineCallGenerator::do_late_inline() {
     return;
   }
 
-  const GrowableArray<SigEntry>* sig_cc = method()->get_sig_cc();
   const TypeTuple* r = call->tf()->domain_cc();
-  for (uint i1 = TypeFunc::Parms, i2 = 0; i1 < r->cnt(); i1++) {
-    if (sig_cc != NULL) {
-      // Skip reserved entries
-      while (!SigEntry::skip_value_delimiters(sig_cc, i2)) {
-        i2++;
-      }
-      if (SigEntry::is_reserved_entry(sig_cc, i2++)) {
-        assert(call->in(i1)->is_top(), "should be top");
-        continue;
-      }
-    }
+  for (uint i1 = TypeFunc::Parms; i1 < r->cnt(); i1++) {
     if (call->in(i1)->is_top() && r->field_at(i1) != Type::HALF) {
       assert(Compile::current()->inlining_incrementally(), "shouldn't happen during parsing");
       return;
@@ -471,10 +460,6 @@ void LateInlineCallGenerator::do_late_inline() {
         map->set_argument(jvms, i1, vt);
       } else {
         map->set_argument(jvms, i1, call->in(j++));
-        BasicType bt = t->basic_type();
-        while (SigEntry::next_is_reserved(sig_cc, bt, true)) {
-          j += type2size[bt]; // Skip reserved arguments
-        }
       }
     }
 

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -2234,11 +2234,6 @@ void PhaseChaitin::dump_frame() const {
           _matcher._parm_regs[j].second() == reg ) {
         tty->print("parm %d: ",j);
         domain->field_at(j + TypeFunc::Parms)->dump();
-        if (!C->FIRST_STACK_mask().Member(reg)) {
-          // Reserved entry in the argument stack area that is not used because
-          // it may hold the return address (see Matcher::init_first_stack_mask()).
-          tty->print(" [RESERVED] ");
-        }
         tty->cr();
         break;
       }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1829,14 +1829,6 @@ void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inli
       }
     }
     call->init_req(idx++, arg);
-    // Skip reserved arguments
-    BasicType bt = t->basic_type();
-    while (SigEntry::next_is_reserved(sig_cc, bt, true)) {
-      call->init_req(idx++, top());
-      if (type2size[bt] == 2) {
-        call->init_req(idx++, top());
-      }
-    }
   }
 }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -736,13 +736,6 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig,
       if (type2size[bt] == 2) {
         n->init_req(base_input++, kit->top());
       }
-      // Skip reserved arguments
-      while (SigEntry::next_is_reserved(sig, bt)) {
-        n->init_req(base_input++, kit->top());
-        if (type2size[bt] == 2) {
-          n->init_req(base_input++, kit->top());
-        }
-      }
     }
   }
 }
@@ -776,10 +769,6 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, Extended
       }
       BasicType bt = type->basic_type();
       base_input += type2size[bt];
-      // Skip reserved arguments
-      while (SigEntry::next_is_reserved(sig, bt)) {
-        base_input += type2size[bt];
-      }
     }
     assert(parm != NULL, "should never be null");
     assert(field_value(i) == NULL, "already set");

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -519,24 +519,6 @@ void Matcher::init_first_stack_mask() {
     C->FIRST_STACK_mask().Insert(i);
   }
 
-  // Check if the method has a reserved entry in the argument stack area that
-  // should not be used for spilling because it may hold the return address.
-  if (!C->is_osr_compilation() && C->method() != NULL && C->method()->has_scalarized_args()) {
-    ExtendedSignature sig_cc = ExtendedSignature(C->method()->get_sig_cc(), SigEntryFilter());
-    for (int off = 0; !sig_cc.at_end(); ) {
-      BasicType bt = (*sig_cc)._bt;
-      off += type2size[bt];
-      while (SigEntry::next_is_reserved(sig_cc, bt)) {
-        // Remove reserved stack slot from mask to avoid spilling
-        OptoRegPair reg = _parm_regs[off];
-        assert(OptoReg::is_valid(reg.first()), "invalid reserved register");
-        C->FIRST_STACK_mask().Remove(reg.first());
-        C->FIRST_STACK_mask().Remove(reg.first()+1); // Always occupies two stack slots
-        off += type2size[bt];
-      }
-    }
-  }
-
   // Add in all bits past the outgoing argument area
   guarantee(RegMask::can_represent_arg(OptoReg::add(_out_arg_limit,-1)),
             "must be able to represent all call arguments in reg mask");

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -881,10 +881,6 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
       map->set_memory(old_mem);
     } else {
       parm = gvn.transform(new ParmNode(start, j++));
-      BasicType bt = t->basic_type();
-      while (i >= TypeFunc::Parms && !is_osr_compilation() && SigEntry::next_is_reserved(sig_cc, bt, true)) {
-        j += type2size[bt]; // Skip reserved arguments
-      }
     }
     map->init_req(i, parm);
     // Record all these guys for later GVN.

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -805,7 +805,6 @@ class CompiledEntrySignature : public StackObj {
   bool _c1_needs_stack_repair;
   bool _c2_needs_stack_repair;
   bool _has_scalarized_args;
-  bool _has_reserved_entries;
 
 public:
   Method* method()                     const { return _method; }
@@ -841,7 +840,6 @@ public:
 
 private:
   int compute_scalarized_cc(GrowableArray<SigEntry>*& sig_cc, VMRegPair*& regs_cc, bool scalar_receiver);
-  int insert_reserved_entry(int ret_off);
 };
 
 #endif // SHARE_RUNTIME_SHAREDRUNTIME_HPP

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -575,8 +575,6 @@ class SigEntry {
   BasicType _bt;
   int _offset;
 
-  enum { ReservedOffset = -2 }; // Special offset to mark the reserved entry
-
   SigEntry()
     : _bt(T_ILLEGAL), _offset(-1) {
   }
@@ -609,13 +607,9 @@ class SigEntry {
     return 0;
   }
   static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, int offset = -1);
-  static void insert_reserved_entry(GrowableArray<SigEntry>* sig, int i, BasicType bt);
-  static bool is_reserved_entry(const GrowableArray<SigEntry>* sig, int i);
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);
   static int fill_sig_bt(const GrowableArray<SigEntry>* sig, BasicType* sig_bt);
   static TempNewSymbol create_symbol(const GrowableArray<SigEntry>* sig);
-
-  static bool next_is_reserved(ExtendedSignature& sig, BasicType& bt, bool can_be_void = false);
 };
 
 class SigEntryFilter {


### PR DESCRIPTION
When packing/unpacking inline type arguments to convert between the scalarized and the non-scalarized calling conventions in the nmethod entry points, we may need to extend the stack. To save stack space, C2 re-uses the existing stack slots and only extends the stack to fit additional fields. As a result, the original return address is in-between and to avoid overwriting it by accident, we need "reserved entries" that are not used by the calling convention.

Similar to C1 (see JDK-8241764), we should extend the stack enough for unpacking to have its "own" stack space to lay out arguments and get rid off all the ridiculous complexity that reserved entries require in the JIT. If necessary, there are other ways to save stack space (for example, to allow overwriting the original return address and restore it on return).

This fix is part of the "Calling Convention 2.0" umbrella (JDK-8254218) which aims to improve and simplify the implementation of the scalarized calling convention.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Build / test |    |  ✔️ (0/0 passed) |    | 
| Test (tier1) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test tasks**
- [Windows x64 (build debug)](https://github.com/TobiHartmann/valhalla/runs/1224743834)
- [Windows x64 (build release)](https://github.com/TobiHartmann/valhalla/runs/1224743819)

### Issue
 * [JDK-8254219](https://bugs.openjdk.java.net/browse/JDK-8254219): [lworld] Remove reserved entries from the calling convention


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/214/head:pull/214`
`$ git checkout pull/214`
