### PR TITLE
8257832: [lworld] C2 compilation fails with assert(_base == AryPtr) failed: Not an array pointer

### DIFF
--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1486,7 +1486,7 @@ public:
     bool not_null_free = k->is_array_klass() && ( k->as_array_klass()->element_klass() == NULL ||
                                                  !k->as_array_klass()->element_klass()->can_be_inline_klass(true));
     bool not_flat = k->is_array_klass() && !k->is_flat_array_klass();
-    return make( TypePtr::Constant, k, Offset(0), false, not_flat, not_null_free);
+    return make(TypePtr::Constant, k, Offset(0), false, not_flat, not_null_free);
   }
   // ptr to klass 'k' or sub-klass
   static const TypeKlassPtr* make(PTR ptr, ciKlass* k, Offset offset, bool flatten_array = false, bool not_flat = false, bool not_null_free = false);


### PR DESCRIPTION
When the array load/store type profile is polluted, it may contradict static array type information and as a result we always trap when using it speculatively. We hit the assert or crash because control/data unexpectedly becomes `top`.

Similar to `Parse::array_store_check()`, we should not use profile information in `Parse::array_addressing` if it contradicts static type information.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257832](https://bugs.openjdk.java.net/browse/JDK-8257832): [lworld] C2 compilation fails with assert(_base == AryPtr) failed: Not an array pointer


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/297/head:pull/297`
`$ git checkout pull/297`
