### PR TITLE
8261631: [lworld] Fatal error in C1 compiled code due to unexpected klass

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -238,7 +238,7 @@ ciType* Constant::exact_type() const {
 
 ciType* LoadIndexed::exact_type() const {
   ciType* array_type = array()->exact_type();
-  if (delayed() != NULL && array_type != NULL) {
+  if (delayed() == NULL && array_type != NULL) {
     assert(array_type->is_array_klass(), "what else?");
     ciArrayKlass* ak = (ciArrayKlass*)array_type;
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3050,6 +3050,11 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
     do_update = exact_klass == NULL || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
   }
 
+  // Inline types can't be null
+  if (exact_klass != NULL && exact_klass->is_inlinetype()) {
+    do_null = false;
+  }
+
   if (!do_null && !do_update) {
     return result;
   }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -118,6 +118,10 @@ public class TestGenerated {
         }
     }
 
+    boolean test8(MyValue1[] array) {
+        return array[0].array == array[0].array;
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -132,6 +136,7 @@ public class TestGenerated {
             t.test5(array3);
             t.test6();
             t.test7(false);
+            t.test8(array3);
         }
     }
 }


### PR DESCRIPTION
An assertion in C1 compiled profiling code triggers because the actual (exact) klass of a field is not as expected. The problem should have been solved by [JDK-8260225](https://bugs.openjdk.java.net/browse/JDK-8260225) but was only partially fixed due to a typo (`!=` vs. `==`). I've also noticed that we are profiling inline types for null, which should be avoided.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261631](https://bugs.openjdk.java.net/browse/JDK-8261631): [lworld] Fatal error in C1 compiled code due to unexpected klass


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/331/head:pull/331`
`$ git checkout pull/331`
