### PR TITLE
Disable further BiasedLocking tests

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -285,7 +285,8 @@ jdk_tools = \
     :svc_tools
 
 jdk_jfr = \
-    jdk/jfr
+    jdk/jfr \
+    -jdk/jfr/event/runtime/TestBiasedLockRevocationEvents.java
 
 jdk_jfr_tier3 = \
     jdk/jfr/event/metadata/TestLookForUntestedEvents.java


### PR DESCRIPTION
Disabled jdk/jfr/event/runtime/TestBiasedLockRevocationEvents.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/264/head:pull/264`
`$ git checkout pull/264`
