### PR TITLE
8252024: [lworld] Lock ordering issue when printing nmethod labels

### DIFF
--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -129,10 +129,6 @@ int ciInlineKlass::oop_count() const {
   GUARDED_VM_ENTRY(return get_InlineKlass()->nonstatic_oop_count();)
 }
 
-Array<SigEntry>* ciInlineKlass::extended_sig() const {
-  GUARDED_VM_ENTRY(return get_InlineKlass()->extended_sig();)
-}
-
 address ciInlineKlass::pack_handler() const {
   GUARDED_VM_ENTRY(return get_InlineKlass()->pack_handler();)
 }

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -87,7 +87,6 @@ public:
   ciInstance* default_instance() const;
   bool contains_oops() const;
   int oop_count() const;
-  Array<SigEntry>* extended_sig() const;
   address pack_handler() const;
   address unpack_handler() const;
   InlineKlass* get_InlineKlass() const;

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -237,7 +237,7 @@ Klass* InlineKlass::array_klass_impl(bool or_null, TRAPS) {
 // types is an argument: drop all T_INLINE_TYPE/T_VOID from the list).
 int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
   int count = 0;
-  SigEntry::add_entry(sig, T_INLINE_TYPE, base_off);
+  SigEntry::add_entry(sig, T_INLINE_TYPE, name(), base_off);
   for (JavaFieldStream fs(this); !fs.done(); fs.next()) {
     if (fs.access_flags().is_static()) continue;
     int offset = base_off + fs.offset() - (base_off > 0 ? first_field_offset() : 0);
@@ -250,12 +250,12 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
       if (bt == T_INLINE_TYPE) {
         bt = T_OBJECT;
       }
-      SigEntry::add_entry(sig, bt, offset);
+      SigEntry::add_entry(sig, bt, fs.signature(), offset);
       count += type2size[bt];
     }
   }
   int offset = base_off + size_helper()*HeapWordSize - (base_off > 0 ? first_field_offset() : 0);
