### PR TITLE
8251966: [lworld] TestArrays.java fails with -XX:+ExpandSubTypeCheckAtParseTime

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2931,7 +2931,7 @@ Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
     MergeMemNode* mem = merged_memory();
     Node* ctrl = control();
     Node* subklass = obj_or_subklass;
-    if (!sub_t->isa_klassptr()) {
+    if (!sub_t->isa_klassptr() && !sub_t->isa_inlinetype()) {
       subklass = load_object_klass(obj_or_subklass);
     }
     Node* n = Phase::gen_subtype_check(subklass, superklass, &ctrl, mem, _gvn);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2391,7 +2391,7 @@ const Type* LoadNode::klass_value_common(PhaseGVN* phase) const {
             return TypeKlassPtr::make(ak);
           }
         }
-        return TypeKlassPtr::make(TypePtr::NotNull, ak, Type::Offset(0));
+        return TypeKlassPtr::make(TypePtr::NotNull, ak, Type::Offset(0), false, tary->is_not_flat(), tary->is_not_null_free());
       } else if (ak->is_type_array_klass()) {
         return TypeKlassPtr::make(ak); // These are always precise
       }

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -977,6 +977,14 @@ const Type *CmpPNode::sub( const Type *t1, const Type *t2 ) const {
             (r1->flatten_array() && (!r0->can_be_inline_type() || (klass0->is_inlinetype() && !klass0->flatten_array())))) {
           // One type is flattened in arrays but the other type is not. Must be unrelated.
           unrelated_classes = true;
+        } else if ((r0->is_not_flat() && klass1->is_flat_array_klass()) ||
+                   (r1->is_not_flat() && klass0->is_flat_array_klass())) {
+          // One type is a non-flattened array and the other type is a flattened array. Must be unrelated.
+          unrelated_classes = true;
+        } else if ((r0->is_not_null_free() && klass1->is_obj_array_klass() && klass1->as_obj_array_klass()->element_klass()->is_inlinetype()) ||
+                   (r1->is_not_null_free() && klass0->is_obj_array_klass() && klass0->as_obj_array_klass()->element_klass()->is_inlinetype())) {
+          // One type is a non-null-free array and the other type is a null-free array. Must be unrelated.
+          unrelated_classes = true;
         }
       }
       if (unrelated_classes) {


### PR DESCRIPTION
[JDK-8251442](https://bugs.openjdk.java.net/browse/JDK-8251442) added SubTypeCheckNode optimizations that make sure that the control path consistently dies with the data path. These need to be implemented in `CmpPNode::sub` as well which requires `TypeKlassPtr` to keep track of not null-free/flat properties for array klasses.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ❌ (1/5 failed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) |    |  ⏳ (9/9 running) | ❌ (1/9 failed) |

**Failed test tasks**
- [Linux x64 (build hotspot optimized)](https://github.com/TobiHartmann/valhalla/runs/1458447948)
- [macOS x64 (hs/tier1 runtime)](https://github.com/TobiHartmann/valhalla/runs/1458740902)

### Issue
 * [JDK-8251966](https://bugs.openjdk.java.net/browse/JDK-8251966): [lworld] TestArrays.java fails with -XX:+ExpandSubTypeCheckAtParseTime


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/281/head:pull/281`
`$ git checkout pull/281`
