### PR TITLE
8258026: [lworld] Endless deoptimization at defaultvalue due to unresolved klass

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -791,7 +791,7 @@ void ciTypeFlow::StateVector::do_new(ciBytecodeStream* str) {
 void ciTypeFlow::StateVector::do_defaultvalue(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
-  if (!will_link || !klass->is_inlinetype()) {
+  if (!will_link || str->is_unresolved_klass() || !klass->is_inlinetype()) {
     trap(str, klass, str->get_klass_index());
   } else {
     push_object(klass);

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -318,15 +318,7 @@ void Parse::do_new() {
 void Parse::do_defaultvalue() {
   bool will_link;
   ciInlineKlass* vk = iter().get_klass(will_link)->as_inline_klass();
-  assert(will_link, "defaultvalue: typeflow responsibility");
-
-  // Should throw an InstantiationError?
-  if (iter().is_unresolved_klass()) {
-    uncommon_trap(Deoptimization::Reason_unhandled,
-                  Deoptimization::Action_none,
-                  vk);
-    return;
-  }
+  assert(will_link && !iter().is_unresolved_klass(), "defaultvalue: typeflow responsibility");
 
   if (C->needs_clinit_barrier(vk, method())) {
     clinit_barrier(vk, method());


### PR DESCRIPTION
Similar to `new`, C2's typeflow analysis should trap if the klass is unresolved at `defaultvalue`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8258026](https://bugs.openjdk.java.net/browse/JDK-8258026): [lworld] Endless deoptimization at defaultvalue due to unresolved klass


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/300/head:pull/300`
`$ git checkout pull/300`
