### PR TITLE
8257579: [lworld] C2 compilation fails because ret_addr_offset() is not within emitted code

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -452,6 +452,10 @@ int MachCallDynamicJavaNode::ret_addr_offset()
 }
 
 int MachCallRuntimeNode::ret_addr_offset() {
+  if (_entry_point == NULL) {
+    // CallLeafNoFPInDirect
+    return 3; // callq (register)
+  }
   int offset = 13; // movq r10,#addr; callq (r10)
   offset += clear_avx_size();
   return offset;
@@ -462,6 +466,7 @@ int MachCallNativeNode::ret_addr_offset() {
   offset += clear_avx_size();
   return offset;
 }
+
 //
 // Compute padding required for nodes which need alignment
 //

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1758,10 +1758,8 @@ void PhaseOutput::fill_buffer(CodeBuffer* cb, uint* blk_starts) {
         return;
       }
 
-#if 0 // new assert, always triggers in Valhalla
       assert(!is_mcall || (call_returns[block->_pre_order] <= (uint)current_offset),
              "ret_addr_offset() not within emitted code");
-#endif
 #ifdef ASSERT
       uint n_size = n->size(C->regalloc());
       if (n_size < (current_offset-instr_offset)) {


### PR DESCRIPTION
`PhaseMacroExpand::expand_mh_intrinsic_return` emits a `CallLeafNoFPNode` with `_enty_point == NULL` which is mapped to an indirect call. The instruction size in `MachCallRuntimeNode::ret_addr_offset` needs to be adjusted accordingly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257579](https://bugs.openjdk.java.net/browse/JDK-8257579): [lworld] C2 compilation fails because ret_addr_offset() is not within emitted code


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/298/head:pull/298`
`$ git checkout pull/298`
