### PR TITLE
8261393: [lworld] Adopt `primitive' as the modifier in declaration of identity free classes in lieu of `inline`

### DIFF
--- a/src/java.base/share/classes/java/lang/__primitive__.java
+++ b/src/java.base/share/classes/java/lang/__primitive__.java
@@ -29,12 +29,12 @@ import java.lang.annotation.*;
 import static java.lang.annotation.ElementType.*;
 
 /**
- * A class annotated {@code @__inline__} is an inline class.
- * This is a temporary workaround to enable use of inline types
- * in editors and IDEs that do not yet understand the 'inline' modifier.
- * @since 1.12
+ * A class annotated {@code @__primitive__} is a primitive class.
+ * This is a temporary workaround to enable use of primitive classes
+ * in editors and IDEs that do not yet understand the 'primitive' modifier.
+ * @since 1.16
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(value={ElementType.TYPE, ElementType.TYPE_USE})
-public @interface __inline__ {
+public @interface __primitive__ {
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2675,7 +2675,7 @@ public class JavacParser implements Parser {
         case CONTINUE: case SEMI: case ELSE: case FINALLY: case CATCH:
         case ASSERT:
             return List.of(parseSimpleStatement());
-        case VALUE:
+        case PRIMITIVE:
         case MONKEYS_AT:
         case FINAL: {
             dc = token.comment(CommentStyle.JAVADOC);
@@ -3210,7 +3210,7 @@ public class JavacParser implements Parser {
             case FINAL       : flag = Flags.FINAL; break;
             case ABSTRACT    : flag = Flags.ABSTRACT; break;
             case NATIVE      : flag = Flags.NATIVE; break;
-            case VALUE       : flag = Flags.VALUE; break;
+            case PRIMITIVE   : flag = Flags.VALUE; break;
             case VOLATILE    : flag = Flags.VOLATILE; break;
             case SYNCHRONIZED: flag = Flags.SYNCHRONIZED; break;
             case STRICTFP    : flag = Flags.STRICTFP; break;
@@ -3243,7 +3243,7 @@ public class JavacParser implements Parser {
                     if (flags == 0 && annotations.isEmpty())
                         pos = ann.pos;
                     final Name name = TreeInfo.name(ann.annotationType);
-                    if (name == names.__inline__ || name == names.java_lang___inline__) {
+                    if (name == names.__primitive__ || name == names.java_lang___primitive__) {
                         flag = Flags.VALUE;
                     } else {
                         annotations.append(ann);
@@ -3458,9 +3458,9 @@ public class JavacParser implements Parser {
         return result;
     }
 
-    // Does the given token signal an inline modifier ? If yes, suitably reclassify token.
+    // Does the given token signal a primitive modifier ? If yes, suitably reclassify token.
     Token recastToken(Token token) {
-        if (token.kind != IDENTIFIER || token.name() != names.inline) {
+        if (token.kind != IDENTIFIER || token.name() != names.primitive) {
             return token;
         }
         if (peekToken(t->t == PRIVATE ||
@@ -3489,7 +3489,7 @@ public class JavacParser implements Parser {
                          t == ENUM ||
                          t == IDENTIFIER)) { // new value Comparable() {}
             checkSourceLevel(Feature.INLINE_TYPES);
-            return new Token(VALUE, token.pos, token.endPos, token.comments);
+            return new Token(PRIMITIVE, token.pos, token.endPos, token.comments);
         }
         return token;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -141,7 +141,7 @@ public class Tokens {
         THROWS("throws"),
         TRANSIENT("transient"),
         TRY("try"),
-        VALUE(), // a phantom token never returned by the scanner, but can result from a reclassification by the parser.
+        PRIMITIVE(), // a phantom token never returned by the scanner, but can result from a reclassification by the parser.
         VOID("void", Tag.NAMED),
         VOLATILE("volatile"),
         WHILE("while"),
@@ -246,8 +246,8 @@ public class Tokens {
                 return "token.double";
             case ERROR:
                 return "token.bad-symbol";
-            case VALUE:
-                return "value";
+            case PRIMITIVE:
+                return "primitive";
             case EOF:
                 return "token.end-of-input";
             case DOT: case COMMA: case SEMI: case LPAREN: case RPAREN:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -100,7 +100,7 @@ public class Names {
     public final Name serialVersionUID;
     public final Name toString;
     public final Name value;
-    public final Name inline;
+    public final Name primitive;
     public final Name valueOf;
     public final Name values;
     public final Name readResolve;
@@ -113,8 +113,8 @@ public class Names {
     public final Name java_lang_Enum;
     public final Name java_lang_Object;
     public final Name java_lang_System;
-    public final Name __inline__;
-    public final Name java_lang___inline__;
+    public final Name __primitive__;
+    public final Name java_lang___primitive__;
     public final Name java_lang_IdentityObject;
 
     // names of builtin classes
@@ -285,7 +285,7 @@ public class Names {
         serialVersionUID = fromString("serialVersionUID");
         toString = fromString("toString");
         value = fromString("value");
-        inline = fromString("inline");
+        primitive = fromString("primitive");
         valueOf = fromString("valueOf");
         values = fromString("values");
         readResolve = fromString("readResolve");
@@ -299,8 +299,8 @@ public class Names {
         java_lang_Enum = fromString("java.lang.Enum");
         java_lang_Object = fromString("java.lang.Object");
         java_lang_System = fromString("java.lang.System");
-        __inline__ = fromString("__inline__");
-        java_lang___inline__ = fromString("java.lang.__inline__");
+        __primitive__ = fromString("__primitive__");
+        java_lang___primitive__ = fromString("java.lang.__primitive__");
         java_lang_IdentityObject = fromString("java.lang.IdentityObject");
 
         // names of builtin classes

--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -230,7 +230,7 @@ class CompletenessAnalyzer {
         PUBLIC(TokenKind.PUBLIC, XDECL1 | XMODIFIER),  //  public
         TRANSIENT(TokenKind.TRANSIENT, XDECL1 | XMODIFIER),  //  transient
         VOLATILE(TokenKind.VOLATILE, XDECL1 | XMODIFIER),  //  volatile
-        VALUE(TokenKind.VALUE, 0),
+        PRIMITIVE(TokenKind.PRIMITIVE, 0),
 
         // Declarations and type parameters (thus expressions)
         EXTENDS(TokenKind.EXTENDS, XEXPR|XDECL),  //  extends

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue1.java
@@ -23,7 +23,7 @@
 
 package compiler.valhalla.inlinetypes;
 
-public final inline class MyValue1 extends MyAbstract {
+public final primitive class MyValue1 extends MyAbstract {
     static int s;
     static final long sf = InlineTypeTest.rL;
     final int x;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue2.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue2.java
@@ -23,7 +23,7 @@
 
 package compiler.valhalla.inlinetypes;
 
-final inline class MyValue2Inline {
+final primitive class MyValue2Inline {
     final double d;
     final long l;
 
@@ -57,7 +57,7 @@ final inline class MyValue2Inline {
     }
 }
 
-public final inline class MyValue2 extends MyAbstract {
+public final primitive class MyValue2 extends MyAbstract {
     final int x;
     final byte y;
     final MyValue2Inline v;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue3.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue3.java
@@ -26,7 +26,7 @@ package compiler.valhalla.inlinetypes;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
 
-final inline class MyValue3Inline {
+final primitive class MyValue3Inline {
     final float f7;
     final double f8;
 
@@ -62,7 +62,7 @@ final inline class MyValue3Inline {
 
 // Inline type definition to stress test return of an inline type in registers
 // (uses all registers of calling convention on x86_64)
-public final inline class MyValue3 extends MyAbstract {
+public final primitive class MyValue3 extends MyAbstract {
     final char c;
     final byte bb;
     final short s;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue4.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValue4.java
@@ -24,7 +24,7 @@
 package compiler.valhalla.inlinetypes;
 
 // Inline type definition with too many fields to return in registers
-final inline class MyValue4 extends MyAbstract {
+final primitive class MyValue4 extends MyAbstract {
     final MyValue3 v1;
     final MyValue3 v2;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValueEmpty.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValueEmpty.java
@@ -23,7 +23,7 @@
 
 package compiler.valhalla.inlinetypes;
 
-public final inline class MyValueEmpty extends MyAbstract {
+public final primitive class MyValueEmpty extends MyAbstract {
     public long hash() { return 0; }
 
     public MyValueEmpty copy(MyValueEmpty other) { return other; }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/Point.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/Point.java
@@ -23,7 +23,7 @@
 
 package compiler.valhalla.inlinetypes;
 
-public inline class Point {
+public primitive class Point {
     int x = 4;
     int y = 7;
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/Rectangle.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/Rectangle.java
@@ -23,7 +23,7 @@
 
 package compiler.valhalla.inlinetypes;
 
-public inline class Rectangle {
+public primitive class Rectangle {
     Point p0 = new Point();
     Point p1 = new Point();
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/SimpleInlineType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/SimpleInlineType.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-final inline class SimpleInlineType {
+final primitive class SimpleInlineType {
     final int x;
 
     private SimpleInlineType() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -33,7 +33,7 @@ import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
-final inline class MyValue1 {
+final primitive class MyValue1 {
     public final int x = 0;
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
@@ -49,7 +49,7 @@ public class TestArrayCopyWithOops {
         long val = Integer.MAX_VALUE;
     }
 
-    static inline class ManyOops {
+    static primitive class ManyOops {
         MyObject o1 = new MyObject();
         MyObject o2 = new MyObject();
         MyObject o3 = new MyObject();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -1865,7 +1865,7 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEquals(result, i);
     }
 
-    inline static class NotFlattenable {
+    primitive static class NotFlattenable {
         private final Object o1 = null;
         private final Object o2 = null;
         private final Object o3 = null;
@@ -2162,7 +2162,7 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEQ(test90(), true);
     }
 
-    inline static final class Test91Value {
+    primitive static final class Test91Value {
         public final int f0;
         public final int f1;
         public final int f2;
@@ -3014,7 +3014,7 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEquals(empty, MyValueEmpty.default);
     }
 
-    static inline class EmptyContainer {
+    static primitive class EmptyContainer {
         MyValueEmpty empty = MyValueEmpty.default;
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -786,12 +786,12 @@ public class TestBasicFunctionality extends InlineTypeTest {
     }
 
     // Test correct loading of flattened fields
-    inline class Test37Value2 {
+    primitive class Test37Value2 {
         final int x = 0;
         final int y = 0;
     }
 
-    inline class Test37Value1 {
+    primitive class Test37Value1 {
         final double d = 0;
         final float f = 0;
         final Test37Value2 v = new Test37Value2();
@@ -809,7 +809,7 @@ public class TestBasicFunctionality extends InlineTypeTest {
     }
 
     // Test elimination of inline type allocations without a unique CheckCastPP
-    inline class Test38Value {
+    primitive class Test38Value {
         public int i;
         public Test38Value(int i) { this.i = i; }
     }
@@ -836,7 +836,7 @@ public class TestBasicFunctionality extends InlineTypeTest {
     }
 
     // Tests split if with inline type Phi users
-    static inline class Test39Value {
+    static primitive class Test39Value {
         public int iFld1;
         public int iFld2;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBimorphicInlining.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBimorphicInlining.java
@@ -47,7 +47,7 @@ interface MyInterface {
     public MyInterface hash(MyInterface arg);
 }
 
-inline final class TestValue1 implements MyInterface {
+primitive final class TestValue1 implements MyInterface {
     final int x;
 
     public TestValue1(int x) {
@@ -59,7 +59,7 @@ inline final class TestValue1 implements MyInterface {
     }
 }
 
-inline final class TestValue2 implements MyInterface {
+primitive final class TestValue2 implements MyInterface {
     final int x;
 
     public TestValue2(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
@@ -54,7 +54,7 @@ import jdk.internal.misc.Unsafe;
  *                   compiler.valhalla.inlinetypes.TestBufferTearing
  */
 
-inline class MyValue {
+primitive class MyValue {
     int x;
     int y;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -106,7 +106,7 @@ public class TestC1 extends InlineTypeTest {
         Asserts.assertEQ(r2, 0x1234567812345678L);
     }
 
-    static inline class SimpleValue2 {
+    static primitive class SimpleValue2 {
         final int value;
         SimpleValue2(int value) {
             this.value = value;
@@ -207,7 +207,7 @@ public class TestC1 extends InlineTypeTest {
     }
 
     // Test 1st level sub-element access to non-flattened field
-    static inline class Big {
+    static primitive class Big {
         long l0,l1,l2,l3,l4,l5,l6,l7,l8,l9,l10,l11,l12,l13,l14,l15,l16,l17,l18,l19 ;
 
         Big(long n) {
@@ -240,7 +240,7 @@ public class TestC1 extends InlineTypeTest {
         }
     }
 
-    static inline class TestValue {
+    static primitive class TestValue {
         int i;
         Big big;
 
@@ -288,7 +288,7 @@ public class TestC1 extends InlineTypeTest {
     // (read/write are not performed, pre-allocated instance is used for reads)
     // Most tests check that error conditions are still correctly handled
     // (OOB, null pointer)
-    static inline class EmptyType {}
+    static primitive class EmptyType {}
 
     @Test(compLevel=C1)
     public EmptyType test9() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC2CCalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC2CCalls.java
@@ -66,7 +66,7 @@ public class TestC2CCalls {
     public static final int COMP_LEVEL_FULL_OPTIMIZATION = 4; // C2 or JVMCI
     public static final int rI = Utils.getRandomInstance().nextInt() % 1000;
 
-    static inline class OtherVal {
+    static primitive class OtherVal {
         public final int x;
 
         private OtherVal(int x) {
@@ -89,7 +89,7 @@ public class TestC2CCalls {
         public int getValue();
     }
 
-    static inline class MyValue1 implements MyInterface1 {
+    static primitive class MyValue1 implements MyInterface1 {
         public final int x;
 
         private MyValue1(int x) {
@@ -155,7 +155,7 @@ public class TestC2CCalls {
         }
     }
 
-    static inline class MyValue2 implements MyInterface1 {
+    static primitive class MyValue2 implements MyInterface1 {
         public final int x;
 
         private MyValue2(int x) {
@@ -221,7 +221,7 @@ public class TestC2CCalls {
         }
     }
 
-    static inline class MyValue3 implements MyInterface1 {
+    static primitive class MyValue3 implements MyInterface1 {
         public final double d1;
         public final double d2;
         public final double d3;
@@ -271,7 +271,7 @@ public class TestC2CCalls {
         }
     }
 
-    static inline class MyValue4 implements MyInterface1 {
+    static primitive class MyValue4 implements MyInterface1 {
         public final int x1;
         public final int x2;
         public final int x3;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -456,7 +456,7 @@ public class TestCallingConvention extends InlineTypeTest {
     }
 
     // Test calling a method that has circular register/stack dependencies when unpacking inline type arguments
-    inline class TestValue23 {
+    primitive class TestValue23 {
         final double f1;
         TestValue23(double val) {
             f1 = val;
@@ -528,7 +528,7 @@ public class TestCallingConvention extends InlineTypeTest {
     }
 
     // Test calling convention with deep hierarchy of flattened fields
-    final inline class Test27Value1 {
+    final primitive class Test27Value1 {
         final Test27Value2 valueField;
 
         private Test27Value1(Test27Value2 val2) {
@@ -541,7 +541,7 @@ public class TestCallingConvention extends InlineTypeTest {
         }
     }
 
-    final inline class Test27Value2 {
+    final primitive class Test27Value2 {
         final Test27Value3 valueField;
 
         private Test27Value2(Test27Value3 val3) {
@@ -554,7 +554,7 @@ public class TestCallingConvention extends InlineTypeTest {
         }
     }
 
-    final inline class Test27Value3 {
+    final primitive class Test27Value3 {
         final int x;
 
         private Test27Value3(int x) {
@@ -767,7 +767,7 @@ public class TestCallingConvention extends InlineTypeTest {
     // Test method resolution with scalarized inline type receiver at invokespecial
     static final MethodHandle test37_mh;
 
-    inline class Test37Value {
+    primitive class Test37Value {
         int x = rI;
 
         @DontInline
@@ -802,7 +802,7 @@ public class TestCallingConvention extends InlineTypeTest {
         Asserts.assertEQ(res, vt);
     }
 
-    static inline class LargeValueWithOops {
+    static primitive class LargeValueWithOops {
         // Use all 6 int registers + 50/2 on stack = 29
         Object o1 = null;
         Object o2 = null;
@@ -835,7 +835,7 @@ public class TestCallingConvention extends InlineTypeTest {
         Object o29 = null;
     }
 
-    static inline class LargeValueWithoutOops {
+    static primitive class LargeValueWithoutOops {
         // Use all 6 int registers + 50/2 on stack = 29
         int i1 = 0;
         int i2 = 0;
@@ -918,7 +918,7 @@ public class TestCallingConvention extends InlineTypeTest {
 
     // More empty inline type tests with containers
 
-    static inline class EmptyContainer {
+    static primitive class EmptyContainer {
         private MyValueEmpty empty;
 
         EmptyContainer(MyValueEmpty empty) {
@@ -932,7 +932,7 @@ public class TestCallingConvention extends InlineTypeTest {
         MyValueEmpty getNoInline() { return empty; }
     }
 
-    static inline class MixedContainer {
+    static primitive class MixedContainer {
         public int val;
         private EmptyContainer empty;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
@@ -111,7 +111,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
                  RefPoint_Access_Impl2.class);
     }
 
-    static inline class Point {
+    static primitive class Point {
         final int x;
         final int y;
         public Point(int x, int y) {
@@ -228,7 +228,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         public int func2(int a, int b, Point p)     { return field + a + b + p.x + p.y + 1; }
     }
 
-    static inline class MyImplVal1 implements Intf {
+    static primitive class MyImplVal1 implements Intf {
         final int field;
         MyImplVal1() {
             field = 11000;
@@ -241,7 +241,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         public int func2(int a, int b, Point p)    { return field + a + b + p.x + p.y + 300; }
     }
 
-    static inline class MyImplVal2 implements Intf {
+    static primitive class MyImplVal2 implements Intf {
         final int field;
         MyImplVal2() {
             field = 12000;
@@ -254,7 +254,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         public int func2(int a, int b, Point p)    { return field + a + b + p.x + p.y + 300; }
     }
 
-    static inline class MyImplVal1X implements Intf {
+    static primitive class MyImplVal1X implements Intf {
         final int field;
         MyImplVal1X() {
             field = 11000;
@@ -267,7 +267,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         public int func2(int a, int b, Point p)    { return field + a + b + p.x + p.y + 300; }
     }
 
-    static inline class MyImplVal2X implements Intf {
+    static primitive class MyImplVal2X implements Intf {
         final int field;
         MyImplVal2X() {
             field = 12000;
@@ -292,7 +292,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         return intfs[n];
     }
 
-    static inline class FixedPoints {
+    static primitive class FixedPoints {
         final boolean Z0 = false;
         final boolean Z1 = true;
         final byte    B  = (byte)2;
@@ -303,7 +303,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
     }
     static FixedPoints fixedPointsField = new FixedPoints();
 
-    static inline class FloatPoint {
+    static primitive class FloatPoint {
         final float x;
         final float y;
         public FloatPoint(float x, float y) {
@@ -311,7 +311,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
             this.y = y;
         }
     }
-    static inline class DoublePoint {
+    static primitive class DoublePoint {
         final double x;
         final double y;
         public DoublePoint(double x, double y) {
@@ -322,7 +322,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
     static FloatPoint floatPointField = new FloatPoint(123.456f, 789.012f);
     static DoublePoint doublePointField = new DoublePoint(123.456, 789.012);
 
-    static inline class EightFloats {
+    static primitive class EightFloats {
         float f1, f2, f3, f4, f5, f6, f7, f8;
         public EightFloats() {
             f1 = 1.1f;
@@ -352,7 +352,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         public int func2(RefPoint rp1, RefPoint rp2, Number n1, RefPoint rp3, RefPoint rp4, Number n2);
     }
 
-    static inline class RefPoint implements RefPoint_Access {
+    static primitive class RefPoint implements RefPoint_Access {
         final Number x;
         final Number y;
         public RefPoint(int x, int y) {
@@ -441,7 +441,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
 
     // This inline class has too many fields to fit in registers on x64 for
     // InlineTypeReturnedAsFields.
-    static inline class TooBigToReturnAsFields {
+    static primitive class TooBigToReturnAsFields {
         int a0 = 0;
         int a1 = 1;
         int a2 = 2;
@@ -2170,7 +2170,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         test103_v = new Test103Value(); // invokestatic "Test103Value.<init>()QTest103Value;"
     }
 
-    static inline class Test103Value {
+    static primitive class Test103Value {
         int x = rI;
     }
 
@@ -2195,7 +2195,7 @@ public class TestCallingConventionC1 extends InlineTypeTest {
         test104_v = new Test104Value(); // invokestatic "Test104Value.<init>()QTest104Value;"
     }
 
-    static inline class Test104Value {
+    static primitive class Test104Value {
         long x0 = rL;
         long x1 = rL;
         long x2 = rL;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadAllocationRemoval.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeadAllocationRemoval.java
@@ -38,7 +38,7 @@ public class TestDeadAllocationRemoval {
     }
 }
 
-inline class MyValue {
+primitive class MyValue {
     public static long instanceCount = 0;
     public float fFld = 0;
     public boolean bFld = true;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
@@ -74,7 +74,7 @@ import sun.hotspot.WhiteBox;
  *                   compiler.valhalla.inlinetypes.TestDeoptimizationWhenBuffering
  */
 
-final inline class MyValue1 {
+final primitive class MyValue1 {
     static int cnt = 0;
     final int x;
     final MyValue2 vtField1;
@@ -95,7 +95,7 @@ final inline class MyValue1 {
     }
 }
 
-final inline class MyValue2 {
+final primitive class MyValue2 {
     static int cnt = 0;
     final int x;
     public MyValue2() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayAliasesCardMark.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayAliasesCardMark.java
@@ -31,7 +31,7 @@
  */
 
 
-inline class Test0 {
+primitive class Test0 {
     int x = 42;
     short[] array = new short[7];
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayThreshold.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatArrayThreshold.java
@@ -32,7 +32,7 @@
 
 import jdk.test.lib.Asserts;
 
-final inline class MyValue1 {
+final primitive class MyValue1 {
     final Object o1;
     final Object o2;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -30,16 +30,16 @@
 
 package compiler.valhalla.inlinetypes;
 
-inline class EmptyValue {
+primitive class EmptyValue {
 
 }
 
-inline class MyValue1 {
+primitive class MyValue1 {
     int x = 42;
     int[] array = new int[1];
 }
 
-inline class MyValue2 {
+primitive class MyValue2 {
     int[] a = new int[1];
     int[] b = new int[6];
     int[] c = new int[5];

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGetfieldChains.java
@@ -181,12 +181,12 @@ public class TestGetfieldChains extends InlineTypeTest {
         Asserts.assertEQ(nsfe.getMessage(), "x");
     }
 
-    static inline class EmptyType { }
-    static inline class EmptyContainer {
+    static primitive class EmptyType { }
+    static primitive class EmptyContainer {
         int i = 0;
         EmptyType et = new EmptyType();
     }
-    static inline class Container {
+    static primitive class Container {
         EmptyContainer container0 = new EmptyContainer();
         EmptyContainer container1 = new EmptyContainer();
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -430,7 +430,7 @@ public class TestIntrinsics extends InlineTypeTest {
     }
 
     // Test copyOf intrinsic with allocated inline type in it's debug information
-    final inline class Test25Value {
+    final primitive class Test25Value {
         final int x;
         public Test25Value() {
             this.x = 42;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsSubstitutableReresolution.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsSubstitutableReresolution.java
@@ -32,7 +32,7 @@ import jdk.test.lib.Asserts;
  * @run main/othervm -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestIsSubstitutableReresolution::test
  *                   compiler.valhalla.inlinetypes.TestIsSubstitutableReresolution
  */
-final inline class MyValue {
+final primitive class MyValue {
     final int x;
 
     public MyValue(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestJNICalls.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestJNICalls.java
@@ -93,7 +93,7 @@ public class TestJNICalls extends InlineTypeTest {
         Asserts.assertEQ(result, vt.hash());
     }
 
-    static inline class MyValueWithNative {
+    static primitive class MyValueWithNative {
         public final int x;
 
         private MyValueWithNative(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -1488,7 +1488,7 @@ public class TestLWorld extends InlineTypeTest {
     }
 
     // Inline type with some non-flattened fields
-    final inline class Test51Value {
+    final primitive class Test51Value {
         final Object objectField1;
         final Object objectField2;
         final Object objectField3;
@@ -1974,7 +1974,7 @@ public class TestLWorld extends InlineTypeTest {
     }
 
     // Test calling a method on an uninitialized inline type
-    final inline class Test72Value {
+    final primitive class Test72Value {
         final int x = 42;
         public int get() {
             return x;
@@ -2130,7 +2130,7 @@ public class TestLWorld extends InlineTypeTest {
     }
 
     // Test flattened field with non-flattenend (but flattenable) inline type field
-    static inline class Small {
+    static primitive class Small {
         final int i;
         final Big big; // Too big to be flattened
 
@@ -2140,7 +2140,7 @@ public class TestLWorld extends InlineTypeTest {
         }
     }
 
-    static inline class Big {
+    static primitive class Big {
         long l0,l1,l2,l3,l4,l5,l6,l7,l8,l9;
         long l10,l11,l12,l13,l14,l15,l16,l17,l18,l19;
         long l20,l21,l22,l23,l24,l25,l26,l27,l28,l29;
@@ -2394,7 +2394,7 @@ public class TestLWorld extends InlineTypeTest {
         Asserts.assertFalse(test91(new Object()));
     }
 
-    static inline class Test92Value {
+    static primitive class Test92Value {
         final int field;
         public Test92Value() {
             field = 0x42;
@@ -2912,7 +2912,7 @@ public class TestLWorld extends InlineTypeTest {
         }
     }
 
-    static inline class LongWrapper implements WrapperInterface {
+    static primitive class LongWrapper implements WrapperInterface {
         final static LongWrapper ZERO = new LongWrapper(0);
         private long val;
 
@@ -3167,7 +3167,7 @@ public class TestLWorld extends InlineTypeTest {
         }
     }
 
-    static inline class LongWrapper2 implements WrapperInterface2 {
+    static primitive class LongWrapper2 implements WrapperInterface2 {
         private long val;
 
         public LongWrapper2(long val) {
@@ -3179,7 +3179,7 @@ public class TestLWorld extends InlineTypeTest {
         }
     }
 
-    static inline class InlineWrapper {
+    static primitive class InlineWrapper {
         WrapperInterface2 content;
 
         public InlineWrapper(long val) {
@@ -3287,11 +3287,11 @@ public class TestLWorld extends InlineTypeTest {
         Asserts.assertTrue(res);
     }
 
-    static inline class EmptyContainer {
+    static primitive class EmptyContainer {
         private MyValueEmpty empty = MyValueEmpty.default;
     }
 
-    static inline class MixedContainer {
+    static primitive class MixedContainer {
         public int val = rI;
         private EmptyContainer empty = EmptyContainer.default;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -369,7 +369,7 @@ public class TestLWorldProfiling extends InlineTypeTest {
 
     // null free array profiling
 
-    inline static class NotFlattenable {
+    primitive static class NotFlattenable {
         private final Object o1 = null;
         private final Object o2 = null;
         private final Object o3 = null;
@@ -916,7 +916,7 @@ public class TestLWorldProfiling extends InlineTypeTest {
     // Test array access with polluted array type profile
     static abstract class Test40Abstract { }
     static class Test40Class extends Test40Abstract { }
-    static inline class Test40Inline extends Test40Abstract { }
+    static primitive class Test40Inline extends Test40Abstract { }
 
     @ForceInline
     public Object test40_access(Object[] array) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNativeClone.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNativeClone.java
@@ -42,7 +42,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import jdk.test.lib.Asserts;
 
-inline class MyValue {
+primitive class MyValue {
     public final int x;
 
     public MyValue(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNestmateAccess.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNestmateAccess.java
@@ -41,7 +41,7 @@ interface MyInterface {
     int hash();
 }
 
-inline class MyValue implements MyInterface {
+primitive class MyValue implements MyInterface {
     int x = 42;
     int y = 43;
 
@@ -69,7 +69,7 @@ class Test1 {
 }
 
 // Same as Test1 but outer class is an inline type
-inline class Test2 {
+primitive class Test2 {
     private MyValue vt;
 
     public Test2(final MyValue vt) {
@@ -123,7 +123,7 @@ class Test4 {
 }
 
 // Same as Test2 but with static field
-inline class Test5 {
+primitive class Test5 {
     private static MyValue vt;
 
     public Test5(final MyValue vt) {
@@ -158,7 +158,7 @@ class Test6 {
 }
 
 // Same as Test6 but outer class is an inline type
-inline class Test7 {
+primitive class Test7 {
     private static MyValue vt;
 
     public MyInterface test(MyValue init) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNewAcmp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNewAcmp.java
@@ -57,7 +57,7 @@ abstract class MyAbstract implements MyInterface {
 
 }
 
-inline class MyValue1 extends MyAbstract {
+primitive class MyValue1 extends MyAbstract {
     final int x;
 
     MyValue1(int x) {
@@ -73,7 +73,7 @@ inline class MyValue1 extends MyAbstract {
     }
 }
 
-inline class MyValue2 extends MyAbstract {
+primitive class MyValue2 extends MyAbstract {
     final int x;
 
     MyValue2(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -2495,7 +2495,7 @@ public class TestNullableArrays extends InlineTypeTest {
     }
 
     // Matrix multiplication test to exercise type flow analysis with nullable inline type arrays
-    inline static class Complex {
+    primitive static class Complex {
         private final double re;
         private final double im;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -477,7 +477,7 @@ public class TestNullableInlineTypes extends InlineTypeTest {
     }
 
     // Test scalarization of default inline type with non-flattenable field
-    final inline class Test17Value {
+    final primitive class Test17Value {
         public final MyValue1.ref valueField;
 
         @ForceInline
@@ -584,7 +584,7 @@ public class TestNullableInlineTypes extends InlineTypeTest {
     }
 
     // Test writing null to a flattenable/non-flattenable inline type field in an inline type
-    final inline class Test21Value {
+    final primitive class Test21Value {
         final MyValue1.ref valueField1;
         final MyValue1 valueField2;
         final MyValue1.ref alwaysNull = null;
@@ -802,7 +802,7 @@ public class TestNullableInlineTypes extends InlineTypeTest {
     }
 
     // Test casting null to unloaded inline type
-    final inline class Test31Value {
+    final primitive class Test31Value {
         private final int i = 0;
     }
 
@@ -834,11 +834,11 @@ public class TestNullableInlineTypes extends InlineTypeTest {
         Asserts.assertEquals(result, null);
     }
 
-    static inline class Test33Value1 {
+    static primitive class Test33Value1 {
         int x = 0;
     }
 
-    static inline class Test33Value2 {
+    static primitive class Test33Value2 {
         Test33Value1.ref vt;
 
         public Test33Value2() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
@@ -177,7 +177,7 @@ public class TestOnStackReplacement extends InlineTypeTest {
     }
 
     // Test OSR in method with inline type receiver
-    inline class Test6Value {
+    primitive class Test6Value {
         public int f = 0;
 
         public int test() {
@@ -203,7 +203,7 @@ public class TestOnStackReplacement extends InlineTypeTest {
     }
 
     // Similar to test6 but with more fields and reserved stack entry
-    static inline class Test7Value1 {
+    static primitive class Test7Value1 {
         public int i1 = rI;
         public int i2 = rI;
         public int i3 = rI;
@@ -212,7 +212,7 @@ public class TestOnStackReplacement extends InlineTypeTest {
         public int i6 = rI;
     }
 
-    static inline class Test7Value2 {
+    static primitive class Test7Value2 {
         public int i1 = rI;
         public int i2 = rI;
         public int i3 = rI;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOptimizeKlassCmp.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOptimizeKlassCmp.java
@@ -34,7 +34,7 @@ package compiler.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
 
-inline class MyValue {
+primitive class MyValue {
     public final int x;
 
     public MyValue(int x) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStressReturnBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestStressReturnBuffering.java
@@ -35,7 +35,7 @@ package compiler.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
 
-inline class MyValue {
+primitive class MyValue {
     public Integer o1;
     public Integer o2;
     public Integer o3;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java
@@ -50,7 +50,7 @@
 
 import jdk.test.lib.Asserts;
 
-final inline class MyValue1 {
+final primitive class MyValue1 {
     final int foo;
 
     private MyValue1() {
@@ -58,7 +58,7 @@ final inline class MyValue1 {
     }
 }
 
-final inline class MyValue1Box {
+final primitive class MyValue1Box {
     final int foo;
 
     private MyValue1Box() {
@@ -66,7 +66,7 @@ final inline class MyValue1Box {
     }
 }
 
-final inline class MyValue2 {
+final primitive class MyValue2 {
     final int foo;
 
     public MyValue2(int n) {
@@ -74,7 +74,7 @@ final inline class MyValue2 {
     }
 }
 
-final inline class MyValue2Box {
+final primitive class MyValue2Box {
     final int foo;
 
     public MyValue2Box(int n) {
@@ -82,7 +82,7 @@ final inline class MyValue2Box {
     }
 }
 
-final inline class MyValue3 {
+final primitive class MyValue3 {
     final int foo;
 
     public MyValue3(int n) {
@@ -90,7 +90,7 @@ final inline class MyValue3 {
     }
 }
 
-final inline class MyValue3Box {
+final primitive class MyValue3Box {
     final int foo;
 
     public MyValue3Box(int n) {
@@ -98,7 +98,7 @@ final inline class MyValue3Box {
     }
 }
 
-final inline class MyValue4 {
+final primitive class MyValue4 {
     final int foo;
 
     public MyValue4(int n) {
@@ -106,7 +106,7 @@ final inline class MyValue4 {
     }
 }
 
-final inline class MyValue4Box {
+final primitive class MyValue4Box {
     final int foo;
 
     public MyValue4Box(int n) {
@@ -114,7 +114,7 @@ final inline class MyValue4Box {
     }
 }
 
-final inline class MyValue5 {
+final primitive class MyValue5 {
     final int foo;
 
     public MyValue5(int n) {
@@ -122,7 +122,7 @@ final inline class MyValue5 {
     }
 }
 
-final inline class MyValue6 {
+final primitive class MyValue6 {
     final int foo;
 
     public MyValue6(int n) {
@@ -134,7 +134,7 @@ final inline class MyValue6 {
     }
 }
 
-final inline class MyValue6Box {
+final primitive class MyValue6Box {
     final int foo;
 
     public MyValue6Box(int n) {
@@ -146,7 +146,7 @@ final inline class MyValue6Box {
     }
 }
 
-final inline class MyValue7 {
+final primitive class MyValue7 {
     final int foo;
 
     public MyValue7(int n) {
@@ -154,7 +154,7 @@ final inline class MyValue7 {
     }
 }
 
-final inline class MyValue7Box {
+final primitive class MyValue7Box {
     final int foo;
 
     public MyValue7Box(int n) {
@@ -162,25 +162,25 @@ final inline class MyValue7Box {
     }
 }
 
-final inline class MyValue8 {
+final primitive class MyValue8 {
     final int foo = 123;
     static {
         TestUnloadedInlineTypeArray.MyValue8_inited = true;
     }
 }
 
-final inline class MyValue9 {
+final primitive class MyValue9 {
     final int foo = 123;
     static {
         TestUnloadedInlineTypeArray.MyValue9_inited = true;
     }
 }
 
-final inline class MyValue10 {
+final primitive class MyValue10 {
     final int foo = 42;
 }
 
-final inline class MyValue11 {
+final primitive class MyValue11 {
     final int foo = 42;
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -76,7 +76,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
     //
     // MyValue1 has already been loaded, because it's in the InlineType attribute of
     // TestUnloadedInlineTypeField, due to TestUnloadedInlineTypeField.test1_precondition().
-    static final inline class MyValue1 {
+    static final primitive class MyValue1 {
         final int foo;
 
         MyValue1() {
@@ -125,7 +125,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
     //
     // MyValue2 has not been loaded, because it is not explicitly referenced by
     // TestUnloadedInlineTypeField.
-    static final inline class MyValue2 {
+    static final primitive class MyValue2 {
         final int foo;
 
         public MyValue2(int n) {
@@ -174,7 +174,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
     //
     // MyValue3 has already been loaded, because it's in the InlineType attribute of
     // TestUnloadedInlineTypeField, due to TestUnloadedInlineTypeField.test3_precondition().
-    static final inline class MyValue3 {
+    static final primitive class MyValue3 {
         final int foo;
 
         public MyValue3() {
@@ -220,7 +220,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 4:
     // Same as case 1, except we use putfield instead of getfield.
-    static final inline class MyValue4 {
+    static final primitive class MyValue4 {
         final int foo;
 
         MyValue4(int n) {
@@ -258,7 +258,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 5:
     // Same as case 2, except we use putfield instead of getfield.
-    static final inline class MyValue5 {
+    static final primitive class MyValue5 {
         final int foo;
 
         MyValue5(int n) {
@@ -308,7 +308,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
     //
     // MyValue6 has already been loaded, because it's in the InlineType attribute of
     // TestUnloadedInlineTypeField, due to TestUnloadedInlineTypeField.test1_precondition().
-    static final inline class MyValue6 {
+    static final primitive class MyValue6 {
         final int foo;
 
         MyValue6() {
@@ -351,7 +351,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
     //
     // MyValue7 has not been loaded, because it is not explicitly referenced by
     // TestUnloadedInlineTypeField.
-    static final inline class MyValue7 {
+    static final primitive class MyValue7 {
         final int foo;
 
         MyValue7(int n) {
@@ -383,7 +383,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 8:
     // Same as case 1, except holder is allocated in test method (-> no holder null check required)
-    static final inline class MyValue8 {
+    static final primitive class MyValue8 {
         final int foo;
 
         MyValue8() {
@@ -424,7 +424,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 9:
     // Same as case 2, except holder is allocated in test method (-> no holder null check required)
-    static final inline class MyValue9 {
+    static final primitive class MyValue9 {
         final int foo;
 
         public MyValue9(int n) {
@@ -461,7 +461,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 10:
     // Same as case 4, but with putfield
-    static final inline class MyValue10 {
+    static final primitive class MyValue10 {
         final int foo;
 
         public MyValue10() {
@@ -509,7 +509,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 11:
     // Same as case 4, except holder is allocated in test method (-> no holder null check required)
-    static final inline class MyValue11 {
+    static final primitive class MyValue11 {
         final int foo;
 
         MyValue11(int n) {
@@ -549,7 +549,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 12:
     // Same as case 5, except holder is allocated in test method (-> no holder null check required)
-    static final inline class MyValue12 {
+    static final primitive class MyValue12 {
         final int foo;
 
         MyValue12(int n) {
@@ -590,7 +590,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 13:
     // Same as case 10, except MyValue13 is allocated in test method
-    static final inline class MyValue13 {
+    static final primitive class MyValue13 {
         final int foo;
 
         public MyValue13() {
@@ -636,7 +636,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 14:
     // Same as case 10, except storing null
-    static final inline class MyValue14 {
+    static final primitive class MyValue14 {
         final int foo;
 
         public MyValue14() {
@@ -682,7 +682,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 15:
     // Same as case 13, except MyValue15 is unloaded
-    static final inline class MyValue15 {
+    static final primitive class MyValue15 {
         final int foo;
 
         public MyValue15() {
@@ -792,7 +792,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 18:
     // Same as test7 but with the holder being loaded
-    static final inline class MyValue18 {
+    static final primitive class MyValue18 {
         final int foo;
 
         MyValue18(int n) {
@@ -826,7 +826,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
 
     // Test case 19:
     // Same as test18 but uninitialized (null) static inline type field
-    static final inline class MyValue19 {
+    static final primitive class MyValue19 {
         final int foo;
 
         MyValue19(int n) {
@@ -864,7 +864,7 @@ public class TestUnloadedInlineTypeField extends InlineTypeTest {
         int x = 42;
     }
 
-    static final inline class MyValue20 {
+    static final primitive class MyValue20 {
         MyObject20 obj;
 
         MyValue20() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedDefault.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedDefault.java
@@ -30,7 +30,7 @@
 
 public class TestUnresolvedDefault {
 
-    static inline class UnresolvedInline {
+    static primitive class UnresolvedInline {
         int x = 42;
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
@@ -98,7 +98,7 @@ public class TestWithfieldC1 extends InlineTypeTest {
         }
     }
 
-    static inline class FooValue {
+    static primitive class FooValue {
         public int x = 0, y = 0;
 
         @ForceInline

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/hack/GetUnresolvedInlineFieldWrongSignature.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/hack/GetUnresolvedInlineFieldWrongSignature.java
@@ -65,11 +65,11 @@ class TestUnloadedInlineTypeField {
         MyValue15 v;
     }
 
-    static inline class MyValue16 {
+    static primitive class MyValue16 {
         int foo = 42;
     }
 
-    static inline class MyValue17 {
+    static primitive class MyValue17 {
         int foo = 42;
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CheckcastTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CheckcastTest.java
@@ -36,7 +36,7 @@ import jdk.test.lib.Asserts;
 
 public class CheckcastTest {
 
-    static inline class Point {
+    static primitive class Point {
         int x;
         int y;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
@@ -37,27 +37,27 @@ public class CircularityTest {
     static boolean b = true;
     static int counter = 0;
 
-    static inline class A {
+    static primitive class A {
         static B b;
         static C c;
         int i = 0;
     }
 
-    static inline class B {
+    static primitive class B {
         static {
             Asserts.assertNotNull(A.c, "Should have returned C's default value");
         }
         int i = 0;
     }
 
-    static inline class C {
+    static primitive class C {
         int i;
         public C(int i) {
             this.i = i;
         }
     }
 
-    static inline class D {
+    static primitive class D {
         static C c;
         int i = 0;
         static {
@@ -68,25 +68,25 @@ public class CircularityTest {
         }
     }
 
-    static inline class E {
+    static primitive class E {
         static F f;
         static C c;
         int i = 0;
     }
 
-    static inline class F {
+    static primitive class F {
         int i = 0;
         static {
             E.c = new C(5);
         }
     }
 
-    static inline class G {
+    static primitive class G {
         static H h;
         int i = 0;
     }
 
-    static inline class H {
+    static primitive class H {
         int i = 0;
         static {
             if (CircularityTest.b) {
@@ -96,13 +96,13 @@ public class CircularityTest {
         }
     }
 
-    static inline class I {
+    static primitive class I {
         static J j;
         static H h;
         int i = 0;
     }
 
-    static inline class J {
+    static primitive class J {
         int i = 0;
         static {
             CircularityTest.counter = 1;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
@@ -56,7 +56,7 @@ import javax.tools.*;
 
 public class CreationErrorTest {
 
-    static inline class InlineClass {
+    static primitive class InlineClass {
         int i = 0;
     }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
@@ -37,13 +37,13 @@ import java.lang.reflect.Field;
 
 public class EmptyInlineTest {
 
-    static inline class EmptyInline {
+    static primitive class EmptyInline {
         public boolean isEmpty() {
             return true;
         }
     }
 
-    static inline class EmptyField {
+    static primitive class EmptyField {
         EmptyInline empty;
 
         EmptyField() {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
@@ -37,11 +37,11 @@ import java.lang.ref.*;
  */
 public class Ifacmp {
 
-    static inline class MyValue {
+    static primitive class MyValue {
         int value;
         public MyValue(int v) { this.value = v; }
     };
-    static inline class MyValue2 {
+    static primitive class MyValue2 {
         int value;
         public MyValue2(int v) { this.value = v; }
     };

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -205,7 +205,7 @@ public class InlineOops {
         public Person otherPerson;
     }
 
-    static final inline class Composition {
+    static final primitive class Composition {
         public final Person onePerson;
         public final Person otherPerson;
 
@@ -601,7 +601,7 @@ public class InlineOops {
 
     // Various field layouts...sanity testing, see MVTCombo testing for full-set
 
-    static final inline class ObjectValue {
+    static final primitive class ObjectValue {
         final Object object;
 
         private ObjectValue(Object obj) {
@@ -635,7 +635,7 @@ public class InlineOops {
         String otherStuff;
     }
 
-    public static final inline class FooValue {
+    public static final primitive class FooValue {
         public final int id;
         public final String name;
         public final String description;
@@ -733,7 +733,7 @@ public class InlineOops {
         String otherStuff;
     }
 
-    static final inline class BarValue {
+    static final primitive class BarValue {
         final FooValue foo;
         final long extendedId;
         final String moreNotes;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -244,7 +244,7 @@ public class InlineTypeArray {
         assertEquals(x, 1, "Bad Point Value");
     }
 
-    static final inline class MyInt implements Comparable<MyInt.ref> {
+    static final primitive class MyInt implements Comparable<MyInt.ref> {
         final int value;
 
         private MyInt() { this(0); }
@@ -277,7 +277,7 @@ public class InlineTypeArray {
         default String hi() { return "Hi"; }
     }
 
-    static final inline class MyOtherInt implements SomeSecondaryType {
+    static final primitive class MyOtherInt implements SomeSecondaryType {
         final int value;
         private MyOtherInt() { value = 0; }
     }
@@ -465,7 +465,7 @@ public class InlineTypeArray {
         } catch (NullPointerException npe) {}
     }
 
-    static final inline class MyPoint {
+    static final primitive class MyPoint {
         final               MyInt x;
         final               MyInt y;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
@@ -73,7 +73,7 @@ public class InlineTypeCreation {
         Asserts.assertEquals(person.getLastName(), "Smith", "Last name incorrect");
     }
 
-    static final inline class StaticSelf {
+    static final primitive class StaticSelf {
 
         static final StaticSelf.ref DEFAULT = create(0);
         final int f1;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
@@ -73,7 +73,7 @@ public class InlineTypeDensity {
 
     interface LocalDateTime extends LocalDate, LocalTime {}
 
-    static final inline class LocalDateValue implements LocalDate {
+    static final primitive class LocalDateValue implements LocalDate {
         final int   year;
         final short month;
         final short day;
@@ -97,7 +97,7 @@ public class InlineTypeDensity {
         }
     }
 
-    static final inline class LocalTimeValue implements LocalTime {
+    static final primitive class LocalTimeValue implements LocalTime {
         final byte hour;
         final byte minute;
         final byte second;
@@ -125,7 +125,7 @@ public class InlineTypeDensity {
         }
     }
 
-    static final inline class LocalDateTimeValue implements LocalDateTime {
+    static final primitive class LocalDateTimeValue implements LocalDateTime {
         final LocalDateValue date;
         final LocalTimeValue time;
 
@@ -233,10 +233,10 @@ public class InlineTypeDensity {
         Asserts.assertLessThan(flatArraySize, objectArraySize, "Flat array accounts for more heap than object array + elements !");
     }
 
-    static inline class MyByte  { byte  v = 0; }
-    static inline class MyShort { short v = 0; }
-    static inline class MyInt   { int   v = 0; }
-    static inline class MyLong  { long  v = 0; }
+    static primitive class MyByte  { byte  v = 0; }
+    static primitive class MyShort { short v = 0; }
+    static primitive class MyInt   { int   v = 0; }
+    static primitive class MyLong  { long  v = 0; }
 
     void assertArraySameSize(Object a, Object b, int nofElements) {
         long aSize = WHITE_BOX.getObjectSize(a);
@@ -287,11 +287,11 @@ public class InlineTypeDensity {
         testLongArraySizesSame(testSizes);
     }
 
-    static inline class bbValue { byte b = 0; byte b2 = 0;}
-    static inline class bsValue { byte b = 0; short s = 0;}
-    static inline class siValue { short s = 0; int i = 0;}
-    static inline class ssiValue { short s = 0; short s2 = 0; int i = 0;}
-    static inline class blValue { byte b = 0; long l = 0; }
+    static primitive class bbValue { byte b = 0; byte b2 = 0;}
+    static primitive class bsValue { byte b = 0; short s = 0;}
+    static primitive class siValue { short s = 0; int i = 0;}
+    static primitive class ssiValue { short s = 0; short s2 = 0; int i = 0;}
+    static primitive class blValue { byte b = 0; long l = 0; }
 
     // Expect aligned array addressing to nearest pow2
     void testAlignedSize() {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
@@ -29,7 +29,7 @@ package runtime.valhalla.inlinetypes;
  * @run main/othervm/native -Xint runtime.valhalla.inlinetypes.InlineWithJni
  * @run main/othervm/native -Xcomp runtime.valhalla.inlinetypes.InlineWithJni
  */
-public inline final class InlineWithJni {
+public primitive final class InlineWithJni {
 
     static {
         System.loadLibrary("InlineWithJni");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/IntValue.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/IntValue.java
@@ -23,7 +23,7 @@
 
 package runtime.valhalla.inlinetypes;
 
-public inline class IntValue {
+public primitive class IntValue {
     int val;
     public IntValue()       { this(0); }
     public IntValue(int v)  { val = v; }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/JumboInline.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/JumboInline.java
@@ -22,7 +22,7 @@
  */
 package runtime.valhalla.inlinetypes;
 
-public inline final class JumboInline {
+public primitive final class JumboInline {
     final long l0;
     final long l1;
     final long l2;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Long8Inline.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Long8Inline.java
@@ -25,7 +25,7 @@ package runtime.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
 
-public final inline class Long8Inline {
+public final primitive class Long8Inline {
 
     final long longField1;
     final long longField2;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MultiANewArrayTest/Element1.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MultiANewArrayTest/Element1.java
@@ -22,6 +22,6 @@
  *
  */
 
-public inline class Element1 {
+public primitive class Element1 {
     int i=0,j=0;
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
@@ -215,7 +215,7 @@ public class ObjectMethods {
         }
     }
 
-    static final inline class MyInt {
+    static final primitive class MyInt {
         final int value;
         private MyInt() { value = 0; }
         public static MyInt create(int v) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Person.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Person.java
@@ -23,7 +23,7 @@
 
 package runtime.valhalla.inlinetypes;
 
-public final inline class Person {
+public final primitive class Person {
 
     final int    id;
     final String firstName;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Point.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Point.java
@@ -22,7 +22,7 @@
  */
 package runtime.valhalla.inlinetypes;
 
-public inline final class Point {
+public primitive final class Point {
     final int x;
     final int y;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/QuickeningTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/QuickeningTest.java
@@ -57,7 +57,7 @@ public class QuickeningTest {
         public void setFj2(JumboInline j) { fj2 = j; }
     }
 
-    static final inline class Value {
+    static final primitive class Value {
         final Point.ref nfp;       /* Not flattenable inline field */
         final Point fp;         /* Flattenable and flattened inline field */
         final JumboInline fj;    /* Flattenable not flattened inline field */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/StaticFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/StaticFieldsTest.java
@@ -38,7 +38,7 @@ public class StaticFieldsTest {
     // ClassA and ClassB have a simple cycle in their static fields, but they should
     // be able to load and initialize themselves successfully. Access to these
     // static fields after their initialization should return the default value.
-    static inline class ClassA {
+    static primitive class ClassA {
         static ClassB b;
         public int i;
 
@@ -47,7 +47,7 @@ public class StaticFieldsTest {
         }
     }
 
-    static inline class ClassB {
+    static primitive class ClassB {
         static ClassA a;
         public int i;
 
@@ -59,7 +59,7 @@ public class StaticFieldsTest {
     // ClassC has a reference to itself in its static field, but it should be able
     // to initialize itelf successfully. Access to this static field after initialization
     // should return the default value.
-    static inline class ClassC {
+    static primitive class ClassC {
         static ClassC c;
         int i;
 
@@ -73,7 +73,7 @@ public class StaticFieldsTest {
     // read these static fields during their initialization, the value read from
     // these fields should be the default value. Both classes should initialize
     // successfully.
-    static inline class ClassD {
+    static primitive class ClassD {
         static ClassE e;
         int i;
 
@@ -86,7 +86,7 @@ public class StaticFieldsTest {
         }
     }
 
-    static inline class ClassE {
+    static primitive class ClassE {
         static ClassD d;
         int i;
 
@@ -102,7 +102,7 @@ public class StaticFieldsTest {
     // ClassF and ClassG have circular references in their static fields, and they
     // create new instances of each other type to initialize these static fields
     // during their initialization. Both classes should initialize successfully.
-    static inline class ClassF {
+    static primitive class ClassF {
         static ClassG g;
         int i;
 
@@ -116,7 +116,7 @@ public class StaticFieldsTest {
         }
     }
 
-    static inline class ClassG {
+    static primitive class ClassG {
         static ClassF f;
         int i;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Test8186715.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Test8186715.java
@@ -43,7 +43,7 @@ public class Test8186715 {
     }
 }
 
-inline final class MyValueType {
+primitive final class MyValueType {
     final int i;
     final int j;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldNullability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldNullability.java
@@ -34,7 +34,7 @@ package runtime.valhalla.inlinetypes;
 import jdk.test.lib.Asserts;
 
 public class TestFieldNullability {
-    static inline class MyValue {
+    static primitive class MyValue {
         int x;
 
         public MyValue() {
@@ -42,7 +42,7 @@ public class TestFieldNullability {
         }
     }
 
-    static inline class MyBigValue {
+    static primitive class MyBigValue {
         long l0, l1, l2, l3, l4, l5, l6, l7, l8, l9;
         long l10, l11, l12, l13, l14, l15, l16, l17, l18, l19;
 
@@ -52,7 +52,7 @@ public class TestFieldNullability {
         }
     }
 
-    static inline class TestInlineType {
+    static primitive class TestInlineType {
         final MyValue.ref nullableField;
         final MyValue nullfreeField;        // flattened
         final MyValue.ref nullField;           // src of null

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIArrays.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIArrays.java
@@ -63,7 +63,7 @@ public class TestJNIArrays {
         System.loadLibrary("TestJNIArrays");
     }
 
-    static inline class IntInt {
+    static primitive class IntInt {
         int i0;
         int i1;
 
@@ -83,7 +83,7 @@ public class TestJNIArrays {
         }
     }
 
-    static inline class Containee {
+    static primitive class Containee {
         float f;
         short s;
 
@@ -93,7 +93,7 @@ public class TestJNIArrays {
         }
     }
 
-    static inline class Container {
+    static primitive class Container {
         double d;
         Containee c;
         byte b;
@@ -111,7 +111,7 @@ public class TestJNIArrays {
 
     }
 
-    static inline class LongLongLongLong {
+    static primitive class LongLongLongLong {
         long l0, l1, l2, l3;
 
         public LongLongLongLong(long l0, long l1, long l2, long l3) {
@@ -122,14 +122,14 @@ public class TestJNIArrays {
         }
     }
 
-    static inline class BigValue {
+    static primitive class BigValue {
         long l0 = 0, l1 = 0,   l2 = 0, l3 = 0, l4 = 0, l5 = 0, l6 = 0, l7 = 0, l8 = 0, l9 = 0;
         long l10 = 0, l11 = 0, l12 = 0, l13 = 0, l14 = 0, l15 = 0, l16 = 0, l17 = 0, l18 = 0, l19 = 0;
         long l20 = 0, l21 = 0, l22 = 0, l23 = 0, l24 = 0, l25 = 0, l26 = 0, l27 = 0, l28 = 0, l29 = 0;
         long l30 = 0, l31 = 0, l32 = 0, l33 = 0, l34 = 0, l35 = 0, l36 = 0, l37 = 0, l38 = 0, l39 = 0;
     }
 
-    static inline class InlineWithOops {
+    static primitive class InlineWithOops {
         String s = "bonjour";
         int i = 0;
         Containee c = new Containee(2.3f, (short)4);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsSameObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsSameObject.java
@@ -34,7 +34,7 @@ import jdk.test.lib.Asserts;
  * @run main/othervm/native TestJNIIsSameObject
  */
 public class TestJNIIsSameObject {
-  static inline class Value {
+  static primitive class Value {
     int i;
 
     public Value(int i) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue1.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue1.java
@@ -28,7 +28,7 @@ final class ContainerValue1 {
     TestValue1[] inlineArray;
 }
 
-public inline final class TestValue1 {
+public primitive final class TestValue1 {
 
     static TestValue1.ref staticValue = getInstance();
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue2.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue2.java
@@ -28,7 +28,7 @@ final class ContainerValue2 {
     TestValue2[] valueArray;
 }
 
-public inline final class TestValue2 {
+public primitive final class TestValue2 {
     static TestValue2.ref staticValue = getInstance();
 
     final long l;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue3.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue3.java
@@ -28,7 +28,7 @@ final class ContainerValue3 {
     TestValue3[] valueArray;
 }
 
-public inline final class TestValue3 {
+public primitive final class TestValue3 {
 
     static TestValue3.ref staticValue = getInstance();
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue4.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestValue4.java
@@ -30,7 +30,7 @@ final class ContainerValue4 {
     TestValue4[] valueArray;
 }
 
-public inline final class TestValue4 {
+public primitive final class TestValue4 {
 
     static TestValue4.ref staticValue = getInstance();
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -42,7 +42,7 @@ import static jdk.test.lib.Asserts.*;
 public class UnsafeTest {
     static final Unsafe U = Unsafe.getUnsafe();
 
-    static inline class Value1 {
+    static primitive class Value1 {
         Point point;
         Point[] array;
         Value1(Point p, Point... points) {
@@ -51,7 +51,7 @@ public class UnsafeTest {
         }
     }
 
-    static inline class Value2 {
+    static primitive class Value2 {
         int i;
         Value1 v;
 
@@ -61,7 +61,7 @@ public class UnsafeTest {
         }
     }
 
-    static inline class Value3 {
+    static primitive class Value3 {
         Object o;
         Value2 v;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VDefaultTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VDefaultTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Asserts;
 
 public class VDefaultTest {
 
-    static inline final class Point {
+    static primitive final class Point {
         final int x;
         final int y;
 
@@ -52,7 +52,7 @@ public class VDefaultTest {
         }
     }
 
-    static inline final class Value {
+    static primitive final class Value {
         final char c;
         final byte b;
         final short s;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VWithFieldTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VWithFieldTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Asserts;
 
 public class VWithFieldTest {
 
-    static inline final class Point {
+    static primitive final class Point {
         final private int x;
         final private int y;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
@@ -111,7 +111,7 @@ public class ValueTearing {
     }
 
     // A normally tearable inline value.
-    static inline class TPoint {
+    static primitive class TPoint {
         TPoint(long x, long y) { this.x = x; this.y = y; }
         final long x, y;
         public String toString() { return String.format("(%d,%d)", x, y); }
@@ -176,7 +176,7 @@ public class ValueTearing {
     interface NT extends NonTearable { }
 
     // A hardened, non-tearable version of TPoint.
-    static inline class NTPoint implements NT {
+    static primitive class NTPoint implements NT {
         NTPoint(long x, long y) { this.x = x; this.y = y; }
         final long x, y;
         public String toString() { return String.format("(%d,%d)", x, y); }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VarArgsArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VarArgsArray.java
@@ -157,7 +157,7 @@ public class VarArgsArray {
         new VarArgsArray().test();
     }
 
-    inline class MyInt {
+    primitive class MyInt {
         int value;
         public MyInt() { this(0); }
         public MyInt(int v) { this.value = v; }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
@@ -39,7 +39,7 @@ import jdk.test.lib.Asserts;
 public class VolatileTest {
     static final Unsafe U = Unsafe.getUnsafe();
 
-    static inline class MyValue {
+    static primitive class MyValue {
         int i = 0;
         int j = 0;
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WithFieldAccessorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WithFieldAccessorTest.java
@@ -33,7 +33,7 @@
 // access to public, protected, and private final fields in an inline type.
 public class WithFieldAccessorTest {
 
-    public static final inline class V {
+    public static final primitive class V {
         public final char c;
         protected final long l;
         private final int i;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/identityObject/InlineType.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/identityObject/InlineType.java
@@ -1,3 +1,3 @@
-public inline class InlineType {
+public primitive class InlineType {
     int i = 0;
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTAssignability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTAssignability.java
@@ -33,7 +33,7 @@
 //
 interface II { }
 
-public inline final class VTAssignability implements II {
+public primitive final class VTAssignability implements II {
     final int x;
     final int y;
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTMonitor.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTMonitor.java
@@ -29,7 +29,7 @@
  * @run main/othervm -Xverify:remote VTMonitor
  */
 
-public inline final class VTMonitor {
+public primitive final class VTMonitor {
     final int x;
     final int y;
 

--- a/test/jdk/valhalla/valuetypes/InlineConstructorTest.java
+++ b/test/jdk/valhalla/valuetypes/InlineConstructorTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.*;
 public class InlineConstructorTest {
 
     // Target test class
-    static inline class SimpleInline {
+    static primitive class SimpleInline {
         public final int x;
 
         SimpleInline() {

--- a/test/jdk/valhalla/valuetypes/InlineTypeConversionTest.java
+++ b/test/jdk/valhalla/valuetypes/InlineTypeConversionTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class InlineTypeConversionTest {
-    static inline class Value {
+    static primitive class Value {
         Point val;
         Point.ref ref;
         Value(Point p1, Point.ref p2) {

--- a/test/jdk/valhalla/valuetypes/LambdaConversion.java
+++ b/test/jdk/valhalla/valuetypes/LambdaConversion.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.*;
 public class LambdaConversion {
 
     static class c_int { }
-    static inline class Pointer<X> {
+    static primitive class Pointer<X> {
         final long addr;
 
         public Pointer(long addr) {

--- a/test/jdk/valhalla/valuetypes/Line.java
+++ b/test/jdk/valhalla/valuetypes/Line.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-public final inline class Line {
+public final primitive class Line {
     public Point p1;
     public Point p2;
 

--- a/test/jdk/valhalla/valuetypes/NonFlattenValue.java
+++ b/test/jdk/valhalla/valuetypes/NonFlattenValue.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-public inline class NonFlattenValue {
+public primitive class NonFlattenValue {
     Point.ref nfp;
 
     NonFlattenValue() {

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -202,7 +202,7 @@ public class ObjectMethods {
         return hc;
     }
 
-    static inline class MyValue1 {
+    static primitive class MyValue1 {
         private Point p;
         private Point.ref np;
 
@@ -234,7 +234,7 @@ public class ObjectMethods {
         }
     }
 
-    static inline class InlineType1 implements Number {
+    static primitive class InlineType1 implements Number {
         int i;
         public InlineType1(int i) {
             this.i = i;
@@ -244,7 +244,7 @@ public class ObjectMethods {
         }
     }
 
-    static inline class InlineType2 implements Number {
+    static primitive class InlineType2 implements Number {
         int i;
         public InlineType2(int i) {
             this.i = i;

--- a/test/jdk/valhalla/valuetypes/Point.java
+++ b/test/jdk/valhalla/valuetypes/Point.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-public inline class Point {
+public primitive class Point {
     static final Object STATIC_FIELD = new Object();
     public int x;
     public int y;

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -199,7 +199,7 @@ public class QTypeDescriptorTest {
         Line toLine(Point p, NonFlattenValue nfv);
     }
 
-    static inline class ValueTest {
+    static primitive class ValueTest {
         private final int value;
         public ValueTest() { this.value = 0; }
 

--- a/test/jdk/valhalla/valuetypes/Serialization.java
+++ b/test/jdk/valhalla/valuetypes/Serialization.java
@@ -78,7 +78,7 @@ public class Serialization {
     }
 
     /** A Serializable Point */
-    static inline class SerializablePoint implements Serializable {
+    static primitive class SerializablePoint implements Serializable {
         public int x;
         public int y;
         SerializablePoint(int x, int y) { this.x = x; this.y = y; }
@@ -90,7 +90,7 @@ public class Serialization {
     }
 
     /** An Externalizable Point */
-    static inline class ExternalizablePoint implements Externalizable {
+    static primitive class ExternalizablePoint implements Externalizable {
         public int x;
         public int y;
         ExternalizablePoint(int x, int y) { this.x = x; this.y = y; }
@@ -130,7 +130,7 @@ public class Serialization {
     }
 
     /** A Serializable Foo, with a serial proxy */
-    static inline class SerializableFoo implements Serializable {
+    static primitive class SerializableFoo implements Serializable {
         public int x;
         SerializableFoo(int x) { this.x = x; }
         static SerializableFoo make(int x) {
@@ -152,7 +152,7 @@ public class Serialization {
     }
 
     /** An Externalizable Foo, with a serial proxy */
-    static inline class ExternalizableFoo implements Externalizable {
+    static primitive class ExternalizableFoo implements Externalizable {
         public String s;
         ExternalizableFoo(String s) {  this.s = s; }
         static ExternalizableFoo make(String s) {

--- a/test/jdk/valhalla/valuetypes/StaticInitFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticInitFactoryTest.java
@@ -40,10 +40,10 @@ import java.util.Arrays;
 public class StaticInitFactoryTest {
     static interface Cons {};
 
-    static inline class DefaultConstructor implements Cons {
+    static primitive class DefaultConstructor implements Cons {
         int x = 0;
     }
-    static inline class ConstructorWithArgs implements Cons {
+    static primitive class ConstructorWithArgs implements Cons {
         int x;
         int y;
         public ConstructorWithArgs(int x) {

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -73,7 +73,7 @@ public class StreamTest {
         stream.forEach(p -> assertTrue((p.x % 2) == 0));
     }
 
-    static inline class Value {
+    static primitive class Value {
         int i;
         Point p;
         Point.ref nullable;

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -119,7 +119,7 @@ public class SubstitutabilityTest {
                        .setLong(4L);
     }
 
-    static inline class MyValue {
+    static primitive class MyValue {
         static int cnt = 0;
         final int x;
         final MyValue2 vtField1;
@@ -132,7 +132,7 @@ public class SubstitutabilityTest {
         }
     }
 
-    static inline class MyValue2 {
+    static primitive class MyValue2 {
         static int cnt = 0;
         final int x;
         public MyValue2() {

--- a/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedInlineValueTest.java
@@ -39,13 +39,13 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class UninitializedInlineValueTest {
-    static inline class EmptyInline {
+    static primitive class EmptyInline {
         public boolean isEmpty() {
             return true;
         }
     }
 
-    static inline class InlineValue {
+    static primitive class InlineValue {
         Object o;
         EmptyInline empty;
         InlineValue() {

--- a/test/jdk/valhalla/valuetypes/Value.java
+++ b/test/jdk/valhalla/valuetypes/Value.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-public inline class Value {
+public primitive class Value {
     char char_v;
     byte byte_v;
     boolean boolean_v;
@@ -148,7 +148,7 @@ public inline class Value {
         }
     }
 
-    static inline class IntValue implements Number {
+    static primitive class IntValue implements Number {
         int i;
         IntValue(int i) {
             this.i = i;
@@ -158,7 +158,7 @@ public inline class Value {
         }
     }
 
-    static inline class ShortValue implements Number {
+    static primitive class ShortValue implements Number {
         short s;
         ShortValue(short s) {
             this.s = s;

--- a/test/jdk/valhalla/valuetypes/ValueBootstrapMethods.java
+++ b/test/jdk/valhalla/valuetypes/ValueBootstrapMethods.java
@@ -72,7 +72,7 @@ public class ValueBootstrapMethods {
         }
     }
 
-    public static inline class Value {
+    public static primitive class Value {
         private final int i;
         private final double d;
         private final String s;

--- a/test/langtools/tools/javac/diags/CheckResourceKeys.java
+++ b/test/langtools/tools/javac/diags/CheckResourceKeys.java
@@ -310,8 +310,7 @@ public class CheckResourceKeys {
             "javac.",
             "verbose.",
             "locn.",
-            "java.lang.__value__",
-            "java.lang.__inline__"
+            "java.lang.__primitive__"
     ));
 
     /**

--- a/test/langtools/tools/javac/diags/examples/InlineMayNotOverride.java
+++ b/test/langtools/tools/javac/diags/examples/InlineMayNotOverride.java
@@ -23,7 +23,7 @@
 
 // key: compiler.err.inline.class.may.not.override
 
-inline class InlineBogusOverride {
+primitive class InlineBogusOverride {
     int x = 42;
     public Object clone() {
         return this;

--- a/test/langtools/tools/javac/diags/examples/ProjectionCantBeInstantiated.java
+++ b/test/langtools/tools/javac/diags/examples/ProjectionCantBeInstantiated.java
@@ -23,7 +23,7 @@
 
 // key: compiler.err.projection.cant.be.instantiated
 
-public inline class ProjectionCantBeInstantiated {
+public primitive class ProjectionCantBeInstantiated {
     int x = 42;
     public static void main(String[] args) {
         new ProjectionCantBeInstantiated();

--- a/test/langtools/tools/javac/diags/examples/ValueInstanceFieldExpectedHere.java
+++ b/test/langtools/tools/javac/diags/examples/ValueInstanceFieldExpectedHere.java
@@ -24,7 +24,7 @@
 // options: -XDallowWithFieldOperator
 // key: compiler.err.value.instance.field.expected.here
 
-final inline class Blah {
+final primitive class Blah {
     final int x;
     static int si;
     Blah() {

--- a/test/langtools/tools/javac/diags/examples/ValuesNotSupported.java
+++ b/test/langtools/tools/javac/diags/examples/ValuesNotSupported.java
@@ -26,4 +26,4 @@
 // key: compiler.warn.source.no.system.modules.path
 // options: -source 13
 
-inline final class ValuesNotSupported {}
+primitive final class ValuesNotSupported {}

--- a/test/langtools/tools/javac/diags/examples/WithFieldOperatorDisallowed.java
+++ b/test/langtools/tools/javac/diags/examples/WithFieldOperatorDisallowed.java
@@ -23,7 +23,7 @@
 
 // key: compiler.err.with.field.operator.disallowed
 
-final inline class Blah {
+final primitive class Blah {
     final int x;
     Blah() {
         Blah b = __WithField(x, 10);

--- a/test/langtools/tools/javac/valhalla/lworld-values/AnonymousValue.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AnonymousValue.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 
 public class AnonymousValue {
 	 static Function<String, String> capitalizer() {
-        return new inline Function<>() {
+        return new primitive Function<>() {
             int x = 10;
 			@Override
 			public String apply(String t) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/AnonymousValueType.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AnonymousValueType.java
@@ -31,7 +31,7 @@
 
 public class AnonymousValueType {
     public static void main(String[] args) {
-        Object o = new inline Comparable<String>() {
+        Object o = new primitive Comparable<String>() {
             int x = 10;
             @Override
             public int compareTo(String o) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 
 public class ArrayCreationWithQuestion {
 
-    static inline class VT {
+    static primitive class VT {
         VT.ref[] a1 = new VT.ref[42];
         VT.ref[] a2 = new VT.ref[42];
         VT[] a3 = new VT[42];

--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayRelationsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayRelationsTest.java
@@ -30,7 +30,7 @@
  * @run main/othervm ArrayRelationsTest
  */
 
-public inline class ArrayRelationsTest {
+public primitive class ArrayRelationsTest {
 
     int x = 42;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/AssortedTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AssortedTests.java
@@ -30,14 +30,14 @@
  * @compile AssortedTests.java
  */
 
-inline class MyValue1 {
+primitive class MyValue1 {
     final int x = 0;
 }
 
 class X {
     static final MyValue1 vField = new MyValue1();
 
-    inline class MyValue2 {
+    primitive class MyValue2 {
         final MyValue1.ref vBoxField;
 
         public MyValue2() {
@@ -48,14 +48,14 @@ class X {
     public static void main(String[] args) { }
 }
 
-inline class MyValue3 {
+primitive class MyValue3 {
     final int x = 0;
     public int hash() { return 0; }
 }
 
 class Y {
 
-    inline class MyValue4 {
+    primitive class MyValue4 {
         final MyValue3.ref vBoxField = null;
 
         public int test() {
@@ -70,7 +70,7 @@ interface MyInterface {
     public void test(MyValue5.ref vt);
 }
 
-inline class MyValue5 implements MyInterface {
+primitive class MyValue5 implements MyInterface {
     final int x = 0;
 
     @Override

--- a/test/langtools/tools/javac/valhalla/lworld-values/AttributesTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AttributesTest.java
@@ -38,7 +38,7 @@ public class AttributesTest {
 
     void foo() {
         @Deprecated
-        inline class V<T> {}
+        primitive class V<T> {}
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/langtools/tools/javac/valhalla/lworld-values/AutoCloseableTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/AutoCloseableTest.java
@@ -26,13 +26,13 @@
 /*
  * @test
  * @bug 8244711
- * @summary Test that inline types work well with TWR
+ * @summary Test that primitive classes work well with TWR
  * @run main AutoCloseableTest
  */
 
 public class AutoCloseableTest {
 
-    inline static class Foo implements AutoCloseable {
+    primitive static class Foo implements AutoCloseable {
 
         String s = "Exception while closing AutoCloseable";
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.java
@@ -11,12 +11,12 @@ public class BinarySuperclassConstraints {
     // -------------------------------------------------------------
 
     // Test that super class cannot be concrete, including express jlO
-    inline class I0 extends SuperclassCollections.BadSuper {} // ERROR: concrete super class
+    primitive class I0 extends SuperclassCollections.BadSuper {} // ERROR: concrete super class
 
     // Test that abstract class is allowed to be super including when extending jlO
-    inline class I3 extends SuperclassCollections.GoodSuper implements SuperclassCollections.GoodSuperInterface {} // jlO can be indirect super class
-    inline class I4 extends SuperclassCollections.Integer {}
-    inline class I5 extends Number {
+    primitive class I3 extends SuperclassCollections.GoodSuper implements SuperclassCollections.GoodSuperInterface {} // jlO can be indirect super class
+    primitive class I4 extends SuperclassCollections.Integer {}
+    primitive class I5 extends Number {
         public double doubleValue() { return 0; }
         public float floatValue() { return 0; }
         public long longValue() { return 0; }
@@ -26,22 +26,22 @@ public class BinarySuperclassConstraints {
     // -------------------------------------------------------------
 
     // Test that super class cannot define instance fields.
-    inline class I6 extends SuperclassCollections.SuperWithInstanceField_01 {} // ERROR:
+    primitive class I6 extends SuperclassCollections.SuperWithInstanceField_01 {} // ERROR:
 
-    inline class I7 extends SuperclassCollections.SuperWithStaticField {} // OK.
+    primitive class I7 extends SuperclassCollections.SuperWithStaticField {} // OK.
 
     // -------------------------------------------------------------
 
     // Test that no-arg constructor must be empty
-    inline class I8 extends SuperclassCollections.SuperWithEmptyNoArgCtor_02 {}
+    primitive class I8 extends SuperclassCollections.SuperWithEmptyNoArgCtor_02 {}
 
-    inline class I9 extends SuperclassCollections.SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
+    primitive class I9 extends SuperclassCollections.SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
 
-    inline class I10 extends SuperclassCollections.SuperWithArgedCtor_01 {} // ERROR:
+    primitive class I10 extends SuperclassCollections.SuperWithArgedCtor_01 {} // ERROR:
 
-    inline class I11 extends SuperclassCollections.SuperWithInstanceInit_01 {} // ERROR:
+    primitive class I11 extends SuperclassCollections.SuperWithInstanceInit_01 {} // ERROR:
 
-    inline class I12 extends SuperclassCollections.SuperWithSynchronizedMethod_1 {} // ERROR:
+    primitive class I12 extends SuperclassCollections.SuperWithSynchronizedMethod_1 {} // ERROR:
 
-    inline class I13 extends SuperclassCollections.InnerSuper {}
+    primitive class I13 extends SuperclassCollections.InnerSuper {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
@@ -1,8 +1,8 @@
-BinarySuperclassConstraints.java:14:12: compiler.err.inline.type.must.not.implement.identity.object: BinarySuperclassConstraints.I0
-BinarySuperclassConstraints.java:29:12: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
-BinarySuperclassConstraints.java:38:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
-BinarySuperclassConstraints.java:40:12: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor
-BinarySuperclassConstraints.java:42:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithInstanceInit(), BinarySuperclassConstraints.I11, SuperclassCollections.SuperWithInstanceInit
-BinarySuperclassConstraints.java:44:12: compiler.err.super.method.cannot.be.synchronized: foo(), BinarySuperclassConstraints.I12, SuperclassCollections.SuperWithSynchronizedMethod
-BinarySuperclassConstraints.java:46:12: compiler.err.encl.class.required: SuperclassCollections.InnerSuper
+BinarySuperclassConstraints.java:14:15: compiler.err.inline.type.must.not.implement.identity.object: BinarySuperclassConstraints.I0
+BinarySuperclassConstraints.java:29:15: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
+BinarySuperclassConstraints.java:38:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
+BinarySuperclassConstraints.java:40:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor
+BinarySuperclassConstraints.java:42:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithInstanceInit(), BinarySuperclassConstraints.I11, SuperclassCollections.SuperWithInstanceInit
+BinarySuperclassConstraints.java:44:15: compiler.err.super.method.cannot.be.synchronized: foo(), BinarySuperclassConstraints.I12, SuperclassCollections.SuperWithSynchronizedMethod
+BinarySuperclassConstraints.java:46:15: compiler.err.encl.class.required: SuperclassCollections.InnerSuper
 7 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BoxValCastTest.java
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 
 public class BoxValCastTest {
 
-    static inline class VT {
+    static primitive class VT {
         int f = 0;
         static final VT.ref vtbox = (VT.ref) new VT(); // no binary cast
         static VT vt = (VT) vtbox; // binary cast

--- a/test/langtools/tools/javac/valhalla/lworld-values/CanonicalCtorTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CanonicalCtorTest.java
@@ -28,7 +28,7 @@
  * @run main/othervm -ea CanonicalCtorTest
  */
 
-public inline class CanonicalCtorTest {
+public primitive class CanonicalCtorTest {
 
 	private final int x, ymx;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/CastNullCheckTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CastNullCheckTest.java
@@ -35,7 +35,7 @@
 
 public class CastNullCheckTest {
 
-    final inline class XX {
+    final primitive class XX {
         final int x = 10;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
@@ -30,28 +30,28 @@
 
 public class ChainedAssignmentTest {
 
-	static primitive class Point {
-		int x;
-		int y;
-		Point() {
-			x = y = 1234; // Problematic
-		}
-	}
+    static primitive class Point {
+        int x;
+        int y;
+        Point() {
+            x = y = 1234; // Problematic
+        }
+    }
 
-	static primitive class LongPoint {
-		long x;
-		long y;
-		LongPoint() {
-			x = y = 1234; // Problematic
-		}
-	}
-	public static void main(String[] args) {
-		Point p = new Point();
+    static primitive class LongPoint {
+        long x;
+        long y;
+        LongPoint() {
+            x = y = 1234; // Problematic
+        }
+    }
+    public static void main(String[] args) {
+        Point p = new Point();
         if (!p.toString().equals("[ChainedAssignmentTest$Point x=1234 y=1234]"))
             throw new AssertionError("Broken");
 
         LongPoint lp = new LongPoint();
         if (!lp.toString().equals("[ChainedAssignmentTest$LongPoint x=1234 y=1234]"))
             throw new AssertionError("Broken");
-	}
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
@@ -30,7 +30,7 @@
 
 public class ChainedAssignmentTest {
 
-	static inline class Point {
+	static primitive class Point {
 		int x;
 		int y;
 		Point() {
@@ -38,7 +38,7 @@ public class ChainedAssignmentTest {
 		}
 	}
 
-	static inline class LongPoint {
+	static primitive class LongPoint {
 		long x;
 		long y;
 		LongPoint() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckBadSelector.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckBadSelector.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckBadSelector.out -XDrawDiagnostics CheckBadSelector.java
  */
 
-inline final class Point {
+primitive final class Point {
 
     void badSelector() {
         Class<?> c = int.class;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.java
@@ -5,8 +5,8 @@
  * @compile/fail/ref=CheckClone.out -XDrawDiagnostics CheckClone.java
  */
 
-final inline class CheckClone {
-    final inline class InnerValue {
+final primitive class CheckClone {
+    final primitive class InnerValue {
         void foo(InnerValue iv) {
             iv.clone();
             clone();

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckCyclicMembership.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckCyclicMembership.java
@@ -5,11 +5,11 @@
  * @compile/fail/ref=CheckCyclicMembership.out -XDrawDiagnostics CheckCyclicMembership.java
  */
 
-final inline class CheckCyclicMembership {
+final primitive class CheckCyclicMembership {
     class InnerRef {
         CheckCyclicMembership ccm;
     }
-    inline final class InnerValue {
+    primitive final class InnerValue {
         final CheckCyclicMembership ccm = CheckCyclicMembership.default; // Error.
     }
     final CheckCyclicMembership ccm = CheckCyclicMembership.default; // Error.

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckExtends.out -XDrawDiagnostics CheckExtends.java
  */
 
-final inline class CheckExtends extends Object {
+final primitive class CheckExtends extends Object {
     static class Nested {}
-    static inline class NestedValue extends Nested {}
+    static primitive class NestedValue extends Nested {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:10:19: compiler.err.inline.type.must.not.implement.identity.object: CheckExtends.NestedValue
+CheckExtends.java:10:22: compiler.err.inline.type.must.not.implement.identity.object: CheckExtends.NestedValue
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.java
@@ -7,7 +7,7 @@
 
 public class CheckFeatureGate1 {
 
-    static inline class Val {
+    static primitive class Val {
         public int v = 42;
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFieldDescriptors.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFieldDescriptors.java
@@ -33,7 +33,7 @@
 
 import com.sun.tools.classfile.*;
 
-public inline class CheckFieldDescriptors {
+public primitive class CheckFieldDescriptors {
 
     int x = 10;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckFinal.out -XDrawDiagnostics CheckFinal.java
  */
 
-inline class CheckFinal { // implicitly final
+primitive class CheckFinal { // implicitly final
     int fi;  // implicitly final
     final int fe; // explicitly final
     void f(int x) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.java
@@ -5,11 +5,11 @@
  * @compile/fail/ref=CheckFinalize.out -XDrawDiagnostics CheckFinalize.java
  */
 
-final inline class CheckFinalize {
+final primitive class CheckFinalize {
     @Override
     protected void finalize() {}
 
-    final inline class CheckFinalizeInner { int x = 10; }
+    final primitive class CheckFinalizeInner { int x = 10; }
 
     void foo(CheckFinalizeInner cfi, CheckFinalize cf) {
         cfi.finalize();          // Error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableCycles.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableCycles.java
@@ -5,11 +5,11 @@
  * @compile/fail/ref=CheckFlattenableCycles.out -XDrawDiagnostics CheckFlattenableCycles.java
  */
 
-final inline class CheckFlattenableCycles {
+final primitive class CheckFlattenableCycles {
     class InnerRef {
         CheckFlattenableCycles cfc;
     }
-    inline final class InnerValue {
+    primitive final class InnerValue {
         final CheckFlattenableCycles     cfc = CheckFlattenableCycles.default; // Error.
     }
     final CheckFlattenableCycles cfc = CheckFlattenableCycles.default; // Error.

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableSyntheticFields.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableSyntheticFields.java
@@ -35,16 +35,16 @@ import com.sun.tools.classfile.*;
 
 public class CheckFlattenableSyntheticFields {
     public class RefOuter {
-        inline  class Inner {
+        primitive  class Inner {
             private final int value2;
             public Inner(int value2) {
                 this.value2 = value2;
             }
         }
     }
-    public inline class ValueOuter {
+    public primitive class ValueOuter {
         int x = 10;
-        inline  class Inner {
+        primitive  class Inner {
             private final int value2;
             public Inner(int value2) {
                 this.value2 = value2;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckIdentityHash.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckIdentityHash.java
@@ -28,7 +28,7 @@
  * @compile CheckIdentityHash.java 
  */
 
-final inline class CheckIdentityHash {
+final primitive class CheckIdentityHash {
     int identityHashCode(CheckIdentityHash x) {
         return 0;
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckIdentityHash01.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckIdentityHash01.java
@@ -29,7 +29,7 @@
  */
 import static java.lang.System.*;
 
-public final inline class CheckIdentityHash01 {
+public final primitive class CheckIdentityHash01 {
     void test(CheckIdentityHash01 v) {
 
         identityHashCode(v);      // <- error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckLocalClasses.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckLocalClasses.java
@@ -37,7 +37,7 @@ public class CheckLocalClasses {
     public class RefOuter {
         void foo() {
             RefOuter o = new RefOuter();
-            inline  class Inner {
+            primitive  class Inner {
                 private final int value2;
                 public Inner(int value2) {
                     System.out.println(o);
@@ -46,11 +46,11 @@ public class CheckLocalClasses {
             }
         }
     }
-    public inline class ValueOuter {
+    public primitive class ValueOuter {
         int x = 10;
         void foo() {
             ValueOuter o = new ValueOuter();
-            inline class Inner {
+            primitive class Inner {
                 private final int value2;
                 public Inner(int value2) {
                     System.out.println(o);

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.java
@@ -4,17 +4,17 @@
  *
  * @compile/fail/ref=CheckMakeDefault.out -XDallowWithFieldOperator -XDrawDiagnostics CheckMakeDefault.java
  */
-inline final class Point {
+primitive final class Point {
 
-    inline interface I { int x = 10; } // Error
-    inline abstract class A { int x = 10; } // Error
+    primitive interface I { int x = 10; } // Error
+    primitive abstract class A { int x = 10; } // Error
     static final class Sinner {
         static Sinner make() {
             return Sinner.default;
         }
     }
 
-    inline static final class SinnerValue {
+    primitive static final class SinnerValue {
         static SinnerValue make() {
             return SinnerValue.default;
         } int x = 10;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.out
@@ -1,5 +1,5 @@
-CheckMakeDefault.java:9:12: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckMakeDefault.java:10:21: compiler.err.illegal.combination.of.modifiers: abstract, inline
+CheckMakeDefault.java:9:15: compiler.err.illegal.combination.of.modifiers: interface, inline
+CheckMakeDefault.java:10:24: compiler.err.illegal.combination.of.modifiers: abstract, inline
 CheckMakeDefault.java:26:32: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: boolean, int)
 CheckMakeDefault.java:27:33: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: byte, boolean)
 CheckMakeDefault.java:28:33: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: char, boolean)

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckMultiDimensionalArrayStore.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckMultiDimensionalArrayStore.java
@@ -5,7 +5,7 @@
  */
 
 public class CheckMultiDimensionalArrayStore {
-    inline final class V {
+    primitive final class V {
         final int x = 10;
         class Y {
             V [][][] va = new V[][][] {{{ null }}};

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckNullAssign.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckNullAssign.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckNullAssign.out -XDrawDiagnostics CheckNullAssign.java
  */
 
-final inline class CheckNullAssign {
+final primitive class CheckNullAssign {
     CheckNullAssign foo(CheckNullAssign cna) {
         // All of the below involve subtype/assignability checks and should be rejected.
         cna = null;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckNullCastable.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckNullCastable.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckNullCastable.out -XDrawDiagnostics CheckNullCastable.java
  */
 
-inline final class CheckNullCastable {
+primitive final class CheckNullCastable {
     void foo(CheckNullCastable cnc) {
         CheckNullCastable cncl = (CheckNullCastable) null;
         if (cnc != null) {};

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckNullWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckNullWithQuestion.java
@@ -30,7 +30,7 @@
  * @compile CheckNullWithQuestion.java
  */
 
-inline class CheckNullWithQuestion {
+primitive class CheckNullWithQuestion {
     final int x = 0;
     void foo(boolean flag) {
         CheckNullWithQuestion.ref vBox = null;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckObjectMethodsUsage.out -XDrawDiagnostics CheckObjectMethodsUsage.java
  */
 
-public inline class CheckObjectMethodsUsage {
+public primitive class CheckObjectMethodsUsage {
     int x = 42;
 
     public void finalize() {}

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckQuestionInMessages.java
@@ -8,7 +8,7 @@
 
 import java.util.List;
 
-inline class X {
+primitive class X {
     List<X.ref> ls = new Object();
     X.ref[] xa = new Object[10];  // no support for Object.ref yet, but they are the same.
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
@@ -31,7 +31,7 @@ public class CheckSeparateCompile0 {
 		int o = 456;
 		public class M {
 			int m = 789;
-			public inline class I {
+			public primitive class I {
 				int i = 0;
 				I() {
 					

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
@@ -26,23 +26,23 @@
  */
 
 public class CheckSeparateCompile0 {
-	int x = 123;
-	public class O {
-		int o = 456;
-		public class M {
-			int m = 789;
-			public primitive class I {
-				int i = 0;
-				I() {
-					
-				}
-				String foo() {
-					return this.toString();
-				}
-			}
+    int x = 123;
+    public class O {
+        int o = 456;
+        public class M {
+            int m = 789;
+            public primitive class I {
+                int i = 0;
+                I() {
+                    
+                }
+                String foo() {
+                    return this.toString();
+                }
+            }
             public String toString() {
                 return "o = " + o + " m = " + m + " x = " + x;
             }
-		}
-	}
+        }
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
@@ -34,7 +34,7 @@ public class CheckSeparateCompile0 {
             public primitive class I {
                 int i = 0;
                 I() {
-                    
+
                 }
                 String foo() {
                     return this.toString();

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckStaticFinalAssign.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckStaticFinalAssign.java
@@ -4,7 +4,7 @@
  * @compile/fail/ref=CheckStaticFinalAssign.out -XDrawDiagnostics -XDdev CheckStaticFinalAssign.java
  */
 
-inline final class CheckStaticFinalAssign {
+primitive final class CheckStaticFinalAssign {
     static final int x;
     static {
         x = 10;

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSync.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSync.java
@@ -9,9 +9,9 @@
    cannot synchronize using the methods declared on jlO.
 */
 
-public final inline class CheckSync {
+public final primitive class CheckSync {
 
-    final inline class Val {
+    final primitive class Val {
         int x = 10;
         void foo() {
             // All calls below are bad.

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckSynchronized.out -XDrawDiagnostics CheckSynchronized.java
  */
 
-inline final class CheckSynchronized {
+primitive final class CheckSynchronized {
     synchronized void foo() { // <<-- ERROR, no monitor associated with `this'
     }
     void goo() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckThisLeak.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckThisLeak.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CheckThisLeak.out -XDrawDiagnostics -XDdev CheckThisLeak.java
  */
 
