### PR TITLE
8254898: [lworld] TestArrayAccessDeopt fails with RuntimeException: 'Uncommon trap occurred'

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -86,7 +86,7 @@ public class TestArrayAccessDeopt {
     static public void main(String[] args) throws Exception {
         if (args.length == 0) {
             // Run test in new VM instance
-            String[] arg = {"-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,TestArrayAccessDeopt::test*",
+            String[] arg = {"-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,TestArrayAccessDeopt::test*", "-XX:-UseArrayLoadStoreProfile",
                             "-XX:+TraceDeoptimization", "-Xbatch", "-XX:-MonomorphicArrayCheck", "-Xmixed", "TestArrayAccessDeopt", "run"};
             OutputAnalyzer oa = ProcessTools.executeTestJvm(arg);
             String output = oa.getOutput();


### PR DESCRIPTION
Test should disable UseArrayLoadStoreProfile (which was enabled by default with JDK-8252030).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (3/3 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8254898](https://bugs.openjdk.java.net/browse/JDK-8254898): [lworld] TestArrayAccessDeopt fails with RuntimeException: 'Uncommon trap occurred'


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/225/head:pull/225`
`$ git checkout pull/225`
