### PR TITLE
GH workflow syntax

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - master
       - lworld
-      - 'type-restrictions'
+      - type-restrictions
       - jep390
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
type-restrictions still triggered

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/253/head:pull/253`
`$ git checkout pull/253`
