### PR TITLE
8260870: [type-restrictions] Generate RestrictedMethod attributes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -152,6 +152,7 @@ public class Names {
     public final Name NestMembers;
     public final Name Record;
     public final Name RestrictedField;
+    public final Name RestrictedMethod;
     public final Name RuntimeInvisibleAnnotations;
     public final Name RuntimeInvisibleParameterAnnotations;
     public final Name RuntimeInvisibleTypeAnnotations;
@@ -339,6 +340,7 @@ public class Names {
         NestMembers = fromString("NestMembers");
         Record = fromString("Record");
         RestrictedField = fromString("RestrictedField");
+        RestrictedMethod = fromString("RestrictedMethod");
         RuntimeInvisibleAnnotations = fromString("RuntimeInvisibleAnnotations");
         RuntimeInvisibleParameterAnnotations = fromString("RuntimeInvisibleParameterAnnotations");
         RuntimeInvisibleTypeAnnotations = fromString("RuntimeInvisibleTypeAnnotations");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -62,6 +62,7 @@ public abstract class Attribute {
     public static final String NestMembers              = "NestMembers";
     public static final String Record                   = "Record";
     public static final String RestrictedField          = "RestrictedField";
+    public static final String RestrictedMethod          = "RestrictedMethod";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
     public static final String RuntimeInvisibleAnnotations = "RuntimeInvisibleAnnotations";
     public static final String RuntimeVisibleParameterAnnotations = "RuntimeVisibleParameterAnnotations";
@@ -139,6 +140,7 @@ public abstract class Attribute {
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
             standardAttributes.put(RestrictedField, RestrictedField_attribute.class);
+            standardAttributes.put(RestrictedMethod, RestrictedMethod_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
             standardAttributes.put(RuntimeInvisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations_attribute.class);
             standardAttributes.put(RuntimeVisibleAnnotations, RuntimeVisibleAnnotations_attribute.class);
@@ -207,6 +209,7 @@ public abstract class Attribute {
         R visitNestMembers(NestMembers_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
         R visitRestrictedField(RestrictedField_attribute attr, P p);
+        R visitRestrictedMethod(RestrictedMethod_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);
         R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p);
         R visitRuntimeVisibleParameterAnnotations(RuntimeVisibleParameterAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -662,6 +662,16 @@ public class ClassWriter {
         }
 
         @Override
+        public Void visitRestrictedMethod(RestrictedMethod_attribute attr, ClassOutputStream out) {
+            out.writeByte(attr.num_params);
+            for (int i = 0; i < attr.num_params; i++) {
+                out.writeShort(attr.restricted_param_type[i]);
+            }
+            out.writeShort(attr.restricted_return_type);
+            return null;
+        }
+
+        @Override
         public Void visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, ClassOutputStream out) {
             annotationWriter.write(attr.annotations, out);
             return null;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedMethod_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/RestrictedMethod_attribute.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+
+public class RestrictedMethod_attribute extends Attribute {
+
+    RestrictedMethod_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        num_params = cr.readUnsignedByte();
+        restricted_param_type = new int [num_params];
+        for (int i = 0; i < num_params; i++) {
+            restricted_param_type[i] = cr.readUnsignedShort();
+        }
+        restricted_return_type = cr.readUnsignedShort();
+    }
+
+    @Override
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitRestrictedMethod(this, data);
+    }
+
+    public int getParameterCount() {
+        return num_params;
+    }
+
+    public int getRestrictedParameterType(int i) {
+        return restricted_param_type[i];
+    }
+
+    public int getRestrictedReturnType() {
+        return restricted_return_type;
+    }
+
+    int num_params;
+    int restricted_param_type[];
+    int restricted_return_type;
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -62,6 +62,7 @@ import com.sun.tools.classfile.NestHost_attribute;
 import com.sun.tools.classfile.NestMembers_attribute;
 import com.sun.tools.classfile.Record_attribute;
 import com.sun.tools.classfile.RestrictedField_attribute;
+import com.sun.tools.classfile.RestrictedMethod_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleParameterAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleTypeAnnotations_attribute;
@@ -816,6 +817,31 @@ public class AttributeWriter extends BasicWriter
             print(item);
             print(" ");
         }
+    }
+
+    @Override
+    public Void visitRestrictedMethod(RestrictedMethod_attribute attr, Void aVoid) {
+        print("RestrictedMethod: (");
+        int tidx;
+        String type;
+        String unrestricted = "<unrestricted>";
+        for (int i = 0, count = attr.getParameterCount(); i < count; i++) {
+            tidx = attr.getRestrictedParameterType(i);
+            try {
+                type = tidx == 0 ? unrestricted : constant_pool.getUTF8Value(tidx);
+            } catch (ConstantPoolException e) {
+                    type = report(e);
+            }
+            print((i == 0 ? "" : ", ") + "#" + tidx + " " + type);
+        }
+        tidx = attr.getRestrictedReturnType();
+        try {
+            type = tidx == 0 ? unrestricted : constant_pool.getUTF8Value(tidx);
+        } catch (ConstantPoolException e) {
+            type = report(e);
+        }
+        println(")#" + tidx + " " + type);
+        return null;
     }
 
     @Override

--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1376,6 +1376,11 @@ public class ClassfileInspector {
         public Void visitRestrictedField(RestrictedField_attribute attr, T p) {
             return null;
         }
+
+        @Override
+        public Void visitRestrictedMethod(RestrictedMethod_attribute attr, T p) {
+            return null;
+        }
     }
 
     private static final Attribute.Visitor<Void, ExpectedTypeAnnotation> typeAnnoMatcher

--- a/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
+++ b/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
@@ -67,4 +67,5 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitPermittedSubclasses(PermittedSubclasses_attribute attr, P p) { return null; }
     public R visitRecord(Record_attribute attr, P p) { return null; }
     public R visitRestrictedField(RestrictedField_attribute attr, P p) { return null; }
+    public R visitRestrictedMethod(RestrictedMethod_attribute attr, P p) { return null; }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/AnnotatedRestrictedMethodTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AnnotatedRestrictedMethodTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8260870
+ * @summary Generate RestrictedMethod attributes from annotations
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @run main AnnotatedRestrictedMethodTest
+ */
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
+
+import java.lang.invoke.RestrictedType;
+
+public class AnnotatedRestrictedMethodTest {
+
+    inline class Point {}
+    inline class Line {}
+
+    Point foo(int x, Point p, int y, Line l) {
+        return p;
+    }
+
+    @RestrictedType("QAnnotatedRestrictedMethodTest$Point;")
+    Object goo(int x,
+               @RestrictedType("QAnnotatedRestrictedMethodTest$Point;") Object p,
+               int y,
+               @RestrictedType("QAnnotatedRestrictedMethodTest$Line;") Object l) {
+        return p;
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(AnnotatedRestrictedMethodTest.class.getResourceAsStream("AnnotatedRestrictedMethodTest.class"));
+
+        for (Method meth: cls.methods) {
+            if (meth.getName(cls.constant_pool).equals("foo")) {
+                String desc = meth.descriptor.getValue(cls.constant_pool);
+                if (!desc.equals("(IQAnnotatedRestrictedMethodTest$Point;IQAnnotatedRestrictedMethodTest$Line;)QAnnotatedRestrictedMethodTest$Point;"))
+                    throw new AssertionError("Unexpected descriptor for method");
+                RestrictedMethod_attribute rma =
+                    (RestrictedMethod_attribute) meth.attributes.get(Attribute.RestrictedMethod);
+                if (rma != null) {
+                    throw new AssertionError("Unexpected restricted method attribute");
+                }
+            } else if (meth.getName(cls.constant_pool).equals("goo")) {
+                String desc = meth.descriptor.getValue(cls.constant_pool);
+                if (!desc.equals("(ILjava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;"))
+                    throw new AssertionError("Unexpected descriptor for method " + desc);
+                RestrictedMethod_attribute rma =
+                    (RestrictedMethod_attribute) meth.attributes.get(Attribute.RestrictedMethod);
+                if (rma == null) {
+                    throw new AssertionError("Missing restricted method attribute");
+                }
+
+                if (rma.getParameterCount() != 4) {
+                    throw new AssertionError("Wrong parameter count");
+                }
+                int typeindex;
+                String type;
+                for (int i = 0; i < 4; i++) {
+                    typeindex = rma.getRestrictedParameterType(i);
+                    switch(i) {
+                        case 0:
+                        case 2:
+                            if (typeindex != 0) {
+                                throw new AssertionError("Unexpected type restriction");
+                            }
+                            break;
+                        case 1:
+                            if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QAnnotatedRestrictedMethodTest$Point;")) {
+                                throw new AssertionError("Unexpected type restriction " + type);
+                            }
+                            break;
+                        case 3:
+                            if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QAnnotatedRestrictedMethodTest$Line;")) {
+                                throw new AssertionError("Unexpected type restriction " + type);
+                            }
+                            break;
+                    }
+                }
+                typeindex = rma.getRestrictedReturnType();
+                if (typeindex == 0) {
+                    throw new AssertionError("Missing type restriction");
+                }
+                if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QAnnotatedRestrictedMethodTest$Point;")) {
+                    throw new AssertionError("Unexpected type restriction " + type);
+                }
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/FlaggedRestrictedMethodTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/FlaggedRestrictedMethodTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8260870
+ * @summary Generate RestrictedMethod attributes triggered via compile time flag
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile -XDflattenWithTypeRestrictions FlaggedRestrictedMethodTest.java
+ * @run main FlaggedRestrictedMethodTest
+ */
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
+
+import java.lang.invoke.RestrictedType;
+
+public class FlaggedRestrictedMethodTest {
+
+    inline class Point {}
+    inline class Line {}
+
+    static Point foo(int x, Point p, int y, Line l) {
+        return p;
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(FlaggedRestrictedMethodTest.class.getResourceAsStream("FlaggedRestrictedMethodTest.class"));
+
+        for (Method meth: cls.methods) {
+            if (meth.getName(cls.constant_pool).equals("foo")) {
+                String desc = meth.descriptor.getValue(cls.constant_pool);
+                if (!desc.equals("(ILFlaggedRestrictedMethodTest$Point$ref;ILFlaggedRestrictedMethodTest$Line$ref;)LFlaggedRestrictedMethodTest$Point$ref;"))
+                    throw new AssertionError("Unexpected descriptor for method" + desc);
+                RestrictedMethod_attribute rma =
+                    (RestrictedMethod_attribute) meth.attributes.get(Attribute.RestrictedMethod);
+                if (rma == null) {
+                    throw new AssertionError("Missing restricted method attribute");
+                }
+
+                if (rma.getParameterCount() != 4) {
+                    throw new AssertionError("Wrong parameter count");
+                }
+                int typeindex;
+                String type;
+                for (int i = 0; i < 4; i++) {
+                    typeindex = rma.getRestrictedParameterType(i);
+                    switch(i) {
+                        case 0:
+                        case 2:
+                            if (typeindex != 0) {
+                                throw new AssertionError("Unexpected type restriction");
+                            }
+                            break;
+                        case 1:
+                            if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QFlaggedRestrictedMethodTest$Point;")) {
+                                throw new AssertionError("Unexpected type restriction " + type);
+                            }
+                            break;
+                        case 3:
+                            if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QFlaggedRestrictedMethodTest$Line;")) {
+                                throw new AssertionError("Unexpected type restriction " + type);
+                            }
+                            break;
+                    }
+                }
+                typeindex = rma.getRestrictedReturnType();
+                if (typeindex == 0) {
+                    throw new AssertionError("Missing type restriction");
+                }
+                if (!(type = cls.constant_pool.getUTF8Value(typeindex)).equals("QFlaggedRestrictedMethodTest$Point;")) {
+                    throw new AssertionError("Unexpected type restriction " + type);
+                }
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedMethodTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedMethodTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8260870
+ * @summary Flatten with type restrictions separate compilation test
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile -XDflattenWithTypeRestrictions FlaggedRestrictedMethodTest.java
+ * @compile/fail/ref=RestrictedMethodTest.out -XDrawDiagnostics -XDflattenWithTypeRestrictions RestrictedMethodTest.java
+ */
+
+public class RestrictedMethodTest {
+
+    public static void main(String[] args) throws Exception {
+        FlaggedRestrictedMethodTest.foo(10, null, 20, null);
+        FlaggedRestrictedMethodTest.foo(10, new FlaggedRestrictedMethodTest.Point(), 20, null);
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RestrictedMethodTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RestrictedMethodTest.out
@@ -1,0 +1,4 @@
+RestrictedMethodTest.java:38:36: compiler.err.cant.apply.symbol: kindname.method, foo, int,FlaggedRestrictedMethodTest.Point,int,FlaggedRestrictedMethodTest.Line, int,compiler.misc.type.null,int,compiler.misc.type.null, kindname.class, FlaggedRestrictedMethodTest, (compiler.misc.no.conforming.assignment.exists: (compiler.misc.inconvertible.types: compiler.misc.type.null, FlaggedRestrictedMethodTest.Point))
+RestrictedMethodTest.java:39:45: compiler.err.encl.class.required: FlaggedRestrictedMethodTest.Point
+RestrictedMethodTest.java:39:36: compiler.err.cant.apply.symbol: kindname.method, foo, int,FlaggedRestrictedMethodTest.Point,int,FlaggedRestrictedMethodTest.Line, int,FlaggedRestrictedMethodTest.Point,int,compiler.misc.type.null, kindname.class, FlaggedRestrictedMethodTest, (compiler.misc.no.conforming.assignment.exists: (compiler.misc.inconvertible.types: compiler.misc.type.null, FlaggedRestrictedMethodTest.Line))
+3 errors


### PR DESCRIPTION
Support for generation of RestrictedMethod attribute both via command line option and type annotations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260870](https://bugs.openjdk.java.net/browse/JDK-8260870): [type-restrictions] Generate RestrictedMethod attributes


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/325/head:pull/325`
`$ git checkout pull/325`
