### PR TITLE
8256929: [lworld] Fails to compile with --with-debug-level=optimized

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2447,8 +2447,10 @@ void Method::print_on(outputStream* st) const {
   if (highest_comp_level() != CompLevel_none)
     st->print_cr(" - highest level:     %d", highest_comp_level());
   st->print_cr(" - vtable index:      %d",   _vtable_index);
+#ifdef ASSERT
   if (valid_itable_index())
     st->print_cr(" - itable index:      %d",   itable_index());
+#endif
   st->print_cr(" - i2i entry:         " INTPTR_FORMAT, p2i(interpreter_entry()));
   st->print(   " - adapters:          ");
   AdapterHandlerEntry* a = ((Method*)this)->adapter();


### PR DESCRIPTION
Guard use of debug "valid_itable_index()" assert macro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8256929](https://bugs.openjdk.java.net/browse/JDK-8256929): [lworld] Fails to compile with  --with-debug-level=optimized


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/276/head:pull/276`
`$ git checkout pull/276`
