### PR TITLE
8261647: [lworld] Missing default initialization of non-flattened field of empty inline type

### DIFF
--- a/src/hotspot/share/oops/flatArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.inline.hpp
@@ -52,7 +52,7 @@ inline oop flatArrayOopDesc::value_alloc_copy_from_index(flatArrayHandle vah, in
     return vklass->default_value();
   } else {
     oop buf = vklass->allocate_instance_buffer(CHECK_NULL);
-    vklass->inline_copy_payload_to_new_oop(vah->value_at_addr(index, vaklass->layout_helper()) ,buf);
+    vklass->inline_copy_payload_to_new_oop(vah->value_at_addr(index, vaklass->layout_helper()), buf);
     return buf;
   }
 }
@@ -60,12 +60,8 @@ inline oop flatArrayOopDesc::value_alloc_copy_from_index(flatArrayHandle vah, in
 inline void flatArrayOopDesc::value_copy_from_index(int index, oop dst) const {
   FlatArrayKlass* vaklass = FlatArrayKlass::cast(klass());
   InlineKlass* vklass = vaklass->element_klass();
-  if (vklass->is_empty_inline_type()) {
-    return; // Assumes dst was a new and clean buffer (OptoRuntime::load_unknown_inline())
-  } else {
-    void* src = value_at_addr(index, vaklass->layout_helper());
-    return vklass->inline_copy_payload_to_new_oop(src ,dst);
-  }
+  void* src = value_at_addr(index, vaklass->layout_helper());
+  return vklass->inline_copy_payload_to_new_oop(src, dst);
 }
 
 inline void flatArrayOopDesc::value_copy_to_index(oop src, int index) const {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3018,8 +3018,6 @@ public class TestArrays extends InlineTypeTest {
         MyValueEmpty empty = MyValueEmpty.default;
     }
 
-    // TODO disabled until JDK-8253893 is fixed
-/*
     // Empty inline type container array access
     @Test(failOn = ALLOC + ALLOCA + LOAD + STORE)
     public MyValueEmpty test131(EmptyContainer[] array) {
@@ -3034,7 +3032,6 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEquals(array[0], EmptyContainer.default);
         Asserts.assertEquals(empty, MyValueEmpty.default);
     }
-*/
 
     // Empty inline type array access with unknown array type
     @Test()
@@ -3055,8 +3052,6 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEquals(empty, null);
     }
 
-    // TODO disabled until JDK-8253893 is fixed
-/*
     // Empty inline type container array access with unknown array type
     @Test()
     public Object test133(Object[] array) {
@@ -3075,7 +3070,6 @@ public class TestArrays extends InlineTypeTest {
         Asserts.assertEquals(array[0], EmptyContainer.default);
         Asserts.assertEquals(empty, null);
     }
-*/
 
     // Non-escaping empty inline type array access
     @Test(failOn = ALLOC + ALLOCA + LOAD + STORE)
@@ -3357,5 +3351,18 @@ public class TestArrays extends InlineTypeTest {
     @DontCompile
     public void test144_verifier(boolean warmup) {
         test144();
+    }
+
+    // Test that array load slow path correctly initializes non-flattened field of empty inline type
+    @Test()
+    public Object test145(Object[] array) {
+        return array[0];
+    }
+
+    @DontCompile
+    public void test145_verifier(boolean warmup) {
+        Object[] array = new EmptyContainer[1];
+        EmptyContainer empty = (EmptyContainer)test145(array);
+        Asserts.assertEquals(empty, EmptyContainer.default);
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3301,17 +3301,15 @@ public class TestLWorld extends InlineTypeTest {
     @Test
     public void test119(boolean deopt) {
         MyValueEmpty[]   array1 = new MyValueEmpty[]{MyValueEmpty.default};
-// TODO disabled until JDK-8253893 is fixed
-//        EmptyContainer[] array2 = new EmptyContainer[]{EmptyContainer.default};
-//        MixedContainer[] array3 = new MixedContainer[]{MixedContainer.default};
+        EmptyContainer[] array2 = new EmptyContainer[]{EmptyContainer.default};
+        MixedContainer[] array3 = new MixedContainer[]{MixedContainer.default};
         if (deopt) {
             // uncommon trap
             WHITE_BOX.deoptimizeMethod(tests.get(getClass().getSimpleName() + "::test119"));
         }
         Asserts.assertEquals(array1[0], MyValueEmpty.default);
-// TODO disabled until JDK-8253893 is fixed
-//        Asserts.assertEquals(array2[0], EmptyContainer.default);
-//        Asserts.assertEquals(array3[0], MixedContainer.default);
+        Asserts.assertEquals(array2[0], EmptyContainer.default);
+        Asserts.assertEquals(array3[0], MixedContainer.default);
     }
 
     @DontCompile


### PR DESCRIPTION
After [JDK-8253893](https://bugs.openjdk.java.net/browse/JDK-8253893) has been fixed, I've re-enabled some compiler tests for empty inline types and noticed that they are failing. The problem is that both during slow path array access through `OptoRuntime::load_unknown_inline()` and when re-allocating during deoptimization, non-flattened fields of an empty inline type are not properly initialized with the default value.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261647](https://bugs.openjdk.java.net/browse/JDK-8261647): [lworld] Missing default initialization of non-flattened field of empty inline type


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/335/head:pull/335`
`$ git checkout pull/335`
