### PR TITLE
8255522: [lworld] References to biased pattern remain in markWord::is_unlocked()

### DIFF
--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -117,7 +117,7 @@ void HeapShared::fixup_mapped_heap_regions() {
 }
 
 unsigned HeapShared::oop_hash(oop const& p) {
-  assert(!p->mark().has_bias_pattern(),
+  assert(!UseBiasedLocking || !p->mark().has_bias_pattern(),
          "this object should never have been locked");  // so identity_hash won't safepoin
   unsigned hash = (unsigned)p->identity_hash();
   return hash;

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -31,7 +31,7 @@
 
 inline void Klass::set_prototype_header(markWord header) {
   assert(!is_inline_klass() || header.is_inline_type(), "Unexpected prototype");
-  assert(!header.has_bias_pattern() || is_instance_klass(), "biased locking currently only supported for Java instances");
+  assert(!UseBiasedLocking || !header.has_bias_pattern() || is_instance_klass(), "biased locking currently only supported for Java instances");
   _prototype_header = header;
 }
 

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -53,7 +53,7 @@ void markWord::print_on(outputStream* st) const {
       } else {
         st->print(" hash=" INTPTR_FORMAT, hash());
       }
-    } else if (has_bias_pattern()) {  // last bits = 101
+    } else if (UseBiasedLocking && has_bias_pattern()) {  // last bits = 101
       st->print("is_biased");
       JavaThread* jt = biased_locker();
       st->print(" biased_locker=" INTPTR_FORMAT " epoch=%d", p2i(jt), bias_epoch());

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -290,34 +290,41 @@ class markWord {
   // fixes up biased locks to be compatible with it when a bias is
   // revoked.
   bool has_bias_pattern() const {
+    ShouldNotReachHere(); // Valhalla: unused
     return (mask_bits(value(), biased_lock_mask_in_place) == biased_lock_pattern);
   }
   JavaThread* biased_locker() const {
+    ShouldNotReachHere(); // Valhalla: unused
     assert(has_bias_pattern(), "should not call this otherwise");
     return (JavaThread*) mask_bits(value(), ~(biased_lock_mask_in_place | age_mask_in_place | epoch_mask_in_place));
   }
   // Indicates that the mark has the bias bit set but that it has not
   // yet been biased toward a particular thread
   bool is_biased_anonymously() const {
+    ShouldNotReachHere(); // Valhalla: unused
     return (has_bias_pattern() && (biased_locker() == NULL));
   }
   // Indicates epoch in which this bias was acquired. If the epoch
   // changes due to too many bias revocations occurring, the biases
   // from the previous epochs are all considered invalid.
   int bias_epoch() const {
+    ShouldNotReachHere(); // Valhalla: unused
     assert(has_bias_pattern(), "should not call this otherwise");
     return (mask_bits(value(), epoch_mask_in_place) >> epoch_shift);
   }
   markWord set_bias_epoch(int epoch) {
+    ShouldNotReachHere(); // Valhalla: unused
     assert(has_bias_pattern(), "should not call this otherwise");
     assert((epoch & (~epoch_mask)) == 0, "epoch overflow");
     return markWord(mask_bits(value(), ~epoch_mask_in_place) | (epoch << epoch_shift));
   }
   markWord incr_bias_epoch() {
+    ShouldNotReachHere(); // Valhalla: unused
     return set_bias_epoch((1 + bias_epoch()) & epoch_mask);
   }
   // Prototype mark for initialization
   static markWord biased_locking_prototype() {
+    ShouldNotReachHere(); // Valhalla: unused
     return markWord( biased_lock_pattern );
   }
 
@@ -326,12 +333,14 @@ class markWord {
     return (mask_bits(value(), lock_mask_in_place) != unlocked_value);
   }
   bool is_unlocked() const {
-    return (mask_bits(value(), biased_lock_mask_in_place) == unlocked_value);
+    return (mask_bits(value(), lock_mask_in_place) == unlocked_value);
   }
   bool is_marked()   const {
     return (mask_bits(value(), lock_mask_in_place) == marked_value);
   }
-  bool is_neutral()  const { return (mask_bits(value(), biased_lock_mask_in_place) == unlocked_value); }
+
+  // is unlocked and not an inline type (which cannot be involved in locking, displacement or inflation)
+  bool is_neutral()  const { return (mask_bits(value(), inline_type_mask_in_place) == unlocked_value); }
 
   // Special temporary state of the markWord while being inflated.
   // Code that looks at mark outside a lock need to take this into account.

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -340,6 +340,7 @@ class markWord {
   }
 
   // is unlocked and not an inline type (which cannot be involved in locking, displacement or inflation)
+  // i.e. test both lock bits and the inline type bit together
   bool is_neutral()  const { return (mask_bits(value(), inline_type_mask_in_place) == unlocked_value); }
 
   // Special temporary state of the markWord while being inflated.

--- a/src/hotspot/share/oops/markWord.inline.hpp
+++ b/src/hotspot/share/oops/markWord.inline.hpp
@@ -71,7 +71,7 @@ inline bool markWord::must_be_preserved_for_promotion_failure(KlassProxy klass) 
 inline markWord markWord::prototype_for_klass(const Klass* klass) {
   markWord prototype_header = klass->prototype_header();
   assert(prototype_header == prototype() ||
-         prototype_header.has_bias_pattern() ||
+         (UseBiasedLocking && prototype_header.has_bias_pattern()) ||
          prototype_header.is_inline_type() ||
          prototype_header.is_flat_array() ||
          prototype_header.is_nullfree_array(), "corrupt prototype header");

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -968,8 +968,10 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
   uint32_t debug_bits = 0;
   // first derive the object's owner and entry_count (if any)
   {
-    // Revoke any biases before querying the mark word
-    BiasedLocking::revoke_at_safepoint(hobj);
+    if (UseBiasedLocking) {
+      // Revoke any biases before querying the mark word
+      BiasedLocking::revoke_at_safepoint(hobj);
+    }
 
     address owner = NULL;
     {

--- a/src/hotspot/share/runtime/biasedLocking.cpp
+++ b/src/hotspot/share/runtime/biasedLocking.cpp
@@ -732,6 +732,7 @@ void BiasedLocking::walk_stack_and_revoke(oop obj, JavaThread* biased_locker) {
 }
 
 void BiasedLocking::revoke_own_lock(Handle obj, TRAPS) {
+  assert(UseBiasedLocking, "biased locking not enabled");
   JavaThread* thread = THREAD->as_Java_thread();
 
   markWord mark = obj->mark();
@@ -755,6 +756,7 @@ void BiasedLocking::revoke_own_lock(Handle obj, TRAPS) {
 }
 
 void BiasedLocking::revoke(Handle obj, TRAPS) {
+  assert(UseBiasedLocking, "biased locking not enabled");
   assert(!SafepointSynchronize::is_at_safepoint(), "must not be called while at safepoint");
 
   while (true) {
@@ -858,6 +860,7 @@ void BiasedLocking::revoke(Handle obj, TRAPS) {
 
 // All objects in objs should be locked by biaser
 void BiasedLocking::revoke(GrowableArray<Handle>* objs, JavaThread *biaser) {
+  assert(UseBiasedLocking, "biased locking not enabled");
   bool clean_my_cache = false;
   for (int i = 0; i < objs->length(); i++) {
     oop obj = (objs->at(i))();
@@ -874,6 +877,7 @@ void BiasedLocking::revoke(GrowableArray<Handle>* objs, JavaThread *biaser) {
 
 
 void BiasedLocking::revoke_at_safepoint(Handle h_obj) {
+  assert(UseBiasedLocking, "biased locking not enabled");
   assert(SafepointSynchronize::is_at_safepoint(), "must only be called while at safepoint");
   oop obj = h_obj();
   HeuristicsResult heuristics = update_heuristics(obj);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -832,7 +832,7 @@ const intx ObjectAlignmentInBytes = 8;
           "Restrict @Contended to trusted classes")                         \
                                                                             \
   product(bool, UseBiasedLocking, false,                                     \
-          "(Deprecated) Enable biased locking in JVM")                      \
+          "(Deprecated) Enable biased locking in JVM (completely disabled by Valhalla)") \
                                                                             \
   product(intx, BiasedLockingStartupDelay, 0,                               \
           "(Deprecated) Number of milliseconds to wait before enabling "    \

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -95,7 +95,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
         if (monitor->owner_is_scalar_replaced()) {
           dest->set_obj(NULL);
         } else {
-          assert(monitor->owner() == NULL || (!monitor->owner()->is_unlocked() && !monitor->owner()->has_bias_pattern()), "object must be null or locked, and unbiased");
+          assert(monitor->owner() == NULL || (!monitor->owner()->is_unlocked() && (!UseBiasedLocking || !monitor->owner()->has_bias_pattern())), "object must be null or locked, and unbiased");
           dest->set_obj(monitor->owner());
           monitor->lock()->move_to(monitor->owner(), dest->lock());
         }


### PR DESCRIPTION
* more gtest mark word tests
* assert any use of "biased locking" (there are some existing "has_biased_pattern()" asserts not guarded "UseBiasedLocking")
* remove biased_lock_mask_in_place from is_unlocked

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8255522](https://bugs.openjdk.java.net/browse/JDK-8255522): [lworld] References to biased pattern remain in markWord::is_unlocked()


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer) ⚠️ Review applies to a1f25a77b321f7fcdd722ab59a718d924049843e
 * [Sergey Kuksenko](https://openjdk.java.net/census#skuksenko) (@kuksenko - Committer) ⚠️ Review applies to a1f25a77b321f7fcdd722ab59a718d924049843e


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/245/head:pull/245`
`$ git checkout pull/245`
