### PR TITLE
8257422: [lworld] Problems with scalarized inline type return and incremental inlining

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -476,16 +476,19 @@ void LateInlineCallGenerator::do_late_inline() {
       return;
     }
 
-    // Allocate a buffer for the returned InlineTypeNode because the caller expects an oop return.
-    // Do this before the method handle call in case the buffer allocation triggers deoptimization.
+    // Check if we are late inlining a method handle call that returns an inline type as fields.
     Node* buffer_oop = NULL;
-    if (is_mh_late_inline() && _inline_cg->method()->return_type()->is_inlinetype()) {
+    ciType* mh_rt = _inline_cg->method()->return_type();
+    if (is_mh_late_inline() && mh_rt->is_inlinetype() && mh_rt->as_inline_klass()->can_be_returned_as_fields()) {
+      // Allocate a buffer for the inline type returned as fields because the caller expects an oop return.
+      // Do this before the method handle call in case the buffer allocation triggers deoptimization and
+      // we need to "re-execute" the call in the interpreter (to make sure the call is only executed once).
       GraphKit arg_kit(jvms, &gvn);
       {
         PreserveReexecuteState preexecs(&arg_kit);
         arg_kit.jvms()->set_should_reexecute(true);
         arg_kit.inc_sp(nargs);
-        Node* klass_node = arg_kit.makecon(TypeKlassPtr::make(_inline_cg->method()->return_type()->as_inline_klass()));
+        Node* klass_node = arg_kit.makecon(TypeKlassPtr::make(mh_rt->as_inline_klass()));
         buffer_oop = arg_kit.new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true);
       }
       jvms = arg_kit.transfer_exceptions_into_jvms();
@@ -519,22 +522,30 @@ void LateInlineCallGenerator::do_late_inline() {
     C->set_do_cleanup(kit.stopped()); // path is dead; needs cleanup
 
     // Handle inline type returns
-    bool returned_as_fields = call->tf()->returns_inline_type_as_fields();
-    if (result->is_InlineType()) {
-      // Only possible if is_mh_late_inline() when the callee does not "know" that the caller expects an oop
-      assert(is_mh_late_inline() && !returned_as_fields, "sanity");
-      assert(buffer_oop != NULL, "should have allocated a buffer");
-      InlineTypeNode* vt = result->as_InlineType();
-      vt->store(&kit, buffer_oop, buffer_oop, vt->type()->inline_klass(), 0);
-      // Do not let stores that initialize this buffer be reordered with a subsequent
-      // store that would make this buffer accessible by other threads.
-      AllocateNode* alloc = AllocateNode::Ideal_allocation(buffer_oop, &kit.gvn());
-      assert(alloc != NULL, "must have an allocation node");
-      kit.insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
-      result = buffer_oop;
-    } else if (result->is_InlineTypePtr() && returned_as_fields) {
-      result->as_InlineTypePtr()->replace_call_results(&kit, call, C);
+    InlineTypeNode* vt = result->isa_InlineType();
+    if (vt != NULL) {
+      if (call->tf()->returns_inline_type_as_fields()) {
+        vt->replace_call_results(&kit, call, C);
+      } else {
+        // Only possible with is_mh_late_inline() when the callee does not "know" that the caller expects an oop
+        assert(is_mh_late_inline(), "sanity");
+        assert(!result->isa_InlineType()->is_allocated(&kit.gvn()), "already allocated");
+        assert(buffer_oop != NULL, "should have allocated a buffer");
+        vt->store(&kit, buffer_oop, buffer_oop, vt->type()->inline_klass());
+        // Do not let stores that initialize this buffer be reordered with a subsequent
+        // store that would make this buffer accessible by other threads.
+        AllocateNode* alloc = AllocateNode::Ideal_allocation(buffer_oop, &kit.gvn());
+        assert(alloc != NULL, "must have an allocation node");
+        kit.insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
+        // Convert to InlineTypePtrNode to keep track of field values
+        kit.gvn().hash_delete(vt);
+        vt->set_oop(buffer_oop);
+        DEBUG_ONLY(buffer_oop = NULL);
+        vt = kit.gvn().transform(vt)->as_InlineType();
+        result = vt->as_ptr(&kit.gvn());
+      }
     }
+    assert(buffer_oop == NULL, "unused buffer allocation");
 
     kit.replace_call(call, result, true);
   }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1800,7 +1800,8 @@ Node* GraphKit::load_array_element(Node* ctl, Node* ary, Node* idx, const TypeAr
 void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inline) {
   PreserveReexecuteState preexecs(this);
   if (EnableValhalla) {
-    // Make sure the call is re-executed, if buffering of inline type arguments triggers deoptimization
+    // Make sure the call is "re-executed", if buffering of inline type arguments triggers deoptimization.
+    // At this point, the call hasn't been executed yet, so we will only ever execute the call once.
     jvms()->set_should_reexecute(true);
     int arg_size = method()->get_declared_signature_at_bci(bci())->arg_size_for_bc(java_bc());
     inc_sp(arg_size);

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -393,7 +393,7 @@ InlineTypePtrNode* InlineTypeBaseNode::buffer(GraphKit* kit, bool safe_for_repla
     ciInlineKlass* vk = inline_klass();
     Node* klass_node = kit->makecon(TypeKlassPtr::make(vk));
     Node* alloc_oop  = kit->new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true, this);
-    store(kit, alloc_oop, alloc_oop, vk, 0);
+    store(kit, alloc_oop, alloc_oop, vk);
 
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
@@ -445,7 +445,7 @@ InlineTypePtrNode* InlineTypeBaseNode::as_ptr(PhaseGVN* phase) const {
 }
 
 // When a call returns multiple values, it has several result
-// projections, one per field. Replacing the result of the call by a
+// projections, one per field. Replacing the result of the call by an
 // inline type node (after late inlining) requires that for each result
 // projection, we find the corresponding inline type field.
 void InlineTypeBaseNode::replace_call_results(GraphKit* kit, Node* call, Compile* C) {
@@ -622,7 +622,7 @@ InlineTypeNode* InlineTypeNode::make_larval(GraphKit* kit, bool allocate) const 
     AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop, &kit->gvn());
     alloc->_larval = true;
 
-    store(kit, alloc_oop, alloc_oop, vk, 0);
+    store(kit, alloc_oop, alloc_oop, vk);
     res->set_oop(alloc_oop);
   }
   res->set_type(TypeInlineType::make(vk, true));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1035,4 +1035,56 @@ public class TestCallingConvention extends InlineTypeTest {
         MyValueEmpty empty = test48(EmptyContainer.default);
         Asserts.assertEquals(empty, MyValueEmpty.default);
     }
+
+    // Test conditional inline type return with incremental inlining
+    public MyValue3 test49_inlined1(boolean b) {
+        if (b) {
+            return MyValue3.create();
+        } else {
+            return MyValue3.create();
+        }
+    }
+
+    public MyValue3 test49_inlined2(boolean b) {
+        return test49_inlined1(b);
+    }
+
+    @Test
+    public void test49(boolean b) {
+        test49_inlined2(b);
+    }
+
+    @DontCompile
+    public void test49_verifier(boolean warmup) {
+        test49(true);
+        test49(false);
+    }
+
+    // Variant of test49 with result verification (triggered different failure mode)
+    final MyValue3 test50_vt = MyValue3.create();
+    final MyValue3 test50_vt2 = test50_vt;
+
+    public MyValue3 test50_inlined1(boolean b) {
+        if (b) {
+            return test50_vt;
+        } else {
+            return test50_vt2;
+        }
+    }
+
+    public MyValue3 test50_inlined2(boolean b) {
+        return test50_inlined1(b);
+    }
+
+    @Test
+    public void test50(boolean b) {
+        MyValue3 vt = test50_inlined2(b);
+        test50_vt.verify(vt);
+    }
+
+    @DontCompile
+    public void test50_verifier(boolean warmup) {
+        test50(true);
+        test50(false);
+    }
 }


### PR DESCRIPTION
TestCallingConvention spuriously fails with -Xcomp and -XX:-TieredCompilation due to incremental inlining not properly handling scalarized inline type returns in rare cases. The actual fix is in parse1.cpp where we accidentally use an inline type PhiNode to return an inline type ptr when incrementally inlining (in some cases, that also manifests as crashes during compilation).

I've also refactored some related code, added stronger asserts, improved comments and added tests that reproduce the issue more reliably.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257422](https://bugs.openjdk.java.net/browse/JDK-8257422): [lworld] Problems with scalarized inline type return and incremental inlining


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/285/head:pull/285`
`$ git checkout pull/285`
