### PR TITLE
8254891: [lworld] runtime/valhalla/inlinetypes/UnsafeTest.java fails with flattening disabled

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -29,8 +29,8 @@ package runtime.valhalla.inlinetypes;
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java UnsafeTest.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.UnsafeTest
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.UnsafeTest
+ * @run main/othervm -Xint -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
+ * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
  */
 
 import jdk.internal.misc.Unsafe;


### PR DESCRIPTION
Please review this small fix for test UnsafeTest.java.  The test depends on flattening being enable so this fix adds options -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 to ensure flattening is enabled.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (3/3 running) | ❌ (1/2 failed) | ⏳ (2/2 running) |

**Failed test task**
- [Windows x64 (build release)](https://github.com/hseigel/valhalla/runs/1264770499)

### Issue
 * [JDK-8254891](https://bugs.openjdk.java.net/browse/JDK-8254891): [lworld] runtime/valhalla/inlinetypes/UnsafeTest.java fails with flattening disabled


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/226/head:pull/226`
`$ git checkout pull/226`
