### PR TITLE
8256329: [lworld] C2 compilation fails with assert(!t->is_flat() && !t->is_not_flat()) failed: Should have been optimized out

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3571,6 +3571,7 @@ Node* GraphKit::flat_array_test(Node* ary, bool flat) {
   // check is moved out of loops (mainly to enable loop unswitching).
   Node* mem = UseArrayMarkWordCheck ? memory(Compile::AliasIdxRaw) : immutable_memory();
   Node* cmp = _gvn.transform(new FlatArrayCheckNode(C, mem, ary));
+  record_for_igvn(cmp); // Give it a chance to be optimized out by IGVN
   return _gvn.transform(new BoolNode(cmp, flat ? BoolTest::eq : BoolTest::ne));
 }
 


### PR DESCRIPTION
In rare cases, the flat array check is not processed by IGVN and therefore not optimized out. The fix is to simply add it to the worklist during parsing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (4/4 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256329](https://bugs.openjdk.java.net/browse/JDK-8256329): [lworld] C2 compilation fails with assert(!t->is_flat() && !t->is_not_flat()) failed: Should have been optimized out


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/258/head:pull/258`
`$ git checkout pull/258`
