### PR TITLE
8257773: [lworld] fix compiler replay for new profile data

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -766,6 +766,19 @@ void ciMethodData::dump_replay_data(outputStream* out) {
       } else if (pdata->is_CallTypeData()) {
           ciCallTypeData* call_type_data = (ciCallTypeData*)pdata;
           dump_replay_data_call_type_helper<ciCallTypeData>(out, round, count, call_type_data);
+      } else if (pdata->is_ArrayLoadStoreData()) {
+        ciArrayLoadStoreData* array_load_store_data = (ciArrayLoadStoreData*)pdata;
+        dump_replay_data_type_helper(out, round, count, array_load_store_data, ciArrayLoadStoreData::array_offset(),
+                                     array_load_store_data->array()->valid_type());
+        dump_replay_data_type_helper(out, round, count, array_load_store_data, ciArrayLoadStoreData::element_offset(),
+                                     array_load_store_data->element()->valid_type());
+      } else if (pdata->is_ACmpData()) {
+        ciACmpData* acmp_data = (ciACmpData*)pdata;
+        dump_replay_data_type_helper(out, round, count, acmp_data, ciACmpData::left_offset(),
+                                     acmp_data->left()->valid_type());
+        dump_replay_data_type_helper(out, round, count, acmp_data, ciACmpData::right_offset(),
+                                     acmp_data->right()->valid_type());
+
       }
     }
     if (parameters != NULL) {


### PR DESCRIPTION
Logic is missing to handle new profile data for array loads/stores and
acmp when a replay file is dump.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257773](https://bugs.openjdk.java.net/browse/JDK-8257773): [lworld] fix compiler replay for new profile data


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/293/head:pull/293`
`$ git checkout pull/293`
