### PR TITLE
8255995: templateTable_x86.cpp (TemplateTable::if_acmp) not always do correct null check.

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -2490,7 +2490,9 @@ void TemplateTable::if_acmp(Condition cc) {
     __ jcc(Assembler::equal, (cc == equal) ? taken : not_taken);
 
     // might be substitutable, test if either rax or rdx is null
-    __ testptr(rdx, rax);
+    __ testptr(rax, rax);
+    __ jcc(Assembler::zero, (cc == equal) ? not_taken : taken);
+    __ testptr(rdx, rdx);
     __ jcc(Assembler::zero, (cc == equal) ? not_taken : taken);
 
     // and both are values ?

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
@@ -128,6 +128,7 @@ public class Ifacmp {
             checkEqual(pair[0], pair[1], false);
         }
         testLocalValues();
+        testAlot();
     }
 
     public void testValues() {
@@ -158,6 +159,21 @@ public class Ifacmp {
         }
         if (a == a1) throw new RuntimeException();
         checkEqual(a, a2, false);
+    }
+
+    public void testAlot() {
+        MyValue a = new MyValue(4711);
+        Reference ref = new WeakReference<Object>(new Object(), new ReferenceQueue<>());
+        do {
+            for (int i = 0; i < 1000; i++) {
+                MyValue b = new MyValue(4711);
+                if (acmpModeInlineAlwaysFalse) {
+                    if (a == b) throw new RuntimeException("Always false fail " + a + " == " + b);
+                } else {
+                    if (a != b) throw new RuntimeException("Substitutability test failed" + a + " != " + b);
+                }
+            }
+        } while (ref.get() != null);
     }
 
     boolean shouldEqualSelf(Object a) {


### PR DESCRIPTION
Testing both pointers at the same time, doesn't account for the case where bits
completely miss each other, resulting in zero as result e.g.

  test(0x10, 0x01) == 0x10 & 0x01 == 0, yet neither are null

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (4/4 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ✔️ (9/9 passed) | ✔️ (9/9 passed) | ✔️ (9/9 passed) |

### Issue
 * [JDK-8255995](https://bugs.openjdk.java.net/browse/JDK-8255995): templateTable_x86.cpp (TemplateTable::if_acmp) not always do correct null check.


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/266/head:pull/266`
`$ git checkout pull/266`
