### PR TITLE
8257846: [lworld] Separate compilation failure of generic inline class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1004,6 +1004,12 @@ public class ClassReader {
                         //- System.err.println(" # " + sym.type);
                         if (sym.kind == MTH && sym.type.getThrownTypes().isEmpty())
                             sym.type.asMethodType().thrown = thrown;
+                        if (sym.kind == MTH  && sym.name == names.init && sym.owner.isValue()) {
+                            sym.type = new MethodType(sym.type.getParameterTypes(),
+                                    syms.voidType,
+                                    sym.type.getThrownTypes(),
+                                    syms.methodClass);
+                        }
 
                     }
                 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/Range.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Range.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public inline class Range<T> {
+    private final T lower;
+    private final T upper;
+
+    private Range(T lower, T upper) {
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    public static <T> Range<T> of(T lower, T upper) {
+        return new Range<>(lower, upper);
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileGenerics.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileGenerics.java
@@ -25,8 +25,8 @@
 
 /**
  * @test
- * @bug 8257846 
- * @summary Separate compilation failure of generic inline class	
+ * @bug 8257846
+ * @summary Separate compilation failure of generic inline class
  * @compile Range.java
  * @run main SeparateCompileGenerics
  */

--- a/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileGenerics.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileGenerics.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8257846 
+ * @summary Separate compilation failure of generic inline class	
+ * @compile Range.java
+ * @run main SeparateCompileGenerics
+ */
+
+public class SeparateCompileGenerics {
+    public static void main(String[] args) {
+        Range<Integer> r = Range.of(1, 2);
+    }
+}


### PR DESCRIPTION
Ensure inline constructors appears as constructors rather than as static factory methods to top layers of javac after Signature attribute processing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257846](https://bugs.openjdk.java.net/browse/JDK-8257846): [lworld] Separate compilation failure of generic inline class


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/308/head:pull/308`
`$ git checkout pull/308`
