### PR TITLE
8255856: Generate RestrictedField attributes from annotations

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/RestrictedType.java
+++ b/src/java.base/share/classes/java/lang/invoke/RestrictedType.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.invoke;
+
+import java.lang.annotation.*;
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * Annotation to facilitate type-restrictions experiments.
+ *
+ * When javac generates code for a field whose type is annotated by @RestrictedType("QFoo;"),
+ * it generates a RestrictedField attribute pointing to a Utf8 constant representing
+ * the given String.
+
+ * The @RestrictedType annotation supports ad hoc attribute generation,
+ * for more fine-grained control.
+ *
+*/
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface RestrictedType {
+    /**
+     * @return the type descriptor string to be encoded in the RestrictedField attribute as a Utf8 constant
+     */
+    String value(); 
+}

--- a/src/java.base/share/classes/java/lang/invoke/RestrictedType.java
+++ b/src/java.base/share/classes/java/lang/invoke/RestrictedType.java
@@ -45,5 +45,5 @@ public @interface RestrictedType {
     /**
      * @return the type descriptor string to be encoded in the RestrictedField attribute as a Utf8 constant
      */
-    String value(); 
+    String value();
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -223,6 +223,7 @@ public class Symtab {
     public final Type typeDescriptorType;
     public final Type recordType;
     public final Type identityObjectType;
+    public final Type restrictedTypeType;
 
     /** The symbol representing the length field of an array.
      */
@@ -595,6 +596,7 @@ public class Symtab {
         previewFeatureType = enterClass("jdk.internal.PreviewFeature");
         previewFeatureInternalType = enterSyntheticAnnotation("jdk.internal.PreviewFeature+Annotation");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
+        restrictedTypeType = enterClass("java.lang.invoke.RestrictedType");
         recordType = enterClass("java.lang.Record");
         identityObjectType = enterClass("java.lang.IdentityObject");
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedTypeAnnotationCodegenTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedTypeAnnotationCodegenTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255856
+ * @summary Generate RestrictedField attributes from annotations
+ * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
+ * @compile RestrictedTypeAnnotationCodegenTest.java
+ * @run main/othervm -Xverify:none RestrictedTypeAnnotationCodegenTest
+ * @modules jdk.compiler
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Paths;
+
+import java.lang.invoke.RestrictedType;
+
+final class PointBox {
+
+    @RestrictedType("QPoint;") Object p;
+
+}
+
+public class RestrictedTypeAnnotationCodegenTest {
+
+    public static void main(String [] args) {
+        new RestrictedTypeAnnotationCodegenTest().run();
+    }
+
+    void run() {
+        String [] params = new String [] { "-v",
+                                            Paths.get(System.getProperty("test.classes"),
+                                                "PointBox.class").toString() };
+        runCheck(params, new String [] {
+         "java.lang.Object p;",
+         "descriptor: Ljava/lang/Object;",
+         "RestrictedField: #11                    // QPoint;",
+         "RuntimeVisibleTypeAnnotations:",
+         "0: #14(#15=s#11): FIELD",
+         "java.lang.invoke.RestrictedType(",
+         "value=\"QPoint;\""
+         });
+
+     }
+
+     void runCheck(String [] params, String [] expectedOut) {
+        StringWriter s;
+        String out;
+
+        System.out.println("Checking javap");
+        try (PrintWriter pw = new PrintWriter(s = new StringWriter())) {
+            com.sun.tools.javap.Main.run(params, pw);
+            out = s.toString();
+        }
+        System.out.println("Javap = " + out);
+        int errors = 0;
+        for (String eo: expectedOut) {
+            if (!out.contains(eo)) {
+                System.err.println("Match not found for string: " + eo);
+                errors++;
+            }
+        }
+         if (errors > 0) {
+             throw new AssertionError("Unexpected javap output: " + out);
+         }
+    }
+}


### PR DESCRIPTION
Enable restricted type experiments with a fine grained control.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8255856](https://bugs.openjdk.java.net/browse/JDK-8255856): Generate RestrictedField attributes from annotations


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/277/head:pull/277`
`$ git checkout pull/277`
