### PR TITLE
8261021: [lworld] valhalla/valuetypes/LambdaConversion.java fails Illegal class name "QLambdaConversion$Pointer;"

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
  * @see LambdaMetafactory
  */
 /* package */ final class InnerClassLambdaMetafactory extends AbstractValidatingLambdaMetafactory {
-    private static final int CLASSFILE_VERSION = V16;
+    private static final int CLASSFILE_VERSION = V17;
     private static final String METHOD_DESCRIPTOR_VOID = Type.getMethodDescriptor(Type.VOID_TYPE);
     private static final String JAVA_LANG_OBJECT = "java/lang/Object";
     private static final String NAME_CTOR = "<init>";


### PR DESCRIPTION
Hi all,

Can I have a review of this trivial fix?

The root cause of this problem is similar to PR #320. As explained before, in short, the major version of the dynamically generated bytecode does not match the version required by ClassFileParser::verify_legal_class_name, resulting in a ClassFormatError.

Thanks,
Yang Yi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261021](https://bugs.openjdk.java.net/browse/JDK-8261021): [lworld] valhalla/valuetypes/LambdaConversion.java fails Illegal class name "QLambdaConversion$Pointer;"


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/321/head:pull/321`
`$ git checkout pull/321`
