### PR TITLE
8261721: [lworld] Javac messages still refer to inline types

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -223,7 +223,7 @@ public enum Source {
         PATTERN_MATCHING_IN_INSTANCEOF(JDK16, Fragments.FeaturePatternMatchingInstanceof, DiagKind.NORMAL),
         REIFIABLE_TYPES_INSTANCEOF(JDK16, Fragments.FeatureReifiableTypesInstanceof, DiagKind.PLURAL),
         RECORDS(JDK16, Fragments.FeatureRecords, DiagKind.PLURAL),
-        INLINE_TYPES(JDK17, Fragments.FeatureInlineType, DiagKind.NORMAL),
+        PRIMITIVE_CLASSES(JDK17, Fragments.FeaturePrimitiveClasses, DiagKind.NORMAL),
         SEALED_CLASSES(JDK17, Fragments.FeatureSealedClasses, DiagKind.PLURAL),
         ;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -167,7 +167,7 @@ public class Attr extends JCTree.Visitor {
         allowLambda = Feature.LAMBDA.allowedInSource(source);
         allowDefaultMethods = Feature.DEFAULT_METHODS.allowedInSource(source);
         allowStaticInterfaceMethods = Feature.STATIC_INTERFACE_METHODS.allowedInSource(source);
-        allowInlineTypes = Feature.INLINE_TYPES.allowedInSource(source);
+        allowPrimitiveClasses = Feature.PRIMITIVE_CLASSES.allowedInSource(source);
         allowReifiableTypesInInstanceof =
                 Feature.REIFIABLE_TYPES_INSTANCEOF.allowedInSource(source) &&
                 (!preview.isPreview(Feature.REIFIABLE_TYPES_INSTANCEOF) || preview.isEnabled());
@@ -201,9 +201,9 @@ public class Attr extends JCTree.Visitor {
      */
     boolean allowDefaultMethods;
 
-    /** Switch: allow inline types?
+    /** Switch: allow primitive classes ?
      */
-    boolean allowInlineTypes;
+    boolean allowPrimitiveClasses;
 
     /** Switch: static interface methods enabled?
      */
@@ -1529,7 +1529,7 @@ public class Attr extends JCTree.Visitor {
                 final Symbol sym = TreeInfo.symbol(tree.field);
                 if (sym == null || sym.kind != VAR || sym.owner.kind != TYP ||
                         (sym.flags() & STATIC) != 0 || !types.isValue(sym.owner.type)) {
-                    log.error(tree.field.pos(), Errors.ValueInstanceFieldExpectedHere);
+                    log.error(tree.field.pos(), Errors.PrimitiveClassInstanceFieldExpectedHere);
                 } else {
                     Type ownType = sym.owner.type;
                     switch(tree.field.getTag()) {
@@ -2561,7 +2561,7 @@ public class Attr extends JCTree.Visitor {
                             if (argSize == 0
                                     || (types.isConvertible(argtypes.head, syms.longType) &&
                                     (argSize == 1 || (argSize == 2 && types.isConvertible(argtypes.tail.head, syms.intType))))) {
-                                log.error(tree.pos(), Errors.ValueDoesNotSupport(name));
+                                log.error(tree.pos(), Errors.PrimitiveClassDoesNotSupport(name));
                             }
                             break;
                         case "notify":
@@ -2569,13 +2569,13 @@ public class Attr extends JCTree.Visitor {
                         case "clone":
                         case "finalize":
                             if (argSize == 0)
-                                log.error(tree.pos(), Errors.ValueDoesNotSupport(name));
+                                log.error(tree.pos(), Errors.PrimitiveClassDoesNotSupport(name));
                             break;
                         case "hashCode":
                         case "equals":
                         case "toString":
                             if (superCallOnValueReceiver)
-                                log.error(tree.pos(), Errors.ValueDoesNotSupport(names.fromString("invocation of super." + name)));
+                                log.error(tree.pos(), Errors.PrimitiveClassDoesNotSupport(names.fromString("invocation of super." + name)));
                             break;
                     }
                 }
@@ -4256,9 +4256,9 @@ public class Attr extends JCTree.Visitor {
         if (tree.name == names._this || tree.name == names._super ||
                 tree.name == names._class || tree.name == names._default)
         {
-            if (tree.name == names._default && !allowInlineTypes) {
+            if (tree.name == names._default && !allowPrimitiveClasses) {
                 log.error(DiagnosticFlag.SOURCE_LEVEL, tree.pos(),
-                        Feature.INLINE_TYPES.error(sourceName));
+                        Feature.PRIMITIVE_CLASSES.error(sourceName));
             }
             skind = KindSelector.TYP;
         } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -744,7 +744,7 @@ public class Check {
             if  (st.tsym == syms.objectType.tsym)
                 return;
             if (!st.tsym.isAbstract()) {
-                log.error(pos, Errors.ConcreteSupertypeForInlineClass(c, st));
+                log.error(pos, Errors.ConcreteSupertypeForPrimitiveClass(c, st));
             }
             if ((st.tsym.flags() & HASINITBLOCK) != 0) {
                 log.error(pos, Errors.SuperClassDeclaresInitBlock(c, st));
@@ -918,7 +918,7 @@ public class Check {
         public Void visitClassType(ClassType t, DiagnosticPosition pos) {
             for (Type targ : t.allparams()) {
                 if (types.isValue(targ)) {
-                    log.error(pos, Errors.GenericParameterizationWithValueType(t));
+                    log.error(pos, Errors.GenericParameterizationWithPrimitiveClass(t));
                 }
                 visit(targ, pos);
             }
@@ -1962,7 +1962,7 @@ public class Check {
         if (origin.isValue() && other.owner == syms.objectType.tsym && m.type.getParameterTypes().size() == 0) {
             if (m.name == names.clone || m.name == names.finalize) {
                 log.error(TreeInfo.diagnosticPositionFor(m, tree),
-                        Errors.InlineClassMayNotOverride(m.name));
+                        Errors.PrimitiveClassMayNotOverride(m.name));
                 m.flags_field |= BAD_OVERRIDE;
                 return;
             }
@@ -2429,7 +2429,7 @@ public class Check {
     // where
     private void checkNonCyclicMembership(ClassSymbol c, DiagnosticPosition pos) {
         if ((c.flags_field & LOCKED) != 0) {
-            log.error(pos, Errors.CyclicValueTypeMembership(c));
+            log.error(pos, Errors.CyclicPrimitiveClassMembership(c));
             return;
         }
         try {
@@ -2696,7 +2696,7 @@ public class Check {
         checkCompatibleConcretes(pos, c);
 
         if (c.isValue() && types.asSuper(c, syms.identityObjectType.tsym, true) != null) {
-            log.error(pos, Errors.InlineTypeMustNotImplementIdentityObject(c));
+            log.error(pos, Errors.PrimitiveClassMustNotImplementIdentityObject(c));
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -105,9 +105,9 @@ public class ClassReader {
      */
     boolean allowModules;
 
-    /** Switch: allow inline types.
+    /** Switch: allow primitive classes.
      */
-    boolean allowInlineTypes;
+    boolean allowPrimitiveClasses;
 
     /** Switch: allow sealed
      */
@@ -276,7 +276,7 @@ public class ClassReader {
         Source source = Source.instance(context);
         preview = Preview.instance(context);
         allowModules     = Feature.MODULES.allowedInSource(source);
-        allowInlineTypes = Feature.INLINE_TYPES.allowedInSource(source);
+        allowPrimitiveClasses = Feature.PRIMITIVE_CLASSES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         allowSealedTypes = (!preview.isPreview(Feature.SEALED_CLASSES) || preview.isEnabled()) &&
                 Feature.SEALED_CLASSES.allowedInSource(source);
@@ -813,7 +813,7 @@ public class ClassReader {
 
             new AttributeReader(names.Code, V45_3, MEMBER_ATTRIBUTE) {
                 protected void read(Symbol sym, int attrLen) {
-                    if (allowInlineTypes) {
+                    if (allowPrimitiveClasses) {
                         if (sym.isConstructor()  && ((MethodSymbol) sym).type.getParameterTypes().size() == 0) {
                             int code_length = buf.getInt(bp + 4);
                             if ((code_length == 1 && buf.getByte( bp + 8) == (byte) ByteCodes.return_) ||
@@ -2506,7 +2506,7 @@ public class ClassReader {
     }
 
     protected ClassSymbol enterClass(Name name) {
-        if (allowInlineTypes && name.toString().endsWith("$ref")) {
+        if (allowPrimitiveClasses && name.toString().endsWith("$ref")) {
             ClassSymbol v = syms.enterClass(currentModule, name.subName(0, name.length() - 4));
             return v.referenceProjection();
         }
@@ -2799,7 +2799,7 @@ public class ClassReader {
         }
         if ((flags & ACC_INLINE) != 0) {
             flags &= ~ACC_INLINE;
-            if (allowInlineTypes) {
+            if (allowPrimitiveClasses) {
                 flags |= VALUE;
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3488,7 +3488,7 @@ public class JavacParser implements Parser {
                          t == INTERFACE ||
                          t == ENUM ||
                          t == IDENTIFIER)) { // new value Comparable() {}
-            checkSourceLevel(Feature.INLINE_TYPES);
+            checkSourceLevel(Feature.PRIMITIVE_CLASSES);
             return new Token(PRIMITIVE, token.pos, token.endPos, token.comments);
         }
         return token;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -397,10 +397,6 @@ compiler.err.cyclic.inheritance=\
     cyclic inheritance involving {0}
 
 # 0: symbol
-compiler.err.cyclic.value.type.membership=\
-    cyclic inline type membership involving {0}
-
-# 0: symbol
 compiler.err.cyclic.annotation.element=\
     type of element {0} is cyclic
 
@@ -1779,9 +1775,6 @@ compiler.warn.poor.choice.for.module.name=\
 compiler.warn.incubating.modules=\
     using incubating module(s): {0}
 
-compiler.warn.get.class.compared.with.interface=\
-    return value of getClass() can never equal the class literal of an interface
-
 # 0: symbol, 1: symbol
 compiler.warn.has.been.deprecated=\
     {0} in {1} has been deprecated
@@ -2959,9 +2952,6 @@ compiler.misc.feature.pattern.matching.instanceof=\
 compiler.misc.feature.reifiable.types.instanceof=\
     reifiable types in instanceof
 
-compiler.misc.feature.inline.type=\
-    inline type
-
 compiler.misc.feature.records=\
     records
 
@@ -3792,61 +3782,71 @@ compiler.err.preview.not.latest=\
 compiler.err.preview.without.source.or.release=\
     --enable-preview must be used with either -source or --release
 
-# 0: name (of method)
-compiler.err.inline.class.may.not.override=\
-    Inline classes may not override the method {0} from Object
+compiler.misc.feature.primitive.classes=\
+    primitive classes
+
+# 0: symbol
+compiler.err.cyclic.primitive.class.membership=\
+    cyclic primitive class membership involving {0}
+
+compiler.warn.get.class.compared.with.interface=\
+    return value of getClass() can never equal the class literal of an interface
 
 # 0: name (of method)
-compiler.err.value.does.not.support=\
-    Inline types do not support {0}
+compiler.err.primitive.class.may.not.override=\
+    primitive classes may not override the method {0} from Object
 
-compiler.err.value.may.not.extend=\
-    Inline type may not extend another inline type or class
+# 0: name (of method)
+compiler.err.primitive.class.does.not.support=\
+    primitive classes do not support {0}
 
-compiler.err.value.instance.field.expected.here=\
-    withfield operator requires an instance field of an inline class here
+compiler.err.primitive.class.may.not.extend=\
+    inappropriate super class declaration for a primitive class
+
+compiler.err.primitive.class.instance.field.expected.here=\
+    withfield operator requires an instance field of a primitive class here
 
 compiler.err.with.field.operator.disallowed=\
     WithField operator is allowed only with -XDallowWithFieldOperator
 
 compiler.err.this.exposed.prematurely=\
-    Inine type instance should not be passed around before being fully initialized
+    primitive class instance should not be passed around before being fully initialized
 
 # 0: type
-compiler.err.generic.parameterization.with.value.type=\
-    Inferred type {0} involves generic parameterization by an inline type
+compiler.err.generic.parameterization.with.primitive.class=\
+    Inferred type {0} involves generic parameterization by a primitive class
 
 # 0: type
-compiler.err.inline.type.must.not.implement.identity.object=\
-    The inline type {0} attempts to implement the incompatible interface IdentityObject
+compiler.err.primitive.class.must.not.implement.identity.object=\
+    The primitive class {0} attempts to implement the incompatible interface IdentityObject
 
 # 0: symbol, 1: type
-compiler.err.concrete.supertype.for.inline.class=\
-    The concrete class {1} is not allowed to be a super class of the inline class {0} either directly or indirectly
+compiler.err.concrete.supertype.for.primitive.class=\
+    The concrete class {1} is not allowed to be a super class of the primitive class {0} either directly or indirectly
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.method.cannot.be.synchronized=\
-    The method {0} in the super class {2} of the inline type {1} is synchronized. This is disallowed
+    The method {0} in the super class {2} of the primitive class {1} is synchronized. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.constructor.cannot.take.arguments=\
-    The super class {2} of the inline type {1} defines a constructor {0} that takes arguments. This is disallowed
+    The super class {2} of the primitive class {1} defines a constructor {0} that takes arguments. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.field.not.allowed=\
-    The super class {2} of the inline type {1} defines an instance field {0}. This is disallowed
+    The super class {2} of the primitive class {1} defines an instance field {0}. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.no.arg.constructor.must.be.empty=\
-    The super class {2} of the inline type {1} defines a nonempty no-arg constructor {0}. This is disallowed
+    The super class {2} of the primitive class {1} defines a nonempty no-arg constructor {0}. This is disallowed
 
 # 0: symbol, 1: type
 compiler.err.super.class.declares.init.block=\
-    The super class {1} of the inline class {0} declares one or more non-empty instance initializer blocks. This is disallowed.
+    The super class {1} of the primitive class {0} declares one or more non-empty instance initializer blocks. This is disallowed.
 
 # 0: symbol, 1: type
 compiler.err.super.class.cannot.be.inner=\
-    The super class {1} of the inline class {0} is an inner class. This is disallowed.
+    The super class {1} of the primitive class {0} is an inner class. This is disallowed.
 
 compiler.err.projection.cant.be.instantiated=\
     Illegal attempt to instantiate a projection type

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -205,16 +205,16 @@ compiler.err.preview.not.latest
 compiler.err.preview.without.source.or.release
 
 # Value types
-compiler.err.cyclic.value.type.membership
-compiler.err.value.does.not.support
-compiler.err.value.may.not.extend
+compiler.err.cyclic.primitive.class.membership
+compiler.err.primitive.class.does.not.support
+compiler.err.primitive.class.may.not.extend
 compiler.err.this.exposed.prematurely
-compiler.err.inline.type.must.not.implement.identity.object
-compiler.err.concrete.supertype.for.inline.class
+compiler.err.primitive.class.must.not.implement.identity.object
+compiler.err.concrete.supertype.for.primitive.class
 compiler.err.super.class.cannot.be.inner
 compiler.err.super.class.declares.init.block
 compiler.err.super.constructor.cannot.take.arguments
 compiler.err.super.field.not.allowed
 compiler.err.super.method.cannot.be.synchronized
 compiler.err.super.no.arg.constructor.must.be.empty
-compiler.err.generic.parameterization.with.value.type
+compiler.err.generic.parameterization.with.primitive.class

--- a/test/langtools/tools/javac/diags/examples/PrimitiveClassInstanceFieldExpectedHere.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveClassInstanceFieldExpectedHere.java
@@ -21,9 +21,14 @@
  * questions.
  */
 
-// key: compiler.err.feature.not.supported.in.source
-// key: compiler.misc.feature.inline.type
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 13
+// options: -XDallowWithFieldOperator
+// key: compiler.err.primitive.class.instance.field.expected.here
 
-primitive final class ValuesNotSupported {}
+final primitive class Blah {
+    final int x;
+    static int si;
+    Blah() {
+        x = 10;
+        Blah b = __WithField(this.si, 10);
+    }
+}

--- a/test/langtools/tools/javac/diags/examples/PrimitiveClassMayNotOverride.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveClassMayNotOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,11 @@
  * questions.
  */
 
-// options: -XDallowWithFieldOperator
-// key: compiler.err.value.instance.field.expected.here
+// key: compiler.err.primitive.class.may.not.override
 
-final primitive class Blah {
-    final int x;
-    static int si;
-    Blah() {
-        x = 10;
-        Blah b = __WithField(this.si, 10);
+primitive class InlineBogusOverride {
+    int x = 42;
+    public Object clone() {
+        return this;
     }
 }

--- a/test/langtools/tools/javac/diags/examples/PrimitiveClassNotSupported.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveClassNotSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,9 @@
  * questions.
  */
 
-// key: compiler.err.inline.class.may.not.override
+// key: compiler.err.feature.not.supported.in.source
+// key: compiler.misc.feature.primitive.classes
+// key: compiler.warn.source.no.system.modules.path
+// options: -source 13
 
-primitive class InlineBogusOverride {
-    int x = 42;
-    public Object clone() {
-        return this;
-    }
-}
+primitive final class ValuesNotSupported {}

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
@@ -1,4 +1,4 @@
-BinarySuperclassConstraints.java:14:15: compiler.err.inline.type.must.not.implement.identity.object: BinarySuperclassConstraints.I0
+BinarySuperclassConstraints.java:14:15: compiler.err.primitive.class.must.not.implement.identity.object: BinarySuperclassConstraints.I0
 BinarySuperclassConstraints.java:29:15: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
 BinarySuperclassConstraints.java:38:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
 BinarySuperclassConstraints.java:40:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
@@ -1,6 +1,6 @@
-CheckClone.java:11:21: compiler.err.value.does.not.support: clone
-CheckClone.java:12:18: compiler.err.value.does.not.support: clone
-CheckClone.java:16:16: compiler.err.value.does.not.support: clone
-CheckClone.java:17:14: compiler.err.value.does.not.support: clone
-CheckClone.java:20:22: compiler.err.inline.class.may.not.override: clone
+CheckClone.java:11:21: compiler.err.primitive.class.does.not.support: clone
+CheckClone.java:12:18: compiler.err.primitive.class.does.not.support: clone
+CheckClone.java:16:16: compiler.err.primitive.class.does.not.support: clone
+CheckClone.java:17:14: compiler.err.primitive.class.does.not.support: clone
+CheckClone.java:20:22: compiler.err.primitive.class.may.not.override: clone
 5 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckCyclicMembership.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckCyclicMembership.out
@@ -1,4 +1,4 @@
-CheckCyclicMembership.java:13:37: compiler.err.cyclic.value.type.membership: CheckCyclicMembership.InnerValue
-CheckCyclicMembership.java:15:33: compiler.err.cyclic.value.type.membership: CheckCyclicMembership
-CheckCyclicMembership.java:19:22: compiler.err.cyclic.value.type.membership: CheckCyclicMembership
+CheckCyclicMembership.java:13:37: compiler.err.cyclic.primitive.class.membership: CheckCyclicMembership.InnerValue
+CheckCyclicMembership.java:15:33: compiler.err.cyclic.primitive.class.membership: CheckCyclicMembership
+CheckCyclicMembership.java:19:22: compiler.err.cyclic.primitive.class.membership: CheckCyclicMembership
 3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:10:22: compiler.err.inline.type.must.not.implement.identity.object: CheckExtends.NestedValue
+CheckExtends.java:10:22: compiler.err.primitive.class.must.not.implement.identity.object: CheckExtends.NestedValue
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.out
@@ -1,2 +1,2 @@
-CheckFeatureGate1.java:10:12: compiler.err.feature.not.supported.in.source: (compiler.misc.feature.inline.type), 13, 17
+CheckFeatureGate1.java:10:12: compiler.err.feature.not.supported.in.source: (compiler.misc.feature.primitive.classes), 13, 17
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate2.out
@@ -1,2 +1,2 @@
-CheckFeatureGate2.java:11:17: compiler.err.feature.not.supported.in.source: (compiler.misc.feature.inline.type), 13, 17
+CheckFeatureGate2.java:11:17: compiler.err.feature.not.supported.in.source: (compiler.misc.feature.primitive.classes), 13, 17
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinal.out
@@ -2,6 +2,6 @@ CheckFinal.java:14:13: compiler.err.cant.assign.val.to.final.var: fi
 CheckFinal.java:15:13: compiler.err.cant.assign.val.to.final.var: fe
 CheckFinal.java:17:13: compiler.err.cant.assign.val.to.final.var: xsf
 CheckFinal.java:19:29: compiler.err.cant.inherit.from.final: CheckFinal
-CheckFinal.java:19:42: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: CheckFinal$1, CheckFinal
+CheckFinal.java:19:42: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: CheckFinal$1, CheckFinal
 CheckFinal.java:19:25: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.anonymous.class: CheckFinal, CheckFinal)
 6 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.out
@@ -1,7 +1,7 @@
-CheckFinalize.java:10:20: compiler.err.inline.class.may.not.override: finalize
+CheckFinalize.java:10:20: compiler.err.primitive.class.may.not.override: finalize
 CheckFinalize.java:15:12: compiler.err.report.access: finalize(), protected, java.lang.Object
-CheckFinalize.java:15:21: compiler.err.value.does.not.support: finalize
-CheckFinalize.java:16:20: compiler.err.value.does.not.support: finalize
+CheckFinalize.java:15:21: compiler.err.primitive.class.does.not.support: finalize
+CheckFinalize.java:16:20: compiler.err.primitive.class.does.not.support: finalize
 - compiler.note.deprecated.filename: CheckFinalize.java
 - compiler.note.deprecated.recompile
 4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableCycles.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableCycles.out
@@ -1,4 +1,4 @@
-CheckFlattenableCycles.java:13:42: compiler.err.cyclic.value.type.membership: CheckFlattenableCycles.InnerValue
-CheckFlattenableCycles.java:15:34: compiler.err.cyclic.value.type.membership: CheckFlattenableCycles
-CheckFlattenableCycles.java:19:26: compiler.err.cyclic.value.type.membership: CheckFlattenableCycles
+CheckFlattenableCycles.java:13:42: compiler.err.cyclic.primitive.class.membership: CheckFlattenableCycles.InnerValue
+CheckFlattenableCycles.java:15:34: compiler.err.cyclic.primitive.class.membership: CheckFlattenableCycles
+CheckFlattenableCycles.java:19:26: compiler.err.cyclic.primitive.class.membership: CheckFlattenableCycles
 3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.out
@@ -1,20 +1,20 @@
-CheckObjectMethodsUsage.java:11:17: compiler.err.inline.class.may.not.override: finalize
-CheckObjectMethodsUsage.java:12:19: compiler.err.inline.class.may.not.override: clone
-CheckObjectMethodsUsage.java:15:23: compiler.err.value.does.not.support: finalize
-CheckObjectMethodsUsage.java:16:13: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:17:19: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:18:13: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:19:19: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:20:13: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:21:19: compiler.err.value.does.not.support: wait
-CheckObjectMethodsUsage.java:22:15: compiler.err.value.does.not.support: notify
-CheckObjectMethodsUsage.java:23:21: compiler.err.value.does.not.support: notify
-CheckObjectMethodsUsage.java:24:18: compiler.err.value.does.not.support: notifyAll
-CheckObjectMethodsUsage.java:25:24: compiler.err.value.does.not.support: notifyAll
-CheckObjectMethodsUsage.java:26:20: compiler.err.value.does.not.support: clone
-CheckObjectMethodsUsage.java:27:23: compiler.err.value.does.not.support: invocation of super.hashCode
-CheckObjectMethodsUsage.java:28:23: compiler.err.value.does.not.support: invocation of super.toString
-CheckObjectMethodsUsage.java:29:21: compiler.err.value.does.not.support: invocation of super.equals
+CheckObjectMethodsUsage.java:11:17: compiler.err.primitive.class.may.not.override: finalize
+CheckObjectMethodsUsage.java:12:19: compiler.err.primitive.class.may.not.override: clone
+CheckObjectMethodsUsage.java:15:23: compiler.err.primitive.class.does.not.support: finalize
+CheckObjectMethodsUsage.java:16:13: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:17:19: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:18:13: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:19:19: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:20:13: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:21:19: compiler.err.primitive.class.does.not.support: wait
+CheckObjectMethodsUsage.java:22:15: compiler.err.primitive.class.does.not.support: notify
+CheckObjectMethodsUsage.java:23:21: compiler.err.primitive.class.does.not.support: notify
+CheckObjectMethodsUsage.java:24:18: compiler.err.primitive.class.does.not.support: notifyAll
+CheckObjectMethodsUsage.java:25:24: compiler.err.primitive.class.does.not.support: notifyAll
+CheckObjectMethodsUsage.java:26:20: compiler.err.primitive.class.does.not.support: clone
+CheckObjectMethodsUsage.java:27:23: compiler.err.primitive.class.does.not.support: invocation of super.hashCode
+CheckObjectMethodsUsage.java:28:23: compiler.err.primitive.class.does.not.support: invocation of super.toString
+CheckObjectMethodsUsage.java:29:21: compiler.err.primitive.class.does.not.support: invocation of super.equals
 - compiler.note.deprecated.filename: CheckObjectMethodsUsage.java
 - compiler.note.deprecated.recompile
 17 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSync.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSync.out
@@ -1,20 +1,20 @@
-CheckSync.java:18:17: compiler.err.value.does.not.support: wait
-CheckSync.java:19:17: compiler.err.value.does.not.support: wait
-CheckSync.java:20:17: compiler.err.value.does.not.support: wait
-CheckSync.java:21:19: compiler.err.value.does.not.support: notify
-CheckSync.java:22:22: compiler.err.value.does.not.support: notifyAll
-CheckSync.java:23:21: compiler.err.value.does.not.support: finalize
-CheckSync.java:24:18: compiler.err.value.does.not.support: clone
-CheckSync.java:32:17: compiler.err.value.does.not.support: wait
-CheckSync.java:33:17: compiler.err.value.does.not.support: wait
+CheckSync.java:18:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:19:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:20:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:21:19: compiler.err.primitive.class.does.not.support: notify
+CheckSync.java:22:22: compiler.err.primitive.class.does.not.support: notifyAll
+CheckSync.java:23:21: compiler.err.primitive.class.does.not.support: finalize
+CheckSync.java:24:18: compiler.err.primitive.class.does.not.support: clone
+CheckSync.java:32:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:33:17: compiler.err.primitive.class.does.not.support: wait
 CheckSync.java:34:18: compiler.warn.has.been.deprecated.for.removal: java.lang.Integer(int), java.lang.Integer
-CheckSync.java:34:17: compiler.err.value.does.not.support: wait
+CheckSync.java:34:17: compiler.err.primitive.class.does.not.support: wait
 CheckSync.java:35:18: compiler.warn.has.been.deprecated.for.removal: java.lang.Long(long), java.lang.Long
-CheckSync.java:35:17: compiler.err.value.does.not.support: wait
-CheckSync.java:36:17: compiler.err.value.does.not.support: wait
-CheckSync.java:37:17: compiler.err.value.does.not.support: wait
-CheckSync.java:38:19: compiler.err.value.does.not.support: notify
-CheckSync.java:39:22: compiler.err.value.does.not.support: notifyAll
+CheckSync.java:35:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:36:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:37:17: compiler.err.primitive.class.does.not.support: wait
+CheckSync.java:38:19: compiler.err.primitive.class.does.not.support: notify
+CheckSync.java:39:22: compiler.err.primitive.class.does.not.support: notifyAll
 - compiler.note.deprecated.filename: CheckSync.java
 - compiler.note.deprecated.recompile
 15 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
@@ -1,3 +1,3 @@
 IllegalByValueTest2.java:19:30: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
-IllegalByValueTest2.java:19:59: compiler.err.inline.type.must.not.implement.identity.object: compiler.misc.anonymous.class: IllegalByValueTest2
+IllegalByValueTest2.java:19:59: compiler.err.primitive.class.must.not.implement.identity.object: compiler.misc.anonymous.class: IllegalByValueTest2
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SneakThroSuperCallTest.out
@@ -1,4 +1,4 @@
-SneakThroSuperCallTest.java:13:21: compiler.err.value.does.not.support: notify
-SneakThroSuperCallTest.java:17:30: compiler.err.value.does.not.support: invocation of super.hashCode
-SneakThroSuperCallTest.java:21:30: compiler.err.value.does.not.support: invocation of super.toString
+SneakThroSuperCallTest.java:13:21: compiler.err.primitive.class.does.not.support: notify
+SneakThroSuperCallTest.java:17:30: compiler.err.primitive.class.does.not.support: invocation of super.hashCode
+SneakThroSuperCallTest.java:21:30: compiler.err.primitive.class.does.not.support: invocation of super.toString
 3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,4 +1,4 @@
-SuperclassConstraints.java:14:15: compiler.err.inline.type.must.not.implement.identity.object: SuperclassConstraints.I0
+SuperclassConstraints.java:14:15: compiler.err.primitive.class.must.not.implement.identity.object: SuperclassConstraints.I0
 SuperclassConstraints.java:44:15: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
 SuperclassConstraints.java:76:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
 SuperclassConstraints.java:85:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -7,6 +7,6 @@ TopInterfaceNegativeTest.java:20:32: compiler.err.cant.resolve.location: kindnam
 TopInterfaceNegativeTest.java:24:48: compiler.err.repeated.interface
 TopInterfaceNegativeTest.java:30:42: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:30:56: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:28:22: compiler.err.inline.type.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
+TopInterfaceNegativeTest.java:28:22: compiler.err.primitive.class.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
 TopInterfaceNegativeTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TopInterfaceNegativeTest.V2, java.lang.IdentityObject)
 11 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -1,5 +1,5 @@
 ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:15:21: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$2, value
+ValueModifierTest.java:15:21: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: ValueModifierTest$2, value
 ValueModifierTest.java:16:23: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.inline.class: compiler.misc.anonymous.class: ValueModifierTest$3, value
+ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: ValueModifierTest$3, value
 4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOperatorTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOperatorTest.out
@@ -1,7 +1,7 @@
 WithFieldOperatorTest.java:25:29: compiler.err.unexpected.type: kindname.variable, kindname.value
-WithFieldOperatorTest.java:26:33: compiler.err.value.instance.field.expected.here
-WithFieldOperatorTest.java:27:33: compiler.err.value.instance.field.expected.here
-WithFieldOperatorTest.java:28:29: compiler.err.value.instance.field.expected.here
+WithFieldOperatorTest.java:26:33: compiler.err.primitive.class.instance.field.expected.here
+WithFieldOperatorTest.java:27:33: compiler.err.primitive.class.instance.field.expected.here
+WithFieldOperatorTest.java:28:29: compiler.err.primitive.class.instance.field.expected.here
 WithFieldOperatorTest.java:29:29: compiler.err.cant.assign.val.to.this
 WithFieldOperatorTest.java:30:30: compiler.err.cant.assign.val.to.this
 WithFieldOperatorTest.java:31:34: compiler.err.prob.found.req: (compiler.misc.possible.loss.of.precision: double, int)


### PR DESCRIPTION
Fix message keys and text; adjust sources and tests accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261721](https://bugs.openjdk.java.net/browse/JDK-8261721): [lworld] Javac messages still refer to inline types


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/334/head:pull/334`
`$ git checkout pull/334`