-inline class V {
+primitive class V {
 
 	private final int x, ymx;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.java
@@ -12,11 +12,11 @@
    All uses of value below should trigger errors.
 */
 class CheckValueModifier {
-   inline int x;
-   inline int foo() {
+   primitive int x;
+   primitive int foo() {
    }
-   inline interface IFace {}
-   inline @interface Annot {}
-   inline enum Enum {}
-   inline abstract class Inner {}
+   primitive interface IFace {}
+   primitive @interface Annot {}
+   primitive enum Enum {}
+   primitive abstract class Inner {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.out
@@ -1,7 +1,7 @@
-CheckValueModifier.java:18:11: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckValueModifier.java:19:12: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckValueModifier.java:20:11: compiler.err.mod.not.allowed.here: inline
-CheckValueModifier.java:21:20: compiler.err.illegal.combination.of.modifiers: abstract, inline
-CheckValueModifier.java:15:15: compiler.err.mod.not.allowed.here: inline
-CheckValueModifier.java:16:15: compiler.err.mod.not.allowed.here: inline
+CheckValueModifier.java:18:14: compiler.err.illegal.combination.of.modifiers: interface, inline
+CheckValueModifier.java:19:15: compiler.err.illegal.combination.of.modifiers: interface, inline
+CheckValueModifier.java:20:14: compiler.err.mod.not.allowed.here: inline
+CheckValueModifier.java:21:23: compiler.err.illegal.combination.of.modifiers: abstract, inline
+CheckValueModifier.java:15:18: compiler.err.mod.not.allowed.here: inline
+CheckValueModifier.java:16:18: compiler.err.mod.not.allowed.here: inline
 6 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralNegativeTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=ClassLiteralNegativeTest.out -XDrawDiagnostics ClassLiteralNegativeTest.java
  */
 
-final inline class ClassLiteralNegativeTest {
+final primitive class ClassLiteralNegativeTest {
     Class<ClassLiteralNegativeTest> c1 = null; // error
     Class<? extends ClassLiteralNegativeTest> c2 = null; // error
     Class<? super ClassLiteralNegativeTest> c3 = null; // error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
@@ -7,7 +7,7 @@
 
 public class ClassLiteralTypingNegativeTest {
 
-    public static inline class Foo {
+    public static primitive class Foo {
         final int value = 0;
 
         public static void main(String[] args) {
@@ -24,7 +24,7 @@ public class ClassLiteralTypingNegativeTest {
 
     interface I {}
 
-    public static inline class Bar implements I {
+    public static primitive class Bar implements I {
         final int value = 0;
 
         public static void main(String[] args) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingTest.java
@@ -42,7 +42,7 @@ public class ClassLiteralTypingTest {
         return 1;
     }
 
-    static inline class V implements I {
+    static primitive class V implements I {
         int x = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/CompilerNoBogusAssert.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CompilerNoBogusAssert.java
@@ -32,7 +32,7 @@
 
 public class CompilerNoBogusAssert {
 
-    static inline class Point {
+    static primitive class Point {
         int x;
         int y;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/CompilesJustFine.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CompilesJustFine.java
@@ -38,7 +38,7 @@ class CompilesFine {
         nfspQm = null;
     }
 }
-inline final class Point {
+primitive final class Point {
     final int x;
     final int y;
 
@@ -50,7 +50,7 @@ inline final class Point {
 
 class CompilesJustFine {
 
-    static final inline class Value {
+    static final primitive class Value {
         final PointBug2.ref nfpQm;
 
         private Value() {
@@ -58,7 +58,7 @@ class CompilesJustFine {
         }
     }
 }
-inline final class PointBug2 {
+primitive final class PointBug2 {
     final int x;
     final int y;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConditionalInlineTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConditionalInlineTypeTest.java
@@ -32,7 +32,7 @@
 
 public class ConditionalInlineTypeTest {
 
-    static inline class V {}
+    static primitive class V {}
 
     public static void main(String [] args) {
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConditionalTypeTest.java
@@ -7,7 +7,7 @@
 
 final class ConditionalTypeTest {
     interface I {}
-    static inline class Node implements I {}
+    static primitive class Node implements I {}
     static void foo(int i) {
         var ret1 = (i == 0) ? new XNodeWrapper() : new Node();
         ret1 = "String cannot be assigned to I";
@@ -32,5 +32,5 @@ final class ConditionalTypeTest {
         var ret9 = (i == 0) ? (Node.ref) new Node() : new Node();
         ret9 = "String cannot be assigned to Node";
     }
-    static inline class XNodeWrapper implements I {}
+    static primitive class XNodeWrapper implements I {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.java
@@ -9,7 +9,7 @@ public class ConflictingSuperInterfaceTest {
 
     interface I<T> {}
     abstract class S implements I<String> {}
-    inline static class Foo extends S implements I<Integer> {
+    primitive static class Foo extends S implements I<Integer> {
         String s = "";
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.out
@@ -1,2 +1,2 @@
-ConflictingSuperInterfaceTest.java:12:19: compiler.err.cant.inherit.diff.arg: ConflictingSuperInterfaceTest.I, java.lang.Integer, java.lang.String
+ConflictingSuperInterfaceTest.java:12:22: compiler.err.cant.inherit.diff.arg: ConflictingSuperInterfaceTest.I, java.lang.Integer, java.lang.String
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConstantPropagationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConstantPropagationTest.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 
 public class ConstantPropagationTest {
 
-    static final inline class X {
+    static final primitive class X {
         static final int sfif = 8888;
         final int ifif = 9999;
         static void foo(X x) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CovariantArrayTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CovariantArrayTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=CovariantArrayTest.out -XDrawDiagnostics -XDdev CovariantArrayTest.java
  */
 public class CovariantArrayTest {
-    static final inline class V {
+    static final primitive class V {
         public final int v1;
         private V () {v1 = 0;}
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CtorChain.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CtorChain.java
@@ -28,7 +28,7 @@
  * @run main/othervm CtorChain
  */
 
-public inline class CtorChain {
+public primitive class CtorChain {
     int x1, x2, x3, x4, x5;
     CtorChain() {
         this(10);

--- a/test/langtools/tools/javac/valhalla/lworld-values/DefaultNonInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DefaultNonInlines.java
@@ -30,7 +30,7 @@
 
 public class DefaultNonInlines {
 
-    static inline class Val {
+    static primitive class Val {
         public int v = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/DocLintSyntheticsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DocLintSyntheticsTest.java
@@ -31,7 +31,7 @@
 /**
  * Test javadoc
  */
-public inline class DocLintSyntheticsTest {
+public primitive class DocLintSyntheticsTest {
   /** field */
   private final int value;
   /**

--- a/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DualPathInnerType.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=DualPathInnerType.out -XDrawDiagnostics DualPathInnerType.java
  */
 
-public inline class DualPathInnerType  {
+public primitive class DualPathInnerType  {
 
     class Inner { }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/EmptyValueTest.java
@@ -29,5 +29,5 @@
  * @summary Test behavior with empty value type.
  * @compile -XDrawDiagnostics -XDdev EmptyValueTest.java
  */
-public final inline class EmptyValueTest {
+public final primitive class EmptyValueTest {
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/EnhancedForLoopTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/EnhancedForLoopTest.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 
 public class EnhancedForLoopTest {
 
-    inline static class Foo<V> implements Iterable<V> {
+    primitive static class Foo<V> implements Iterable<V> {
 
         List<V> lv;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.function.*;
 import java.util.NoSuchElementException;
 
-inline class OptionalInt {
+primitive class OptionalInt {
     // private static final OptionalInt EMPTY = OptionalInt.default;
 
     private boolean isPresent = false;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes2.java
@@ -35,7 +35,7 @@ import java.util.function.*;
 import java.util.NoSuchElementException;
 import java.util.stream.*;
 
-inline class OptionalInt {
+primitive class OptionalInt {
     // private static final OptionalInt EMPTY = OptionalInt.default;
 
     private boolean isPresent = false;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes3.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ExplicitLambdaWithNullableTypes3.java
@@ -35,7 +35,7 @@ import java.util.function.*;
 import java.util.NoSuchElementException;
 import java.util.stream.*;
 
-inline class OptionalInt {
+primitive class OptionalInt {
     // private static final OptionalInt EMPTY = OptionalInt.default;
 
     private boolean isPresent = false;

--- a/test/langtools/tools/javac/valhalla/lworld-values/FinalFieldTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/FinalFieldTest.java
@@ -4,7 +4,7 @@
  * @compile/fail/ref=FinalFieldTest.out --should-stop=at=FLOW -XDrawDiagnostics  FinalFieldTest.java
  */
 
-final inline class Blah {
+final primitive class Blah {
     final int x = 10;
     final int y;
     Blah() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/FlattenableFlagFromClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/FlattenableFlagFromClass.java
@@ -23,7 +23,7 @@
 
 public class FlattenableFlagFromClass {
 
-    public inline final class V {
+    public primitive final class V {
         final int x = 10;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/FlattenableNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/FlattenableNegativeTest.java
@@ -6,10 +6,10 @@
  */
 
 public class FlattenableNegativeTest {
-    inline final class V {
+    primitive final class V {
         final int x = 10;
         
-        inline final class X {
+        primitive final class X {
             final V v = null;  // Error: initialization illegal
             final V v2 = v;    // OK, null not constant propagated.
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericArrayRegression.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericArrayRegression.java
@@ -31,7 +31,7 @@
 
 public class GenericArrayRegression {
 
-   static inline class Entry<E> {
+   static primitive class Entry<E> {
      private final int value;
 
      public Entry(int value) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericArrayTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericArrayTest.java
@@ -7,7 +7,7 @@
 
 public class GenericArrayTest {
 
-    public inline class Value<T> {
+    public primitive class Value<T> {
 
         T t = null;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.java
@@ -9,7 +9,7 @@ abstract class Low<T, U> {}
 abstract class Mid<T, U> extends Low<U, T> {}
 abstract class High<T, U> extends Mid<U, T> {}
 
-inline
+primitive
 class GenericInlineTest<T, U> extends High<U, T> {
 
     int x = 0;

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues1.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues1.java
@@ -30,7 +30,7 @@
  * @compile GenericsAndValues1.java
  */
 
- @__inline__ class Foo implements Comparable<Foo.ref>{
+ @__primitive__ class Foo implements Comparable<Foo.ref>{
     final int value;
   
     public Foo(int value) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues2.java
@@ -32,7 +32,7 @@
 
 import java.util.function.Consumer;
 
-  @__inline__ class CaptureBug {
+  @__primitive__ class CaptureBug {
     final int value;
   
     public CaptureBug(int value) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues3.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues3.java
@@ -32,7 +32,7 @@
 
 import java.util.stream.IntStream;
 
-@__inline__ class StreamBug {
+@__primitive__ class StreamBug {
   final int value;
   
   public StreamBug(int value) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues4.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues4.java
@@ -30,7 +30,7 @@
  * @compile GenericsAndValues4.java
  */
 
-inline class InlineType<E> {
+primitive class InlineType<E> {
 
     interface Sample<K extends Comparable<? super K>, V> {
         void doesCompile(InlineType<? extends K> argument);

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues5.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsAndValues5.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
 import java.util.List;
 import java.util.ArrayList;
 
-inline class Optional<T> {
+primitive class Optional<T> {
     private T value;
 
     @SuppressWarnings("unchecked")

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericsWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericsWithQuestion.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 
 public class GenericsWithQuestion {
 
-    inline class V {
+    primitive class V {
         int x = 10;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.java
@@ -17,8 +17,8 @@ public class IllegalByValueTest {
 
     public static void main(String[] args) {
         // Error cases.
-        new inline @Annot inline Comparable <String>() {};
-        int [] ia = new inline int[10];
-        new inline String("Hello");
+        new primitive @Annot primitive Comparable <String>() {};
+        int [] ia = new primitive int[10];
+        new primitive String("Hello");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.out
@@ -1,4 +1,4 @@
-IllegalByValueTest.java:20:27: compiler.err.repeated.modifier
-IllegalByValueTest.java:21:32: compiler.err.mod.not.allowed.here: inline
+IllegalByValueTest.java:20:30: compiler.err.repeated.modifier
+IllegalByValueTest.java:21:35: compiler.err.mod.not.allowed.here: inline
 IllegalByValueTest.java:22:9: compiler.err.mod.not.allowed.here: inline
 3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.java
@@ -16,6 +16,6 @@ public class IllegalByValueTest2 {
     }
 
     public static void main(String[] args) {
-        new @Annot inline @Annot IllegalByValueTest2() {};
+        new @Annot primitive @Annot IllegalByValueTest2() {};
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
@@ -1,3 +1,3 @@
-IllegalByValueTest2.java:19:27: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
-IllegalByValueTest2.java:19:56: compiler.err.inline.type.must.not.implement.identity.object: compiler.misc.anonymous.class: IllegalByValueTest2
+IllegalByValueTest2.java:19:30: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
+IllegalByValueTest2.java:19:59: compiler.err.inline.type.must.not.implement.identity.object: compiler.misc.anonymous.class: IllegalByValueTest2
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/InferredValueParameterizationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InferredValueParameterizationTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 // This used to be negative test earlier in LW2.
 // Now no value type V <: T where T is a type variable.
 
-public inline class InferredValueParameterizationTest {
+public primitive class InferredValueParameterizationTest {
     int x = 10;
 
     static class Y<T> {

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.java
@@ -7,9 +7,9 @@
 
 class InlineAnnotationOnAnonymousClass {
     interface I {}
-    @__inline__
+    @__primitive__
     public static void main(String args []) {
-        new @__inline__ I() {
+        new @__primitive__ I() {
         };
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.java
@@ -5,15 +5,15 @@
  * @compile/fail/ref=InlineAnnotationTest.out -XDrawDiagnostics InlineAnnotationTest.java
  */
 
-@__inline__
+@__primitive__
 class InlineAnnotationTest01 extends Object { 
 }
 
-@__inline__
+@__primitive__
 class InlineAnnotationTest02 { 
 }
 
-@java.lang.__inline__
+@java.lang.__primitive__
 class InlineAnnotationTest03  { 
     int x = 10;
     InlineAnnotationTest03() {
@@ -21,6 +21,6 @@ class InlineAnnotationTest03  {
     }
 }
 
-@__inline__
+@__primitive__
 interface InlineAnnotationTest04 { 
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
@@ -30,7 +30,7 @@
  * @run main/othervm InlineClassTest
  */
 
-public inline class InlineClassTest {
+public primitive class InlineClassTest {
     int x = 42;
     public static void main(String [] args) {
         if (!new InlineClassTest().toString().equals("[InlineClassTest x=42]"))

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineDiamondTest.java
@@ -39,7 +39,7 @@ public class InlineDiamondTest<E> {
         return new Y<>();
     }
 
-    private inline class Y<U> implements I<U> {
+    private primitive class Y<U> implements I<U> {
         int x = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
@@ -33,7 +33,7 @@ import com.sun.tools.classfile.AccessFlags;
 
 public class InnerClassAttributeValuenessTest {
 
-    static inline class Inner {
+    static primitive class Inner {
         int f;
         private Inner() { f=0; }
         private Inner(int v) { f=v; }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InnerValueNew.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InnerValueNew.java
@@ -30,7 +30,7 @@
 
 
 public class InnerValueNew {
-    final inline class Y {
+    final primitive class Y {
         final int x;
         final int p = 123456;
         Y() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
@@ -30,7 +30,7 @@
 
 public class InstanceOfTopTypeTest {
     interface InlineObject {}
-    static inline class V implements InlineObject {
+    static primitive class V implements InlineObject {
         int x = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/InstanceofProjectionArray.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InstanceofProjectionArray.java
@@ -31,7 +31,7 @@
  */
 
 
-public inline class InstanceofProjectionArray {
+public primitive class InstanceofProjectionArray {
 
     int value;
     public InstanceofProjectionArray() { this.value = 0; }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest.java
@@ -28,11 +28,11 @@
  * @run main/othervm -Xverify:none IntercastTest
  */
 
-public inline class IntercastTest {
+public primitive class IntercastTest {
 
     int ARRAY[] = { 10, 20, 30 };
 
-    static inline class Tuple {
+    static primitive class Tuple {
         private final int index;
         private final int element;
 
@@ -42,7 +42,7 @@ public inline class IntercastTest {
         }
     }
 
-    static inline class Cursor {
+    static primitive class Cursor {
         private final int[] array;
         private final int index;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IntercastTest2.java
@@ -28,11 +28,11 @@
  * @run main/othervm -Xverify:none IntercastTest2
  */
 
-public inline class IntercastTest2 {
+public primitive class IntercastTest2 {
 
     int ARRAY[] = { 10, 20, 30 };
 
-    static inline class Tuple {
+    static primitive class Tuple {
         private final int index;
         private final int element;
 
@@ -42,7 +42,7 @@ public inline class IntercastTest2 {
         }
     }
 
-    static inline class Cursor {
+    static primitive class Cursor {
         private final int[] array;
         private final int index;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/LocalValueNew.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LocalValueNew.java
@@ -33,7 +33,7 @@ public class LocalValueNew {
     int xf = 1234;
     void foo() {
         int xl = 10; int yl = 20;
-        final inline class Y {
+        final primitive class Y {
             final int x;
             final int p = 123456;
             Y() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest.java
@@ -28,11 +28,11 @@
  * @run main/othervm -Xverify:none LookupOnLoxTest
  */
 
-public inline class LookupOnLoxTest {
+public primitive class LookupOnLoxTest {
 
     int ARRAY[] = { 10, 20, 30 };
 
-    static inline class Tuple {
+    static primitive class Tuple {
         private final int index;
         private final int element;
 
@@ -42,7 +42,7 @@ public inline class LookupOnLoxTest {
         }
     }
 
-    static inline class Cursor {
+    static primitive class Cursor {
         private final int[] array;
         private final int index;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LookupOnLoxTest2.java
@@ -28,11 +28,11 @@
  * @run main/othervm -Xverify:none LookupOnLoxTest2
  */
 
-public inline class LookupOnLoxTest2 {
+public primitive class LookupOnLoxTest2 {
 
     int ARRAY[] = { 10, 20, 30 };
 
-    static inline class Tuple {
+    static primitive class Tuple {
         private final int index;
         private final int element;
 
@@ -42,7 +42,7 @@ public inline class LookupOnLoxTest2 {
         }
     }
 
-    static inline class Cursor {
+    static primitive class Cursor {
         private final int[] array;
         private final int index;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/LubWithInlines.java
@@ -38,7 +38,7 @@ public class LubWithInlines {
         var ret = (e == null) ? new XNodeWrapper() : e;
         return ret;
     }
-    static inline class XNodeWrapper implements I {
+    static primitive class XNodeWrapper implements I {
         int i = 42;
     }
     public static void main(String [] args) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/MiscThisLeak.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/MiscThisLeak.java
@@ -9,7 +9,7 @@ public class MiscThisLeak {
     interface I {
         void foo();
     }
-    inline class V {
+    primitive class V {
         class K {}
         int f;
         V() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/MyValue.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/MyValue.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-inline public final class MyValue {
+primitive public final class MyValue {
   final int f = 0;
   static MyValue create() {
     return MyValue.default;

--- a/test/langtools/tools/javac/valhalla/lworld-values/NoCrashTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/NoCrashTest.java
@@ -34,7 +34,7 @@ public class NoCrashTest {
 
     interface I {}
     static class C implements I {}
-    static inline final class V implements I { int x = 0; }
+    static primitive final class V implements I { int x = 0; }
 
     static void triggerNPE(V.ref [] vra) {
         vra[0] = null;

--- a/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/NoVolatileFields.java
@@ -11,7 +11,7 @@ public class NoVolatileFields {
         volatile final int i = 0; // Error
     }
 
-    static inline class Bar {
+    static primitive class Bar {
         volatile int i = 0; // Error
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/OverloadingPhaseTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/OverloadingPhaseTest.java
@@ -7,7 +7,7 @@
 
 public class OverloadingPhaseTest {
 
-    static inline class V {
+    static primitive class V {
         int x = 0;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/OverloadingPhaseTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/OverloadingPhaseTest2.java
@@ -33,7 +33,7 @@ public class OverloadingPhaseTest2 {
     interface A {}
     interface B extends A {}
 
-    static inline class X {
+    static primitive class X {
 
         int x = 42;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ParameterizedDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ParameterizedDefault.java
@@ -28,7 +28,7 @@
  * @run main/othervm ParameterizedDefault
  */
 
-public inline class ParameterizedDefault<E> {
+public primitive class ParameterizedDefault<E> {
     E value;
     ParameterizedDefault(E value) { this.value = value; }
     static String foo (Object p) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/Point.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Point.java
@@ -30,7 +30,7 @@
  * @compile -XDallowWithFieldOperator Point.java
  */
 
-inline class Point {
+primitive class Point {
     static final Point.ref origin = makePoint(10, 20);
     static final Point.ref origin2 = makePoint(10, 20);
     int x;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectedArrayDotClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectedArrayDotClass.java
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 
 public class ProjectedArrayDotClass {
 
-    static inline class VT {
+    static primitive class VT {
         int x = 42;
         public static void main(String[] args) {
             System.out.println(VT.ref[].class);

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionInstantiationTest.java
@@ -6,7 +6,7 @@
  */
 import java.util.function.Supplier;
 
-final inline class ProjectionInstantiationTest {
+final primitive class ProjectionInstantiationTest {
     int x = 42;
     public static void main(String[] args) {
         new ProjectionInstantiationTest();

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProjectionRelationsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProjectionRelationsTest.java
@@ -60,7 +60,7 @@ public class ProjectionRelationsTest {
     }
 
     public static void main(String... args) throws Exception {
-        String code = "inline class C {\n" +
+        String code = "primitive class C {\n" +
                 "         C.ref cref     = new C();\n" +
                 "         C []  ca       = null;\n" +
                 "         C.ref [] cra   = null;\n" +

--- a/test/langtools/tools/javac/valhalla/lworld-values/ProperTypeApplySelectTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ProperTypeApplySelectTest.java
@@ -36,7 +36,7 @@ public class ProperTypeApplySelectTest {
 
   static String out = "";
 
-  inline static class Foo<V> {
+  primitive static class Foo<V> {
     int x;
     Foo(int x) { this.x = x; }
   }

--- a/test/langtools/tools/javac/valhalla/lworld-values/QPoint.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QPoint.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-inline class QPoint {
+primitive class QPoint {
     int x = 0;
     int y = 0;
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/QTypedValue.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QTypedValue.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-inline class QTypedValue {
+primitive class QTypedValue {
 
     QTypedValue [] f1 = new QTypedValue[10];
     QTypedValue [] f2 = new QTypedValue[10];

--- a/test/langtools/tools/javac/valhalla/lworld-values/QualifiedSuperCtor.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QualifiedSuperCtor.java
@@ -28,7 +28,7 @@
  * @run main/othervm QualifiedSuperCtor
  */
 
-inline class A {
+primitive class A {
     int x = 1000000;
     class Inner { 
         String aDotThis;

--- a/test/langtools/tools/javac/valhalla/lworld-values/QualifiedThisTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QualifiedThisTest.java
@@ -28,7 +28,7 @@
  * @run main/othervm QualifiedThisTest
  */
 
-public inline  class QualifiedThisTest {
+public primitive class QualifiedThisTest {
 
     final int x;
     final int y;

--- a/test/langtools/tools/javac/valhalla/lworld-values/Range.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Range.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-public inline class Range<T> {
+public primitive class Range<T> {
     private final T lower;
     private final T upper;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/RefDotClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RefDotClass.java
@@ -30,7 +30,7 @@
  * @run main RefDotClass
  */
 
-public inline class RefDotClass {
+public primitive class RefDotClass {
     final int value;
 
     public RefDotClass(int value) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest01.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SeparateCompileTest01.java
@@ -40,7 +40,7 @@ class ForeignType<X> {
     public Pointer<X> allocate() { return null; }
 }
 
-inline class Point {
+primitive class Point {
     final int x;
     final int y;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
@@ -31,7 +31,7 @@
 
 public class SideEffectTest {
 
-	static inline class V {
+	static primitive class V {
 
         static String output = "";
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
@@ -31,36 +31,36 @@
 
 public class SideEffectTest {
 
-	static primitive class V {
+    static primitive class V {
 
         static String output = "";
 
         int x;
 
-		V() {
+        V() {
             foo(x = 1234);
-		}
+        }
 
-		V(int x) {
+        V(int x) {
             int l = 1234; 
             foo(l += this.x = x);
-		}
+        }
 
         static void foo(int x) {
             output += x;
         }
-	}
+    }
 
-	public static void main(String[] args) {
-		V v = new V();
+    public static void main(String[] args) {
+        V v = new V();
         if (!v.output.equals("1234"))
             throw new AssertionError("Broken");
         if (!v.toString().equals("[SideEffectTest$V x=1234]"))
             throw new AssertionError("Broken");
-		v = new V(8765);
+        v = new V(8765);
         if (!v.output.equals("12349999"))
             throw new AssertionError("Broken");
         if (!v.toString().equals("[SideEffectTest$V x=8765]"))
             throw new AssertionError("Broken");
-	}
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/SignatureTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SignatureTest.java
@@ -33,7 +33,7 @@
 
 import com.sun.tools.classfile.*;
 
-public inline class SignatureTest<T> implements java.io.Serializable {
+public primitive class SignatureTest<T> implements java.io.Serializable {
     public static void main(String[] args) throws Exception {
         ClassFile cls = ClassFile.read(SignatureTest.class.getResourceAsStream("SignatureTest$ref.class"));
         Signature_attribute signature = (Signature_attribute) cls.attributes.get(Attribute.Signature);

--- a/test/langtools/tools/javac/valhalla/lworld-values/SmallSet.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SmallSet.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-public inline class SmallSet {
+public primitive class SmallSet {
 
   final int value;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=SneakThroSuperCallTest.out -XDrawDiagnostics -XDdev SneakThroSuperCallTest.java
  */
 
-public inline class SneakThroSuperCallTest { 
+public primitive class SneakThroSuperCallTest { 
 
     int x = 10;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=SneakThroSuperCallTest.out -XDrawDiagnostics -XDdev SneakThroSuperCallTest.java
  */
 
-public primitive class SneakThroSuperCallTest { 
+public primitive class SneakThroSuperCallTest {
 
     int x = 10;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/StaticSelectedThroughProjection.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/StaticSelectedThroughProjection.java
@@ -31,7 +31,7 @@
  */
 
 public class StaticSelectedThroughProjection {
-    static inline class MyValue {
+    static primitive class MyValue {
         int x = 42;
         static String test() {
             return "OK";

--- a/test/langtools/tools/javac/valhalla/lworld-values/StreamsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/StreamsTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 
 public class StreamsTest {
 
-    public static inline class X {
+    public static primitive class X {
 
         String data;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.java
@@ -11,22 +11,22 @@ public class SuperclassConstraints {
 
     // Test that super class cannot be concrete, including express jlO
     static class BadSuper {}
-    inline class I0 extends BadSuper {} // ERROR: concrete super class
-    inline class I1 extends Object {}   // OK: concrete jlO can be express-superclass
-    inline class I2 {} // OK
+    primitive class I0 extends BadSuper {} // ERROR: concrete super class
+    primitive class I1 extends Object {}   // OK: concrete jlO can be express-superclass
+    primitive class I2 {} // OK
 
     // Test that abstract class is allowed to be super including when extending jlO
     interface GoodSuperInterface {}
     static abstract class GoodSuper extends Object {}
-    inline class I3 extends GoodSuper implements GoodSuperInterface {} // jlO can be indirect super class
+    primitive class I3 extends GoodSuper implements GoodSuperInterface {} // jlO can be indirect super class
     static abstract class Integer extends Number {
         public double doubleValue() { return 0; }
         public float floatValue() { return 0; }
         public long longValue() { return 0; }
         public int intValue() { return 0; }
     }
-    inline class I4 extends Integer {}
-    inline class I5 extends Number {
+    primitive class I4 extends Integer {}
+    primitive class I5 extends Number {
         public double doubleValue() { return 0; }
         public float floatValue() { return 0; }
         public long longValue() { return 0; }
@@ -41,13 +41,13 @@ public class SuperclassConstraints {
     }
     static abstract class SuperWithInstanceField_01 extends SuperWithInstanceField {}
 
-    inline class I6 extends SuperWithInstanceField_01 {} // ERROR:
+    primitive class I6 extends SuperWithInstanceField_01 {} // ERROR:
 
     // Test that super class can define static fields.
     static abstract class SuperWithStaticField {
         static int x;
     }
-    inline class I7 extends SuperWithStaticField {} // OK.
+    primitive class I7 extends SuperWithStaticField {} // OK.
 
     // -------------------------------------------------------------
 
@@ -65,7 +65,7 @@ public class SuperclassConstraints {
     static abstract class SuperWithEmptyNoArgCtor_02 extends SuperWithEmptyNoArgCtor_01 {
         // Synthesized chaining no-arg constructor
     }
-    inline class I8 extends SuperWithEmptyNoArgCtor_02 {}
+    primitive class I8 extends SuperWithEmptyNoArgCtor_02 {}
 
     static abstract class SuperWithNonEmptyNoArgCtor {
         SuperWithNonEmptyNoArgCtor() {
@@ -73,7 +73,7 @@ public class SuperclassConstraints {
         }
     }
     static abstract class SuperWithNonEmptyNoArgCtor_01 extends SuperWithNonEmptyNoArgCtor {}
-    inline class I9 extends SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
+    primitive class I9 extends SuperWithNonEmptyNoArgCtor_01 {} // ERROR:
 
     // Test that there can be no other constructors.
     static abstract class SuperWithArgedCtor {
@@ -82,7 +82,7 @@ public class SuperclassConstraints {
         }
     }
     static abstract class SuperWithArgedCtor_01 extends SuperWithArgedCtor {}
-    inline class I10 extends SuperWithArgedCtor_01 {} // ERROR:
+    primitive class I10 extends SuperWithArgedCtor_01 {} // ERROR:
 
     // Test that instance initializers are not allowed in supers
     static abstract class SuperWithInstanceInit {
@@ -95,7 +95,7 @@ public class SuperclassConstraints {
             // Not disqualified since it is a meaningless empty block.
         }
     }
-    inline class I11 extends SuperWithInstanceInit_01 {} // ERROR:
+    primitive class I11 extends SuperWithInstanceInit_01 {} // ERROR:
 
     // Test that synchronized methods are not allowed in supers.
     static abstract class SuperWithSynchronizedMethod {
@@ -103,9 +103,9 @@ public class SuperclassConstraints {
     }
     static abstract class SuperWithSynchronizedMethod_1 extends SuperWithSynchronizedMethod {
     }
-    inline class I12 extends SuperWithSynchronizedMethod_1 {} // ERROR:
+    primitive class I12 extends SuperWithSynchronizedMethod_1 {} // ERROR:
 
     // No instance fields and no arged constructor also means inner classes cannot be supers
     abstract class InnerSuper {}
-    inline class I13 extends InnerSuper {}
+    primitive class I13 extends InnerSuper {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,8 +1,8 @@
-SuperclassConstraints.java:14:12: compiler.err.inline.type.must.not.implement.identity.object: SuperclassConstraints.I0
-SuperclassConstraints.java:44:12: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
-SuperclassConstraints.java:76:12: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
-SuperclassConstraints.java:85:12: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor
-SuperclassConstraints.java:98:12: compiler.err.super.class.declares.init.block: SuperclassConstraints.I11, SuperclassConstraints.SuperWithInstanceInit
-SuperclassConstraints.java:106:12: compiler.err.super.method.cannot.be.synchronized: foo(), SuperclassConstraints.I12, SuperclassConstraints.SuperWithSynchronizedMethod
-SuperclassConstraints.java:110:12: compiler.err.super.class.cannot.be.inner: SuperclassConstraints.I13, SuperclassConstraints.InnerSuper
+SuperclassConstraints.java:14:15: compiler.err.inline.type.must.not.implement.identity.object: SuperclassConstraints.I0
+SuperclassConstraints.java:44:15: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
+SuperclassConstraints.java:76:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
+SuperclassConstraints.java:85:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor
+SuperclassConstraints.java:98:15: compiler.err.super.class.declares.init.block: SuperclassConstraints.I11, SuperclassConstraints.SuperWithInstanceInit
+SuperclassConstraints.java:106:15: compiler.err.super.method.cannot.be.synchronized: foo(), SuperclassConstraints.I12, SuperclassConstraints.SuperWithSynchronizedMethod
+SuperclassConstraints.java:110:15: compiler.err.super.class.cannot.be.inner: SuperclassConstraints.I13, SuperclassConstraints.InnerSuper
 7 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/TestQualifierOnInit.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TestQualifierOnInit.java
@@ -32,7 +32,7 @@
  */
 
 
-inline final class TestValue1 {
+primitive final class TestValue1 {
     final int x;
     public TestValue1(int x) {
         this.x = x;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ThisIsNotAnInstanceField.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ThisIsNotAnInstanceField.java
@@ -30,13 +30,13 @@
  * @run main ThisIsNotAnInstanceField
  */
 
-public inline class ThisIsNotAnInstanceField {
+public primitive class ThisIsNotAnInstanceField {
 
     int i = 513;
 
     Inner.ref i2 = new Inner();
 
-    inline class Inner {
+    primitive class Inner {
         int c = 511;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.java
@@ -25,9 +25,9 @@ public class TopInterfaceNegativeTest  {
     static class C6 implements IdentityObject, ID {}
     static class C7 implements II, ID {}
 
-    static inline class V1 implements IdentityObject { int x = 0; }
-    static inline class V2 implements InlineObject {}
-    static inline class V3 implements InlineObject, InlineObject  {}
+    static primitive class V1 implements IdentityObject { int x = 0; }
+    static primitive class V2 implements InlineObject {}
+    static primitive class V3 implements InlineObject, InlineObject  {}
 
     void foo(V2 v) {
         if (v instanceof IdentityObject)

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -1,12 +1,12 @@
-TopInterfaceNegativeTest.java:29:39: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
+TopInterfaceNegativeTest.java:29:42: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:11:26: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:13:44: compiler.err.repeated.interface
 TopInterfaceNegativeTest.java:14:44: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:17:28: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:20:32: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:24:48: compiler.err.repeated.interface
-TopInterfaceNegativeTest.java:30:39: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:30:53: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:28:19: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
+TopInterfaceNegativeTest.java:30:42: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
+TopInterfaceNegativeTest.java:30:56: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
+TopInterfaceNegativeTest.java:28:22: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
 TopInterfaceNegativeTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TopInterfaceNegativeTest.V2, java.lang.IdentityObject)
 11 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceTest.java
@@ -32,7 +32,7 @@ public class TopInterfaceTest  {
 
     static class C {}
 
-    static inline class V {
+    static primitive class V {
         int x = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=TypeRelationsNegativeTest.out -XDrawDiagnostics TypeRelationsNegativeTest.java
  */
 
-final inline class TypeRelationsNegativeTest {
+final primitive class TypeRelationsNegativeTest {
 
     void foo() {
         TypeRelationsNegativeTest x = null; // error

--- a/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsTest.java
@@ -30,7 +30,7 @@
  * @run main/othervm TypeRelationsTest
  */
 
-public inline class TypeRelationsTest {
+public primitive class TypeRelationsTest {
 
     int x = 42;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnannotatedProjection.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnannotatedProjection.java
@@ -53,7 +53,7 @@ public class UnannotatedProjection {
     @interface TARR {}
 
     @DA @DARR
-    public inline class V<@TA @TARR T> {}
+    public primitive class V<@TA @TARR T> {}
 
     public static void main(String[] args) throws Exception {
         ClassFile cls = ClassFile.read(UnannotatedProjection.class.getResourceAsStream("UnannotatedProjection$V.class"));

--- a/test/langtools/tools/javac/valhalla/lworld-values/UncheckedDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UncheckedDefault.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=UncheckedDefault.out -Xlint:all -Werror -XDrawDiagnostics -XDdev UncheckedDefault.java
  */
 
-public inline class UncheckedDefault<E> {
+public primitive class UncheckedDefault<E> {
     E value;
     UncheckedDefault(E value) { this.value = value; }
     public static void main(String [] args) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnrelatedThisLeak.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnrelatedThisLeak.java
@@ -29,7 +29,7 @@
  */
 
 public class UnrelatedThisLeak {
-    inline class V {
+    primitive class V {
         int f;
         V() {
             UnrelatedThisLeak x = UnrelatedThisLeak.this;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.java
@@ -7,9 +7,9 @@
 
 class ValueAnnotationOnAnonymousClass {
     interface I {}
-    @__inline__
+    @__primitive__
     public static void main(String args []) {
-        new @__inline__ I() {
+        new @__primitive__ I() {
         };
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.java
@@ -5,15 +5,15 @@
  * @compile/fail/ref=ValueAnnotationTest.out -XDrawDiagnostics ValueAnnotationTest.java
  */
 
-@__inline__
+@__primitive__
 class ValueAnnotationTest01 extends Object { 
 }
 
-@__inline__
+@__primitive__
 class ValueAnnotationTest02 { 
 }
 
-@java.lang.__inline__
+@java.lang.__primitive__
 class ValueAnnotationTest03  { 
     int x = 10;
     ValueAnnotationTest03() {
@@ -21,6 +21,6 @@ class ValueAnnotationTest03  {
     }
 }
 
-@__inline__
+@__primitive__
 interface ValueAnnotationTest04 { 
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAsEnclosingClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAsEnclosingClass.java
@@ -28,9 +28,9 @@
  * @run main/othervm ValueAsEnclosingClass
  */
 
-public inline class ValueAsEnclosingClass {
+public primitive class ValueAsEnclosingClass {
 
-    static inline class V {
+    static primitive class V {
         int y = 52;
 
         class Bar { }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueBootstrapMethodsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueBootstrapMethodsTest.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 public class ValueBootstrapMethodsTest {
 
-    public static final inline class Value {
+    public static final primitive class Value {
         private final int i;
         private final double d;
         private final String s;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
@@ -31,7 +31,7 @@
 
 import java.util.function.Supplier;
 
-public inline class ValueConstructorRef {
+public primitive class ValueConstructorRef {
 
     final int x;
     final int y;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueCreationTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueCreationTest.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 
 public class ValueCreationTest {
 
-    inline
+    primitive
     static final class Point {
 
         final int x;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.java
@@ -8,12 +8,12 @@
 public class ValueModifierTest {
     interface value {}
     void foo() {
-        new inline value() {};
+        new primitive value() {};
     }
     void goo() {
-        inline class value {}
+        primitive class value {}
         new value() {};
-        new inline value() {};
+        new primitive value() {};
         new value();
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -1,5 +1,5 @@
 ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: value
 ValueModifierTest.java:15:21: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$2, value
-ValueModifierTest.java:16:20: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:16:28: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$3, value
+ValueModifierTest.java:16:23: compiler.err.cant.inherit.from.final: value
+ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$3, value
 4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueNewReadWrite.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueNewReadWrite.java
@@ -28,7 +28,7 @@
  * @run main/othervm ValueNewReadWrite
  */
 
-public inline class ValueNewReadWrite {
+public primitive class ValueNewReadWrite {
 
     int y = 10;
     int twice_x_plus_y;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueOverGenericsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueOverGenericsTest.java
@@ -8,7 +8,7 @@
 import java.util.ArrayList;
 import java.io.Serializable;
 
-inline class ValueOverGenericsTest {
+primitive class ValueOverGenericsTest {
     int x = 10;
     ArrayList<ValueOverGenericsTest> ax = null;
     void foo(ArrayList<? extends ValueOverGenericsTest> p) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValuesAsRefs.java
@@ -30,11 +30,11 @@
  */
 import java.util.ArrayList;
 
-public final inline class ValuesAsRefs {
+public final primitive class ValuesAsRefs {
 
     final ArrayList<? extends ValuesAsRefs.ref> ao = null; // values can be wildcard bounds.
 
-    final inline class I implements java.io.Serializable {
+    final primitive class I implements java.io.Serializable {
         final int y = 42;
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldAccessorTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldAccessorTest.java
@@ -31,7 +31,7 @@
 
 public class WithFieldAccessorTest {
 
-    public static final inline class V {
+    public static final primitive class V {
         private final int i;
         V() {
             this.i = 0;

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldNegativeTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldNegativeTests.java
@@ -5,11 +5,11 @@
  * @compile/fail/ref=WithFieldNegativeTests.out -XDrawDiagnostics WithFieldNegativeTests.java
  */
 
-inline final class A {
+primitive final class A {
     final int x = 10;
     static final int sx = 10;
 
-    inline final class B {
+    primitive final class B {
 
         final A a = A.default;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfExplicitSelector.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfExplicitSelector.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 
 public class WithFieldOfExplicitSelector {
 
-    final inline class X {
+    final primitive class X {
 
         final int i;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfGenericType.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfGenericType.java
@@ -29,7 +29,7 @@
  * @run main/othervm WithFieldOfGenericType
  */
 
-public final inline class WithFieldOfGenericType<E> {
+public final primitive class WithFieldOfGenericType<E> {
   private final boolean value;
 
   public static <E> WithFieldOfGenericType<E> create() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfImplicitThis.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfImplicitThis.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
 
 public class WithFieldOfImplicitThis {
 
-    final inline class X {
+    final primitive class X {
 
         final int x;
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOperatorTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOperatorTest.java
@@ -8,9 +8,9 @@ public class WithFieldOperatorTest {
     static int xs;
     int ifld;
     class Y {}
-    public final inline class V { int x = 10; }
+    public final primitive class V { int x = 10; }
 
-    public final inline class X {
+    public final primitive class X {
 
         final int x;
         final V v;

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldRuntimeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldRuntimeTest.java
@@ -28,7 +28,7 @@
  * @run main/othervm WithFieldRuntimeTest
  */
 
-public final inline class WithFieldRuntimeTest {
+public final primitive class WithFieldRuntimeTest {
 
     final int x = 10;
 

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray0.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray0.java
@@ -51,7 +51,7 @@ public class InlineArray0 {
         public int my_method();
     }
 
-    public static inline class Val1 implements MyInterface {
+    public static primitive class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -62,7 +62,7 @@ public class InlineArray0 {
         }
     }
 
-    public static inline class Val2 implements MyInterface {
+    public static primitive class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -73,7 +73,7 @@ public class InlineArray0 {
         }
     }
 
-    public static inline class Val3 implements MyInterface {
+    public static primitive class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray1.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray1.java
@@ -51,7 +51,7 @@ public class InlineArray1 {
         public int my_method();
     }
 
-    public static inline class Val1 implements MyInterface {
+    public static primitive class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -63,7 +63,7 @@ public class InlineArray1 {
         }
     }
 
-    public static inline class Val2 implements MyInterface {
+    public static primitive class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -75,7 +75,7 @@ public class InlineArray1 {
         }
     }
 
-    public static inline class Val3 implements MyInterface {
+    public static primitive class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashExplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashExplicit.java
@@ -47,7 +47,7 @@ public class InlineArrayHashExplicit {
 
     public static final int SIZE = 128;
 
-    public static inline class Val1  {
+    public static primitive class Val1  {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -58,7 +58,7 @@ public class InlineArrayHashExplicit {
         }
     }
 
-    public static inline class Val2  {
+    public static primitive class Val2  {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -69,7 +69,7 @@ public class InlineArrayHashExplicit {
         }
     }
 
-    public static inline class Val3  {
+    public static primitive class Val3  {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashImplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashImplicit.java
@@ -47,21 +47,21 @@ public class InlineArrayHashImplicit {
 
     public static final int SIZE = 128;
 
-    public static inline class Val1  {
+    public static primitive class Val1  {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
         }
     }
 
-    public static inline class Val2  {
+    public static primitive class Val2  {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
         }
     }
 
-    public static inline class Val3  {
+    public static primitive class Val3  {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineField.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineField.java
@@ -51,7 +51,7 @@ public class InlineField {
         public int my_method();
     }
 
-    public static inline class Val1 implements MyInterface {
+    public static primitive class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -62,7 +62,7 @@ public class InlineField {
         }
     }
 
-    public static inline class Val2 implements MyInterface {
+    public static primitive class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -73,7 +73,7 @@ public class InlineField {
         }
     }
 
-    public static inline class Val3 implements MyInterface {
+    public static primitive class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineField1.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineField1.java
@@ -51,7 +51,7 @@ public class InlineField1 {
         public int my_method();
     }
 
-    public static inline class Val1 implements MyInterface {
+    public static primitive class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -63,7 +63,7 @@ public class InlineField1 {
         }
     }
 
-    public static inline class Val2 implements MyInterface {
+    public static primitive class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -75,7 +75,7 @@ public class InlineField1 {
         }
     }
 
-    public static inline class Val3 implements MyInterface {
+    public static primitive class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineRec.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineRec.java
@@ -47,7 +47,7 @@ public class InlineRec {
     @Param("100")
     public int depth;
 
-    public static inline class V {
+    public static primitive class V {
         final int v;
 
         public V(int v) {

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/PrimitiveInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/PrimitiveInt.java
@@ -1,6 +1,6 @@
 package org.openjdk.bench.valhalla.sandbox.corelibs;
 
-public inline class PrimitiveInt {
+public primitive class PrimitiveInt {
     int value;
 
     PrimitiveInt(int value) {

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
@@ -1095,7 +1095,7 @@ public class XArrayList<E> extends AbstractList<E>
     /**
      * Create an inline cursor for this XArrayList.
      */
-    private inline class AListCursor<E> implements InlineCursor<E> {
+    private primitive class AListCursor<E> implements InlineCursor<E> {
         // Inner class field 'this' is initialized
         int index;
         int expectedModCount;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
@@ -224,7 +224,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
     /**
      * Basic hash bin node, used for most entries.
      */
-    static inline class YNode<K,V> implements Map.Entry<K,V> {
+    static primitive class YNode<K,V> implements Map.Entry<K,V> {
         final int hash;
         final short probes; // maybe only a byte
         final K key;
@@ -278,7 +278,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
         }
     }
 
-    inline class YNodeWrapper implements Map.Entry<K,V> {
+    primitive class YNodeWrapper implements Map.Entry<K,V> {
         final int index;
         final YNode<K,V> entry;
 

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
@@ -305,7 +305,7 @@ public class XHashMap<K,V> extends XAbstractMap<K,V>
      * Basic hash bin node, used for most entries.  (See below for
      * TreeNode subclass, and in LinkedHashMap for its Entry subclass.)
      */
-    static inline class XNode<K,V> implements Map.Entry<K,V> {
+    static primitive class XNode<K,V> implements Map.Entry<K,V> {
         final int hash;
         final K key;
         V value;
@@ -390,7 +390,7 @@ public class XHashMap<K,V> extends XAbstractMap<K,V>
         }
     }
 
-    inline class XNodeWrapper implements Map.Entry<K,V> {
+    primitive class XNodeWrapper implements Map.Entry<K,V> {
         int index;
 
         XNodeWrapper(int index) {

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128byte.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q128byte implements Int128, ByByte {
+public primitive class Q128byte implements Int128, ByByte {
 
     public final Q64byte v0;
     public final Q64byte v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128int.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q128int implements Int128, ByInt {
+public primitive class Q128int implements Int128, ByInt {
 
     public final Q64int v0;
     public final Q64int v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128long.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128long.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q128long implements Int128, ByLong {
+public primitive class Q128long implements Int128, ByLong {
 
     public final long v0;
     public final long v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q32byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q32byte.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q32byte implements Int32, ByByte {
+public primitive class Q32byte implements Int32, ByByte {
 
     public final byte v0;
     public final byte v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q32int.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q32int implements Int32, ByInt {
+public primitive class Q32int implements Int32, ByInt {
 
     public final int v0;
 

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64byte.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q64byte implements Int64, ByByte {
+public primitive class Q64byte implements Int64, ByByte {
 
     public final Q32byte v0;
     public final Q32byte v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64int.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q64int implements Int64, ByInt {
+public primitive class Q64int implements Int64, ByInt {
 
     public final Q32int v0;
     public final Q32int v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64long.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class Q64long implements Int64, ByLong {
+public primitive class Q64long implements Int64, ByLong {
 
     public final long v0;
 

--- a/test/micro/org/openjdk/bench/valhalla/types/QComplex.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/QComplex.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public inline class QComplex implements Complex {
+public primitive class QComplex implements Complex {
 
     public final double re;
     public final double im;

--- a/test/micro/org/openjdk/bench/valhalla/types/QOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/QOpt.java
@@ -24,7 +24,7 @@ package org.openjdk.bench.valhalla.types;
 
 import java.util.NoSuchElementException;
 
-public inline class QOpt<T> implements Opt<T> {
+public primitive class QOpt<T> implements Opt<T> {
 
     public final T value;
 


### PR DESCRIPTION
Compiler changes to accept primitive as the modifier in class declaration plus test changes across components necessitated by said change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261393](https://bugs.openjdk.java.net/browse/JDK-8261393): [lworld] Adopt `primitive' as the modifier in declaration of identity free classes in lieu of `inline`


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/328/head:pull/328`
`$ git checkout pull/328`
