### PR TITLE
8254985: [lworld] C2 compilation fails with assert(field_type->is_loaded()) failed: field type must be loaded

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -810,7 +810,6 @@ void ciTypeFlow::StateVector::do_withfield(ciBytecodeStream* str) {
   } else {
     ciType* type = pop_value();
     ciType* field_type = field->type();
-    assert(field_type->is_loaded(), "field type must be loaded");
     if (field_type->is_two_word()) {
       ciType* type2 = pop_value();
       assert(type2->is_two_word(), "must be 2nd half");

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -857,4 +857,29 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
             Asserts.assertEQ(test19(rI), rI);
         }
     }
+
+    // Test case 20:
+    // Inline type with object field of unloaded type.
+    static class MyObject20 {
+        int x = 42;
+    }
+
+    static final inline class MyValue20 {
+        MyObject20 obj;
+
+        MyValue20() {
+            this.obj = null;
+        }
+    }
+
+    @Test
+    public MyValue20 test20() {
+        return new MyValue20();
+    }
+
+    @DontCompile
+    public void test20_verifier(boolean warmup) {
+        MyValue20 vt = test20();
+        Asserts.assertEQ(vt.obj, null);
+    }
 }


### PR DESCRIPTION
Removed the assert which is too strong and added a regression test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8254985](https://bugs.openjdk.java.net/browse/JDK-8254985): [lworld] C2 compilation fails with assert(field_type->is_loaded()) failed: field type must be loaded


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/230/head:pull/230`
`$ git checkout pull/230`
