### PR TITLE
8256663: [test] Deprecated use of new Double in jshell ImportTest

### DIFF
--- a/test/langtools/jdk/jshell/ImportTest.java
+++ b/test/langtools/jdk/jshell/ImportTest.java
@@ -68,7 +68,7 @@ public class ImportTest extends KullaTesting {
 
     public void testImportStatic() {
         assertImportKeyMatch("import static java.lang.Math.PI;", "PI", SINGLE_STATIC_IMPORT_SUBKIND, added(VALID));
-        assertEval("new Double(PI).toString().substring(0, 16).equals(\"3.14159265358979\");", "true");
+        assertEval("Double.valueOf(PI).toString().substring(0, 16).equals(\"3.14159265358979\");", "true");
     }
 
     public void testImportStaticOnDemand() {

--- a/test/langtools/tools/javac/lambda/8074381/T8074381a.java
+++ b/test/langtools/tools/javac/lambda/8074381/T8074381a.java
@@ -13,7 +13,7 @@ class T8074381a {
         boolean m(String s);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     void testRaw() {
         Sub s1 = c -> true;
         Sub s2 = Boolean::new;
@@ -23,7 +23,7 @@ class T8074381a {
         };
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     void testNonRaw() {
         Sub<Integer> s1 = c -> true;
         Sub<Integer> s2 = Boolean::new;


### PR DESCRIPTION
The jep-390 warnings caused a couple of tests to fail.
Suppressing the warnings to re-enable the tests.

/issue 8256667  # test/langtools/tools/javac/lambda/8074381/T8074381a.java
/issue 8256663  # test/langtools/jdk/jshell/ImportTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Build / test | ⏳ (1/1 running) |    |     |     | 
| Test (tier1) |    |  ❌ (1/9 failed) | ⏳ (4/9 running) | ✔️ (9/9 passed) |

**Failed test tasks**
- [Linux x64 (build hotspot zero)](https://github.com/RogerRiggs/valhalla/runs/1426741435)
- [Linux x86 (hs/tier1 compiler)](https://github.com/RogerRiggs/valhalla/runs/1426919740)

### Issues
 * [JDK-8256663](https://bugs.openjdk.java.net/browse/JDK-8256663): [test] Deprecated use of new Double in jshell ImportTest
 * [JDK-8256667](https://bugs.openjdk.java.net/browse/JDK-8256667): [test] Unexpected warnings in javac test T8074381a


### Reviewers
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/270/head:pull/270`
`$ git checkout pull/270`
