### PR TITLE
8261264: [lworld] runtime/valhalla/inlinetypes tests fail to compile

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class Ifacmp {
     }
 
     boolean shouldEqualSelf(Object a) {
-        return acmpModeInlineAlwaysFalse ? (!(a != null && a.getClass().isInlineClass())) : true;
+        return acmpModeInlineAlwaysFalse ? (!(a != null && a.getClass().isPrimitiveClass())) : true;
     }
 
     void checkEqual(Object a, Object b, boolean isEqual) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,7 +289,7 @@ public class InlineTypeArray {
         assertTrue(myInts instanceof MyInt.ref[]);
 
         Class<?> cls = MyInt.class;
-        assertTrue(cls.isInlineClass());
+        assertTrue(cls.isPrimitiveClass());
         Object arrObj = Array.newInstance(cls, 1);
         assertTrue(arrObj instanceof Object[], "Not Object array");
         assertTrue(arrObj instanceof Comparable[], "Not Comparable array");


### PR DESCRIPTION
Please review this small fix to have runtime/valhalla tests call method Class.isPrimitiveClass() instead of Class.isInlineClass().

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261264](https://bugs.openjdk.java.net/browse/JDK-8261264): [lworld] runtime/valhalla/inlinetypes tests fail to compile


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/324/head:pull/324`
`$ git checkout pull/324`
