### PR TITLE
8259230: [lworld] Several crashes with C2 stress options

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -190,6 +190,7 @@ Node* ArrayCopyNode::try_clone_instance(PhaseGVN *phase, bool can_reshape, int c
   const Type* src_type = phase->type(base_src);
 
   MergeMemNode* mem = phase->transform(MergeMemNode::make(in_mem))->as_MergeMem();
+  phase->record_for_igvn(mem);
 
   const TypeInstPtr* inst_src = src_type->isa_instptr();
 

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -358,15 +358,17 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   const TypePtr *in_type   = inn->isa_ptr();
   const TypePtr *my_type   = _type->isa_ptr();
   const Type *result = _type;
-  if( in_type != NULL && my_type != NULL ) {
-    if (my_type->isa_aryptr() && in_type->isa_aryptr()) {
+  if (in_type != NULL && my_type != NULL) {
+    if (!StressReflectiveCode && my_type->isa_aryptr() && in_type->isa_aryptr()) {
       // Propagate array properties (not flat/null-free)
+      // Don't do this when StressReflectiveCode is enabled because it might lead to
+      // a dying data path while the corresponding flat/null-free check is not folded.
       my_type = my_type->is_aryptr()->update_properties(in_type->is_aryptr());
       if (my_type == NULL) {
         return Type::TOP; // Inconsistent properties
       }
     }
-    TypePtr::PTR   in_ptr    = in_type->ptr();
+    TypePtr::PTR in_ptr = in_type->ptr();
     if (in_ptr == TypePtr::Null) {
       result = in_type;
     } else if (in_ptr == TypePtr::Constant) {

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3372,7 +3372,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
               op == Op_FastLock || op == Op_AryEq || op == Op_StrComp || op == Op_HasNegatives ||
               op == Op_StrCompressedCopy || op == Op_StrInflatedCopy ||
               op == Op_StrEquals || op == Op_StrIndexOf || op == Op_StrIndexOfChar ||
-              op == Op_SubTypeCheck || op == Op_InlineType || op == Op_InlineTypePtr ||
+              op == Op_SubTypeCheck || op == Op_InlineType || op == Op_InlineTypePtr || op == Op_FlatArrayCheck ||
               BarrierSet::barrier_set()->barrier_set_c2()->is_gc_barrier_node(use))) {
           n->dump();
           use->dump();

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3659,7 +3659,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
     }
   }
 
-  if (!from_inline) {
+  if (!stopped() && !from_inline) {
     res = record_profiled_receiver_for_speculation(res);
     if (to_inline && toop->inline_klass()->is_scalarizable()) {
       assert(!gvn().type(res)->maybe_null(), "Inline types are null-free");
@@ -3918,7 +3918,7 @@ Node* GraphKit::get_layout_helper(Node* klass_node, jint& constant_value) {
   if (!StressReflectiveCode && inst_klass != NULL) {
     ciKlass* klass = inst_klass->klass();
     assert(klass != NULL, "klass should not be NULL");
-    bool    xklass = inst_klass->klass_is_exact();
+    bool xklass = inst_klass->klass_is_exact();
     bool can_be_flattened = false;
     if (UseFlatArray && klass->is_obj_array_klass()) {
       ciKlass* elem = klass->as_obj_array_klass()->element_klass();

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4748,7 +4748,8 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
            (tap->_klass_is_exact && !tap->klass()->is_subtype_of(klass())) ||
            // 'this' is exact and super or unrelated:
            (this->_klass_is_exact && !klass()->is_subtype_of(tap->klass())))) {
-      if (above_centerline(ptr) || (tary->_elem->make_ptr() && above_centerline(tary->_elem->make_ptr()->_ptr))) {
+      if (above_centerline(ptr) || (tary->_elem->make_ptr() && above_centerline(tary->_elem->make_ptr()->_ptr)) ||
+          tary->_elem->isa_inlinetype()) {
         tary = TypeAry::make(Type::BOTTOM, tary->_size, tary->_stable, tary->_not_flat, tary->_not_null_free);
       }
       return make(NotNull, NULL, tary, lazy_klass, false, off, field_off, InstanceBot, speculative, depth);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -193,6 +193,7 @@ public abstract class InlineTypeTest {
     protected static final boolean UseArrayLoadStoreProfile = (Boolean)WHITE_BOX.getVMFlag("UseArrayLoadStoreProfile");
     protected static final long TypeProfileLevel = (Long)WHITE_BOX.getVMFlag("TypeProfileLevel");
     protected static final boolean UseACmpProfile = (Boolean)WHITE_BOX.getVMFlag("UseACmpProfile");
+    protected static final long PerMethodTrapLimit = (Long)WHITE_BOX.getVMFlag("PerMethodTrapLimit");
 
     protected static final Hashtable<String, Method> tests = new Hashtable<String, Method>();
     protected static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
@@ -848,7 +849,7 @@ public abstract class InlineTypeTest {
     }
 
     static private TriState compiledByC2(Method m) {
-        if (!USE_COMPILER || XCOMP || TEST_C1 ||
+        if (!USE_COMPILER || XCOMP || TEST_C1 || (PerMethodTrapLimit == 0) ||
             (STRESS_CC && !WHITE_BOX.isMethodCompilable(m, COMP_LEVEL_FULL_OPTIMIZATION, false))) {
             return TriState.Maybe;
         }


### PR DESCRIPTION
This fixes several smaller C2 issues I've found when running testing with stress options like `StressReflectiveCode` and others enabled.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8259230](https://bugs.openjdk.java.net/browse/JDK-8259230): [lworld] Several crashes with C2 stress options


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/305/head:pull/305`
`$ git checkout pull/305`
