### PR TITLE
8257446: [lworld] VM flag PrintInlineLayout doesn't work anymore

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -978,7 +978,7 @@ void FieldLayoutBuilder::epilogue() {
   // allow larger values to be atomic, if properly aligned.
 
 
-  if (PrintFieldLayout) {
+  if (PrintFieldLayout || (PrintInlineLayout && _has_flattening_information)) {
     ResourceMark rm;
     tty->print_cr("Layout of class %s", _classname->as_C_string());
     tty->print_cr("Instance fields:");


### PR DESCRIPTION
Trivial fix to restore the PrintInlineLayout feature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8257446](https://bugs.openjdk.java.net/browse/JDK-8257446): [lworld] VM flag PrintInlineLayout doesn't work anymore


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/283/head:pull/283`
`$ git checkout pull/283`
