### PR TITLE
8255733: [type-restrictions] Enhance Javac to help with generation of test files for type restrictions experiments

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -104,6 +104,9 @@ public class Types {
     /** enable alternate code generation to faciliate specialization experiments using type restrictions */
     public boolean flattenWithTypeRestrictions;
 
+    /** enable alternate code generation to faciliate specialization experiments, without restricted field attribute */
+    public boolean flattenWithErasure;
+
     public final Warner noWarnings;
 
     // <editor-fold defaultstate="collapsed" desc="Instantiating">
@@ -130,6 +133,7 @@ public class Types {
         Options options = Options.instance(context);
         allowValueBasedClasses = options.isSet("allowValueBasedClasses");
         flattenWithTypeRestrictions = options.isSet("flattenWithTypeRestrictions");
+        flattenWithErasure = options.isSet("flattenWithErasure");
     }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -974,8 +974,10 @@ public class ClassWriter extends ClassFile {
         }
         databuf.appendChar(poolWriter.putName(v.name));
         boolean emitRestrictedField = false;
-        if (types.flattenWithTypeRestrictions && v.type.isValue()) {
-            emitRestrictedField = true;
+        if ((types.flattenWithTypeRestrictions || types.flattenWithErasure) && v.type.isValue()) {
+            if (types.flattenWithTypeRestrictions) {
+                emitRestrictedField = true;
+            }
             databuf.appendChar(poolWriter.putDescriptor(v.type.referenceProjection()));
         } else {
             databuf.appendChar(poolWriter.putDescriptor(v));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
@@ -148,7 +148,7 @@ public class Items {
      *  @param member   The represented symbol.
      */
     Item makeStaticItem(Symbol member) {
-        if (this.types.flattenWithTypeRestrictions && member.kind == Kind.VAR && member.type.isValue()) {
+        if ((types.flattenWithTypeRestrictions || types.flattenWithErasure) && member.kind == Kind.VAR && member.type.isValue()) {
             return new StaticItem(getFlattenedField(member));
         } else {
             return new StaticItem(member);
@@ -161,7 +161,7 @@ public class Items {
      *                      and private members).
      */
     Item makeMemberItem(Symbol member, boolean nonvirtual) {
-        if (this.types.flattenWithTypeRestrictions && member.kind == Kind.VAR && member.type.isValue()) {
+        if ((types.flattenWithTypeRestrictions || types.flattenWithErasure) && member.kind == Kind.VAR && member.type.isValue()) {
             return new MemberItem(getFlattenedField(member), nonvirtual);
         } else {
             return new MemberItem(member, nonvirtual);


### PR DESCRIPTION
Added option -XDflattenWithErasure to generate class files without the RestrictedField attribute

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ❌ (1/9 failed) | ✔️ (9/9 passed) |

**Failed test task**
- [Windows x64 (hs/tier1 runtime)](https://github.com/sadayapalam/valhalla/runs/1341697582)

### Issue
 * [JDK-8255733](https://bugs.openjdk.java.net/browse/JDK-8255733): [type-restrictions] Enhance Javac to help with generation of test files for type restrictions experiments


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/251/head:pull/251`
`$ git checkout pull/251`
