### PR TITLE
[lworld] Missed disabling testcase that does not pack well with  -XX:ForceNonTearable

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
@@ -296,19 +296,19 @@ public class InlineTypeDensity {
     // Expect aligned array addressing to nearest pow2
     void testAlignedSize() {
         int testSize = 10;
-        if (!VM_FLAG_FORCENONTEARABLE) {
-            assertArraySameSize(new short[testSize], new bbValue[testSize], testSize);
-            assertArraySameSize(new long[testSize], new siValue[testSize], testSize);
-            assertArraySameSize(new long[testSize], new ssiValue[testSize], testSize);
-            assertArraySameSize(new long[testSize*2], new blValue[testSize], testSize);
-        }
+        assertArraySameSize(new short[testSize], new bbValue[testSize], testSize);
+        assertArraySameSize(new long[testSize], new siValue[testSize], testSize);
+        assertArraySameSize(new long[testSize], new ssiValue[testSize], testSize);
+        assertArraySameSize(new long[testSize*2], new blValue[testSize], testSize);
         assertArraySameSize(new int[testSize], new bsValue[testSize], testSize);
     }
 
     public void test() {
         ensureArraySizeWin();
         testPrimitiveArraySizesSame();
-        testAlignedSize();
+        if (!VM_FLAG_FORCENONTEARABLE) {
+          testAlignedSize();
+        }
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Disable testAlignedSize for -XX:ForceNonTearable

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/284/head:pull/284`
`$ git checkout pull/284`
