### PR TITLE
8261751: [lworld] Fix lingering references to inline/value types 

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -64,10 +64,10 @@ public enum Modifier {
      */
      DEFAULT,
     /**
-     * The modifier {@code value}
-     * @since 1.11
+     * The modifier {@code primitive}
+     * @since 1.17
      */
-    VALUE,
+    PRIMITIVE,
 
     /** The modifier {@code static} */          STATIC,
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -98,8 +98,8 @@ public class Flags {
     /** Added in SE8, represents constructs implicitly declared in source. */
     public static final int MANDATED     = 1<<15;
 
-    /** Marks a type as a value-type */
-    public static final int VALUE        = 1<<16;
+    /** Marks a type as a primitive class */
+    public static final int PRIMITIVE_CLASS  = 1<<16;
 
     public static final int StandardFlags = 0x0fff;
 
@@ -110,7 +110,7 @@ public class Flags {
     public static final int ACC_SUPER    = 0x0020;
     public static final int ACC_BRIDGE   = 0x0040;
     public static final int ACC_VARARGS  = 0x0080;
-    public static final int ACC_INLINE   = 0x0100;
+    public static final int ACC_PRIMITIVE = 0x0100;
     public static final int ACC_MODULE   = 0x8000;
 
     /*****************************************
@@ -401,7 +401,7 @@ public class Flags {
      */
     public static final int
         AccessFlags                       = PUBLIC | PROTECTED | PRIVATE,
-        LocalClassFlags                   = FINAL | ABSTRACT | STRICTFP | ENUM | SYNTHETIC  | VALUE,
+        LocalClassFlags                   = FINAL | ABSTRACT | STRICTFP | ENUM | SYNTHETIC  | PRIMITIVE_CLASS,
         StaticLocalFlags                  = LocalClassFlags | STATIC | INTERFACE,
         MemberClassFlags                  = LocalClassFlags | INTERFACE | AccessFlags,
         MemberStaticClassFlags            = MemberClassFlags | STATIC,
@@ -416,7 +416,7 @@ public class Flags {
         RecordMethodFlags                 = AccessFlags | ABSTRACT | STATIC |
                                             SYNCHRONIZED | FINAL | STRICTFP;
     public static final long
-        ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED | VALUE,
+        ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS,
         ExtendedMemberClassFlags          = (long)MemberClassFlags | SEALED | NON_SEALED,
         ExtendedMemberStaticClassFlags    = (long) MemberStaticClassFlags | SEALED | NON_SEALED,
         ExtendedClassFlags                = (long)ClassFlags | SEALED | NON_SEALED,
@@ -447,7 +447,7 @@ public class Flags {
             if (0 != (flags & NATIVE))    modifiers.add(Modifier.NATIVE);
             if (0 != (flags & STRICTFP))  modifiers.add(Modifier.STRICTFP);
             if (0 != (flags & DEFAULT))   modifiers.add(Modifier.DEFAULT);
-            if (0 != (flags & VALUE))     modifiers.add(Modifier.VALUE);
+            if (0 != (flags & PRIMITIVE_CLASS))     modifiers.add(Modifier.PRIMITIVE);
             modifiers = Collections.unmodifiableSet(modifiers);
             modifierSets.put(flags, modifiers);
         }
@@ -494,7 +494,7 @@ public class Flags {
         BLOCK(Flags.BLOCK),
         ENUM(Flags.ENUM),
         MANDATED(Flags.MANDATED),
-        INLINE(Flags.VALUE),
+        PRIMITIVE(Flags.PRIMITIVE_CLASS),
         NOOUTERTHIS(Flags.NOOUTERTHIS),
         EXISTS(Flags.EXISTS),
         COMPOUND(Flags.COMPOUND),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -414,8 +414,8 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return (flags_field & Flags.AccessFlags) == PRIVATE;
     }
 
-    public boolean isValue() {
-        return (flags() & VALUE) != 0;
+    public boolean isPrimitiveClass() {
+        return (flags() & PRIMITIVE_CLASS) != 0;
     }
 
     /**
@@ -1665,7 +1665,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override
         public boolean isReferenceProjection() {
-            return projection != null && projection.isValue();
+            return projection != null && projection.isPrimitiveClass();
         }
 
         @Override
@@ -1675,7 +1675,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override
         public ClassSymbol referenceProjection() {
-            if (!isValue())
+            if (!isPrimitiveClass())
                 return null;
 
             if (projection != null)
@@ -1692,7 +1692,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             ct.projection = projectedType;
 
             Name projectionName = this.name.append('$', this.name.table.names.ref);
-            long projectionFlags = (this.flags() & ~(VALUE | UNATTRIBUTED | FINAL)) | SEALED;
+            long projectionFlags = (this.flags() & ~(PRIMITIVE_CLASS | UNATTRIBUTED | FINAL)) | SEALED;
 
             projection = new ClassSymbol(projectionFlags, projectionName, projectedType, this.owner);
             projection.members_field = WriteableScope.create(projection);
@@ -1840,14 +1840,14 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override
         public VarSymbol referenceProjection() {
-            return this.owner.isValue() ?
+            return this.owner.isPrimitiveClass() ?
                     this.owner.referenceProjection() != null ? projection : null
                                : null;
         }
 
         @Override
         public VarSymbol valueProjection() {
-            return  projection != null ? projection.owner.isValue() ? projection : null: null;
+            return  projection != null ? projection.owner.isPrimitiveClass() ? projection : null: null;
         }
 
         /**
@@ -2206,10 +2206,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             /* If any inline types are involved, ask the same question in the reference universe,
                where the hierarchy is navigable
             */
-            if (origin.isValue())
+            if (origin.isPrimitiveClass())
                 origin = (TypeSymbol) origin.referenceProjection();
 
-            if (this.owner.isValue()) {
+            if (this.owner.isPrimitiveClass()) {
                 return this.projection != null &&
                         this.projection.overrides(_other, origin, types, checkResult, requireConcreteIfInherited);
             }
@@ -2272,9 +2272,9 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             /* If any inline types are involved, ask the same question in the reference universe,
                where the hierarchy is navigable
             */
-            if (clazz.isValue())
+            if (clazz.isPrimitiveClass())
                 clazz = clazz.referenceProjection();
-            if (this.owner.isValue())
+            if (this.owner.isPrimitiveClass())
                 return this.projection.isInheritedIn(clazz, types);
 
             switch ((int)(flags_field & Flags.AccessFlags)) {
@@ -2293,14 +2293,14 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override
         public MethodSymbol referenceProjection() {
-            return this.owner.isValue() ?
+            return this.owner.isPrimitiveClass() ?
                     this.owner.referenceProjection() != null ? projection : null
                     : null;
         }
 
         @Override
         public MethodSymbol valueProjection() {
-            return  projection != null ? projection.owner.isValue() ? projection : null : null;
+            return  projection != null ? projection.owner.isPrimitiveClass() ? projection : null : null;
         }
 
         /** override this method to point to the original enclosing method if this method symbol represents a synthetic

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -270,7 +270,7 @@ public class Symtab {
                     /* Temporary treatment for inline class: Given an inline class V that implements
                        I1, I2, ... In, V.class is typed to be Class<? extends Object & I1 & I2 .. & In>
                     */
-                    if (type.isValue()) {
+                    if (type.isPrimitiveClass()) {
                         List<Type> bounds = List.of(objectType).appendList(((ClassSymbol) type.tsym).getInterfaces());
                         arg = new WildcardType(bounds.size() > 1 ? types.makeIntersectionType(bounds) : objectType, BoundKind.EXTENDS, boundClass);
                     } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -235,7 +235,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         this.metadata = metadata;
     }
 
-    public boolean isValue() {
+    public boolean isPrimitiveClass() {
         return false;
     }
 
@@ -1195,8 +1195,8 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
 
         @Override
-        public boolean isValue() {
-            return tsym != null && tsym.isValue();
+        public boolean isPrimitiveClass() {
+            return tsym != null && tsym.isPrimitiveClass();
         }
 
         @Override
@@ -1229,7 +1229,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         @Override
         public ClassType referenceProjection() {
 
-            if (!isValue() || projection != null)
+            if (!isPrimitiveClass() || projection != null)
                 return projection;
 
             // make a best case effort to cache the other projection.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -606,8 +606,8 @@ public class Types {
             return true;
         }
 
-        boolean tValue = t.isValue();
-        boolean sValue = s.isValue();
+        boolean tValue = t.isPrimitiveClass();
+        boolean sValue = s.isPrimitiveClass();
         if (tValue != sValue) {
             return tValue ?
                     isSubtype(t.referenceProjection(), s) :
@@ -1007,8 +1007,8 @@ public class Types {
        }
     }
 
-    public boolean isValue(Type t) {
-        return t != null && t.tsym != null && (t.tsym.flags_field & Flags.VALUE) != 0;
+    public boolean isPrimitiveClass(Type t) {
+        return t != null && t.tsym != null && (t.tsym.flags_field & Flags.PRIMITIVE_CLASS) != 0;
     }
 
     // <editor-fold defaultstate="collapsed" desc="isSubtype">
@@ -1037,9 +1037,9 @@ public class Types {
                     // if T.ref <: S, then T[] <: S[]
                     Type es = elemtype(s);
                     Type et = elemtype(t);
-                    if (isValue(et)) {
+                    if (isPrimitiveClass(et)) {
                         et = et.referenceProjection();
-                        if (isValue(es))
+                        if (isPrimitiveClass(es))
                             es = es.referenceProjection();  // V <: V, surely
                     }
                     if (!isSubtypeUncheckedInternal(et, es, false, warn))
@@ -1141,7 +1141,7 @@ public class Types {
                      return isSubtypeNoCapture(t.getUpperBound(), s);
                  case BOT:
                      return
-                         s.hasTag(BOT) || (s.hasTag(CLASS) && !isValue(s)) ||
+                         s.hasTag(BOT) || (s.hasTag(CLASS) && !isPrimitiveClass(s)) ||
                          s.hasTag(ARRAY) || s.hasTag(TYPEVAR);
                  case WILDCARD: //we shouldn't be here - avoids crash (see 7034495)
                  case NONE:
@@ -1223,9 +1223,9 @@ public class Types {
                         // if T.ref <: S, then T[] <: S[]
                         Type es = elemtype(s);
                         Type et = elemtype(t);
-                        if (isValue(et)) {
+                        if (isPrimitiveClass(et)) {
                             et = et.referenceProjection();
-                            if (isValue(es))
+                            if (isPrimitiveClass(es))
                                 es = es.referenceProjection();  // V <: V, surely
                         }
                         return isSubtypeNoCapture(et, es);
@@ -1718,7 +1718,7 @@ public class Types {
                subtyping, thereby necessitating special handling.
             */
             if ((ss.isReferenceProjection() && ss.valueProjection() == ts) ||
-                (ss.isValue() && ss.referenceProjection() == ts)) {
+                (ss.isPrimitiveClass() && ss.referenceProjection() == ts)) {
                 return false;
             }
             if (isSubtype(erasure(ts.type), erasure(ss.type))) {
@@ -1776,7 +1776,7 @@ public class Types {
 
             @Override
             public Boolean visitClassType(ClassType t, Type s) {
-                if (s.hasTag(ERROR) || (s.hasTag(BOT) && !isValue(t)))
+                if (s.hasTag(ERROR) || (s.hasTag(BOT) && !isPrimitiveClass(t)))
                     return true;
 
                 if (s.hasTag(TYPEVAR)) {
@@ -1795,11 +1795,11 @@ public class Types {
                 }
 
                 if (s.hasTag(CLASS) || s.hasTag(ARRAY)) {
-                    if (isValue(t)) {
+                    if (isPrimitiveClass(t)) {
                         // (s) Value ? == (s) Value.ref
                         t = t.referenceProjection();
                     }
-                    if (isValue(s)) {
+                    if (isPrimitiveClass(s)) {
                         // (Value) t ? == (Value.ref) t
                         s = s.referenceProjection();
                     }
@@ -2235,15 +2235,15 @@ public class Types {
            superclass)
         */
         if (checkReferenceProjection)
-            t = t.isValue() ? t.referenceProjection() : t;
+            t = t.isPrimitiveClass() ? t.referenceProjection() : t;
 
         if (sym.type == syms.objectType) { //optimization
-            if (!isValue(t))
+            if (!isPrimitiveClass(t))
                 return syms.objectType;
         }
         if (sym.type == syms.identityObjectType) {
             // IdentityObject is super interface of every concrete identity class other than jlO
-            if (t.isValue() || t.tsym == syms.objectType.tsym)
+            if (t.isPrimitiveClass() || t.tsym == syms.objectType.tsym)
                 return null;
             if (t.hasTag(ARRAY))
                 return syms.identityObjectType;
@@ -2268,7 +2268,7 @@ public class Types {
                     return t;
 
                 // No man may be an island, but the bell tolls for a value.
-                if (isValue(t))
+                if (isPrimitiveClass(t))
                     return null;
 
                 Symbol c = t.tsym;
@@ -2390,10 +2390,10 @@ public class Types {
            where the hierarchy is navigable. V and V.ref have identical membership
            with no bridging needs.
         */
-        if (t.isValue())
+        if (t.isPrimitiveClass())
             t = t.referenceProjection();
 
-        if (sym.owner.isValue())
+        if (sym.owner.isPrimitiveClass())
             sym = sym.referenceProjection();
 
         return memberType.visit(t, sym);
@@ -2607,8 +2607,8 @@ public class Types {
             bounds = bounds.prepend(syms.objectType);
         }
         long flags = ABSTRACT | PUBLIC | SYNTHETIC | COMPOUND | ACYCLIC;
-        if (isValue(bounds.head))
-            flags |= VALUE;
+        if (isPrimitiveClass(bounds.head))
+            flags |= PRIMITIVE_CLASS;
         ClassSymbol bc =
             new ClassSymbol(flags,
                             Type.moreInfo
@@ -5245,7 +5245,7 @@ public class Types {
                     if (type.isCompound()) {
                         reportIllegalSignature(type);
                     }
-                    if (types.isValue(type))
+                    if (types.isPrimitiveClass(type))
                         append('Q');
                     else
                         append('L');

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -496,7 +496,7 @@ public class Enter extends JCTree.Visitor {
         // Enter type parameters.
         ct.typarams_field = classEnter(tree.typarams, localEnv);
         ct.allparams_field = null;
-        if (ct.isValue()) {
+        if (ct.isPrimitiveClass()) {
             if (ct.projection != null) {
                 ct.projection.typarams_field = ct.typarams_field;
                 ct.projection.allparams_field = ct.allparams_field;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2124,7 +2124,7 @@ public class Flow {
                         firstadr = nextadr;
                         this.thisExposability = ALLOWED;
                     } else {
-                        if (types.isValue(tree.sym.owner.type))
+                        if (types.isPrimitiveClass(tree.sym.owner.type))
                             this.thisExposability = BANNED;
                         else
                             this.thisExposability = ALLOWED;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2340,7 +2340,7 @@ public class LambdaToMethod extends TreeTranslator {
                         receiverIsReferenceProjection() ||
                         (tree.getMode() == ReferenceMode.NEW &&
                           tree.kind != ReferenceKind.ARRAY_CTOR &&
-                          (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner() || tree.sym.owner.isValue()));
+                          (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner() || tree.sym.owner.isPrimitiveClass()));
             }
 
             Type generatedRefSig() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2100,7 +2100,7 @@ public class Lower extends TreeTranslator {
      */
     public <T extends JCExpression> T translate(T tree, Type type) {
         return (tree == null) ? null :
-                applyInlineConversionsAsNeeded(boxIfNeeded(translate(tree), type), type);
+                applyPrimitiveConversionsAsNeeded(boxIfNeeded(translate(tree), type), type);
     }
 
     /** Visitor method: Translate tree.
@@ -3097,11 +3097,11 @@ public class Lower extends TreeTranslator {
         return result.toList();
     }
 
-    /** Apply inline widening/narrowing conversions as needed */
+    /** Apply primitive value/reference conversions as needed */
     @SuppressWarnings("unchecked")
-    <T extends JCExpression> T applyInlineConversionsAsNeeded(T tree, Type type) {
-        boolean haveValue = tree.type.isValue();
-        if (haveValue == type.isValue())
+    <T extends JCExpression> T applyPrimitiveConversionsAsNeeded(T tree, Type type) {
+        boolean haveValue = tree.type.isPrimitiveClass();
+        if (haveValue == type.isPrimitiveClass())
             return tree;
         if (haveValue) {
             // widening coversion is a NOP for the VM due to subtyping relationship at class file

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -218,7 +218,7 @@ public class MemberEnter extends JCTree.Visitor {
 
         localEnv.info.scope.leave();
         if (chk.checkUnique(tree.pos(), m, enclScope)) {
-            ClassSymbol refProjection = m.owner.isValue() ? (ClassSymbol) m.owner.referenceProjection() : null;
+            ClassSymbol refProjection = m.owner.isPrimitiveClass() ? (ClassSymbol) m.owner.referenceProjection() : null;
             enclScope.enter(m);
             if (refProjection != null) {
                 MethodSymbol clone = m.clone(refProjection);
@@ -300,7 +300,7 @@ public class MemberEnter extends JCTree.Visitor {
         */
         if (tree.init != null) {
             v.flags_field |= HASINIT;
-            if ((v.flags_field & FINAL) != 0 && ((v.flags_field & STATIC) != 0 || !types.isValue(v.owner.type)) &&
+            if ((v.flags_field & FINAL) != 0 && ((v.flags_field & STATIC) != 0 || !types.isPrimitiveClass(v.owner.type)) &&
                 needsLazyConstValue(tree.init)) {
                 Env<AttrContext> initEnv = getInitEnv(tree, env);
                 initEnv.info.enclVar = v;
@@ -309,7 +309,7 @@ public class MemberEnter extends JCTree.Visitor {
         }
         if (chk.checkUnique(tree.pos(), v, enclScope)) {
             chk.checkTransparentVar(tree.pos(), v, enclScope);
-            ClassSymbol refProjection =  v.owner.isValue() ? (ClassSymbol) v.owner.referenceProjection() : null;
+            ClassSymbol refProjection =  v.owner.isPrimitiveClass() ? (ClassSymbol) v.owner.referenceProjection() : null;
             enclScope.enter(v);
             if (refProjection != null) {
                 VarSymbol clone = v.clone(refProjection);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -418,11 +418,11 @@ public class Resolve {
             /* If any inline types are involved, ask the same question in the reference universe,
                where the hierarchy is navigable
             */
-            if (site.isValue())
+            if (site.isPrimitiveClass())
                 site = site.referenceProjection();
-            if (sym.owner.isValue())
+            if (sym.owner.isPrimitiveClass())
                 sym = sym.referenceProjection();
-            if (env.enclClass.sym.isValue())
+            if (env.enclClass.sym.isPrimitiveClass())
                 env.enclClass.sym = env.enclClass.sym.referenceProjection();
         } else if (sym.kind == TYP) {
             // A type is accessible in a reference projection if it was
@@ -487,9 +487,9 @@ public class Resolve {
         /* If any inline types are involved, ask the same question in the reference universe,
            where the hierarchy is navigable
         */
-        if (site.isValue())
+        if (site.isPrimitiveClass())
             site = site.referenceProjection();
-        if (sym.owner.isValue())
+        if (sym.owner.isPrimitiveClass())
             sym = sym.referenceProjection();
 
         Symbol s2 = ((MethodSymbol)sym).implementation(site.tsym, types, true);
@@ -3063,7 +3063,7 @@ public class Resolve {
                             return sym;
                         }
                     };
-                    ClassSymbol refProjection = newConstr.owner.isValue() ?
+                    ClassSymbol refProjection = newConstr.owner.isPrimitiveClass() ?
                                                      (ClassSymbol) newConstr.owner.referenceProjection() : null;
                     if (refProjection != null) {
                         MethodSymbol clone = newConstr.clone(refProjection);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransTypes.java
@@ -288,7 +288,7 @@ public class TransTypes extends TreeTranslator {
         bridges.append(md);
 
         // Add bridge to scope of enclosing class and keep track of the bridge span.
-        ClassSymbol refProjection = origin.isValue() ? origin.referenceProjection() : null;
+        ClassSymbol refProjection = origin.isPrimitiveClass() ? origin.referenceProjection() : null;
         origin.members().enter(bridge);
         if (refProjection != null) {
             MethodSymbol clone = bridge.clone(refProjection);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -681,7 +681,7 @@ public class TypeEnter implements Completer {
             // Determine supertype.
             Type supertype;
             JCExpression extending;
-            final boolean isValueType = (tree.mods.flags & Flags.VALUE) != 0;
+            final boolean isValueType = (tree.mods.flags & Flags.PRIMITIVE_CLASS) != 0;
 
             if (tree.extending != null) {
                 extending = clearTypeParams(tree.extending);
@@ -733,7 +733,7 @@ public class TypeEnter implements Completer {
                 ct.all_interfaces_field = (all_interfaces == null)
                         ? ct.interfaces_field : all_interfaces.toList();
             }
-            if (ct.isValue()) {
+            if (ct.isPrimitiveClass()) {
                 ClassSymbol cSym = (ClassSymbol) ct.tsym;
                 if (cSym.projection != null) {
                     ClassType projectedType = (ClassType) cSym.projection.type;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -297,7 +297,7 @@ public class ClassReader {
     private void enterMember(ClassSymbol c, Symbol sym) {
         // Synthetic members are not entered -- reason lost to history (optimization?).
         // Lambda methods must be entered because they may have inner classes (which reference them)
-        ClassSymbol refProjection =  c.isValue() ? c.referenceProjection() : null;
+        ClassSymbol refProjection =  c.isPrimitiveClass() ? c.referenceProjection() : null;
         if ((sym.flags_field & (SYNTHETIC|BRIDGE)) != SYNTHETIC || sym.name.startsWith(names.lambda)) {
             c.members_field.enter(sym);
             if (refProjection != null) {
@@ -1004,7 +1004,7 @@ public class ClassReader {
                         //- System.err.println(" # " + sym.type);
                         if (sym.kind == MTH && sym.type.getThrownTypes().isEmpty())
                             sym.type.asMethodType().thrown = thrown;
-                        if (sym.kind == MTH  && sym.name == names.init && sym.owner.isValue()) {
+                        if (sym.kind == MTH  && sym.name == names.init && sym.owner.isPrimitiveClass()) {
                             sym.type = new MethodType(sym.type.getParameterTypes(),
                                     syms.voidType,
                                     sym.type.getThrownTypes(),
@@ -2677,7 +2677,7 @@ public class ClassReader {
 
     public void readClassFile(ClassSymbol c) {
         readClassFileInternal(c);
-        if (c.isValue()) {
+        if (c.isPrimitiveClass()) {
             /* http://cr.openjdk.java.net/~briangoetz/valhalla/sov/04-translation.html
                The relationship of value and reference projections differs between the language model
                and the VM model. In the language, the value projection is not a subtype of the
@@ -2797,10 +2797,10 @@ public class ClassReader {
             flags &= ~ACC_MODULE;
             flags |= MODULE;
         }
-        if ((flags & ACC_INLINE) != 0) {
-            flags &= ~ACC_INLINE;
+        if ((flags & ACC_PRIMITIVE) != 0) {
+            flags &= ~ACC_PRIMITIVE;
             if (allowPrimitiveClasses) {
-                flags |= VALUE;
+                flags |= PRIMITIVE_CLASS;
             }
         }
         return flags & ~ACC_SUPER; // SUPER and SYNCHRONIZED bits overloaded

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -1782,7 +1782,7 @@ public class Code {
                 int width = width(t);
                 Type old = stack[stacksize-width];
                 Assert.check(types.isSubtype(types.erasure(old), types.erasure(t)) ||
-                        (old.isValue() != t.isValue() && types.isConvertible(types.erasure(old), types.erasure(t))));
+                        (old.isPrimitiveClass() != t.isPrimitiveClass() && types.isConvertible(types.erasure(old), types.erasure(t))));
                 stack[stacksize-width] = t;
                 break;
             default:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2046,7 +2046,7 @@ public class Gen extends JCTree.Visitor {
             }
             int elemcode = Code.arraycode(elemtype);
             if (elemcode == 0 || (elemcode == 1 && ndims == 1)) {
-                code.emitAnewarray(makeRef(pos, elemtype, types.isValue(elemtype)), type);
+                code.emitAnewarray(makeRef(pos, elemtype, types.isPrimitiveClass(elemtype)), type);
             } else if (elemcode == 1) {
                 code.emitMultianewarray(ndims, makeRef(pos, type), type);
             } else {
@@ -2278,7 +2278,7 @@ public class Gen extends JCTree.Visitor {
             (!tree.clazz.type.tsym.isReferenceProjection() || tree.clazz.type.tsym.valueProjection() != tree.expr.type.tsym) &&
            types.asSuper(tree.expr.type, tree.clazz.type.tsym) == null) {
             checkDimension(tree.pos(), tree.clazz.type);
-            if (types.isValue(tree.clazz.type)) {
+            if (types.isPrimitiveClass(tree.clazz.type)) {
                 code.emitop2(checkcast, new ConstantPoolQType(tree.clazz.type, types), PoolWriter::putClass);
             } else {
                 code.emitop2(checkcast, tree.clazz.type, PoolWriter::putClass);
@@ -2349,7 +2349,7 @@ public class Gen extends JCTree.Visitor {
             result = items.makeStackItem(pt);
             return;
         } else if (tree.name == names._default) {
-            if (tree.type.asElement().isValue()) {
+            if (tree.type.asElement().isPrimitiveClass()) {
                 code.emitop2(defaultvalue, checkDimension(tree.pos(), tree.type), PoolWriter::putClass);
             } else if (tree.type.isReference()) {
                 code.emitop0(aconst_null);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -508,8 +508,8 @@ public class PoolWriter {
         if (typarams.nonEmpty()) {
             signatureGen.assembleParamsSig(typarams);
         }
-        signatureGen.assembleSig(t.isValue() ? t.referenceProjection() : types.supertype(t));
-        if (!t.isValue()) {
+        signatureGen.assembleSig(t.isPrimitiveClass() ? t.referenceProjection() : types.supertype(t));
+        if (!t.isPrimitiveClass()) {
             for (Type i : types.interfaces(t))
                 signatureGen.assembleSig(i);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
@@ -364,7 +364,7 @@ public class TransValues extends TreeTranslator {
     // Translate a reference style instance creation attempt on a value type to a static factory call.
     @Override
     public void visitNewClass(JCNewClass tree) {
-        if (types.isValue(tree.clazz.type)) {
+        if (types.isPrimitiveClass(tree.clazz.type)) {
             // Enclosing instances or anonymous classes should have been eliminated by now.
             Assert.check(tree.encl == null && tree.def == null);
             tree.args = translate(tree.args);
@@ -385,7 +385,7 @@ public class TransValues extends TreeTranslator {
 
     // Utility methods ...
     private boolean constructingValue() {
-        return currentClass != null && (currentClass.sym.flags() & Flags.VALUE) != 0 && currentMethod != null && currentMethod.sym.isConstructor();
+        return currentClass != null && (currentClass.sym.flags() & Flags.PRIMITIVE_CLASS) != 0 && currentMethod != null && currentMethod.sym.isConstructor();
     }
 
     private boolean isInstanceMemberAccess(Symbol symbol) {
@@ -397,7 +397,7 @@ public class TransValues extends TreeTranslator {
 
     private MethodSymbol getValueFactory(MethodSymbol init) {
         Assert.check(init.name.equals(names.init));
-        Assert.check(types.isValue(init.owner.type));
+        Assert.check(types.isPrimitiveClass(init.owner.type));
         MethodSymbol factory = init2factory.get(init);
         if (factory != null)
             return factory;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2331,7 +2331,7 @@ public class JavacParser implements Parser {
         case BYTE: case SHORT: case CHAR: case INT: case LONG: case FLOAT:
         case DOUBLE: case BOOLEAN:
             if (mods.flags != 0) {
-                long badModifiers = (mods.flags & Flags.VALUE) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
+                long badModifiers = (mods.flags & Flags.PRIMITIVE_CLASS) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
                 log.error(token.pos, Errors.ModNotAllowedHere(asFlagSet(badModifiers)));
             }
             if (typeArgs == null) {
@@ -2402,7 +2402,7 @@ public class JavacParser implements Parser {
             }
             return e;
         } else if (token.kind == LPAREN) {
-            long badModifiers = mods.flags & ~(Flags.VALUE | Flags.FINAL);
+            long badModifiers = mods.flags & ~(Flags.PRIMITIVE_CLASS | Flags.FINAL);
             if (badModifiers != 0)
                 log.error(token.pos, Errors.ModNotAllowedHere(asFlagSet(badModifiers)));
             // handle type annotations for instantiations and anonymous classes
@@ -2411,7 +2411,7 @@ public class JavacParser implements Parser {
             }
             JCNewClass newClass = classCreatorRest(newpos, null, typeArgs, t, mods.flags);
             if ((newClass.def == null) && (mods.flags != 0)) {
-                badModifiers = (mods.flags & Flags.VALUE) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
+                badModifiers = (mods.flags & Flags.PRIMITIVE_CLASS) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
                 log.error(newClass.pos, Errors.ModNotAllowedHere(asFlagSet(badModifiers)));
             }
             return newClass;
@@ -3210,7 +3210,7 @@ public class JavacParser implements Parser {
             case FINAL       : flag = Flags.FINAL; break;
             case ABSTRACT    : flag = Flags.ABSTRACT; break;
             case NATIVE      : flag = Flags.NATIVE; break;
-            case PRIMITIVE   : flag = Flags.VALUE; break;
+            case PRIMITIVE   : flag = Flags.PRIMITIVE_CLASS; break;
             case VOLATILE    : flag = Flags.VOLATILE; break;
             case SYNCHRONIZED: flag = Flags.SYNCHRONIZED; break;
             case STRICTFP    : flag = Flags.STRICTFP; break;
@@ -3244,7 +3244,7 @@ public class JavacParser implements Parser {
                         pos = ann.pos;
                     final Name name = TreeInfo.name(ann.annotationType);
                     if (name == names.__primitive__ || name == names.java_lang___primitive__) {
-                        flag = Flags.VALUE;
+                        flag = Flags.PRIMITIVE_CLASS;
                     } else {
                         annotations.append(ann);
                         flag = 0;
@@ -3265,7 +3265,7 @@ public class JavacParser implements Parser {
             pos = Position.NOPOS;
 
         // Force value classes to be automatically final.
-        if ((flags & (Flags.VALUE | Flags.ABSTRACT | Flags.INTERFACE | Flags.ENUM)) == Flags.VALUE) {
+        if ((flags & (Flags.PRIMITIVE_CLASS | Flags.ABSTRACT | Flags.INTERFACE | Flags.ENUM)) == Flags.PRIMITIVE_CLASS) {
             flags |= Flags.FINAL;
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
@@ -49,7 +49,7 @@ public class AccessFlags {
     public static final int ACC_BRIDGE        = 0x0040; //                      method
     public static final int ACC_TRANSIENT     = 0x0080; //               field
     public static final int ACC_VARARGS       = 0x0080; //                      method
-    public static final int ACC_INLINE        = 0x0100; // class
+    public static final int ACC_PRIMITIVE     = 0x0100; // class
     public static final int ACC_NATIVE        = 0x0100; //                      method
     public static final int ACC_INTERFACE     = 0x0200; // class, inner
     public static final int ACC_ABSTRACT      = 0x0400; // class, inner,        method
@@ -83,12 +83,12 @@ public class AccessFlags {
     }
 
     private static final int[] classModifiers = {
-        ACC_PUBLIC, ACC_FINAL, ACC_ABSTRACT, ACC_INLINE
+        ACC_PUBLIC, ACC_FINAL, ACC_ABSTRACT, ACC_PRIMITIVE
     };
 
     private static final int[] classFlags = {
         ACC_PUBLIC, ACC_FINAL, ACC_SUPER, ACC_INTERFACE, ACC_ABSTRACT,
-        ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_MODULE, ACC_INLINE
+        ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_MODULE, ACC_PRIMITIVE
     };
 
     public Set<String> getClassModifiers() {
@@ -102,12 +102,12 @@ public class AccessFlags {
 
     private static final int[] innerClassModifiers = {
         ACC_PUBLIC, ACC_PRIVATE, ACC_PROTECTED, ACC_STATIC, ACC_FINAL,
-        ACC_ABSTRACT, ACC_INLINE
+        ACC_ABSTRACT, ACC_PRIMITIVE
     };
 
     private static final int[] innerClassFlags = {
         ACC_PUBLIC, ACC_PRIVATE, ACC_PROTECTED, ACC_STATIC, ACC_FINAL, ACC_SUPER,
-        ACC_INTERFACE, ACC_ABSTRACT, ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_INLINE
+        ACC_INTERFACE, ACC_ABSTRACT, ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_PRIMITIVE
     };
 
     public Set<String> getInnerClassModifiers() {
@@ -236,7 +236,7 @@ public class AccessFlags {
         case 0x80:
             return (t == Kind.Field ? "ACC_TRANSIENT" : "ACC_VARARGS");
         case 0x100:
-            return (t == Kind.Class || t == Kind.InnerClass) ? "ACC_INLINE" : "ACC_NATIVE";
+            return (t == Kind.Class || t == Kind.InnerClass) ? "ACC_PRIMITIVE" : "ACC_NATIVE";
         case ACC_INTERFACE:
             return "ACC_INTERFACE";
         case ACC_ABSTRACT:

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFlags.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFlags.java
@@ -37,7 +37,7 @@ public class CheckFlags {
     public static void main(String[] args) throws Exception {
         ClassFile cls = ClassFile.read(CheckFlags.class.getResourceAsStream("Point.class"));
 
-        if (!cls.access_flags.is(AccessFlags.ACC_INLINE))
+        if (!cls.access_flags.is(AccessFlags.ACC_PRIMITIVE))
             throw new Exception("Value flag not set");
 
         if (!cls.access_flags.is(AccessFlags.ACC_FINAL))

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableSyntheticFields.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFlattenableSyntheticFields.java
@@ -55,7 +55,7 @@ public class CheckFlattenableSyntheticFields {
     public static void main(String[] args) throws Exception {
         ClassFile cls = ClassFile.read(CheckFlattenableSyntheticFields.class.getResourceAsStream("CheckFlattenableSyntheticFields$ValueOuter$Inner.class"));
 
-        if (!cls.access_flags.is(AccessFlags.ACC_INLINE))
+        if (!cls.access_flags.is(AccessFlags.ACC_PRIMITIVE))
             throw new Exception("Value flag not set");
 
         if (!cls.access_flags.is(AccessFlags.ACC_FINAL))
@@ -63,7 +63,7 @@ public class CheckFlattenableSyntheticFields {
 
         cls = ClassFile.read(CheckFlattenableSyntheticFields.class.getResourceAsStream("CheckFlattenableSyntheticFields$RefOuter$Inner.class"));
 
-        if (!cls.access_flags.is(AccessFlags.ACC_INLINE))
+        if (!cls.access_flags.is(AccessFlags.ACC_PRIMITIVE))
             throw new Exception("Value flag not set");
 
         if (!cls.access_flags.is(AccessFlags.ACC_FINAL))

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckLocalClasses.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckLocalClasses.java
@@ -63,7 +63,7 @@ public class CheckLocalClasses {
     public static void main(String[] args) throws Exception {
         ClassFile cls = ClassFile.read(CheckLocalClasses.class.getResourceAsStream("CheckLocalClasses$ValueOuter$1Inner.class"));
 
-        if (!cls.access_flags.is(AccessFlags.ACC_INLINE))
+        if (!cls.access_flags.is(AccessFlags.ACC_PRIMITIVE))
             throw new Exception("Value flag not set");
 
         if (!cls.access_flags.is(AccessFlags.ACC_FINAL))
@@ -71,7 +71,7 @@ public class CheckLocalClasses {
 
         cls = ClassFile.read(CheckLocalClasses.class.getResourceAsStream("CheckLocalClasses$RefOuter$1Inner.class"));
 
-        if (!cls.access_flags.is(AccessFlags.ACC_INLINE))
+        if (!cls.access_flags.is(AccessFlags.ACC_PRIMITIVE))
             throw new Exception("Value flag not set");
 
         if (!cls.access_flags.is(AccessFlags.ACC_FINAL))

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckMakeDefault.out
@@ -1,5 +1,5 @@
-CheckMakeDefault.java:9:15: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckMakeDefault.java:10:24: compiler.err.illegal.combination.of.modifiers: abstract, inline
+CheckMakeDefault.java:9:15: compiler.err.illegal.combination.of.modifiers: interface, primitive
+CheckMakeDefault.java:10:24: compiler.err.illegal.combination.of.modifiers: abstract, primitive
 CheckMakeDefault.java:26:32: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: boolean, int)
 CheckMakeDefault.java:27:33: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: byte, boolean)
 CheckMakeDefault.java:28:33: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: char, boolean)

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckValueModifier.out
@@ -1,7 +1,7 @@
-CheckValueModifier.java:18:14: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckValueModifier.java:19:15: compiler.err.illegal.combination.of.modifiers: interface, inline
-CheckValueModifier.java:20:14: compiler.err.mod.not.allowed.here: inline
-CheckValueModifier.java:21:23: compiler.err.illegal.combination.of.modifiers: abstract, inline
-CheckValueModifier.java:15:18: compiler.err.mod.not.allowed.here: inline
-CheckValueModifier.java:16:18: compiler.err.mod.not.allowed.here: inline
+CheckValueModifier.java:18:14: compiler.err.illegal.combination.of.modifiers: interface, primitive
+CheckValueModifier.java:19:15: compiler.err.illegal.combination.of.modifiers: interface, primitive
+CheckValueModifier.java:20:14: compiler.err.mod.not.allowed.here: primitive
+CheckValueModifier.java:21:23: compiler.err.illegal.combination.of.modifiers: abstract, primitive
+CheckValueModifier.java:15:18: compiler.err.mod.not.allowed.here: primitive
+CheckValueModifier.java:16:18: compiler.err.mod.not.allowed.here: primitive
 6 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest.out
@@ -1,4 +1,4 @@
 IllegalByValueTest.java:20:30: compiler.err.repeated.modifier
-IllegalByValueTest.java:21:35: compiler.err.mod.not.allowed.here: inline
-IllegalByValueTest.java:22:9: compiler.err.mod.not.allowed.here: inline
+IllegalByValueTest.java:21:35: compiler.err.mod.not.allowed.here: primitive
+IllegalByValueTest.java:22:9: compiler.err.mod.not.allowed.here: primitive
 3 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationOnAnonymousClass.out
@@ -1,2 +1,2 @@
-InlineAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: inline
+InlineAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: primitive
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineAnnotationTest.out
@@ -1,3 +1,3 @@
-InlineAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
+InlineAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, primitive
 InlineAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InnerClassAttributeValuenessTest.java
@@ -48,7 +48,7 @@ public class InnerClassAttributeValuenessTest {
     }
 
     public static void main(String[] args) {
-        if ((Inner.class.getModifiers() & AccessFlags.ACC_INLINE) == 0)
+        if ((Inner.class.getModifiers() & AccessFlags.ACC_PRIMITIVE) == 0)
             throw new AssertionError("Value flag missing");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
@@ -47,7 +47,7 @@ public class QTypeTest {
                                                 "QTypedValue.class").toString() };
         runCheck(params, new String [] {
               "final value class QTypedValue",
-              "  flags: (0x0130) ACC_FINAL, ACC_SUPER, ACC_INLINE",
+              "  flags: (0x0130) ACC_FINAL, ACC_SUPER, ACC_PRIMITIVE",
               "  this_class: #1                          // QTypedValue",
               "   #1 = Class              #2             // QTypedValue",
               "   #2 = Utf8               QTypedValue",

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationOnAnonymousClass.out
@@ -1,2 +1,2 @@
-ValueAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: inline
+ValueAnnotationOnAnonymousClass.java:11:24: compiler.err.mod.not.allowed.here: primitive
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueAnnotationTest.out
@@ -1,3 +1,3 @@
-ValueAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, inline
+ValueAnnotationTest.java:25:1: compiler.err.illegal.combination.of.modifiers: interface, primitive
 ValueAnnotationTest.java:20:9: compiler.err.cant.assign.val.to.final.var: x
 2 errors


### PR DESCRIPTION
Adopt new nomenclature from Primitive Objects JEP

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261751](https://bugs.openjdk.java.net/browse/JDK-8261751): [lworld] Fix lingering references to inline/value types 


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/336/head:pull/336`
`$ git checkout pull/336`
