### PR TITLE
8256391: [lworld] C2 compilation fails with assert(EnableValhalla) failed: should only be used for inline types

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -603,11 +603,12 @@ Node* AndLNode::Identity(PhaseGVN* phase) {
       }
     }
 
-    if (con == markWord::inline_type_pattern) {
+    // Check if this is part of an inline type test
+    if (con == markWord::inline_type_pattern && in(1)->is_Load() &&
+        phase->type(in(1)->in(MemNode::Address))->is_ptr()->offset() == oopDesc::mark_offset_in_bytes() &&
+        phase->type(in(1)->in(MemNode::Address))->is_inlinetypeptr()) {
       assert(EnableValhalla, "should only be used for inline types");
-      if (in(1)->is_Load() && phase->type(in(1)->in(MemNode::Address))->is_inlinetypeptr()) {
-        return in(2); // Obj is known to be an inline type
-      }
+      return in(2); // Obj is known to be an inline type
     }
   }
   return MulNode::Identity(phase);


### PR DESCRIPTION
The assert is too strong, AndLNodes with constant markWord::inline_type_pattern (= 5) input can also be generated without EnableValhalla. Moved the assert and strengthened the checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ❌ (1/9 failed) |    |  ⏳ (4/9 running) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/TobiHartmann/valhalla/runs/1406350294)

### Issue
 * [JDK-8256391](https://bugs.openjdk.java.net/browse/JDK-8256391): [lworld] C2 compilation fails with assert(EnableValhalla) failed: should only be used for inline types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/260/head:pull/260`
`$ git checkout pull/260`
