### PR TITLE
8257166: [lworld] CCP fails to optimize FlatArrayCheckNode

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1300,11 +1300,13 @@ const Type* FlatArrayCheckNode::Value(PhaseGVN* phase) const {
   for (uint i = Array; i < req(); ++i) {
     Node* array = in(i);
     if (!array->is_top()) {
-      const TypeAryPtr* t = phase->type(array)->isa_aryptr();
-      if (t != NULL && t->is_flat()) {
+      const Type* t = phase->type(array);
+      if (t == Type::TOP) {
+        return Type::TOP;
+      } else if (t->is_aryptr()->is_flat()) {
         // One of the input arrays is flat, check always passes
         return TypeInt::CC_EQ;
-      } else if (t == NULL || !t->is_not_flat()) {
+      } else if (!t->is_aryptr()->is_not_flat()) {
         // One of the input arrays might be flat
         all_not_flat = false;
       }


### PR DESCRIPTION
We hit `assert(!t->is_flat() && !t->is_not_flat()) failed: Should have been optimized out` during macro expansion of a FlatArrayCheckNode because the input array is known to be not flat but the check hasn't been optimized out by IGVN. The problem is that when CCP processes the node via `FlatArrayCheckNode::Value` the type immediately goes from TOP to BOTTOM because the input array hasn't been processed yet (still has type TOP). Afterwards, the node is not processed anymore although the type could be improved once the input array has been processed and is now known to be not flat.

We should add verification code that catches such cases. I've filed [JDK-8257197](https://bugs.openjdk.java.net/browse/JDK-8257197) to do this in mainline. A quick prototype suggests that we have multiple similar issues in mainline code.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ✔️ (5/5 passed) | ✔️ (2/2 passed) | ✔️ (2/2 passed) |
| Test (tier1) | ❌ (1/9 failed) | ⏳ (8/9 running) | ⏳ (8/9 running) |

**Failed test task**
- [Linux x64 (hs/tier1 runtime)](https://github.com/TobiHartmann/valhalla/runs/1462675612)

### Issue
 * [JDK-8257166](https://bugs.openjdk.java.net/browse/JDK-8257166): [lworld] CCP fails to optimize FlatArrayCheckNode


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/282/head:pull/282`
`$ git checkout pull/282`
