### PR TITLE
8260283: [lworld] C1's EliminateFieldAccess optimization fails with "wrong types"

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1911,7 +1911,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             assert(!needs_patching, "Can't patch delayed field access");
             obj = pending_field_access()->obj();
             offset += pending_field_access()->offset() - field->holder()->as_inline_klass()->first_field_offset();
-            field = pending_field_access()->field()->holder()->get_field_by_offset(offset, false);
+            field = pending_field_access()->holder()->get_field_by_offset(offset, false);
             assert(field != NULL, "field not found");
             set_pending_field_access(NULL);
           } else if (has_pending_load_indexed()) {
@@ -1967,7 +1967,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               pending_field_access()->inc_offset(offset - field->holder()->as_inline_klass()->first_field_offset());
             } else {
               null_check(obj);
-              DelayedFieldAccess* dfa = new DelayedFieldAccess(obj, field, field->offset());
+              DelayedFieldAccess* dfa = new DelayedFieldAccess(obj, field->holder(), field->offset());
               set_pending_field_access(dfa);
             }
           } else {

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1912,6 +1912,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             obj = pending_field_access()->obj();
             offset += pending_field_access()->offset() - field->holder()->as_inline_klass()->first_field_offset();
             field = pending_field_access()->field()->holder()->get_field_by_offset(offset, false);
+            assert(field != NULL, "field not found");
             set_pending_field_access(NULL);
           } else if (has_pending_load_indexed()) {
             assert(!needs_patching, "Can't patch delayed field access");
@@ -1963,7 +1964,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             if (has_pending_load_indexed()) {
               pending_load_indexed()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
             } else if (has_pending_field_access()) {
-              pending_field_access()->update(field, offset - field->holder()->as_inline_klass()->first_field_offset());
+              pending_field_access()->inc_offset(offset - field->holder()->as_inline_klass()->first_field_offset());
             } else {
               null_check(obj);
               DelayedFieldAccess* dfa = new DelayedFieldAccess(obj, field, field->offset());

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1820,7 +1820,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
     }
   }
 
-  const int offset = !needs_patching ? field->offset() : -1;
+  int offset = !needs_patching ? field->offset() : -1;
   switch (code) {
     case Bytecodes::_getstatic: {
       // check for compile-time constants, i.e., initialized static final fields
@@ -1907,12 +1907,11 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
           state_before = copy_state_for_exception();
         }
         if (!field->is_flattened()) {
-          LoadField* load;
           if (has_pending_field_access()) {
             assert(!needs_patching, "Can't patch delayed field access");
-            load = new LoadField(pending_field_access()->obj(),
-                                 pending_field_access()->offset() + offset - field->holder()->as_inline_klass()->first_field_offset(),
-                                 field, false, state_before, needs_patching);
+            obj = pending_field_access()->obj();
+            offset += pending_field_access()->offset() - field->holder()->as_inline_klass()->first_field_offset();
+            field = pending_field_access()->field()->holder()->get_field_by_offset(offset, false);
             set_pending_field_access(NULL);
           } else if (has_pending_load_indexed()) {
             assert(!needs_patching, "Can't patch delayed field access");
@@ -1922,9 +1921,8 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             push(type, append(li));
             set_pending_load_indexed(NULL);
             break;
-          } else {
-            load = new LoadField(obj, offset, field, false, state_before, needs_patching);
           }
+          LoadField* load = new LoadField(obj, offset, field, false, state_before, needs_patching);
           Value replacement = !needs_patching ? _memory->load(load) : load;
           if (replacement != load) {
             assert(replacement->is_linked() || !replacement->can_be_linked(), "should already by linked");

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -37,22 +37,17 @@ class MemoryBuffer;
 
 class DelayedFieldAccess : public CompilationResourceObj {
 private:
-  Value _obj;
+  Value    _obj;
   ciField* _field;
-  int _offset;
+  int      _offset;
 public:
   DelayedFieldAccess(Value obj, ciField* field, int offset)
-  : _obj(obj)
-  , _field(field)
-  , _offset(offset) { }
+  : _obj(obj), _field(field) , _offset(offset) { }
 
-  void update(ciField* field, int offset) {
-    _field = field;
-    _offset += offset;
-  }
-  Value obj() { return _obj; }
-  ciField* field() { return _field; }
-  int offset() { return _offset; }
+  Value obj() const           { return _obj; }
+  ciField* field() const      { return _field; }
+  int offset() const          { return _offset; }
+  void inc_offset(int offset) { _offset += offset; }
 };
 
 class GraphBuilder {

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -37,17 +37,17 @@ class MemoryBuffer;
 
 class DelayedFieldAccess : public CompilationResourceObj {
 private:
-  Value    _obj;
-  ciField* _field;
-  int      _offset;
+  Value            _obj;
+  ciInstanceKlass* _holder;
+  int              _offset;
 public:
-  DelayedFieldAccess(Value obj, ciField* field, int offset)
-  : _obj(obj), _field(field) , _offset(offset) { }
+  DelayedFieldAccess(Value obj, ciInstanceKlass* holder, int offset)
+  : _obj(obj), _holder(holder) , _offset(offset) { }
 
-  Value obj() const           { return _obj; }
-  ciField* field() const      { return _field; }
-  int offset() const          { return _offset; }
-  void inc_offset(int offset) { _offset += offset; }
+  Value obj() const               { return _obj; }
+  ciInstanceKlass* holder() const { return _holder; }
+  int offset() const              { return _offset; }
+  void inc_offset(int offset)     { _offset += offset; }
 };
 
 class GraphBuilder {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034 8260225
+ * @bug 8260034 8260225 8260283
  * @summary Generated inline type tests.
  * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestGenerated
  */
@@ -78,6 +78,17 @@ public class TestGenerated {
         return array[0].array[0];
     }
 
+    long f3;
+    MyValue1 f4 = new MyValue1();
+
+    void test6() {
+        f3 = 123L;
+        int res = f4.x;
+        if (res != 42) {
+            throw new RuntimeException("test6 failed");
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -90,6 +101,7 @@ public class TestGenerated {
             t.test3(array2);
             t.test4(array3);
             t.test5(array3);
+            t.test6();
         }
     }
 }


### PR DESCRIPTION
C1's delayed field access optimization ([JDK-8229897](https://bugs.openjdk.java.net/browse/JDK-8229897)) does not update the field when updating a `LoadField`. The `EliminateFieldAccess` optimization then uses the wrong field (offset) to look up the loaded value in the `MemoryBuffer`. We hit an assert because the field types do not match.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260283](https://bugs.openjdk.java.net/browse/JDK-8260283): [lworld] C1's EliminateFieldAccess optimization fails with "wrong types"


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/311/head:pull/311`
`$ git checkout pull/311`
