### PR TITLE
8259804: Field.setAccessible should not allow changing fields of inline classes

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -734,7 +734,9 @@ class Field extends AccessibleObject implements Member {
      *     this {@code Field} object;</li>
      * <li>the field is non-static; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isHidden()
-     *     hidden class}; and</li>
+     *     hidden class};</li>
+     * <li>the field's declaring class is not an {@linkplain Class#isInlineClass()
+     *     inline class}; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isRecord()
      *     record class}.</li>
      * </ul>

--- a/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
+++ b/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ import java.io.FilePermission;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleFinder;
-import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.InaccessibleObjectException;
@@ -43,7 +42,6 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -52,7 +50,6 @@ import java.util.PropertyPermission;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jdk.internal.module.Modules;
 
@@ -63,7 +60,6 @@ import jdk.internal.module.Modules;
  *          be set accessible if the right permission is granted; this test
  *          loads all classes and get their declared fields
  *          and call setAccessible(false) followed by setAccessible(true);
- *          Except for fields of inline classes that are never settable
  * @modules java.base/jdk.internal.module
  * @run main/othervm --add-modules=ALL-SYSTEM FieldSetAccessibleTest UNSECURE
  * @run main/othervm --add-modules=ALL-SYSTEM FieldSetAccessibleTest SECURE
@@ -96,9 +92,7 @@ public class FieldSetAccessibleTest {
             // otherwise it would fail.
             boolean isPublic = Modifier.isPublic(f.getModifiers()) &&
                 Modifier.isPublic(c.getModifiers());
-            boolean access = !c.isInlineClass() &&
-                    ((exported && isPublic) || target.isOpen(pn, self));
-
+            boolean access = ((exported && isPublic) || target.isOpen(pn, self));
             try {
                 f.setAccessible(false);
                 f.setAccessible(true);

--- a/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
+++ b/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.io.FilePermission;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleFinder;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.InaccessibleObjectException;
@@ -42,6 +43,7 @@ import java.security.Policy;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -50,6 +52,7 @@ import java.util.PropertyPermission;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.internal.module.Modules;
 
@@ -91,15 +94,15 @@ public class FieldSetAccessibleTest {
             // is public and of a public class, or it's opened
             // otherwise it would fail.
             boolean isPublic = Modifier.isPublic(f.getModifiers()) &&
-                Modifier.isPublic(c.getModifiers());
-            boolean access = ((exported && isPublic) || target.isOpen(pn, self));
+                    Modifier.isPublic(c.getModifiers());
+            boolean access = (exported && isPublic) || target.isOpen(pn, self);
             try {
                 f.setAccessible(false);
                 f.setAccessible(true);
                 if (!access) {
                     throw new RuntimeException(
-                        String.format("Expected InaccessibleObjectException is not thrown "
-                                      + "for field %s in class %s%n", f.getName(), c.getName()));
+                            String.format("Expected InaccessibleObjectException is not thrown "
+                                    + "for field %s in class %s%n", f.getName(), c.getName()));
                 }
             } catch (InaccessibleObjectException expected) {
                 if (access) {
@@ -273,7 +276,7 @@ public class FieldSetAccessibleTest {
                         .map(p -> p.subpath(2, p.getNameCount()))
                         .map(p -> p.toString())
                         .filter(s -> s.endsWith(".class") && !s.endsWith("module-info.class"))
-                    .iterator();
+                        .iterator();
             } catch(IOException x) {
                 throw new UncheckedIOException("Unable to walk \"/modules\"", x);
             }
@@ -284,14 +287,14 @@ public class FieldSetAccessibleTest {
          */
         static Set<String> systemModules() {
             Set<String> mods = Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws",
-                // All JVMCI packages other than jdk.vm.ci.services are dynamically
-                // exported to jdk.internal.vm.compiler and jdk.aot
-                "jdk.internal.vm.compiler", "jdk.aot"
+                    // All JVMCI packages other than jdk.vm.ci.services are dynamically
+                    // exported to jdk.internal.vm.compiler and jdk.aot
+                    "jdk.internal.vm.compiler", "jdk.aot"
             );
             return ModuleFinder.ofSystem().findAll().stream()
-                               .map(mref -> mref.descriptor().name())
-                               .filter(mn -> !mods.contains(mn))
-                               .collect(Collectors.toSet());
+                    .map(mref -> mref.descriptor().name())
+                    .filter(mn -> !mods.contains(mn))
+                    .collect(Collectors.toSet());
         }
     }
 


### PR DESCRIPTION
Update the javadoc for setAccessibleObject and Field.set to restrict setting of final fields.

Correct the javadoc to match the implementation changes made in 8237444: Trust final fields in records

Also, the corresponding test is updated to match the restrictions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8259804](https://bugs.openjdk.java.net/browse/JDK-8259804): Field.setAccessible should not allow changing fields of inline classes


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)
 * [Chris Hegarty](https://openjdk.java.net/census#chegar) (@ChrisHegarty - Committer) ⚠️ Review applies to 25f16c627475ae27ec30dde9778f5ec2d91b67ea


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/307/head:pull/307`
`$ git checkout pull/307`
