### PR TITLE
8261037: [lworld] Assert during C2 compilation due to inconsistent JVMState at safepoint

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -196,8 +196,6 @@ int InlineTypeBaseNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node
   ciInlineKlass* vk = inline_klass();
   uint nfields = vk->nof_nonstatic_fields();
   JVMState* jvms = sfpt->jvms();
-  int start = jvms->debug_start();
-  int end   = jvms->debug_end();
   // Replace safepoint edge by SafePointScalarObjectNode and add field values
   assert(jvms != NULL, "missing JVMS");
   uint first_ind = (sfpt->req() - jvms->scloff());
@@ -221,7 +219,7 @@ int InlineTypeBaseNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node
   jvms->set_endoff(sfpt->req());
   sobj = igvn->transform(sobj)->as_SafePointScalarObject();
   igvn->rehash_node_delayed(sfpt);
-  return sfpt->replace_edges_in_range(this, sobj, start, end);
+  return sfpt->replace_edges_in_range(this, sobj, jvms->debug_start(), jvms->debug_end());
 }
 
 void InlineTypeBaseNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -217,7 +217,6 @@ public abstract class InlineTypeTest {
     protected static final String COUNTEDLOOP = START + "CountedLoop\\b" + MID + "" + END;
     protected static final String COUNTEDLOOP_MAIN = START + "CountedLoop\\b" + MID + "main" + END;
     protected static final String TRAP   = START + "CallStaticJava" + MID + "uncommon_trap.*(unstable_if|predicate)" + END;
-    protected static final String RETURN = START + "Return" + MID + "returns" + END;
     protected static final String LINKTOSTATIC = START + "CallStaticJava" + MID + "linkToStatic" + END;
     protected static final String NPE = START + "CallStaticJava" + MID + "null_check" + END;
     protected static final String CALL = START + "CallStaticJava" + MID + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283
+ * @bug 8260034 8260225 8260283 8261037
  * @summary Generated inline type tests.
  * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestGenerated
  */
@@ -37,6 +37,12 @@ inline class EmptyValue {
 inline class MyValue1 {
     int x = 42;
     int[] array = new int[1];
+}
+
+inline class MyValue2 {
+    int[] a = new int[1];
+    int[] b = new int[6];
+    int[] c = new int[5];
 }
 
 public class TestGenerated {
@@ -89,6 +95,29 @@ public class TestGenerated {
         }
     }
 
+    MyValue2 f5;
+
+    void test7(boolean b) {
+        MyValue2[] array1 = {new MyValue2(), new MyValue2(), new MyValue2(),
+                             new MyValue2(), new MyValue2(), new MyValue2()};
+        MyValue2 h = new MyValue2();
+        MyValue2 n = new MyValue2();
+        int[] array2 = new int[1];
+
+        for (int i = 0; i < 10; ++i) {
+          for (int j = 0; j < 10; ++j) {
+            array1[0] = array1[0];
+            if (i == 1) {
+              h = h;
+              array2[0] *= 42;
+            }
+          }
+        }
+        if (b) {
+          f5 = n;
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -102,6 +131,7 @@ public class TestGenerated {
             t.test4(array3);
             t.test5(array3);
             t.test6();
+            t.test7(false);
         }
     }
 }


### PR DESCRIPTION
We assert when scalarizing an inline type in a safepoint because `debug_end()` (-> `_endoff`) of the attached `JVMState` is larger than `SafePointNode::_max`. I don't think JVMStates should be shared between safepoint nodes and I intend to fix this in mainline with [JDK-8261158](https://bugs.openjdk.java.net/browse/JDK-8261158).

Gory details:
In `PhaseIdealLoop::is_counted_loop`, we `// Check for immediately preceding SafePoint and remove` by cloning _SafePointNode1_ to _SafePointNode2_ without cloning the attached _JVMState_. Loop unswitching then clones the loop and therefore also clones _SafePointNode2_ to _SafePointNode3_, again without cloning the _JVMState_. All three safepoint nodes now share the same _JVMState_. An inline type is scalarized in _SafePointNode2_, increasing _JVMState_`::_endoff` to account for the fields. Once another inline type is scalarized in _SafePointNode3_,  _JVMState_`::_endoff ` is out of bounds of _SafePointNode3_`::_max`.

This fix refactors the code (which also serves as workaround because we now access `debug_end()` only after we updated it to the correct value for the current safepoint) and adds a regression test.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261037](https://bugs.openjdk.java.net/browse/JDK-8261037): [lworld] Assert during C2 compilation due to inconsistent JVMState at safepoint


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/322/head:pull/322`
`$ git checkout pull/322`
