### PR TITLE
8241894: [lworld] crash in ZGC running InlineOops.java#id3

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -298,14 +298,14 @@ public class InlineOops {
 
         // Sanity check, FixMe need more test cases
         objects = testFrameOops(couple);
-        //assertTrue(objects.length == 5, "Number of frame oops incorrect = " + objects.length);
-        //assertTrue(objects[0] == couple, "Bad oop 0");
-        //assertTrue(objects[1] == fn1, "Bad oop 1");
-        //assertTrue(objects[2] == ln1, "Bad oop 2");
-        //assertTrue(objects[3] == TEST_STRING1, "Bad oop 3");
-        //assertTrue(objects[4] == TEST_STRING2, "Bad oop 4");
+        assertTrue(objects.length == 5, "Number of frame oops incorrect = " + objects.length);
+        assertTrue(objects[0] == couple, "Bad oop 0");
+        assertTrue(objects[1] == fn1, "Bad oop 1");
+        assertTrue(objects[2] == ln1, "Bad oop 2");
+        assertTrue(objects[3] == TEST_STRING1, "Bad oop 3");
+        assertTrue(objects[4] == TEST_STRING2, "Bad oop 4");
 
-        //testFrameOopsVBytecodes();
+        testFrameOopsVBytecodes();
     }
 
     static final String GET_OOP_MAP_NAME = "getOopMap";


### PR DESCRIPTION
Remove raw oop load from CollectOops::do_oop()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8241894](https://bugs.openjdk.java.net/browse/JDK-8241894): [lworld] crash in ZGC running InlineOops.java#id3


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/327/head:pull/327`
`$ git checkout pull/327`
