### PR TITLE
8257674: [lworld] C1's substitutability check does not respect UseCompressedClassPointers

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -2078,7 +2078,7 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
     Register left_klass_op = op->left_klass_op()->as_register();
     Register right_klass_op = op->right_klass_op()->as_register();
 
-    if (UseCompressedOops) {
+    if (UseCompressedClassPointers) {
       __ movl(left_klass_op,  Address(left,  oopDesc::klass_offset_in_bytes()));
       __ movl(right_klass_op, Address(right, oopDesc::klass_offset_in_bytes()));
       __ cmpl(left_klass_op, right_klass_op);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -2269,8 +2269,6 @@ public class TestLWorld extends InlineTypeTest {
         MyValue2[] src = new MyValue2[100];
         Arrays.fill(src, testValue2);
         MyValue2[] dst = new MyValue2[100];
-        Method m = tests.get("TestLWorld::test84");
-
         rerun_and_recompile_for("TestLWorld::test84", 10,
                                 () ->  { test84(src, dst);
                                          Asserts.assertTrue(Arrays.equals(src, dst)); });


### PR DESCRIPTION
`UseCompressedOops` is used instead of `UseCompressedClassPointers` when loading the klass pointers in C1's substitutability check. This explains several intermittent test failures.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257674](https://bugs.openjdk.java.net/browse/JDK-8257674): [lworld] C1's substitutability check does not respect UseCompressedClassPointers


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/292/head:pull/292`
`$ git checkout pull/292`
