### PR TITLE
8254271: Development to deprecate wrapper class constructors for removal

### DIFF
--- a/src/java.base/share/classes/java/lang/Boolean.java
+++ b/src/java.base/share/classes/java/lang/Boolean.java
@@ -98,7 +98,7 @@ public final class Boolean implements java.io.Serializable,
      * Also consider using the final fields {@link #TRUE} and {@link #FALSE}
      * if possible.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Boolean(boolean value) {
         this.value = value;
     }
@@ -118,7 +118,7 @@ public final class Boolean implements java.io.Serializable,
      * {@code boolean} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Boolean} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Boolean(String s) {
         this(parseBoolean(s));
     }

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -337,7 +337,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * {@link #valueOf(byte)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Byte(byte value) {
         this.value = value;
     }
@@ -360,7 +360,7 @@ public final class Byte extends Number implements Comparable<Byte>, Constable {
      * {@code byte} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Byte} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Byte(String s) throws NumberFormatException {
         this.value = parseByte(s, 10);
     }

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -8501,7 +8501,7 @@ class Character implements java.io.Serializable, Comparable<Character>, Constabl
      * {@link #valueOf(char)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Character(char value) {
         this.value = value;
     }

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -605,7 +605,7 @@ public final class Double extends Number
      * {@link #valueOf(double)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Double(double value) {
         this.value = value;
     }
@@ -626,7 +626,7 @@ public final class Double extends Number
      * {@code double} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Double} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Double(String s) throws NumberFormatException {
         value = parseDouble(s);
     }

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -518,7 +518,7 @@ public final class Float extends Number
      * {@link #valueOf(float)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Float(float value) {
         this.value = value;
     }
@@ -534,7 +534,7 @@ public final class Float extends Number
      * static factory method {@link #valueOf(float)} method as follows:
      * {@code Float.valueOf((float)value)}.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Float(double value) {
         this.value = (float)value;
     }
@@ -555,7 +555,7 @@ public final class Float extends Number
      * {@code float} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Float} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Float(String s) throws NumberFormatException {
         value = parseFloat(s);
     }

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1085,7 +1085,7 @@ public final class Integer extends Number
      * {@link #valueOf(int)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Integer(int value) {
         this.value = value;
     }
