### PR TITLE
8257154: [lworld] AndLNode::Identity optimization does not handle top input

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -605,8 +605,8 @@ Node* AndLNode::Identity(PhaseGVN* phase) {
 
     // Check if this is part of an inline type test
     if (con == markWord::inline_type_pattern && in(1)->is_Load() &&
-        phase->type(in(1)->in(MemNode::Address))->is_ptr()->offset() == oopDesc::mark_offset_in_bytes() &&
-        phase->type(in(1)->in(MemNode::Address))->is_inlinetypeptr()) {
+        phase->type(in(1)->in(MemNode::Address))->is_inlinetypeptr() &&
+        phase->type(in(1)->in(MemNode::Address))->is_ptr()->offset() == oopDesc::mark_offset_in_bytes()) {
       assert(EnableValhalla, "should only be used for inline types");
       return in(2); // Obj is known to be an inline type
     }


### PR DESCRIPTION
The memory input of the load can be top if the subgraph is dead but has not been removed. The fix is to simply reorder the checks to bail out if the input is not a pointer.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) | ⏳ (6/9 running) |    |  ⏳ (9/9 running) |

### Issue
 * [JDK-8257154](https://bugs.openjdk.java.net/browse/JDK-8257154): [lworld] AndLNode::Identity optimization does not handle top input


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/280/head:pull/280`
`$ git checkout pull/280`
