### PR TITLE
8255541: [lworld] Improve array layout checks in C2 compiled code

### DIFF
--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -853,15 +853,12 @@ class GraphKit : public Phase {
   // and the array-store bytecode
   Node* gen_checkcast(Node *subobj, Node* superkls, Node* *failure_control = NULL);
 
-  Node* inline_type_test(Node* obj);
-  Node* is_inline_type(Node* obj);
-  Node* is_not_inline_type(Node* obj);
-  Node* is_non_flattened_array(Node* ary);
-  Node* check_null_free_bit(Node* klass, bool null_free);
-  Node* is_nullable_array(Node* ary);
-  Node* gen_inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace = false);
-  Node* load_lh_array_tag(Node* kls);
-  Node* gen_lh_array_test(Node* kls, unsigned int lh_value);
+  // Inline types
+  Node* inline_type_test(Node* obj, bool is_inline = true);
+  Node* array_lh_test(Node* kls, jint mask, jint val, bool eq = true);
+  Node* flat_array_test(Node* ary, bool flat = true);
+  Node* null_free_array_test(Node* klass, bool null_free = true);
+  Node* inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace = false);
 
   Node* gen_subtype_check(Node* obj, Node* superklass);
 

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1194,22 +1194,22 @@ bool IfNode::is_non_flattened_array_check(PhaseTransform* phase, Node** array) {
   }
   Node* cmp_in1 = cmp->in(1);
   Node* cmp_in2 = cmp->in(2);
-  if ((unsigned int)cmp_in2->find_int_con(0) != Klass::_lh_array_tag_vt_value) {
+  if (cmp_in2->find_int_con(-1) != 0) {
     return false;
   }
-  if (cmp_in1->Opcode() != Op_RShiftI) {
+  if (cmp_in1->Opcode() != Op_AndI) {
     return false;
   }
-  Node* shift_in1 = cmp_in1->in(1);
-  Node* shift_in2 = cmp_in1->in(2);
-  if ((unsigned int)shift_in2->find_int_con(0) != Klass::_lh_array_tag_shift) {
+  Node* and_in1 = cmp_in1->in(1);
+  Node* and_in2 = cmp_in1->in(2);
+  if (and_in2->find_int_con(0) != Klass::_lh_array_tag_vt_value_bit_inplace) {
     return false;
   }
-  if (shift_in1->Opcode() != Op_LoadI) {
+  if (and_in1->Opcode() != Op_LoadI) {
     return false;
   }
   intptr_t offset;
-  Node* ptr = shift_in1->in(MemNode::Address);
+  Node* ptr = and_in1->in(MemNode::Address);
   Node* addr = AddPNode::Ideal_base_and_offset(ptr, phase, offset);
   if (addr == NULL || offset != in_bytes(Klass::layout_helper_offset())) {
     return false;
@@ -1225,7 +1225,6 @@ bool IfNode::is_non_flattened_array_check(PhaseTransform* phase, Node** array) {
     Node* address = klass_load->in(MemNode::Address);
     *array = address->as_AddP()->in(AddPNode::Base);
   }
-  assert(bol->isa_Bool()->_test._test == BoolTest::ne, "IfTrue proj must point to non-flattened array");
   return true;
 }
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3492,9 +3492,9 @@ Node* LibraryCallKit::generate_array_guard_common(Node* kls, RegionNode* region,
     }
     case FlatArray:
     case NonFlatArray: {
-      value = Klass::_lh_array_tag_vt_value;
-      layout_val = _gvn.transform(new RShiftINode(layout_val, intcon(Klass::_lh_array_tag_shift)));
-      btest = (kind == FlatArray) ? BoolTest::eq : BoolTest::ne;
+      value = 0;
+      layout_val = _gvn.transform(new AndINode(layout_val, intcon(Klass::_lh_array_tag_vt_value_bit_inplace)));
+      btest = (kind == FlatArray) ? BoolTest::ne : BoolTest::eq;
       break;
     }
     case AnyArray:    value = Klass::_lh_neutral_value; btest = BoolTest::lt; break;
@@ -3737,7 +3737,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
         // No validation. The subtype check emitted at macro expansion time will not go to the slow
         // path but call checkcast_arraycopy which can not handle flat/null-free inline type arrays.
         // TODO 8251971: Optimize for the case when src/dest are later found to be both flat/null-free.
-        generate_fair_guard(check_null_free_bit(klass_node, true), bailout);
+        generate_fair_guard(null_free_array_test(klass_node), bailout);
       }
     }
 

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -134,7 +134,8 @@ private:
 
   // More helper methods for array copy
   Node* generate_nonpositive_guard(Node** ctrl, Node* index, bool never_negative);
-  Node* generate_flat_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
+  Node* array_lh_test(Node* array, jint mask);
+  Node* generate_flat_array_guard(Node** ctrl, Node* array, RegionNode* region);
   Node* generate_null_free_array_guard(Node** ctrl, Node* array, RegionNode* region);
   Node* generate_object_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
   Node* generate_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region, jint lh_con);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1415,7 +1415,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // The generate_arraycopy subroutine checks this.
 
     // Handle inline type arrays
-    if (!top_src->is_flat()) {
+    if (EnableValhalla && !top_src->is_flat()) {
       if (UseFlatArray && !top_src->is_not_flat()) {
         // Src might be flat and dest might not be flat. Go to the slow path if src is flat.
         generate_flat_array_guard(&ctrl, src, slow_region);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1415,14 +1415,16 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     // The generate_arraycopy subroutine checks this.
 
     // Handle inline type arrays
-    if (EnableValhalla && !top_src->is_flat()) {
+    if (!top_src->is_flat()) {
       if (UseFlatArray && !top_src->is_not_flat()) {
         // Src might be flat and dest might not be flat. Go to the slow path if src is flat.
         generate_flat_array_guard(&ctrl, src, slow_region);
       }
-      // No validation. The subtype check emitted at macro expansion time will not go to the slow
-      // path but call checkcast_arraycopy which can not handle flat/null-free inline type arrays.
-      generate_null_free_array_guard(&ctrl, dest, slow_region);
+      if (EnableValhalla) {
+        // No validation. The subtype check emitted at macro expansion time will not go to the slow
+        // path but call checkcast_arraycopy which can not handle flat/null-free inline type arrays.
+        generate_null_free_array_guard(&ctrl, dest, slow_region);
+      }
     } else {
       assert(top_dest->is_flat(), "dest array must be flat");
     }


### PR DESCRIPTION
C2 should use a single bit test of the layout helper value to check for flat/null-free inline type arrays. This is a prerequisite of JDK-8255046 which will then add support for checking the corresponding bits in the mark word instead.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x32 | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/1 failed) | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ❌ (1/9 failed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x32 (build debug)](https://github.com/TobiHartmann/valhalla/runs/1321726642)
- [Linux x64 (hs/tier1 runtime)](https://github.com/TobiHartmann/valhalla/runs/1322041756)

### Issue
 * [JDK-8255541](https://bugs.openjdk.java.net/browse/JDK-8255541): [lworld] Improve array layout checks in C2 compiled code


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/244/head:pull/244`
`$ git checkout pull/244`
