### PR TITLE
Remove unused field from Method

### DIFF
--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -117,7 +117,6 @@ class Method : public Metadata {
   // NULL only at safepoints (because of a de-opt).
   CompiledMethod* volatile _code;                       // Points to the corresponding piece of native code
   volatile address           _from_interpreted_entry; // Cache of _code ? _adapter->i2c_entry() : _i2i_entry
-  int _max_vt_buffer; // max number of VT buffer chunk to use before recycling
 
 #if INCLUDE_AOT && defined(TIERED)
   CompiledMethod* _aot_code;
@@ -764,8 +763,6 @@ public:
   static int method_data_offset_in_bytes()       { return offset_of(Method, _method_data); }
   static int intrinsic_id_offset_in_bytes()      { return offset_of(Method, _intrinsic_id); }
   static int intrinsic_id_size_in_bytes()        { return sizeof(u2); }
-
-  static ByteSize max_vt_buffer_offset()         { return byte_offset_of(Method, _max_vt_buffer); }
 
   // Static methods that are used to implement member methods where an exposed this pointer
   // is needed due to possible GCs


### PR DESCRIPTION
Remove an unused field from the Method class, leftover of the value types thread local buffer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/312/head:pull/312`
`$ git checkout pull/312`
