### PR TITLE
8254254: [lworld][type-restrictions] Serviceability tests failing missing FIELDINFO_TAG_MASK

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -56,7 +56,6 @@ public class InstanceKlass extends Klass {
   private static int HIGH_OFFSET;
   private static int FIELD_SLOTS;
   private static short FIELDINFO_TAG_SIZE;
-  private static short FIELDINFO_TAG_MASK;
   private static short FIELDINFO_TAG_OFFSET;
 
   // ClassState constants
@@ -117,7 +116,6 @@ public class InstanceKlass extends Klass {
     HIGH_OFFSET                    = db.lookupIntConstant("FieldInfo::high_packed_offset").intValue();
     FIELD_SLOTS                    = db.lookupIntConstant("FieldInfo::field_slots").intValue();
     FIELDINFO_TAG_SIZE             = db.lookupIntConstant("FIELDINFO_TAG_SIZE").shortValue();
-    FIELDINFO_TAG_MASK             = db.lookupIntConstant("FIELDINFO_TAG_MASK").shortValue();
     FIELDINFO_TAG_OFFSET           = db.lookupIntConstant("FIELDINFO_TAG_OFFSET").shortValue();
 
     // read ClassState constants
@@ -392,7 +390,7 @@ public class InstanceKlass extends Klass {
     U2Array fields = getFields();
     short lo = fields.at(index * FIELD_SLOTS + LOW_OFFSET);
     short hi = fields.at(index * FIELD_SLOTS + HIGH_OFFSET);
-    if ((lo & FIELDINFO_TAG_MASK) == FIELDINFO_TAG_OFFSET) {
+    if ((lo & FIELDINFO_TAG_OFFSET) == FIELDINFO_TAG_OFFSET) {
       return VM.getVM().buildIntFromShorts(lo, hi) >> FIELDINFO_TAG_SIZE;
     }
     throw new RuntimeException("should not reach here");


### PR DESCRIPTION
Please review this changeset which updates the SA to match the new format of FieldInfo.

Tested locally with test/hotspot/jtreg/serviceability/sa/ tests.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Build / test |    |  ✔️ (0/0 passed) |    | 
| Test (tier1) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test tasks**
- [Windows x64 (build debug)](https://github.com/fparain/valhalla/runs/1227654036)
- [Windows x64 (build release)](https://github.com/fparain/valhalla/runs/1227654014)

### Issue
 * [JDK-8254254](https://bugs.openjdk.java.net/browse/JDK-8254254): [lworld][type-restrictions] Serviceability tests failing missing FIELDINFO_TAG_MASK


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/219/head:pull/219`
`$ git checkout pull/219`
