### PR TITLE
8255396: [lworld] locking breaks oopDesc is_flatArray/is_nullfreeArray type checks

### DIFF
--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -206,8 +206,14 @@ bool oopDesc::is_typeArray() const { return klass()->is_typeArray_klass(); }
 
 bool oopDesc::is_inline_type() const { return mark().is_inline_type(); }
 #if _LP64
-bool oopDesc::is_flatArray()     const { return mark().is_flat_array(); }
-bool oopDesc::is_nullfreeArray() const { return mark().is_nullfree_array(); }
+bool oopDesc::is_flatArray() const {
+  markWord mrk = mark();
+  return (mrk.is_unlocked()) ? mrk.is_flat_array() : klass()->is_flatArray_klass();
+}
+bool oopDesc::is_nullfreeArray() const {
+  markWord mrk = mark();
+  return (mrk.is_unlocked()) ? mrk.is_nullfree_array() : klass()->is_null_free_array_klass();
+}
 #else
 bool oopDesc::is_flatArray()     const { return klass()->is_flatArray_klass(); }
 bool oopDesc::is_nullfreeArray() const { return klass()->is_null_free_array_klass(); }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -111,10 +111,26 @@ public class InlineTypeArray {
         Point[] points = createSimplePointArray();
         System.gc(); // check that VTs survive GC
         checkSimplePointArray(points);
-
         assertTrue(points instanceof Point[], "Instance of");
 
         testSimplePointArrayCopy();
+
+        // Locked/unlocked flat array type checks
+        points = createSimplePointArray();
+        Point[] pointsCopy = new Point[points.length];
+        synchronized (points) {
+            assertTrue(points instanceof Point[], "Instance of");
+            checkSimplePointArray(points);
+            System.arraycopy(points, 0, pointsCopy, 0, points.length);
+            synchronized (pointsCopy) {
+                assertTrue(pointsCopy instanceof Point[], "Instance of");
+                checkSimplePointArray(pointsCopy);
+                System.gc();
+            }
+            System.gc();
+        }
+        assertTrue(pointsCopy instanceof Point[], "Instance of");
+        checkSimplePointArray(pointsCopy);
     }
 
     void testSimplePointArrayCopy() {
@@ -391,6 +407,16 @@ public class InlineTypeArray {
         checkArrayElementsEqual(srcNulls, dstNulls);
         srcNulls[1] = MyInt.create(1);
         System.arraycopy(srcNulls, 0, dstNulls, 0, 2);
+        checkArrayElementsEqual(srcNulls, dstNulls);
+
+
+        // Locked/unlocked flat array type checks
+        synchronized (srcNulls) {
+            System.arraycopy(srcNulls, 0, dstNulls, 0, 2);
+            checkArrayElementsEqual(srcNulls, dstNulls);
+            System.gc();
+        }
+        System.gc();
         checkArrayElementsEqual(srcNulls, dstNulls);
     }
 


### PR DESCRIPTION
Added unlocked test and fallback to klass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (2/5 failed) | ❌ (2/2 failed) | ✔️ (2/2 passed) |
| Build / test | ⏳ (1/1 running) | ⏳ (1/1 running) |    | 
| Test (tier1) |    |     |  ⏳ (1/9 running) |

**Failed test tasks**
- [Linux x64 (build hotspot minimal)](https://github.com/MrSimms/valhalla/runs/1309286985)
- [Linux x64 (build hotspot zero)](https://github.com/MrSimms/valhalla/runs/1309286952)
- [Windows x64 (build debug)](https://github.com/MrSimms/valhalla/runs/1309287069)
- [Windows x64 (build release)](https://github.com/MrSimms/valhalla/runs/1309287041)

### Issue
 * [JDK-8255396](https://bugs.openjdk.java.net/browse/JDK-8255396): [lworld] locking breaks oopDesc is_flatArray/is_nullfreeArray type checks


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/238/head:pull/238`
`$ git checkout pull/238`
