### PR TITLE
8238369: [lworld] Incorrect layout of inline type in flattened array.

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -164,7 +164,7 @@ oop FlatArrayKlass::multi_allocate(int rank, jint* last_size, TRAPS) {
 
 jint FlatArrayKlass::array_layout_helper(InlineKlass* vk) {
   BasicType etype = T_INLINE_TYPE;
-  int esize = upper_log2(vk->raw_value_byte_size());
+  int esize = upper_log2(vk->get_exact_size_in_bytes());
   int hsize = arrayOopDesc::base_offset_in_bytes(etype);
 
   int lh = Klass::array_layout_helper(_lh_array_tag_vt_value, true, hsize, etype, esize);

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -182,9 +182,6 @@ class InlineKlass: public InstanceKlass {
   // returning to Java (i.e.: inline_copy)
   instanceOop allocate_instance_buffer(TRAPS);
 
-  // minimum number of bytes occupied by nonstatic fields, HeapWord aligned or pow2
-  int raw_value_byte_size();
-
   address data_for_oop(oop o) const;
   oop oop_for_data(address data) const;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
@@ -50,6 +50,7 @@ import jdk.test.lib.Asserts;
 public class InlineTypeDensity {
 
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    private static final boolean VM_FLAG_FORCENONTEARABLE = WHITE_BOX.getStringVMFlag("ForceNonTearable").equals("*");
 
     public InlineTypeDensity() {
         if (WHITE_BOX.getIntxVMFlag("FlatArrayElementMaxSize") != -1) {
@@ -286,9 +287,28 @@ public class InlineTypeDensity {
         testLongArraySizesSame(testSizes);
     }
 
+    static inline class bbValue { byte b = 0; byte b2 = 0;}
+    static inline class bsValue { byte b = 0; short s = 0;}
+    static inline class siValue { short s = 0; int i = 0;}
+    static inline class ssiValue { short s = 0; short s2 = 0; int i = 0;}
+    static inline class blValue { byte b = 0; long l = 0; }
+
+    // Expect aligned array addressing to nearest pow2
+    void testAlignedSize() {
+        int testSize = 10;
+        if (!VM_FLAG_FORCENONTEARABLE) {
+            assertArraySameSize(new short[testSize], new bbValue[testSize], testSize);
+            assertArraySameSize(new long[testSize], new siValue[testSize], testSize);
+            assertArraySameSize(new long[testSize], new ssiValue[testSize], testSize);
+            assertArraySameSize(new long[testSize*2], new blValue[testSize], testSize);
+        }
+        assertArraySameSize(new int[testSize], new bsValue[testSize], testSize);
+    }
+
     public void test() {
         ensureArraySizeWin();
         testPrimitiveArraySizesSame();
+        testAlignedSize();
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Removed obsolete and incorrect raw_value_byte_size

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (3/4 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8238369](https://bugs.openjdk.java.net/browse/JDK-8238369): [lworld] Incorrect layout of inline type in flattened array.


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/265/head:pull/265`
`$ git checkout pull/265`
