### PR TITLE
8255600: [lworld] C2 compilation fails with assert: modified node was not processed by IGVN.transform_old()

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2302,6 +2302,11 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           Node *ii = in(i);
           if (ii->is_MergeMem()) {
             MergeMemNode* n = ii->as_MergeMem();
+            if (igvn) {
+              // TODO revisit this with JDK-8247216
+              // Put 'n' on the worklist because it might be modified by MergeMemStream::iteration_setup
+              igvn->_worklist.push(n);
+            }
             for (MergeMemStream mms(result, n); mms.next_non_empty2(); ) {
               // If we have not seen this slice yet, make a phi for it.
               bool made_new_phi = false;


### PR DESCRIPTION
MergeMemStream might modify the MergeMem inputs. Simply put it on the worklist for now and investigate a proper fix with JDK-8247216.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ⏳ (2/2 running) | ⏳ (1/2 running) |
| Test (tier1) | ⏳ (6/9 running) |    |     | 

### Issue
 * [JDK-8255600](https://bugs.openjdk.java.net/browse/JDK-8255600): [lworld] C2 compilation fails with assert: modified node was not processed by IGVN.transform_old()


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/248/head:pull/248`
`$ git checkout pull/248`
