### PR TITLE
8257028: [type-restrictions] Assorted issues with generation of RestrictedField attributes from annotations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -461,7 +461,7 @@ public class TypeAnnotations {
                         enclTy != null &&
                         enclTy.getKind() != TypeKind.NONE &&
                         enclTy.getKind() != TypeKind.ERROR &&
-                        (enclTr.getKind() == JCTree.Kind.MEMBER_SELECT ||
+                        ((enclTr.getKind() == JCTree.Kind.MEMBER_SELECT  && !enclTy.isReferenceProjection()) ||  // .ref is only a pseudo member select.
                                 enclTr.getKind() == JCTree.Kind.PARAMETERIZED_TYPE ||
                                 enclTr.getKind() == JCTree.Kind.ANNOTATED_TYPE)) {
                     // Iterate also over the type tree, not just the type: the type is already

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1270,8 +1270,10 @@ public class ClassReader {
                 protected void read(Symbol sym, int attrLen) {
                     if (sym.kind == VAR && sym.owner.kind == TYP) {
                         final Type type = poolReader.getType(nextChar());
-                        Assert.check(((ClassSymbol)((ClassType)sym.type).tsym).projection == type.tsym);
-                        sym.flags_field |= RESTRICTED_FIELD;
+                        if (types.flattenWithTypeRestrictions) {
+                            Assert.check(((ClassSymbol)((ClassType)sym.type).tsym).projection == type.tsym);
+                            sym.flags_field |= RESTRICTED_FIELD;
+                        }
                     }
                 }
             },

--- a/test/langtools/tools/javac/valhalla/lworld-values/PointBox.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/PointBox.java
@@ -23,27 +23,23 @@
  * questions.
  */
 
-package java.lang.invoke;
+import java.lang.invoke.RestrictedType;
 
-import java.lang.annotation.*;
-import static java.lang.annotation.ElementType.*;
+class PointBox {
 
-/**
- * Annotation to facilitate type-restrictions experiments.
- *
- * When javac generates code for a field whose type is annotated by @RestrictedType("QFoo;"),
- * it generates a RestrictedField attribute pointing to a Utf8 constant representing
- * the given String.
+    static inline class Point {
+        public double x;
+        public double y;
+        public Point(double x, double y) { this.x = x; this.y = y; }
+    }
 
- * The @RestrictedType annotation supports ad hoc attribute generation,
- * for more fine-grained control.
- *
-*/
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE_USE)
-public @interface RestrictedType {
-    /**
-     * @return the type descriptor string to be encoded in the RestrictedField attribute as a Utf8 constant
-     */
-    String value();
+    @RestrictedType("QPoint;")
+    public Object p368;
+
+    public static void main(String... args) {
+        PointBox b = new PointBox();
+        if (b.p368 != new Point(0,0)) throw new RuntimeException();
+        b.p368 = new Point(1.0, 2.0);
+        if (b.p368 != new Point(1.0, 2.0)) throw new RuntimeException();
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/PointBoxTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/PointBoxTest.java
@@ -23,27 +23,46 @@
  * questions.
  */
 
-package java.lang.invoke;
+/*
+ * @test
+ * @bug 8257028
+ * @summary Javac crashes on separate compilation.
+ * @compile PointBox.java PointBoxTest.java
+ * @compile PointBoxTest.java
+ */
 
-import java.lang.annotation.*;
-import static java.lang.annotation.ElementType.*;
+public class PointBoxTest {
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000; i++) {
+            test1();
+            test2();
+            test3();
+        }
+    }
 
-/**
- * Annotation to facilitate type-restrictions experiments.
- *
- * When javac generates code for a field whose type is annotated by @RestrictedType("QFoo;"),
- * it generates a RestrictedField attribute pointing to a Utf8 constant representing
- * the given String.
+    static void test1() {
+        double x = 0.0D;
+        for (int i = 0; i < 50000; i++) {
+            PointBox pb = new PointBox();
+            x = ((PointBox.Point)(pb.p368)).x;
+            pb.p368 = new PointBox.Point(2.0, 3.0);
+        }
+    }
 
- * The @RestrictedType annotation supports ad hoc attribute generation,
- * for more fine-grained control.
- *
-*/
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE_USE)
-public @interface RestrictedType {
-    /**
-     * @return the type descriptor string to be encoded in the RestrictedField attribute as a Utf8 constant
-     */
-    String value();
+    static void test2() {
+        for (int i = 0; i < 50000; i++) {
+            PointBox pb = new PointBox();
+            pb.p368 = new PointBox.Point(2.0, 3.0);
+        }
+    }
+
+    static PointBox.Point.ref spoint = new PointBox.Point(1.0, 2.0);
+
+    static void test3() {
+        spoint = null;
+        for (int i = 0; i < 50000; i++) {
+            PointBox pb = new PointBox();
+            pb.p368 = spoint;
+        }
+    }
 }


### PR DESCRIPTION
- Fix trouble with type annotating reference projection type
    - Change retention of experimental annotation to SOURCE
    - Fix javac crash with separate compilation
    - Improve robusness of tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (5/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8257028](https://bugs.openjdk.java.net/browse/JDK-8257028): [type-restrictions] Assorted issues with generation of RestrictedField attributes from annotations


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/278/head:pull/278`
`$ git checkout pull/278`