-  SigEntry::add_entry(sig, T_VOID, offset);
+  SigEntry::add_entry(sig, T_VOID, name(), offset);
   if (base_off == 0) {
     sig->sort(SigEntry::compare);
   }

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -445,8 +445,7 @@ void LateInlineCallGenerator::do_late_inline() {
     // Make enough space in the expression stack to transfer
     // the incoming arguments and return value.
     map->ensure_stack(jvms, jvms->method()->max_stack());
-    const TypeTuple *domain_sig = call->_tf->domain_sig();
-    ExtendedSignature sig_cc = ExtendedSignature(method()->get_sig_cc(), SigEntryFilter());
+    const TypeTuple* domain_sig = call->_tf->domain_sig();
     uint nargs = method()->arg_size();
     assert(domain_sig->cnt() - TypeFunc::Parms == nargs, "inconsistent signature");
 
@@ -457,7 +456,7 @@ void LateInlineCallGenerator::do_late_inline() {
         // Inline type arguments are not passed by reference: we get an argument per
         // field of the inline type. Build InlineTypeNodes from the inline type arguments.
         GraphKit arg_kit(jvms, &gvn);
-        InlineTypeNode* vt = InlineTypeNode::make_from_multi(&arg_kit, call, sig_cc, t->inline_klass(), j, true);
+        InlineTypeNode* vt = InlineTypeNode::make_from_multi(&arg_kit, call, t->inline_klass(), j, true);
         map->set_control(arg_kit.control());
         map->set_argument(jvms, i1, vt);
       } else {

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -604,9 +604,9 @@ InlineTypeNode* InlineTypeNode::make_from_flattened(GraphKit* kit, ciInlineKlass
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
-InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, ciInlineKlass* vk, uint& base_input, bool in) {
+InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi, ciInlineKlass* vk, uint& base_input, bool in) {
   InlineTypeNode* vt = make_uninitialized(kit->gvn(), vk);
-  vt->initialize_fields(kit, multi, sig, base_input, in);
+  vt->initialize_fields(kit, multi, base_input, in);
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
@@ -713,7 +713,7 @@ Node* InlineTypeNode::tagged_klass(ciInlineKlass* vk, PhaseGVN& gvn) {
   return gvn.makecon(TypeRawPtr::make((address)bits));
 }
 
-void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input) {
+void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input) {
   for (uint i = 0; i < field_count(); i++) {
     int offset = field_offset(i);
     ciType* type = field_type(i);
@@ -722,7 +722,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig,
     if (field_is_flattened(i)) {
       // Flattened inline type field
       InlineTypeNode* vt = arg->as_InlineType();
-      vt->pass_fields(kit, n, sig, base_input);
+      vt->pass_fields(kit, n, base_input);
     } else {
       if (arg->is_InlineType()) {
         // Non-flattened inline type field
@@ -740,7 +740,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig,
   }
 }
 
-void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, bool in) {
+void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in) {
   PhaseGVN& gvn = kit->gvn();
   for (uint i = 0; i < field_count(); ++i) {
     ciType* type = field_type(i);
@@ -748,7 +748,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, Extended
     if (field_is_flattened(i)) {
       // Flattened inline type field
       InlineTypeNode* vt = make_uninitialized(gvn, type->as_inline_klass());
-      vt->initialize_fields(kit, multi, sig, base_input, in);
+      vt->initialize_fields(kit, multi, base_input, in);
       parm = gvn.transform(vt);
     } else {
       if (multi->is_Start()) {

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -126,7 +126,7 @@ public:
   // Create and initialize by loading the field values from a flattened field or array
   static InlineTypeNode* make_from_flattened(GraphKit* kit, ciInlineKlass* vk, Node* obj, Node* ptr, ciInstanceKlass* holder = NULL, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED);
   // Create and initialize with the inputs or outputs of a MultiNode (method entry or call)
-  static InlineTypeNode* make_from_multi(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, ciInlineKlass* vk, uint& base_input, bool in);
+  static InlineTypeNode* make_from_multi(GraphKit* kit, MultiNode* multi, ciInlineKlass* vk, uint& base_input, bool in);
 
   InlineTypeNode* make_larval(GraphKit* kit, bool allocate) const;
   InlineTypeNode* finish_larval(GraphKit* kit) const;
@@ -139,9 +139,9 @@ public:
   }
   static Node* tagged_klass(ciInlineKlass* vk, PhaseGVN& gvn);
   // Pass inline type as fields at a call or return
-  void pass_fields(GraphKit* kit, Node* n, ExtendedSignature& sig, uint& base_input);
+  void pass_fields(GraphKit* kit, Node* n, uint& base_input);
   // Initialize the inline type fields with the inputs or outputs of a MultiNode
-  void initialize_fields(GraphKit* kit, MultiNode* multi, ExtendedSignature& sig, uint& base_input, bool in);
+  void initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in);
 
   // Allocation optimizations
   void remove_redundant_allocations(PhaseIterGVN* igvn, PhaseIdealLoop* phase);

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -862,7 +862,6 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
   }
   PhaseGVN& gvn = *initial_gvn();
   uint i = 0;
-  ExtendedSignature sig_cc = ExtendedSignature(method()->get_sig_cc(), SigEntryFilter());
   for (uint j = 0; i < (uint)arg_size; i++) {
     const Type* t = tf->domain_sig()->field_at(i);
     Node* parm = NULL;
@@ -874,7 +873,7 @@ JVMState* Compile::build_start_state(StartNode* start, const TypeFunc* tf) {
       Node* old_mem = map->memory();
       // Use immutable memory for inline type loads and restore it below
       kit.set_all_memory(C->immutable_memory());
-      parm = InlineTypeNode::make_from_multi(&kit, start, sig_cc, t->inline_klass(), j, true);
+      parm = InlineTypeNode::make_from_multi(&kit, start, t->inline_klass(), j, true);
       map->set_control(kit.control());
       map->set_memory(old_mem);
     } else {
@@ -931,12 +930,8 @@ void Compile::return_values(JVMState* jvms) {
       } else {
         ret->init_req(TypeFunc::Parms, vt->tagged_klass(kit.gvn()));
       }
-      const Array<SigEntry>* sig_array = vt->type()->inline_klass()->extended_sig();
-      GrowableArray<SigEntry> sig = GrowableArray<SigEntry>(sig_array->length());
-      sig.appendAll(sig_array);
-      ExtendedSignature sig_cc = ExtendedSignature(&sig, SigEntryFilter());
-      uint idx = TypeFunc::Parms+1;
-      vt->pass_fields(&kit, ret, sig_cc, idx);
+      uint idx = TypeFunc::Parms + 1;
+      vt->pass_fields(&kit, ret, idx);
     } else {
       ret->add_req(res);
       // Note:  The second dummy edge is not needed by a ReturnNode.

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2768,20 +2768,19 @@ int CompiledEntrySignature::compute_scalarized_cc(GrowableArray<SigEntry>*& sig_
     if (holder->is_inline_klass() && scalar_receiver && InlineKlass::cast(holder)->can_be_passed_as_fields()) {
       sig_cc->appendAll(InlineKlass::cast(holder)->extended_sig());
     } else {
-      SigEntry::add_entry(sig_cc, T_OBJECT);
+      SigEntry::add_entry(sig_cc, T_OBJECT, holder->name());
     }
   }
-  Thread* THREAD = Thread::current();
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
     if (ss.type() == T_INLINE_TYPE) {
       InlineKlass* vk = ss.as_inline_klass(holder);
       if (vk->can_be_passed_as_fields()) {
         sig_cc->appendAll(vk->extended_sig());
       } else {
-        SigEntry::add_entry(sig_cc, T_OBJECT);
+        SigEntry::add_entry(sig_cc, T_OBJECT, ss.as_symbol());
       }
     } else {
-      SigEntry::add_entry(sig_cc, ss.type());
+      SigEntry::add_entry(sig_cc, ss.type(), ss.as_symbol());
     }
   }
   regs_cc = NEW_RESOURCE_ARRAY(VMRegPair, sig_cc->length() + 2);
@@ -2835,7 +2834,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
       _has_inline_recv = true;
       _num_inline_args++;
     }
-    SigEntry::add_entry(_sig, T_OBJECT);
+    SigEntry::add_entry(_sig, T_OBJECT, _method->name());
   }
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
     BasicType bt = ss.type();
@@ -2845,7 +2844,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
       }
       bt = T_OBJECT;
     }
-    SigEntry::add_entry(_sig, bt);
+    SigEntry::add_entry(_sig, bt, ss.as_symbol());
   }
   if (_method->is_abstract() && !has_inline_arg()) {
     return;

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -576,10 +576,10 @@ ssize_t SignatureVerifier::is_valid_type(const char* type, ssize_t limit) {
 #endif // ASSERT
 
 // Adds an argument to the signature
-void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, int offset) {
-  sig->append(SigEntry(bt, offset));
+void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol, int offset) {
+  sig->append(SigEntry(bt, offset, symbol));
   if (bt == T_LONG || bt == T_DOUBLE) {
-    sig->append(SigEntry(T_VOID, offset)); // Longs and doubles take two stack slots
+    sig->append(SigEntry(T_VOID, offset, symbol)); // Longs and doubles take two stack slots
   }
 }
 

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -574,15 +574,13 @@ class SigEntry {
  public:
   BasicType _bt;
   int _offset;
+  Symbol* _symbol;
 
   SigEntry()
-    : _bt(T_ILLEGAL), _offset(-1) {
-  }
-  SigEntry(BasicType bt, int offset)
-    : _bt(bt), _offset(offset) {}
+    : _bt(T_ILLEGAL), _offset(-1), _symbol(NULL) {}
 
-  SigEntry(BasicType bt)
-    : _bt(bt), _offset(-1) {}
+  SigEntry(BasicType bt, int offset, Symbol* symbol)
+    : _bt(bt), _offset(offset), _symbol(symbol) {}
 
   static int compare(SigEntry* e1, SigEntry* e2) {
     if (e1->_offset != e2->_offset) {
@@ -606,7 +604,7 @@ class SigEntry {
     ShouldNotReachHere();
     return 0;
   }
-  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, int offset = -1);
+  static void add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* symbol, int offset = -1);
   static bool skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i);
   static int fill_sig_bt(const GrowableArray<SigEntry>* sig, BasicType* sig_bt);
   static TempNewSymbol create_symbol(const GrowableArray<SigEntry>* sig);


### PR DESCRIPTION
We hit an assert while printing nmethod entry point labels when attempting to create a symbol from the `SigEntry` to iterate over. The problem is that we are holding the tty lock and symbol creation also acquires certain locks. I've refactored the code to completely avoid symbol creation and also fixed an issue where names of reference argument types are not printed anymore (because we don't keep track of that in `SigEntry`). I've also removed lots of dead code leftovers from old reserved entry support in the calling convention.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252024](https://bugs.openjdk.java.net/browse/JDK-8252024): [lworld] Lock ordering issue when printing nmethod labels


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/302/head:pull/302`
`$ git checkout pull/302`
