### PR TITLE
8256330: [lworld] Dead inline type nodes are not reclaimed assertions

### DIFF
--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -1964,7 +1964,7 @@ public:
   virtual bool is_ACmpData() const { return true; }
 
   static int static_cell_count() {
-    return BranchData::static_cell_count()+ SingleTypeEntry::static_cell_count() * 2;
+    return BranchData::static_cell_count() + SingleTypeEntry::static_cell_count() * 2;
   }
 
   virtual int cell_count() const {

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1189,6 +1189,7 @@ bool CallStaticJavaNode::remove_useless_allocation(PhaseGVN *phase, Node* ctl, N
   }
   if (!alloc_mem->is_MergeMem()) {
     alloc_mem = MergeMemNode::make(alloc_mem);
+    igvn->register_new_node_with_optimizer(alloc_mem);
   }
 
   // and that there's no unexpected side effect

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -614,6 +614,7 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
   offset -= vk->first_field_offset();
   // Create a new InlineTypeNode and retrieve the field values from memory
   InlineTypeNode* vt = InlineTypeNode::make_uninitialized(_igvn, vk)->as_InlineType();
+  transform_later(vt);
   for (int i = 0; i < vk->nof_declared_nonstatic_fields(); ++i) {
     ciType* field_type = vt->field_type(i);
     int field_offset = offset + vt->field_offset(i);
@@ -642,7 +643,7 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
       return NULL;
     }
   }
-  return transform_later(vt);
+  return vt;
 }
 
 // Check the possibility of scalar replacement.

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1084,7 +1084,7 @@ void PhaseIterGVN::init_verifyPhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    if (n->outcnt() != 0 && !n->is_Con() && !_worklist.member(n)) {
+    if (!n->is_Con() && !_worklist.member(n)) {
       n->dump();
       fatal("modified node is not on IGVN._worklist");
     }
@@ -1098,7 +1098,7 @@ void PhaseIterGVN::verify_PhaseIterGVN() {
   Unique_Node_List* modified_list = C->modified_nodes();
   while (modified_list != NULL && modified_list->size()) {
     Node* n = modified_list->pop();
-    if (n->outcnt() != 0 && !n->is_Con()) { // skip dead and Con nodes
+    if (!n->is_Con()) { // skip Con nodes
       n->dump();
       fatal("modified node was not processed by IGVN.transform_old()");
     }


### PR DESCRIPTION
Fixed missing registration of new nodes with IGVN and re-enabled assert such that code is in sync with mainline.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8256330](https://bugs.openjdk.java.net/browse/JDK-8256330): [lworld] Dead inline type nodes are not reclaimed assertions 


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/296/head:pull/296`
`$ git checkout pull/296`
