### PR TITLE
8253962: Add @ValueBased to unmodifable Collection implementation classes

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -137,6 +137,7 @@ class ImmutableCollections {
 
     static UnsupportedOperationException uoe() { return new UnsupportedOperationException(); }
 
+    @jdk.internal.ValueBased
     static abstract class AbstractImmutableCollection<E> extends AbstractCollection<E> {
         // all mutating methods throw UnsupportedOperationException
         @Override public boolean add(E e) { throw uoe(); }
@@ -160,6 +161,7 @@ class ImmutableCollections {
         }
     }
 
+    @jdk.internal.ValueBased
     static abstract class AbstractImmutableList<E> extends AbstractImmutableCollection<E>
             implements List<E>, RandomAccess {
 
@@ -444,6 +446,7 @@ class ImmutableCollections {
         }
     }
 
+    @jdk.internal.ValueBased
     static final class List12<E> extends AbstractImmutableList<E>
             implements Serializable {
 
@@ -526,6 +529,7 @@ class ImmutableCollections {
         }
     }
 
+    @jdk.internal.ValueBased
     static final class ListN<E> extends AbstractImmutableList<E>
             implements Serializable {
 
@@ -607,6 +611,7 @@ class ImmutableCollections {
 
     // ---------- Set Implementations ----------
 
+    @jdk.internal.ValueBased
     static abstract class AbstractImmutableSet<E> extends AbstractImmutableCollection<E>
             implements Set<E> {
 
@@ -634,6 +639,7 @@ class ImmutableCollections {
         public abstract int hashCode();
     }
 
+    @jdk.internal.ValueBased
     static final class Set12<E> extends AbstractImmutableSet<E>
             implements Serializable {
 
@@ -759,6 +765,7 @@ class ImmutableCollections {
      * least one null is always present.
      * @param <E> the element type
      */
+    @jdk.internal.ValueBased
     static final class SetN<E> extends AbstractImmutableSet<E>
             implements Serializable {
 
@@ -925,6 +932,7 @@ class ImmutableCollections {
 
     // ---------- Map Implementations ----------
 
+    @jdk.internal.ValueBased
     abstract static class AbstractImmutableMap<K,V> extends AbstractMap<K,V> implements Serializable {
         @Override public void clear() { throw uoe(); }
         @Override public V compute(K key, BiFunction<? super K,? super V,? extends V> rf) { throw uoe(); }
@@ -955,6 +963,7 @@ class ImmutableCollections {
         }
     }
 
+    @jdk.internal.ValueBased
     static final class Map1<K,V> extends AbstractImmutableMap<K,V> {
         @Stable
         private final K k0;
@@ -1021,6 +1030,7 @@ class ImmutableCollections {
      * @param <K> the key type
      * @param <V> the value type
      */
+    @jdk.internal.ValueBased
     static final class MapN<K,V> extends AbstractImmutableMap<K,V> {
 
         @Stable

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -163,7 +163,6 @@ class ImmutableCollections {
 
     @jdk.internal.ValueBased
     static abstract class AbstractImmutableList<E> extends AbstractImmutableCollection<E>
-
             implements List<E>, RandomAccess {
 
         // all mutating methods throw UnsupportedOperationException


### PR DESCRIPTION
As per JEP 390, The implementations of ImmutableCollections are marked as being @ValueBased.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ❌ (1/9 failed) | ❌ (1/9 failed) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1414570009)
- [Windows x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1414726676)
- [macOS x64 (langtools/tier1)](https://github.com/RogerRiggs/valhalla/runs/1414612161)

### Issue
 * [JDK-8253962](https://bugs.openjdk.java.net/browse/JDK-8253962): Add @ValueBased to unmodifable Collection implementation classes


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/267/head:pull/267`
`$ git checkout pull/267`
