### PR TITLE
8261226: [lworld] Array access profiling should be disabled at compilation level 1 and 2

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3120,6 +3120,7 @@ void LIRGenerator::profile_flags(ciMethodData* md, ciProfileData* data, int flag
 }
 
 void LIRGenerator::profile_null_free_array(LIRItem array, ciMethodData* md, ciArrayLoadStoreData* load_store) {
+  assert(compilation()->profile_array_accesses(), "array access profiling is disabled");
   LabelObj* L_end = new LabelObj();
   LIR_Opr tmp = new_register(T_METADATA);
   __ check_null_free_array(array.result(), tmp);
@@ -3128,6 +3129,7 @@ void LIRGenerator::profile_null_free_array(LIRItem array, ciMethodData* md, ciAr
 }
 
 void LIRGenerator::profile_array_type(AccessIndexed* x, ciMethodData*& md, ciArrayLoadStoreData*& load_store) {
+  assert(compilation()->profile_array_accesses(), "array access profiling is disabled");
   int bci = x->profiled_bci();
   md = x->profiled_method()->method_data();
   assert(md != NULL, "Sanity");
@@ -3140,12 +3142,12 @@ void LIRGenerator::profile_array_type(AccessIndexed* x, ciMethodData*& md, ciArr
 }
 
 void LIRGenerator::profile_element_type(Value element, ciMethodData* md, ciArrayLoadStoreData* load_store) {
+  assert(compilation()->profile_array_accesses(), "array access profiling is disabled");
   assert(md != NULL && load_store != NULL, "should have been initialized");
   LIR_Opr mdp = LIR_OprFact::illegalOpr;
   profile_type(md, md->byte_offset_of_slot(load_store, ArrayLoadStoreData::element_offset()), 0,
                load_store->element()->type(), element, mdp, false, NULL, NULL);
 }
-
 
 void LIRGenerator::do_Base(Base* x) {
   __ std_entry(LIR_OprFact::illegalOpr);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -465,6 +465,10 @@ static void profile_flat_array(JavaThread* thread) {
   ResourceMark rm(thread);
   vframeStream vfst(thread, true);
   assert(!vfst.at_end(), "Java frame must exist");
+  // Check if array access profiling is enabled
+  if (vfst.nm()->comp_level() != CompLevel_full_profile || !C1UpdateMethodData) {
+    return;
+  }
   int bci = vfst.bci();
   Method* method = vfst.method();
   MethodData* md = method->method_data();


### PR DESCRIPTION
C1 compilations at level 1 and 2 should not profile array accesses.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261226](https://bugs.openjdk.java.net/browse/JDK-8261226): [lworld] Array access profiling should be disabled at compilation level 1 and 2


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/323/head:pull/323`
`$ git checkout pull/323`
