### PR TITLE
8260363: [lworld] C2 compilation fails with assert(n->Opcode() != Op_Phi) failed: cannot match

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -240,7 +240,7 @@ void PhaseCFG::schedule_pinned_nodes(VectorSet &visited) {
       }
 
       // process all inputs that are non NULL
-      for (int i = node->req()-1; i >= 0; --i) {
+      for (int i = node->len()-1; i >= 0; --i) {
         if (node->in(i) != NULL) {
           spstack.push(node->in(i));
         }

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -2140,7 +2140,7 @@ void Matcher::find_shared(Node* n) {
       if (find_shared_visit(mstack, n, nop, mem_op, mem_addr_idx)) {
         continue;
       }
-      for (int i = n->req() - 1; i >= 0; --i) { // For my children
+      for (int i = n->len() - 1; i >= 0; --i) { // For my children
         Node* m = n->in(i); // Get ith input
         if (m == NULL) {
           continue;  // Ignore NULLs

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3010,9 +3010,13 @@ Node *StoreCMNode::Ideal(PhaseGVN *phase, bool can_reshape){
 
   Node* my_store = in(MemNode::OopStore);
   if (my_store->is_MergeMem()) {
-    Node* mem = my_store->as_MergeMem()->memory_at(oop_alias_idx());
-    set_req(MemNode::OopStore, mem);
-    return this;
+    if (oop_alias_idx() != phase->C->get_alias_index(TypeAryPtr::INLINES) ||
+        phase->C->flattened_accesses_share_alias()) {
+      // The alias that was recorded is no longer accurate enough.
+      Node* mem = my_store->as_MergeMem()->memory_at(oop_alias_idx());
+      set_req(MemNode::OopStore, mem);
+      return this;
+    }
   }
 
   return NULL;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayAliasesCardMark.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayAliasesCardMark.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260363
+ * @summary [lworld] C2 compilation fails with assert(n->Opcode() != Op_Phi) failed: cannot match
+ *
+ * @run main/othervm -XX:-BackgroundCompilation TestFlatArrayAliasesCardMark
+ *
+ */
+
+
+inline class Test0 {
+    int x = 42;
+    short[] array = new short[7];
+}
+
+public class TestFlatArrayAliasesCardMark {
+    int f = 1;
+
+    public void method1(Test0[] array) {
+        for (int i = 0; i < 100; ++i) {
+            array[0] = array[0];
+            for (int j = 0; j < 10; ++j) {
+                for (int k = 0; k < 10; ++k) {
+                    f = 42;
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFlatArrayAliasesCardMark t = new TestFlatArrayAliasesCardMark();
+        Test0[] array = new Test0[] {new Test0()};
+        for (int l1 = 0; l1 < 10000; ++l1) {
+            t.method1(array);
+        }
+    }
+}


### PR DESCRIPTION
This is caused by a StoreCM whose OopStore doesn't point to a Store
node because it was optimized out but to a memory Phi. The Phi is for
slice TypeAryPtr::INLINES. When
Compile::adjust_flattened_array_access_aliases() runs, the
TypeAryPtr::INLINES slice becomes dead and is replaced by independent
slices for each field of flat array elements. Because the StoreCM
doesn't point to a Store, it's impossible to tell what slice it's for
so its input still points to the TypeAryPtr::INLINES Phi once
Compile::adjust_flattened_array_access_aliases() is over.

Given the TypeAryPtr::INLINES slice is dead that's a problem: assuming
we can end up with a StoreCM that points to a Phi for a non eliminated
Store (the Store would be behind the Phi I suppose in that case), then
after Compile::adjust_flattened_array_access_aliases() runs, the Store
would have moved to a new Phi but the StoreCM wouldn't have been
updated.

But that's not what causes the crash. The crash occurs because the
TypeAryPtr::INLINES memory subgraph is partially killed by
Compile::adjust_flattened_array_access_aliases() so when matching
occurs the Phi is only reachable through a precedence edge from the
StoreCM (final graph reshaping moves the OopStore input to precedence
edges). It's unreachable from root at matching time (because that code
doesn't follow precendence edge) and is not marked as shared
by Matcher::find_shared().

When Compile::adjust_flattened_array_access_aliases() runs, the
StoreCM OopStore is actually first set to a MergeMem node that
captures slices created for flat array fields but when
StoreCMNode::Ideal() executes it sets the input to the
TypeAryPtr::INLINES input of the MergeMem. I think that last steps is
what's incorrect after
Compile::adjust_flattened_array_access_aliases(). So I changed that
logic so it keeps the MergeMem input and also changed final graph
reshape so it adds as many precedence edges as there are flat field
inputs to the MergeMem. These changes are required to preserve
correctness, I believe.

With that, i still hit the assert because the bottom memory input to
the MergeMem can end up as a precedence edge to the StoreCM (if that
entry to the MergeMem is top). That bottom memory in the case of the
regression test is a Phi that was created by
Compile::adjust_flattened_array_access_aliases() and is usually
optimized out. It's only reachable from the StoreCM precedence edge. I
don't think there's a fundamental problem here so I change matching so
it looks at precedence edges when looking for shared node. I also had
to change node scheduling in a similar way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260363](https://bugs.openjdk.java.net/browse/JDK-8260363): [lworld] C2 compilation fails with assert(n->Opcode() != Op_Phi) failed: cannot match


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/317/head:pull/317`
`$ git checkout pull/317`