@@ -1107,7 +1107,7 @@ public final class Integer extends Number
      * {@code int} primitive, or use {@link #valueOf(String)}
      * to convert a string to an {@code Integer} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Integer(String s) throws NumberFormatException {
         this.value = parseInt(s, 10);
     }

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1316,7 +1316,7 @@ public final class Long extends Number
      * {@link #valueOf(long)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Long(long value) {
         this.value = value;
     }
@@ -1339,7 +1339,7 @@ public final class Long extends Number
      * {@code long} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Long} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Long(String s) throws NumberFormatException {
         this.value = parseLong(s, 10);
     }

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -342,7 +342,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * {@link #valueOf(short)} is generally a better choice, as it is
      * likely to yield significantly better space and time performance.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Short(short value) {
         this.value = value;
     }
@@ -365,7 +365,7 @@ public final class Short extends Number implements Comparable<Short>, Constable 
      * {@code short} primitive, or use {@link #valueOf(String)}
      * to convert a string to a {@code Short} object.
      */
-    @Deprecated(since="9")
+    @Deprecated(since="9", forRemoval = true)
     public Short(String s) throws NumberFormatException {
         this.value = parseShort(s, 10);
     }

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -773,7 +773,7 @@ final class MemberName implements Member, Cloneable {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public int hashCode() {
         // Avoid autoboxing getReferenceKind(), since this is used early and will force
         // early initialization of Byte$ByteCache

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl_Stub.java
@@ -258,7 +258,10 @@ public final class RMIConnectionImpl_Stub
     public javax.management.remote.NotificationResult fetchNotifications(long $param_long_1, int $param_int_2, long $param_long_3)
             throws java.io.IOException {
         try {
-            Object $result = ref.invoke(this, $method_fetchNotifications_7, new java.lang.Object[]{new java.lang.Long($param_long_1), new java.lang.Integer($param_int_2), new java.lang.Long($param_long_3)}, -5037523307973544478L);
+            Object $result = ref.invoke(this, $method_fetchNotifications_7,
+                    new java.lang.Object[]{java.lang.Long.valueOf($param_long_1),
+                            java.lang.Integer.valueOf($param_int_2),
+                            java.lang.Long.valueOf($param_long_3)}, -5037523307973544478L);
             return ((javax.management.remote.NotificationResult) $result);
         } catch (java.lang.RuntimeException e) {
             throw e;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/traversers/XSDHandler.java
@@ -4013,7 +4013,8 @@ public class XSDHandler {
                     ","+oldName:currSchema.fTargetNamespace+","+oldName;
             int attGroupRefsCount = changeRedefineGroup(processedBaseName, componentType, newName, child, currSchema);
             if (attGroupRefsCount > 1) {
-                reportSchemaError("src-redefine.7.1", new Object []{new Integer(attGroupRefsCount)}, child);
+                reportSchemaError("src-redefine.7.1",
+                        new Object []{Integer.valueOf(attGroupRefsCount)}, child);
             }
             else if (attGroupRefsCount == 1) {
                 //                return true;
@@ -4029,7 +4030,7 @@ public class XSDHandler {
                     ","+oldName:currSchema.fTargetNamespace+","+oldName;
             int groupRefsCount = changeRedefineGroup(processedBaseName, componentType, newName, child, currSchema);
             if (groupRefsCount > 1) {
-                reportSchemaError("src-redefine.6.1.1", new Object []{new Integer(groupRefsCount)}, child);
+                reportSchemaError("src-redefine.6.1.1", new Object []{Integer.valueOf(groupRefsCount)}, child);
             }
             else if (groupRefsCount == 1) {
                 //                return true;

--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/HTMLdtd.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serialize/HTMLdtd.java
@@ -438,8 +438,8 @@ public final class HTMLdtd
     private static void defineEntity( String name, char value )
     {
         if ( _byName.get( name ) == null ) {
-            _byName.put( name, new Integer( value ) );
-            _byChar.put( new Integer( value ), name );
+            _byName.put( name, Integer.valueOf( value ) );
+            _byChar.put( Integer.valueOf( value ), name );
         }
     }
 

--- a/src/jdk.internal.vm.compiler/share/classes/jdk.internal.vm.compiler.collections.test/src/jdk/internal/vm/compiler/collections/test/EconomicMapImplTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/jdk.internal.vm.compiler.collections.test/src/jdk/internal/vm/compiler/collections/test/EconomicMapImplTest.java
@@ -133,7 +133,7 @@ public class EconomicMapImplTest {
         Assert.assertTrue(set.add(newInteger(0)));
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     private static Integer newInteger(int value) {
         return new Integer(value);
     }

--- a/src/jdk.internal.vm.compiler/share/classes/jdk.internal.vm.compiler.collections.test/src/jdk/internal/vm/compiler/collections/test/EconomicSetTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/jdk.internal.vm.compiler.collections.test/src/jdk/internal/vm/compiler/collections/test/EconomicSetTest.java
@@ -161,7 +161,7 @@ public class EconomicSetTest {
         Assert.assertEquals(newInteger(9), finalList.get(0));
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     private static Integer newInteger(int value) {
         return new Integer(value);
     }

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/EscapeAnalysisTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/EscapeAnalysisTest.java
@@ -58,7 +58,7 @@ public class EscapeAnalysisTest extends EATestBase {
         testEscapeAnalysis("test1Snippet", JavaConstant.forInt(101), false);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public static int test1Snippet() {
         Integer x = new Integer(101);
         return x.intValue();
@@ -89,7 +89,7 @@ public class EscapeAnalysisTest extends EATestBase {
         testEscapeAnalysis("testMonitorSnippet", JavaConstant.forInt(0), false);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public static int testMonitorSnippet() {
         Integer x = new Integer(0);
         Double y = new Double(0);
@@ -113,7 +113,7 @@ public class EscapeAnalysisTest extends EATestBase {
      * This test case differs from the last one in that it requires inlining within a synchronized
      * region.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public static int testMonitor2Snippet() {
         Integer x = new Integer(0);
         Double y = new Double(0);
@@ -335,7 +335,7 @@ public class EscapeAnalysisTest extends EATestBase {
 
     public volatile Object field;
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public int testChangeHandlingSnippet(int a) {
         Object obj;
         Integer one = 1;

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PEAAssertionsTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PEAAssertionsTest.java
@@ -42,7 +42,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
 
     public static Object field;
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippet1(int i) {
         Integer object = new Integer(i);
         GraalDirectives.ensureVirtualized(object);
@@ -53,7 +53,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippet1", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippet2(int i) {
         Integer object = new Integer(i);
         GraalDirectives.ensureVirtualized(object);
@@ -65,7 +65,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippet2", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippet3(int i) {
         Integer object = new Integer(i);
         field = object;
@@ -77,7 +77,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippet3", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetHere1(int i) {
         Integer object = new Integer(i);
         GraalDirectives.ensureVirtualizedHere(object);
@@ -88,7 +88,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetHere1", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetHere2(int i) {
         Integer object = new Integer(i);
         GraalDirectives.ensureVirtualizedHere(object);
@@ -100,7 +100,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetHere2", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetHere3(int i) {
         Integer object = new Integer(i);
         field = object;
@@ -133,7 +133,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetBoxing2", 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetControlFlow1(boolean b, int i) {
         Integer object = new Integer(i);
         if (b) {
@@ -148,7 +148,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetControlFlow1", true, 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetControlFlow2(boolean b, int i) {
         Integer object = new Integer(i);
         if (b) {
@@ -165,7 +165,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetControlFlow2", true, 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetControlFlow3(boolean b, int i) {
         Integer object = new Integer(i);
         GraalDirectives.ensureVirtualized(object);
@@ -183,7 +183,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetControlFlow3", true, 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetControlFlow4(boolean b, int i) {
         Integer object = new Integer(i);
         if (b) {
@@ -199,7 +199,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetControlFlow4", true, 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetControlFlow5(boolean b, int i) {
         Integer object = new Integer(i);
         if (b) {
@@ -220,7 +220,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         Object b;
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetIndirect1(boolean b, int i) {
         Integer object = new Integer(i);
         TestClass t = new TestClass();
@@ -239,7 +239,7 @@ public class PEAAssertionsTest extends GraalCompilerTest {
         test("snippetIndirect1", true, 1);
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static void snippetIndirect2(boolean b, int i) {
         Integer object = new Integer(i);
         TestClass t = new TestClass();

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PartialEscapeAnalysisTest.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PartialEscapeAnalysisTest.java
@@ -115,7 +115,7 @@ public class PartialEscapeAnalysisTest extends EATestBase {
         testPartialEscapeAnalysis("test3Snippet", 0.5, 1, StoreFieldNode.class, LoadFieldNode.class);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public static Object test3Snippet(int a) {
         if (a < 0) {
             TestObject obj = new TestObject(1, 2);

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/tutorial/StaticAnalysisTests.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/tutorial/StaticAnalysisTests.java
@@ -114,7 +114,7 @@ public class StaticAnalysisTests {
         assertEquals(m(sa, B.class, "foo").getFormalReturn(), t(Data.class));
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     static void test03Entry() {
         Data data = new Data();
         data.f = new Integer(42);
@@ -142,7 +142,7 @@ public class StaticAnalysisTests {
         assertEquals(m(sa, B.class, "foo").getFormalReturn(), t(Data.class), t(Integer.class));
     }
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     static void test04Entry() {
         Data data = null;
         for (int i = 0; i < 2; i++) {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigAccess.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigAccess.java
@@ -386,13 +386,13 @@ public class GraalHotSpotVMConfigAccess {
             // overhead when running with assertions enabled.
             T sentinel;
             if (type == Boolean.class) {
-                sentinel = type.cast(new Boolean(false));
+                sentinel = type.cast(false);
             } else if (type == Byte.class) {
-                sentinel = type.cast(new Byte((byte) 123));
+                sentinel = type.cast((byte) 123);
             } else if (type == Integer.class) {
-                sentinel = type.cast(new Integer(1234567890));
+                sentinel = type.cast(1234567890);
             } else if (type == Long.class) {
-                sentinel = type.cast(new Long(1234567890987654321L));
+                sentinel = type.cast(1234567890987654321L);
             } else if (type == String.class) {
                 sentinel = type.cast(new String("1234567890987654321"));
             } else {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/hotpath/HP_allocate02.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/hotpath/HP_allocate02.java
@@ -32,7 +32,7 @@ import org.graalvm.compiler.jtt.JTTTest;
  */
 public class HP_allocate02 extends JTTTest {
 
-    @SuppressWarnings({"deprecation", "unused"})
+    @SuppressWarnings({"deprecation", "removal", "unused"})
     public static int test(int count) {
         int sum = 0;
         for (int i = 0; i < count; i++) {

--- a/test/jdk/java/lang/WrappersTest.java
+++ b/test/jdk/java/lang/WrappersTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @bug 8252180
+ * @summary Test the primitive wrappers constructors are deprecated for removal
+ * @run testng WrappersTest
+ */
+
+@Test
+public class WrappersTest {
+
+    @Test
+    void checkForDeprecated() {
+        List<Class<?>> classes =
+                List.of(Byte.class,
+                        Short.class,
+                        Integer.class,
+                        Long.class,
+                        Float.class,
+                        Double.class,
+                        Character.class,
+                        Boolean.class);
+        for (Class<?> cl : classes) {
+            for (Constructor<?> cons : cl.getConstructors()) {
+                Deprecated dep = cons.getAnnotation(Deprecated.class);
+                assertNotNull(dep, "Missing @Deprecated annotation");
+                System.out.println(cons + ": " + dep);
+                assertTrue(dep.forRemoval(), cl.toString() + " deprecated for removal: ");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The public constructors of the following classes have been deprecated since SE 9, and should be deprecated for removal in anticipation of these classes becoming inline classes.

java.lang.Boolean, Byte, Short, Integer, Long, Float, Double, and Character.

Existing uses of the constructors are converted to use the .valueOf(xxx) methods in classes and tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ❌ (1/9 failed) | ❌ (1/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1232836396)
- [Windows x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1232933286)
- [macOS x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1232787026)

### Issue
 * [JDK-8254271](https://bugs.openjdk.java.net/browse/JDK-8254271): Development to deprecate wrapper class constructors for removal


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/221/head:pull/221`
`$ git checkout pull/221`
