### PR TITLE
[lworld] Field::get should return default value instead of null on non-flattened inline field

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -284,25 +284,6 @@ public final class Unsafe {
     }
 
     /**
-     * Stores a reference value into a given Java variable.
-     * This method can store a reference to either an object or value
-     * or a null reference.
-     * <p>
-     * Unless the reference {@code x} being stored is either null
-     * or matches the field type, the results are undefined.
-     * If the reference {@code o} is non-null, card marks or
-     * other store barriers for that object (if the VM requires them)
-     * are updated.
-     * @see #putInt(Object, long, int)
-     */
-    public void putReference(Object o, long offset, Class<?> vc, Object x) {
-        if (vc.isInlineClass() && x == null) {
-            throw new NullPointerException("cannot write null to a field of an inline type: " + vc.getName());
-        }
-        putReference(o, offset, x);
-    }
-
-    /**
      * Returns an uninitialized default value of the given inline class.
      */
     public native <V> V uninitializedDefaultValue(Class<?> vc);
@@ -2450,17 +2431,6 @@ public final class Unsafe {
      */
     @IntrinsicCandidate
     public native void putReferenceVolatile(Object o, long offset, Object x);
-
-    /**
-     * Stores a reference value into a given Java variable, with
-     * volatile store semantics. Otherwise identical to {@link #putReference(Object, long, Object)}
-     */
-    public void putReferenceVolatile(Object o, long offset, Class<?> vc, Object x) {
-        if (vc.isInlineClass() && x == null) {
-            throw new NullPointerException("cannot write null to a field of an inline type: " + vc.getName());
-        }
-        putReferenceVolatile(o, offset, x);
-    }
 
     public final <V> void putValueVolatile(Object o, long offset, Class<?> valueType, V x) {
         synchronized (valueLock) {

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -284,6 +284,25 @@ public final class Unsafe {
     }
 
     /**
+     * Stores a reference value into a given Java variable.
+     * This method can store a reference to either an object or value
+     * or a null reference.
+     * <p>
+     * Unless the reference {@code x} being stored is either null
+     * or matches the field type, the results are undefined.
+     * If the reference {@code o} is non-null, card marks or
+     * other store barriers for that object (if the VM requires them)
+     * are updated.
+     * @see #putInt(Object, long, int)
+     */
+    public void putReference(Object o, long offset, Class<?> vc, Object x) {
+        if (vc.isInlineClass() && x == null) {
+            throw new NullPointerException("cannot write null to a field of an inline type: " + vc.getName());
+        }
+        putReference(o, offset, x);
+    }
+
+    /**
      * Returns an uninitialized default value of the given inline class.
      */
     public native <V> V uninitializedDefaultValue(Class<?> vc);
@@ -2431,6 +2450,17 @@ public final class Unsafe {
      */
     @IntrinsicCandidate
     public native void putReferenceVolatile(Object o, long offset, Object x);
+
+    /**
+     * Stores a reference value into a given Java variable, with
+     * volatile store semantics. Otherwise identical to {@link #putReference(Object, long, Object)}
+     */
+    public void putReferenceVolatile(Object o, long offset, Class<?> vc, Object x) {
+        if (vc.isInlineClass() && x == null) {
+            throw new NullPointerException("cannot write null to a field of an inline type: " + vc.getName());
+        }
+        putReferenceVolatile(o, offset, x);
+    }
 
     public final <V> void putValueVolatile(Object o, long offset, Class<?> valueType, V x) {
         synchronized (valueLock) {

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeObjectFieldAccessorImpl.java
@@ -35,7 +35,7 @@ class UnsafeObjectFieldAccessorImpl extends UnsafeFieldAccessorImpl {
     public Object get(Object obj) throws IllegalArgumentException {
         ensureObj(obj);
         return isFlattened() ? unsafe.getValue(obj, fieldOffset, field.getType())
-                             : unsafe.getReference(obj, fieldOffset);
+                             : unsafe.getReference(obj, fieldOffset, field.getType());
     }
 
     public boolean getBoolean(Object obj) throws IllegalArgumentException {

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
@@ -83,7 +83,7 @@ class UnsafeQualifiedObjectFieldAccessorImpl
         if (isFlattened()) {
             unsafe.putValue(obj, fieldOffset, field.getType(), value);
         } else {
-        unsafe.putReferenceVolatile(obj, fieldOffset, value);
+            unsafe.putReferenceVolatile(obj, fieldOffset, value);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedObjectFieldAccessorImpl.java
@@ -37,7 +37,7 @@ class UnsafeQualifiedObjectFieldAccessorImpl
     public Object get(Object obj) throws IllegalArgumentException {
         ensureObj(obj);
         return isFlattened() ? unsafe.getValue(obj, fieldOffset, field.getType())
-                             : unsafe.getReferenceVolatile(obj, fieldOffset);
+                             : unsafe.getReferenceVolatile(obj, fieldOffset, field.getType());
     }
 
     public boolean getBoolean(Object obj) throws IllegalArgumentException {

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
@@ -81,7 +81,7 @@ class UnsafeQualifiedStaticObjectFieldAccessorImpl
         if (isFlattened()) {
             unsafe.putValue(base, fieldOffset, field.getType(), value);
         } else {
-        unsafe.putReferenceVolatile(base, fieldOffset, value);
+            unsafe.putReferenceVolatile(base, fieldOffset, value);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeQualifiedStaticObjectFieldAccessorImpl.java
@@ -36,7 +36,7 @@ class UnsafeQualifiedStaticObjectFieldAccessorImpl
 
     public Object get(Object obj) throws IllegalArgumentException {
         return isFlattened() ? unsafe.getValue(obj, fieldOffset, field.getType())
-                             : unsafe.getReferenceVolatile(base, fieldOffset);
+                             : unsafe.getReferenceVolatile(base, fieldOffset, field.getType());
     }
 
     public boolean getBoolean(Object obj) throws IllegalArgumentException {

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeStaticObjectFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeStaticObjectFieldAccessorImpl.java
@@ -34,7 +34,7 @@ class UnsafeStaticObjectFieldAccessorImpl extends UnsafeStaticFieldAccessorImpl 
 
     public Object get(Object obj) throws IllegalArgumentException {
         return isFlattened() ? unsafe.getValue(base, fieldOffset, field.getType())
-                             : unsafe.getReference(base, fieldOffset);
+                             : unsafe.getReference(base, fieldOffset, field.getType());
     }
 
     public boolean getBoolean(Object obj) throws IllegalArgumentException {
@@ -79,7 +79,7 @@ class UnsafeStaticObjectFieldAccessorImpl extends UnsafeStaticFieldAccessorImpl 
         if (isFlattened()) {
             unsafe.putValue(obj, fieldOffset, field.getType(), value);
         } else {
-        unsafe.putReference(base, fieldOffset, value);
+            unsafe.putReference(base, fieldOffset, value);
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @compile --enable-preview --source ${jdk.version} UninitializedInlineValueTest.java
+ * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=128 UninitializedInlineValueTest
+ * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=0 UninitializedInlineValueTest
+ * @summary Test reflection and method handle on accessing a field of inline type
+ *          that may be flattened or non-flattened
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class UninitializedInlineValueTest {
+    static inline class EmptyInline {
+        public boolean isEmpty() {
+            return true;
+        }
+    }
+
+    static inline class InlineValue {
+        Object o;
+        EmptyInline empty;
+        InlineValue() {
+            this.o = null;
+            this.empty = new EmptyInline();
+        }
+    }
+
+    static class MutableValue {
+        Object o;
+        EmptyInline empty;
+    }
+
+    @Test
+    public void emptyInlineClass() throws ReflectiveOperationException {
+        EmptyInline e = new EmptyInline();
+        Field[] fields = e.getClass().getDeclaredFields();
+        assertTrue(fields.length == 0);
+    }
+
+    @Test
+    public void testInlineValue() throws ReflectiveOperationException {
+        InlineValue v = new InlineValue();
+        Field f0 = v.getClass().getDeclaredField("o");
+        Object o = f0.get(v);
+        assertTrue(o == null);
+
+        // field of inline type must be non-null
+        Field f1 = v.getClass().getDeclaredField("empty");
+        assertTrue(f1.getType() == EmptyInline.class);
+        EmptyInline empty = (EmptyInline)f1.get(v);
+        assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+    }
+
+    @Test
+    public void testMutableValue() throws ReflectiveOperationException {
+        MutableValue v = new MutableValue();
+        Field f0 = v.getClass().getDeclaredField("o");
+        f0.set(v, null);
+        assertTrue( f0.get(v) == null);
+
+        // field of inline type must be non-null
+        Field f1 = v.getClass().getDeclaredField("empty");
+        assertTrue(f1.getType() == EmptyInline.class);
+        EmptyInline empty = (EmptyInline)f1.get(v);
+        assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+
+        f1.set(v, new EmptyInline());
+        assertTrue((EmptyInline)f1.get(v) == new EmptyInline());
+    }
+
+    @Test
+    public void testMethodHandleInlineValue() throws Throwable {
+        InlineValue v = new InlineValue();
+        MethodHandle mh = MethodHandles.lookup().findGetter(InlineValue.class, "empty", EmptyInline.class);
+        EmptyInline empty = (EmptyInline) mh.invokeExact(v);
+        assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+    }
+
+    @Test
+    public void testMethodHandleMutableValue() throws Throwable {
+        MutableValue v = new MutableValue();
+        MethodHandle getter = MethodHandles.lookup().findGetter(MutableValue.class, "empty", EmptyInline.class);
+        EmptyInline empty = (EmptyInline) getter.invokeExact(v);
+        assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+
+        MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyInline.class);
+        setter.invokeExact(v, new EmptyInline());
+        empty = (EmptyInline) getter.invokeExact(v);
+        assertTrue(empty == new EmptyInline());
+    }
+
+    @Test(expectedExceptions = { IllegalAccessException.class})
+    public void noWriteAccess() throws ReflectiveOperationException {
+        InlineValue v = new InlineValue();
+        Field f = v.getClass().getDeclaredField("empty");
+        f.set(v, null);
+    }
+
+    @Test(expectedExceptions = { NullPointerException.class})
+    public void nonNullableField_reflection() throws ReflectiveOperationException {
+        MutableValue v = new MutableValue();
+        Field f = v.getClass().getDeclaredField("empty");
+        f.set(v, null);
+    }
+
+    @Test(expectedExceptions = { NullPointerException.class})
+    public void nonNullableField_MethodHandle() throws Throwable {
+        MutableValue v = new MutableValue();
+        MethodHandle mh = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyInline.class);
+        EmptyInline.ref e = null;
+        EmptyInline empty = (EmptyInline) mh.invokeExact(v, (EmptyInline)e);
+    }
+}

--- a/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
@@ -48,11 +48,9 @@ public class UninitializedInlineValueTest {
     static inline class InlineValue {
         Object o;
         EmptyInline empty;
-        volatile EmptyInline vempty;
         InlineValue() {
             this.o = null;
             this.empty = new EmptyInline();
-            this.vempty = new EmptyInline();
         }
     }
 
@@ -81,11 +79,6 @@ public class UninitializedInlineValueTest {
         assertTrue(f1.getType() == EmptyInline.class);
         EmptyInline empty = (EmptyInline)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
-
-        Field f2 = v.getClass().getDeclaredField("vempty");
-        assertTrue(f2.getType() == EmptyInline.class);
-        EmptyInline vempty = (EmptyInline)f2.get(v);
-        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
     }
 
     @Test
@@ -118,10 +111,6 @@ public class UninitializedInlineValueTest {
         MethodHandle mh = MethodHandles.lookup().findGetter(InlineValue.class, "empty", EmptyInline.class);
         EmptyInline empty = (EmptyInline) mh.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
-
-        MethodHandle mh1 = MethodHandles.lookup().findGetter(InlineValue.class, "vempty", EmptyInline.class);
-        EmptyInline vempty = (EmptyInline) mh1.invokeExact(v);
-        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
     }
 
     @Test
@@ -131,7 +120,7 @@ public class UninitializedInlineValueTest {
         EmptyInline empty = (EmptyInline) getter.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
-        MethodHandle getter1 = MethodHandles.lookup().findGetter(InlineValue.class, "vempty", EmptyInline.class);
+        MethodHandle getter1 = MethodHandles.lookup().findGetter(MutableValue.class, "vempty", EmptyInline.class);
         EmptyInline vempty = (EmptyInline) getter1.invokeExact(v);
         assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
 

--- a/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
@@ -48,15 +48,18 @@ public class UninitializedInlineValueTest {
     static inline class InlineValue {
         Object o;
         EmptyInline empty;
+        volatile EmptyInline vempty;
         InlineValue() {
             this.o = null;
             this.empty = new EmptyInline();
+            this.vempty = new EmptyInline();
         }
     }
 
     static class MutableValue {
         Object o;
         EmptyInline empty;
+        volatile EmptyInline vempty;
     }
 
     @Test
@@ -78,6 +81,11 @@ public class UninitializedInlineValueTest {
         assertTrue(f1.getType() == EmptyInline.class);
         EmptyInline empty = (EmptyInline)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+
+        Field f2 = v.getClass().getDeclaredField("vempty");
+        assertTrue(f2.getType() == EmptyInline.class);
+        EmptyInline vempty = (EmptyInline)f2.get(v);
+        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
     }
 
     @Test
@@ -93,8 +101,15 @@ public class UninitializedInlineValueTest {
         EmptyInline empty = (EmptyInline)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
+        Field f2 = v.getClass().getDeclaredField("vempty");
+        assertTrue(f2.getType() == EmptyInline.class);
+        EmptyInline vempty = (EmptyInline)f2.get(v);
+        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
+
         f1.set(v, new EmptyInline());
         assertTrue((EmptyInline)f1.get(v) == new EmptyInline());
+        f2.set(v, new EmptyInline());
+        assertTrue((EmptyInline)f2.get(v) == new EmptyInline());
     }
 
     @Test
@@ -103,6 +118,10 @@ public class UninitializedInlineValueTest {
         MethodHandle mh = MethodHandles.lookup().findGetter(InlineValue.class, "empty", EmptyInline.class);
         EmptyInline empty = (EmptyInline) mh.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
+
+        MethodHandle mh1 = MethodHandles.lookup().findGetter(InlineValue.class, "vempty", EmptyInline.class);
+        EmptyInline vempty = (EmptyInline) mh1.invokeExact(v);
+        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
     }
 
     @Test
@@ -112,10 +131,19 @@ public class UninitializedInlineValueTest {
         EmptyInline empty = (EmptyInline) getter.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
+        MethodHandle getter1 = MethodHandles.lookup().findGetter(InlineValue.class, "vempty", EmptyInline.class);
+        EmptyInline vempty = (EmptyInline) getter1.invokeExact(v);
+        assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
+
         MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyInline.class);
         setter.invokeExact(v, new EmptyInline());
         empty = (EmptyInline) getter.invokeExact(v);
         assertTrue(empty == new EmptyInline());
+
+        MethodHandle setter1 = MethodHandles.lookup().findSetter(MutableValue.class, "vempty", EmptyInline.class);
+        setter1.invokeExact(v, new EmptyInline());
+        vempty = (EmptyInline) getter1.invokeExact(v);
+        assertTrue(vempty == new EmptyInline());
     }
 
     @Test(expectedExceptions = { IllegalAccessException.class})


### PR DESCRIPTION
A field could be of a non-flattened inline type.  `Unsafe::getReference(Object o, long offset, Class<?> valueType)` should be used instead.   The value type parameter is used to differentiate if the field is an inline type or not; if so, it will return an uninitialized value of the inline type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/314/head:pull/314`
`$ git checkout pull/314`
