### PR TITLE
8257657: [lworld] TestLWorld and TestNullableInlineTypes fail during IR verification

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -49,9 +49,9 @@ public class TestLWorld extends InlineTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 1: return new String[] {"-DVerifyIR=false" };
-        case 2: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1"};
-        case 3: return new String[] {"-XX:-MonomorphicArrayCheck"};
+        case 2: return new String[] {"-DVerifyIR=false"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1"};
+        case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -46,8 +46,8 @@ public class TestNullableInlineTypes extends InlineTypeTest {
     @Override
     public String[] getExtraVMParameters(int scenario) {
         switch (scenario) {
-        case 1: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1"};
-        case 2: return new String[] {"-XX:-MonomorphicArrayCheck"};
+        case 3: return new String[] {"-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1"};
+        case 4: return new String[] {"-XX:-MonomorphicArrayCheck"};
         }
         return null;
     }


### PR DESCRIPTION
https://github.com/openjdk/valhalla/pull/289 removed some deprecated flags from the test scenarios and accidentally changed the extra flags for the default scenarios leading to failures in IR verification (due to different flag settings).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257657](https://bugs.openjdk.java.net/browse/JDK-8257657): [lworld] TestLWorld and TestNullableInlineTypes fail during IR verification


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/291/head:pull/291`
`$ git checkout pull/291`
