### PR TITLE
8255054: Fix test broken by incorrect removal of java.lang.ValueBased

### DIFF
--- a/src/java.base/share/classes/java/lang/ValueBased.java
+++ b/src/java.base/share/classes/java/lang/ValueBased.java
@@ -30,7 +30,7 @@ import java.lang.annotation.*;
 /**
  * An informative annotation type used to indicate that a value type existed in a
  * prior avatar as a <a href="../lang/doc-files/ValueBased.html">value-based</a>
- * class. Armed with this information, the compiler may choose to treat with leniency 
+ * class. Armed with this information, the compiler may choose to treat with leniency
  * certain constructs which are erroneous when used with value types, thereby easing the
  * pain of migration.
  */

--- a/src/java.base/share/classes/java/lang/ValueBased.java
+++ b/src/java.base/share/classes/java/lang/ValueBased.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.lang.annotation.*;
+
+/**
+ * An informative annotation type used to indicate that a value type existed in a
+ * prior avatar as a <a href="../lang/doc-files/ValueBased.html">value-based</a>
+ * class. Armed with this information, the compiler may choose to treat with leniency 
+ * certain constructs which are erroneous when used with value types, thereby easing the
+ * pain of migration.
+ */
+
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ValueBased {}
+


### PR DESCRIPTION
8254957 mistakenly deleted java/lang/ValueBased.java.
The file is restored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8255054](https://bugs.openjdk.java.net/browse/JDK-8255054): Fix test broken by incorrect removal of java.lang.ValueBased


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/232/head:pull/232`
`$ git checkout pull/232`
