### PR TITLE
8255130: [lworld] Adjust github actions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -448,6 +448,7 @@ jobs:
           --with-gtest="$env:GITHUB_WORKSPACE/gtest"
           --with-default-make-target="product-bundles test-bundles"
           --enable-jtreg-failure-handler
+          --disable-precompiled-headers
         working-directory: jdk
 
       - name: Build

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -106,7 +106,6 @@ jobs:
           - build release
           - build debug
           - build hotspot no-pch
-          - build hotspot zero
           - build hotspot minimal
         include:
           - flavor: build debug
@@ -114,9 +113,6 @@ jobs:
             artifact: -debug
           - flavor: build hotspot no-pch
             flags: --enable-debug --disable-precompiled-headers
-            build-target: hotspot
-          - flavor: build hotspot zero
-            flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
             build-target: hotspot
           - flavor: build hotspot minimal
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=minimal

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ or either of these files:
 
 See <https://openjdk.java.net/> for more information about
 the OpenJDK Community and the JDK.
+
+Github build/test actions appear broken, need to test this more

--- a/README.md
+++ b/README.md
@@ -9,5 +9,3 @@ or either of these files:
 
 See <https://openjdk.java.net/> for more information about
 the OpenJDK Community and the JDK.
-
-Github build/test actions appear broken, need to test this more

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -27,6 +27,7 @@
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
 #include "compiler/disassembler.hpp"
+#include "ci/ciInlineKlass.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
@@ -5267,6 +5268,7 @@ void MacroAssembler::reinit_heapbase() {
 
 #endif // _LP64
 
+#ifdef COMPILER2
 // C2 compiled method's prolog code.
 void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
   int framesize = C->output()->frame_size_in_bytes();
@@ -5360,6 +5362,7 @@ void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
   }
 #endif
 }
+#endif // COMPILER2
 
 // clear memory of size 'cnt' qwords, starting at 'base' using XMM/YMM registers
 void MacroAssembler::xmm_clear_mem(Register base, Register cnt, Register val, XMMRegister xtmp) {

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -88,6 +88,7 @@ MacroAssembler::RegState* MacroAssembler::init_reg_state(VMRegPair* regs, int nu
   return reg_state;
 }
 
+#ifdef COMPILER2
 int MacroAssembler::unpack_inline_args(Compile* C, bool receiver_only) {
   assert(C->has_scalarized_args(), "inline type argument scalarization is disabled");
   Method* method = C->method()->get_Method();
@@ -148,6 +149,7 @@ int MacroAssembler::unpack_inline_args(Compile* C, bool receiver_only) {
                       sp_inc);
   return sp_inc;
 }
+#endif // COMPILER2
 
 void MacroAssembler::shuffle_inline_args(bool is_packing, bool receiver_only,
                                          const GrowableArray<SigEntry>* sig,

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1027,8 +1027,6 @@ int ClassHierarchyDCmd::num_arguments() {
   }
 }
 
-#endif
-
 PrintClassLayoutDCmd::PrintClassLayoutDCmd(outputStream* output, bool heap) :
                                        DCmdWithParser(output, heap),
   _classname("classname", "Name of class whose layout should be printed. ",
@@ -1051,6 +1049,8 @@ int PrintClassLayoutDCmd::num_arguments() {
     return 0;
   }
 }
+
+#endif // INCLUDE_SERVICES
 
 class VM_DumpTouchedMethods : public VM_Operation {
 private:


### PR DESCRIPTION
Cleaned up minimal target, disabled zero port, disabled PCH for Windows:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255130](https://bugs.openjdk.java.net/browse/JDK-8255130): [lworld] Adjust github actions


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/242/head:pull/242`
`$ git checkout pull/242`
