### PR TITLE
8261633: [lworld] TestLWorld::test10 fails IR verification

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -328,6 +328,7 @@ public class TestLWorld extends InlineTypeTest {
     }
 
     // merge of inline types in an object local
+    @ForceInline
     public Object test10_helper() {
         return valueField1;
     }


### PR DESCRIPTION
IR verification fails because there is an unexpected inline type allocation in the code. This is a test bug. The root cause is a missing `@ForceInline` annotation that makes sure the `test10_helper` method is always inlined such that the allocation can be avoided.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261633](https://bugs.openjdk.java.net/browse/JDK-8261633): [lworld] TestLWorld::test10 fails IR verification


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/332/head:pull/332`
`$ git checkout pull/332`
