### PR TITLE
8260375: [lworld] ValueTearing fails with -XX:FlatArrayElementMaxSize=0 -XX:InlineFieldMaxFlatSize=0

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -35,7 +35,7 @@ import java.lang.reflect.Method;
  * @compile TestLWorldProfiling.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=300 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
- *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI
+ *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI -XX:FlatArrayElementMaxSize=-1
  *                               compiler.valhalla.inlinetypes.InlineTypeTest
  *                               compiler.valhalla.inlinetypes.TestLWorldProfiling
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
@@ -31,7 +31,7 @@ import java.lang.reflect.Field;
  * @summary Test support for empty inline types (no instance fields)
  * @library /test/lib
  * @compile EmptyInlineTest.java
- * @run main/othervm -XX:+EnableValhalla runtime.valhalla.inlinetypes.EmptyInlineTest
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=128 runtime.valhalla.inlinetypes.EmptyInlineTest
 
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -42,7 +42,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint -XX:+UseSerialGC -Xmx128m
+ * @run main/othervm -Xint -XX:+UseSerialGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -57,7 +57,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint  -XX:+UseG1GC -Xmx128m
+ * @run main/othervm -Xint  -XX:+UseG1GC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops 20
  */
@@ -72,7 +72,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint -XX:+UseParallelGC -Xmx128m
+ * @run main/othervm -Xint -XX:+UseParallelGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -88,7 +88,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xint -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -103,7 +103,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseSerialGC -Xmx128m
+ * @run main/othervm -Xcomp -XX:+UseSerialGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -118,7 +118,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseG1GC -Xmx128m
+ * @run main/othervm -Xcomp -XX:+UseG1GC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops 20
  */
@@ -133,7 +133,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseParallelGC -Xmx128m
+ * @run main/othervm -Xcomp -XX:+UseParallelGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -149,7 +149,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xcomp -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
@@ -42,7 +42,7 @@ import jdk.test.lib.Asserts;
  * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI InlineTypeDensity
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:ForceNonTearable=*
  *                   -XX:+WhiteBoxAPI InlineTypeDensity
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIArrays.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIArrays.java
@@ -40,8 +40,10 @@ import jdk.internal.vm.jni.SubElementSelector;
  * @requires (os.simpleArch == "x64")
  * @requires (os.family == "linux" | os.family == "mac")
  * @compile -XDallowWithFieldOperator TestJNIArrays.java
- * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128 -XX:+UseCompressedOops TestJNIArrays
- * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128 -XX:-UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128
+ *      -XX:InlineFieldMaxFlatSize=128 -XX:+UseCompressedOops TestJNIArrays
+ * @run main/othervm/native/timeout=3000 -XX:FlatArrayElementMaxSize=128
+ *      -XX:InlineFieldMaxFlatSize=128 -XX:-UseCompressedOops TestJNIArrays
  */
 public class TestJNIArrays {
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
@@ -43,26 +43,26 @@ import static jdk.test.lib.Asserts.*;
  * @compile ValueTearing.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
- *                   -DSTEP_COUNT=10000
+ *                   -DSTEP_COUNT=10000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
  * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
- *                   -DSTEP_COUNT=10000
+ *                   -DSTEP_COUNT=10000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xbatch -DSTEP_COUNT=10000000
+ * @run main/othervm -Xbatch -DSTEP_COUNT=10000000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
- *                   -DTEAR_MODE=fieldonly
+ *                   -DTEAR_MODE=fieldonly -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
- *                   -DTEAR_MODE=arrayonly
+ *                   -DTEAR_MODE=arrayonly -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
  * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
- *                   -DTEAR_MODE=both
+ *                   -DTEAR_MODE=both -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
@@ -28,7 +28,7 @@ package runtime.valhalla.inlinetypes;
  * @summary check effect of volatile keyword on flattenable fields
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @run main/othervm runtime.valhalla.inlinetypes.VolatileTest
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=128 runtime.valhalla.inlinetypes.VolatileTest
  */
 
 import jdk.internal.misc.Unsafe;


### PR DESCRIPTION
Please review this fix forcing field and array flattening for tests relying on flattening.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260375](https://bugs.openjdk.java.net/browse/JDK-8260375): [lworld] ValueTearing fails with -XX:FlatArrayElementMaxSize=0 -XX:InlineFieldMaxFlatSize=0


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/313/head:pull/313`
`$ git checkout pull/313`
