### PR TITLE
8259556: [lworld] Various C2 crashes with -XX:-ScalarizeInlineTypes

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4682,11 +4682,12 @@ Node* GraphKit::make_constant_from_field(ciField* field, Node* obj) {
                                                         /*is_unsigned_load=*/false);
   if (con_type != NULL) {
     Node* con = makecon(con_type);
-    assert(!field->type()->is_inlinetype() || (field->is_static() && !con_type->is_zero_type()), "sanity");
     // Check type of constant which might be more precise
     if (con_type->is_inlinetypeptr() && con_type->inline_klass()->is_scalarizable()) {
-      // Load inline type from constant oop
+      assert(!con_type->is_zero_type(), "Inline types are null-free");
       con = InlineTypeNode::make_from_oop(this, con, con_type->inline_klass());
+    } else if (con_type->is_zero_type() && field->type()->is_inlinetype()) {
+      con = InlineTypeNode::default_oop(gvn(), field->type()->as_inline_klass());
     }
     return con;
   }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2411,7 +2411,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     Node* p = NULL;
     // Try to constant fold a load from a constant field
 
-    if (heap_base_oop != top() && field != NULL && field->is_constant() && !mismatched) {
+    if (heap_base_oop != top() && field != NULL && field->is_constant() && !field->is_flattened() && !mismatched) {
       // final or stable field
       p = make_constant_from_field(field, heap_base_oop);
     }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1195,7 +1195,7 @@ bool PhaseMacroExpand::eliminate_allocate_node(AllocateNode *alloc) {
     // are already replaced with SafePointScalarObject because
     // we can't search for a fields value without instance_id.
     if (safepoints.length() > 0) {
-      assert(!inline_alloc, "Inline type allocations should not have safepoint uses");
+      assert(!inline_alloc || !tklass->klass()->as_inline_klass()->is_scalarizable(), "Scalarizable inline type allocations should not have safepoint uses");
       return false;
     }
   }

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -121,7 +121,7 @@ void Parse::do_field_access(bool is_get, bool is_field) {
 void Parse::do_get_xxx(Node* obj, ciField* field) {
   BasicType bt = field->layout_type();
   // Does this field have a constant value?  If so, just push the value.
-  if (field->is_constant() &&
+  if (field->is_constant() && !field->is_flattened() &&
       // Keep consistent with types found by ciTypeFlow: for an
       // unloaded field type, ciTypeFlow::StateVector::do_getstatic()
       // speculates the field is null. The code in the rest of this

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -348,7 +348,7 @@ void Parse::do_withfield() {
   }
   if (!val->is_InlineType() && field->type()->is_inlinetype()) {
     // Scalarize inline type field value
-    assert(!gvn().type(holder)->maybe_null(), "Inline types are null-free");
+    assert(!gvn().type(val)->maybe_null(), "Inline types are null-free");
     val = InlineTypeNode::make_from_oop(this, val, gvn().type(val)->inline_klass());
   } else if (val->is_InlineType() && !field->type()->is_inlinetype()) {
     // Field value needs to be allocated because it can be merged with an oop.

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -194,6 +194,7 @@ public abstract class InlineTypeTest {
     protected static final long TypeProfileLevel = (Long)WHITE_BOX.getVMFlag("TypeProfileLevel");
     protected static final boolean UseACmpProfile = (Boolean)WHITE_BOX.getVMFlag("UseACmpProfile");
     protected static final long PerMethodTrapLimit = (Long)WHITE_BOX.getVMFlag("PerMethodTrapLimit");
+    protected static final boolean ProfileInterpreter = (Boolean)WHITE_BOX.getVMFlag("ProfileInterpreter");
 
     protected static final Hashtable<String, Method> tests = new Hashtable<String, Method>();
     protected static final boolean USE_COMPILER = WHITE_BOX.getBooleanVMFlag("UseCompiler");
@@ -849,7 +850,7 @@ public abstract class InlineTypeTest {
     }
 
     static private TriState compiledByC2(Method m) {
-        if (!USE_COMPILER || XCOMP || TEST_C1 || (PerMethodTrapLimit == 0) ||
+        if (!USE_COMPILER || XCOMP || TEST_C1 ||
             (STRESS_CC && !WHITE_BOX.isMethodCompilable(m, COMP_LEVEL_FULL_OPTIMIZATION, false))) {
             return TriState.Maybe;
         }
@@ -865,7 +866,7 @@ public abstract class InlineTypeTest {
     }
 
     static void assertDeoptimizedByC2(Method m) {
-        if (compiledByC2(m) == TriState.Yes) {
+        if (compiledByC2(m) == TriState.Yes && PerMethodTrapLimit != 0 && ProfileInterpreter) {
             throw new RuntimeException("Expected to have deoptimized");
         }
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -87,7 +87,7 @@ public class TestArrayAccessDeopt {
         if (args.length == 0) {
             // Run test in new VM instance
             String[] arg = {"-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,TestArrayAccessDeopt::test*", "-XX:-UseArrayLoadStoreProfile",
-                            "-XX:+TraceDeoptimization", "-Xbatch", "-XX:-MonomorphicArrayCheck", "-Xmixed", "TestArrayAccessDeopt", "run"};
+                            "-XX:+TraceDeoptimization", "-Xbatch", "-XX:-MonomorphicArrayCheck", "-Xmixed", "-XX:+ProfileInterpreter", "TestArrayAccessDeopt", "run"};
             OutputAnalyzer oa = ProcessTools.executeTestJvm(arg);
             String output = oa.getOutput();
             oa.shouldNotContain("Uncommon trap occurred");

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -2457,7 +2457,7 @@ public class TestLWorld extends InlineTypeTest {
                     }
                 }
                 boolean compiled = isCompiledByC2(m);
-                Asserts.assertTrue(!USE_COMPILER || XCOMP || STRESS_CC || TEST_C1 || compiled || (j != extra-1));
+                Asserts.assertTrue(!USE_COMPILER || XCOMP || STRESS_CC || TEST_C1 || !ProfileInterpreter || compiled || (j != extra-1));
                 if (!compiled) {
                     enqueueMethodForCompilation(m, COMP_LEVEL_FULL_OPTIMIZATION);
                 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -361,7 +361,7 @@ public class TestLWorldProfiling extends InlineTypeTest {
                     deopt = true;
                 }
             }
-            if (!TieredCompilation && !STRESS_CC && (deopt && (UseArrayLoadStoreProfile || TypeProfileLevel == 222))) {
+            if (deopt && !TieredCompilation && !STRESS_CC && ProfileInterpreter && (UseArrayLoadStoreProfile || TypeProfileLevel == 222)) {
                 throw new RuntimeException("Monomorphic array check should rely on profiling and be accurate");
             }
         }


### PR DESCRIPTION
This fixes several issues in C2 with -XX:-ScalarizeInlineTypes and improves robustness of the tests to be able to run with more stress options. We still need a good heuristic to decide when **not** to scalarize inline types (for example, if there are too many (oop) fields), this will be addressed by [JDK-8215479](https://bugs.openjdk.java.net/browse/JDK-8215479).

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8259556](https://bugs.openjdk.java.net/browse/JDK-8259556): [lworld] Various C2 crashes with -XX:-ScalarizeInlineTypes


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/306/head:pull/306`
`$ git checkout pull/306`
