### PR TITLE
8260034: [lworld] C1 compilation fails with assert "should not be optimized out"

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -48,32 +48,32 @@ public class TestGenerated {
             f2 = array[0];
         }
     }
-    
+
     MyValue1 test2(MyValue1[] array) {
         MyValue1 res = MyValue1.default;
         for (int i = 0; i < array.length; ++i) {
             res = array[i];
         }
         for (int i = 0; i < 1000; ++i) {
-        
+
         }
         return res;
     }
-    
+
     void test3(MyValue1[] array) {
         for (int i = 0; i < array.length; ++i) {
             array[i] = MyValue1.default;
         }
         for (int i = 0; i < 1000; ++i) {
-        
+
         }
     }
-  
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
         MyValue1[] array2 = new MyValue1[10];
-        
+
         for (int i = 0; i < 50_000; ++i) {
             t.test1(array1);
             t.test2(array2);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260034
+ * @summary Generated inline type tests.
+ * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestGenerated
+ */
+
+package compiler.valhalla.inlinetypes;
+
+inline class EmptyValue {
+
+}
+
+inline class MyValue1 {
+    int x = 42;
+}
+
+public class TestGenerated {
+    EmptyValue f1 = new EmptyValue();
+    EmptyValue f2 = new EmptyValue();
+
+    void test1(EmptyValue[] array) {
+        for (int i = 0; i < 10; ++i) {
+            f1 = array[0];
+            f2 = array[0];
+        }
+    }
+    
+    MyValue1 test2(MyValue1[] array) {
+        MyValue1 res = MyValue1.default;
+        for (int i = 0; i < array.length; ++i) {
+            res = array[i];
+        }
+        for (int i = 0; i < 1000; ++i) {
+        
+        }
+        return res;
+    }
+    
+    void test3(MyValue1[] array) {
+        for (int i = 0; i < array.length; ++i) {
+            array[i] = MyValue1.default;
+        }
+        for (int i = 0; i < 1000; ++i) {
+        
+        }
+    }
+  
+    public static void main(String[] args) {
+        TestGenerated t = new TestGenerated();
+        EmptyValue[] array1 = { new EmptyValue() };
+        MyValue1[] array2 = new MyValue1[10];
+        
+        for (int i = 0; i < 50_000; ++i) {
+            t.test1(array1);
+            t.test2(array2);
+            t.test3(array2);
+        }
+    }
+}


### PR DESCRIPTION
We hit an assert during C1 compilation because an array load is optimized out. The assert is too strong. While looking at the code, I've noticed that we are always profiling array stores, even if the array is known to be a loaded, flattened array. I don't think that's needed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260034](https://bugs.openjdk.java.net/browse/JDK-8260034): [lworld] C1 compilation fails with assert "should not be optimized out"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/309/head:pull/309`
`$ git checkout pull/309`
