### PR TITLE
8256400: [lworld] C2 compilation fails with assert(addp->is_AddP() && addp->outcnt() > 0) failed: Don't process dead nodes

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -327,9 +327,6 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
       return false;
     }
 
-    adr_src  = phase->transform(new AddPNode(base_src, base_src, src_offset));
-    adr_dest = phase->transform(new AddPNode(base_dest, base_dest, dest_offset));
-
     BasicType elem = ary_src->klass()->as_array_klass()->element_type()->basic_type();
     if (elem == T_ARRAY || (elem == T_INLINE_TYPE && ary_src->klass()->is_obj_array_klass())) {
       elem = T_OBJECT;
@@ -342,6 +339,9 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
       // It's an object array copy but we can't emit the card marking that is needed
       return false;
     }
+
+    adr_src  = phase->transform(new AddPNode(base_src, base_src, src_offset));
+    adr_dest = phase->transform(new AddPNode(base_dest, base_dest, dest_offset));
 
     // The address is offseted to an aligned address where a raw copy would start.
     // If the clone copy is decomposed into load-stores - the address is adjusted to

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -137,7 +137,6 @@ private:
   Node* array_lh_test(Node* array, jint mask);
   Node* generate_flat_array_guard(Node** ctrl, Node* array, RegionNode* region);
   Node* generate_null_free_array_guard(Node** ctrl, Node* array, RegionNode* region);
-  Node* generate_object_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region);
   Node* generate_array_guard(Node** ctrl, Node* mem, Node* obj, RegionNode* region, jint lh_con);
 
   void finish_arraycopy_call(Node* call, Node** ctrl, MergeMemNode** mem, const TypePtr* adr_type);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -209,10 +209,6 @@ Node* PhaseMacroExpand::generate_null_free_array_guard(Node** ctrl, Node* array,
   return generate_fair_guard(ctrl, array_lh_test(array, Klass::_lh_null_free_bit_inplace), region);
 }
 
-Node* PhaseMacroExpand::generate_object_array_guard(Node** ctrl, Node* mem, Node* obj_or_klass, RegionNode* region) {
-  return generate_array_guard(ctrl, mem, obj_or_klass, region, Klass::_lh_array_tag_obj_value);
-}
-
 Node* PhaseMacroExpand::generate_array_guard(Node** ctrl, Node* mem, Node* obj_or_klass, RegionNode* region, jint lh_con) {
   if ((*ctrl)->is_top())  return NULL;
 


### PR DESCRIPTION
Escape analysis does not like dead AddP nodes. We should only create them in `ArrayCopyNode::prepare_array_copy` after we've checked for bailout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (5/9 running) |    |  ⏳ (6/9 running) |

### Issue
 * [JDK-8256400](https://bugs.openjdk.java.net/browse/JDK-8256400): [lworld] C2 compilation fails with assert(addp->is_AddP() && addp->outcnt() > 0) failed: Don't process dead nodes


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/261/head:pull/261`
`$ git checkout pull/261`
