### PR TITLE
8258480: [lworld] Adapter creation asserts with -XX:+VerifyAdapterSharing

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -708,13 +708,13 @@ class AdapterHandlerEntry : public BasicHashtableEntry<mtCode> {
   AdapterHandlerEntry();
 
  public:
-  address get_i2c_entry()                  const { return _i2c_entry; }
-  address get_c2i_entry()                  const { return _c2i_entry; }
+  address get_i2c_entry()                   const { return _i2c_entry; }
+  address get_c2i_entry()                   const { return _c2i_entry; }
   address get_c2i_inline_entry()            const { return _c2i_inline_entry; }
   address get_c2i_inline_ro_entry()         const { return _c2i_inline_ro_entry; }
-  address get_c2i_unverified_entry()       const { return _c2i_unverified_entry; }
+  address get_c2i_unverified_entry()        const { return _c2i_unverified_entry; }
   address get_c2i_unverified_inline_entry() const { return _c2i_unverified_inline_entry; }
-  address get_c2i_no_clinit_check_entry()  const { return _c2i_no_clinit_check_entry; }
+  address get_c2i_no_clinit_check_entry()   const { return _c2i_no_clinit_check_entry; }
 
   address base_address();
   void relocate(address new_base);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -162,8 +162,8 @@ public abstract class InlineTypeTest {
     private static final String[] printFlags = {
         "-XX:+PrintCompilation", "-XX:+PrintIdeal", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintOptoAssembly"};
     private static final String[] verifyFlags = {
-        "-XX:+VerifyOops", "-XX:+VerifyStack", "-XX:+VerifyLastFrame", "-XX:+VerifyBeforeGC", "-XX:+VerifyAfterGC",
-        "-XX:+VerifyDuringGC", "-XX:+VerifyAdapterSharing"};
+        "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerifyOops", "-XX:+VerifyStack", "-XX:+VerifyLastFrame",
+        "-XX:+VerifyBeforeGC", "-XX:+VerifyAfterGC", "-XX:+VerifyDuringGC", "-XX:+VerifyAdapterSharing"};
 
     protected static final int InlineTypePassFieldsAsArgsOn = 0x1;
     protected static final int InlineTypePassFieldsAsArgsOff = 0x2;
@@ -848,7 +848,8 @@ public abstract class InlineTypeTest {
     }
 
     static private TriState compiledByC2(Method m) {
-        if (!USE_COMPILER || XCOMP || TEST_C1) {
+        if (!USE_COMPILER || XCOMP || TEST_C1 ||
+            (STRESS_CC && !WHITE_BOX.isMethodCompilable(m, COMP_LEVEL_FULL_OPTIMIZATION, false))) {
             return TriState.Maybe;
         }
         if (WHITE_BOX.isMethodCompiled(m, false) &&


### PR DESCRIPTION
`VerifyAdapterSharing` fails because the code of two adapters with the same fingerprint is not equal. The problem is that we are accidentally creating an "only unpack receiver" c2i adapter for a static method with an inline type as only argument. As a result, the special handling in sharedRuntime.cpp:2446 does not work.

I've also refactored related code and fixed a test bug.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8258480](https://bugs.openjdk.java.net/browse/JDK-8258480): [lworld] Adapter creation asserts with -XX:+VerifyAdapterSharing


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/304/head:pull/304`
`$ git checkout pull/304`
