### PR TITLE
8260225: [lworld] C1's delayed load indexed optimization sets incorrect type

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -238,7 +238,7 @@ ciType* Constant::exact_type() const {
 
 ciType* LoadIndexed::exact_type() const {
   ciType* array_type = array()->exact_type();
-  if (array_type != NULL) {
+  if (delayed() != NULL && array_type != NULL) {
     assert(array_type->is_array_klass(), "what else?");
     ciArrayKlass* ak = (ciArrayKlass*)array_type;
 
@@ -252,8 +252,10 @@ ciType* LoadIndexed::exact_type() const {
   return Instruction::exact_type();
 }
 
-
 ciType* LoadIndexed::declared_type() const {
+  if (delayed() != NULL) {
+    return delayed()->field()->type();
+  }
   ciType* array_type = array()->declared_type();
   if (array_type == NULL || !array_type->is_loaded()) {
     return NULL;

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1012,7 +1012,7 @@ LEAF(LoadIndexed, AccessIndexed)
   NewInlineTypeInstance* vt() const { return _vt; }
   void set_vt(NewInlineTypeInstance* vt) { _vt = vt; }
 
-  DelayedLoadIndexed* delayed() { return _delayed; }
+  DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
 
   // generic

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034
+ * @bug 8260034 8260225
  * @summary Generated inline type tests.
  * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestGenerated
  */
@@ -36,6 +36,7 @@ inline class EmptyValue {
 
 inline class MyValue1 {
     int x = 42;
+    int[] array = new int[1];
 }
 
 public class TestGenerated {
@@ -69,15 +70,26 @@ public class TestGenerated {
         }
     }
 
+    void test4(MyValue1[] array) {
+        array[0].array[0] = 0;
+    }
+
+    int test5(MyValue1[] array) {
+        return array[0].array[0];
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
         MyValue1[] array2 = new MyValue1[10];
+        MyValue1[] array3 = { new MyValue1() };
 
         for (int i = 0; i < 50_000; ++i) {
             t.test1(array1);
             t.test2(array2);
             t.test3(array2);
+            t.test4(array3);
+            t.test5(array3);
         }
     }
 }


### PR DESCRIPTION
`LoadIndexed::exact_type()` and `declared_type` return and incorrect type if the load is delayed. See bug report for a detailed description.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260225](https://bugs.openjdk.java.net/browse/JDK-8260225): [lworld] C1's delayed load indexed optimization sets incorrect type


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/310/head:pull/310`
`$ git checkout pull/310`
