### PR TITLE
8228634: [lworld] ciField::will_link() returns incorrect result for the withfield bytecode

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -644,8 +644,7 @@ void Canonicalizer::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {}
 void Canonicalizer::do_NewTypeArray   (NewTypeArray*    x) {}
 void Canonicalizer::do_NewObjectArray (NewObjectArray*  x) {}
 void Canonicalizer::do_NewMultiArray  (NewMultiArray*   x) {}
-void Canonicalizer::do_WithField      (WithField*       x) {}
-void Canonicalizer::do_DefaultValue   (DefaultValue*    x) {}
+void Canonicalizer::do_Deoptimize     (Deoptimize*      x) {}
 void Canonicalizer::do_CheckCast      (CheckCast*       x) {
   if (x->klass()->is_loaded() && !x->klass()->is_inlinetype()) {
     // Don't canonicalize for non-nullable types -- we need to throw NPE.

--- a/src/hotspot/share/c1/c1_Canonicalizer.hpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.hpp
@@ -85,8 +85,7 @@ class Canonicalizer: InstructionVisitor {
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);
-  virtual void do_WithField      (WithField*       x);
-  virtual void do_DefaultValue   (DefaultValue*    x);
+  virtual void do_Deoptimize     (Deoptimize*      x);
   virtual void do_CheckCast      (CheckCast*       x);
   virtual void do_InstanceOf     (InstanceOf*      x);
   virtual void do_MonitorEnter   (MonitorEnter*    x);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2046,18 +2046,17 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 // Baseline version of withfield, allocate every time
 void GraphBuilder::withfield(int field_index)
 {
+  // Save the entire state and re-execute on deopt
+  ValueStack* state_before = copy_state_before();
+  state_before->set_should_reexecute(true);
+
   bool will_link;
   ciField* field_modify = stream()->get_field(will_link);
   ciInstanceKlass* holder = field_modify->holder();
   BasicType field_type = field_modify->type()->basic_type();
   ValueType* type = as_ValueType(field_type);
-
   Value val = pop(type);
   Value obj = apop();
-
-  // Save the entire state and re-execute on deopt
-  ValueStack* state_before = copy_state_before();
-  state_before->set_should_reexecute(true);
 
   if (!holder->is_loaded()) {
     apush(append_split(new Deoptimize(state_before)));

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -300,8 +300,7 @@ class GraphBuilder {
   // inline types
   void default_value(int klass_index);
   void withfield(int field_index);
-  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off,
-                           ValueStack* state_before, bool needs_patching);
+  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before);
 
   // stack/code manipulation helpers
   Instruction* append_with_bci(Instruction* instr, int bci);
@@ -399,12 +398,13 @@ class GraphBuilder {
   // Inline type support
   void update_larval_state(Value v) {
     if (v != NULL && v->as_NewInlineTypeInstance() != NULL) {
-      v->as_NewInlineTypeInstance()->update_larval_state();
+      v->as_NewInlineTypeInstance()->set_not_larva_anymore();
     }
   }
   void update_larva_stack_count(Value v) {
-    if (v != NULL && v->as_NewInlineTypeInstance() != NULL) {
-      v->as_NewInlineTypeInstance()->update_stack_count();
+    if (v != NULL && v->as_NewInlineTypeInstance() != NULL &&
+        v->as_NewInlineTypeInstance()->in_larval_state()) {
+      v->as_NewInlineTypeInstance()->decrement_on_stack_count();
     }
   }
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -518,9 +518,6 @@ void InstructionPrinter::do_NewTypeArray(NewTypeArray* x) {
 
 void InstructionPrinter::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
   output()->print("new inline type instance ");
-  if (x->is_optimizable_for_withfield()) {
-    output()->print("(optimizable) ");
-  }
   print_klass(x->klass());
 }
 
@@ -543,14 +540,9 @@ void InstructionPrinter::do_NewMultiArray(NewMultiArray* x) {
   print_klass(x->klass());
 }
 
-void InstructionPrinter::do_WithField(WithField* x) {
-  output()->print("withfield");
+void InstructionPrinter::do_Deoptimize(Deoptimize* x) {
+  output()->print("deoptimize");
 }
-
-void InstructionPrinter::do_DefaultValue(DefaultValue* x) {
-  output()->print("defaultvalue");
-}
-
 
 void InstructionPrinter::do_MonitorEnter(MonitorEnter* x) {
   output()->print("enter ");

--- a/src/hotspot/share/c1/c1_InstructionPrinter.hpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.hpp
@@ -108,8 +108,7 @@ class InstructionPrinter: public InstructionVisitor {
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);
-  virtual void do_WithField      (WithField*       x);
-  virtual void do_DefaultValue   (DefaultValue*    x);
+  virtual void do_Deoptimize     (Deoptimize*      x);
   virtual void do_CheckCast      (CheckCast*       x);
   virtual void do_InstanceOf     (InstanceOf*      x);
   virtual void do_MonitorEnter   (MonitorEnter*    x);

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -54,6 +54,7 @@ void LIR_Assembler::patching_epilog(PatchingStub* patch, LIR_PatchCode patch_cod
       case Bytecodes::_getstatic:
       case Bytecodes::_putfield:
       case Bytecodes::_getfield:
+      case Bytecodes::_withfield:
         break;
       default:
         ShouldNotReachHere();

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2346,21 +2346,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   }
 }
 
-void LIRGenerator::do_WithField(WithField* x) {
-  // This happens only when a class X uses the withfield bytecode to refer to
-  // an inline class V, where V has not yet been loaded. This is not a common
-  // case. Let's just deoptimize.
-  CodeEmitInfo* info = state_for(x, x->state_before());
-  CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
-                                      Deoptimization::Reason_unloaded,
-                                      Deoptimization::Action_make_not_entrant);
-  __ jump(stub);
-  LIR_Opr reg = rlock_result(x, T_OBJECT);
-  __ move(LIR_OprFact::oopConst(NULL), reg);
-}
-
-void LIRGenerator::do_DefaultValue(DefaultValue* x) {
-  // Same as withfield above. Let's deoptimize.
+void LIRGenerator::do_Deoptimize(Deoptimize* x) {
   CodeEmitInfo* info = state_for(x, x->state_before());
   CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                       Deoptimization::Reason_unloaded,

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -592,8 +592,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);
-  virtual void do_WithField      (WithField*       x);
-  virtual void do_DefaultValue   (DefaultValue*    x);
+  virtual void do_Deoptimize     (Deoptimize*      x);
   virtual void do_CheckCast      (CheckCast*       x);
   virtual void do_InstanceOf     (InstanceOf*      x);
   virtual void do_MonitorEnter   (MonitorEnter*    x);

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -517,8 +517,7 @@ public:
   void do_NewTypeArray   (NewTypeArray*    x);
   void do_NewObjectArray (NewObjectArray*  x);
   void do_NewMultiArray  (NewMultiArray*   x);
-  void do_WithField      (WithField*       x);
-  void do_DefaultValue   (DefaultValue*    x);
+  void do_Deoptimize     (Deoptimize*      x);
   void do_CheckCast      (CheckCast*       x);
   void do_InstanceOf     (InstanceOf*      x);
   void do_MonitorEnter   (MonitorEnter*    x);
@@ -709,8 +708,7 @@ void NullCheckVisitor::do_NewInlineTypeInstance(NewInlineTypeInstance* x) { nce(
 void NullCheckVisitor::do_NewTypeArray   (NewTypeArray*    x) { nce()->handle_NewArray(x); }
 void NullCheckVisitor::do_NewObjectArray (NewObjectArray*  x) { nce()->handle_NewArray(x); }
 void NullCheckVisitor::do_NewMultiArray  (NewMultiArray*   x) { nce()->handle_NewArray(x); }
-void NullCheckVisitor::do_WithField      (WithField*       x) {}
-void NullCheckVisitor::do_DefaultValue   (DefaultValue*    x) {}
+void NullCheckVisitor::do_Deoptimize     (Deoptimize*      x) {}
 void NullCheckVisitor::do_CheckCast      (CheckCast*       x) { nce()->clear_last_explicit_null_check(); }
 void NullCheckVisitor::do_InstanceOf     (InstanceOf*      x) {}
 void NullCheckVisitor::do_MonitorEnter   (MonitorEnter*    x) { nce()->handle_AccessMonitor(x); }

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
@@ -151,8 +151,7 @@ public:
     void do_NewTypeArray   (NewTypeArray*    x) { /* nothing to do */ };
     void do_NewObjectArray (NewObjectArray*  x) { /* nothing to do */ };
     void do_NewMultiArray  (NewMultiArray*   x) { /* nothing to do */ };
-    void do_WithField      (WithField*       x) { /* nothing to do */ };
-    void do_DefaultValue   (DefaultValue*    x) { /* nothing to do */ };
+    void do_Deoptimize     (Deoptimize*      x) { /* nothing to do */ };
     void do_CheckCast      (CheckCast*       x) { /* nothing to do */ };
     void do_InstanceOf     (InstanceOf*      x) { /* nothing to do */ };
     void do_BlockBegin     (BlockBegin*      x) { /* nothing to do */ };

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -190,8 +190,7 @@ class ValueNumberingVisitor: public InstructionVisitor {
   void do_NewTypeArray   (NewTypeArray*    x) { /* nothing to do */ }
   void do_NewObjectArray (NewObjectArray*  x) { /* nothing to do */ }
   void do_NewMultiArray  (NewMultiArray*   x) { /* nothing to do */ }
-  void do_WithField      (WithField*       x) { /* nothing to do */ }
-  void do_DefaultValue   (DefaultValue*    x) { /* nothing to do */ }
+  void do_Deoptimize     (Deoptimize*      x) { /* nothing to do */ }
   void do_CheckCast      (CheckCast*       x) { /* nothing to do */ }
   void do_InstanceOf     (InstanceOf*      x) { /* nothing to do */ }
   void do_BlockBegin     (BlockBegin*      x) { /* nothing to do */ }

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -253,6 +253,7 @@ class Bytecode_field: public Bytecode_member_ref {
   bool is_putfield() const                       { return java_code() == Bytecodes::_putfield; }
   bool is_getstatic() const                      { return java_code() == Bytecodes::_getstatic; }
   bool is_putstatic() const                      { return java_code() == Bytecodes::_putstatic; }
+  bool is_withfield() const                      { return java_code() == Bytecodes::_withfield; }
 
   bool is_getter() const                         { return is_getfield()  || is_getstatic(); }
   bool is_static() const                         { return is_getstatic() || is_putstatic(); }
@@ -260,7 +261,8 @@ class Bytecode_field: public Bytecode_member_ref {
   bool is_valid() const                          { return is_getfield()   ||
                                                           is_putfield()   ||
                                                           is_getstatic()  ||
-                                                          is_putstatic(); }
+                                                          is_putstatic()  ||
+                                                          is_withfield(); }
   void verify() const;
 };
 

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1025,22 +1025,21 @@ void LinkResolver::resolve_field(fieldDescriptor& fd,
     if (is_put && fd.access_flags().is_final()) {
 
       if (sel_klass != current_klass) {
-      // If byte code is a withfield check if they are nestmates.
-      bool are_nestmates = false;
-      if (sel_klass->is_instance_klass() &&
-          InstanceKlass::cast(sel_klass)->is_inline_klass() &&
-          current_klass->is_instance_klass()) {
-        are_nestmates = InstanceKlass::cast(link_info.current_klass())->has_nestmate_access_to(
-                                                        InstanceKlass::cast(sel_klass), THREAD);
-      }
-      if (!are_nestmates) {
-        ResourceMark rm(THREAD);
-        stringStream ss;
-        ss.print("Update to %s final field %s.%s attempted from a different class (%s) than the field's declaring class",
-                 is_static ? "static" : "non-static", resolved_klass->external_name(), fd.name()->as_C_string(),
-                  current_klass->external_name());
-        THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), ss.as_string());
-      }
+        // If byte code is a withfield check if they are nestmates.
+        bool are_nestmates = false;
+        if (sel_klass->is_instance_klass() &&
+            InstanceKlass::cast(sel_klass)->is_inline_klass() &&
+            current_klass->is_instance_klass()) {
+          are_nestmates = InstanceKlass::cast(current_klass)->has_nestmate_access_to(InstanceKlass::cast(sel_klass), THREAD);
+        }
+        if (!are_nestmates) {
+          ResourceMark rm(THREAD);
+          stringStream ss;
+          ss.print("Update to %s final field %s.%s attempted from a different class (%s) than the field's declaring class",
+                   is_static ? "static" : "non-static", resolved_klass->external_name(), fd.name()->as_C_string(),
+                    current_klass->external_name());
+          THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), ss.as_string());
+        }
       }
 
       if (fd.constants()->pool_holder()->major_version() >= 53) {


### PR DESCRIPTION
In `GraphBuilder::withfield`, `ciField::will_link()` can return false even if the holder klass is loaded (see bug comments). In that case we should not deoptimize but patch the store instruction that writes the new field value. That is required even if the field offset is known because the field could not be accessible/available and we would need to throw an exception during patching. The load/store instructions emitted by `copy_inline_content` to initialize the fields of the new inline type buffer copy should never require patching: We know their offsets (because the holder is loaded) and we don't need to check access restrictions.

Unrelated changes:
- Array loads should not be delayed if the subsequent getfield requires patching (see changes to `GraphBuilder::load_indexed`)
- Replaced the `WithField` and `DefaultValue` IR nodes by a `Deoptimize` node
- Refactoring and removal of dead code

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8228634](https://bugs.openjdk.java.net/browse/JDK-8228634): [lworld] ciField::will_link() returns incorrect result for the withfield bytecode


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/301/head:pull/301`
`$ git checkout pull/301`
