### PR TITLE
8254326: [lworld] [lw3] Extend definition of empty inline types

### DIFF
--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -92,9 +92,7 @@ bool ciInlineKlass::can_be_returned_as_fields() const {
 }
 
 bool ciInlineKlass::is_empty() {
-  // Do not use InlineKlass::is_empty_inline_type here because it does
-  // not recursively account for flattened fields of empty inline types.
-  return nof_nonstatic_fields() == 0;
+  GUARDED_VM_ENTRY(return to_InlineKlass()->is_empty_inline_type();)
 }
 
 // When passing an inline type's fields as arguments, count the number

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -92,7 +92,10 @@ bool ciInlineKlass::can_be_returned_as_fields() const {
 }
 
 bool ciInlineKlass::is_empty() {
-  GUARDED_VM_ENTRY(return to_InlineKlass()->is_empty_inline_type();)
+  // Do not use InlineKlass::is_empty_inline_type here because it does
+  // consider the container empty even if fields of empty inline types
+  // are not flattened
+  return nof_nonstatic_fields() == 0;
 }
 
 // When passing an inline type's fields as arguments, count the number

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -288,13 +288,19 @@ class InstanceKlass: public Klass {
     _misc_is_being_redefined                  = 1 << 14, // used for locking redefinition
     _misc_has_contended_annotations           = 1 << 15,  // has @Contended annotation
     _misc_has_inline_type_fields              = 1 << 16, // has inline fields and related embedded section is not empty
-    _misc_is_empty_inline_type                = 1 << 17, // empty inline type
+    _misc_is_empty_inline_type                = 1 << 17, // empty inline type (*)
     _misc_is_naturally_atomic                 = 1 << 18, // loaded/stored in one instruction
     _misc_is_declared_atomic                  = 1 << 19, // implements jl.NonTearable
     _misc_invalid_inline_super                = 1 << 20, // invalid super type for an inline type
     _misc_invalid_identity_super              = 1 << 21, // invalid super type for an identity type
     _misc_has_injected_identityObject         = 1 << 22  // IdentityObject has been injected by the JVM
   };
+
+  // (*) An inline type is considered empty if it contains no non-static fields or
+  // if it contains only empty inline fields. Note that JITs have a slightly different
+  // definition: empty inline fields must be flattened otherwise the container won't
+  // be considered empty
+
   u2 shared_loader_type_bits() const {
     return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
   }


### PR DESCRIPTION
Please review these changes which extend the runtime definition of empty inline types to also include inline type with only empty non-static fields.

This is a first step of an attempt to unify the definition of empty inline types between the runtime and the JITs.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (3/3 passed) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Build / test |    |  ✔️ (0/0 passed) |    | 
| Test (tier1) | ✔️ (9/9 passed) |    |  ✔️ (9/9 passed) |

**Failed test tasks**
- [Windows x64 (build debug)](https://github.com/fparain/valhalla/runs/1231601573)
- [Windows x64 (build release)](https://github.com/fparain/valhalla/runs/1231601546)

### Issue
 * [JDK-8254326](https://bugs.openjdk.java.net/browse/JDK-8254326): [lworld] [lw3] Extend definition of empty inline types


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/220/head:pull/220`
`$ git checkout pull/220`
