### PR TITLE
8255045: [lworld] LoadNode::Value() use of markWord::prototype() may strip type bits

### DIFF
--- a/src/hotspot/share/ci/ciKlass.cpp
+++ b/src/hotspot/share/ci/ciKlass.cpp
@@ -208,6 +208,15 @@ jint ciKlass::access_flags() {
 }
 
 // ------------------------------------------------------------------
+// ciKlass::prototype_header
+markWord ciKlass::prototype_header() const {
+  assert(is_loaded(), "not loaded");
+  GUARDED_VM_ENTRY(
+    return get_Klass()->prototype_header();
+  )
+}
+
+// ------------------------------------------------------------------
 // ciKlass::print_impl
 //
 // Implementation of the print method

--- a/src/hotspot/share/ci/ciKlass.hpp
+++ b/src/hotspot/share/ci/ciKlass.hpp
@@ -130,6 +130,8 @@ public:
   // Fetch Klass::access_flags.
   jint                   access_flags();
 
+  markWord prototype_header() const;
+
   // What kind of ciObject is this?
   bool is_klass() const { return true; }
 

--- a/src/hotspot/share/opto/locknode.cpp
+++ b/src/hotspot/share/opto/locknode.cpp
@@ -184,7 +184,7 @@ void Parse::do_monitor_enter() {
 
   Node* obj = peek();
   const Type* obj_type = gvn().type(obj);
-  if (obj_type->isa_inlinetype() && !obj_type->is_inlinetypeptr()) {
+  if (obj_type->isa_inlinetype() || obj_type->is_inlinetypeptr()) {
     uncommon_trap(Deoptimization::Reason_class_check,
                   Deoptimization::Action_none);
     return;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1075,4 +1075,59 @@ public class TestIntrinsics extends InlineTypeTest {
     public void test57_verifier(boolean warmup) {
         test57();
     }
+
+    // Test unsafe allocation
+    @Test()
+    public boolean test58(Class<?> c1, Class<?> c2) throws Exception {
+        Object obj1 = U.allocateInstance(c1);
+        Object obj2 = U.allocateInstance(c2);
+        return obj1 == obj2;
+    }
+
+    @DontCompile
+    public void test58_verifier(boolean warmup) throws Exception {
+        boolean res = test58(MyValue1.class, MyValue1.class);
+        Asserts.assertTrue(res);
+        res = test58(Object.class, MyValue1.class);
+        Asserts.assertFalse(res);
+        res = test58(MyValue1.class, Object.class);
+        Asserts.assertFalse(res);
+    }
+
+    // Test synchronization on unsafe inline type allocation
+    @Test()
+    public void test59(Class<?> c) throws Exception {
+        Object obj = U.allocateInstance(c);
+        synchronized (obj) {
+
+        }
+    }
+
+    @DontCompile
+    public void test59_verifier(boolean warmup) throws Exception {
+        test59(Integer.class);
+        try {
+            test59(MyValue1.class);
+            throw new RuntimeException("test59 failed: synchronization on inline type should not succeed");
+        } catch (IllegalMonitorStateException e) {
+
+        }
+    }
+
+    // Test mark word load optimization on unsafe inline type allocation
+    @Test()
+    public boolean test60(Class<?> c1, Class<?> c2, boolean b1, boolean b2) throws Exception {
+        Object obj1 = b1 ? new Object() : U.allocateInstance(c1);
+        Object obj2 = b2 ? new Object() : U.allocateInstance(c2);
+        return obj1 == obj2;
+    }
+
+    @DontCompile
+    public void test60_verifier(boolean warmup) throws Exception {
+        Asserts.assertTrue(test60(MyValue1.class, MyValue1.class, false, false));
+        Asserts.assertFalse(test60(MyValue1.class, MyValue2.class, false, false));
+        Asserts.assertFalse(test60(MyValue1.class, MyValue1.class, false, true));
+        Asserts.assertFalse(test60(MyValue1.class, MyValue1.class, true, false));
+        Asserts.assertFalse(test60(MyValue1.class, MyValue1.class, true, true));
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3623,4 +3623,26 @@ public class TestLWorld extends InlineTypeTest {
             // Expected
         }
     }
+
+    // Variant with non-scalarized inline type
+    @Test()
+    public static void test134(boolean b) {
+        Object obj = null;
+        if (b) {
+            obj = MyValue2.createWithFieldsInline(rI, rD);
+        }
+        synchronized (obj) {
+
+        }
+    }
+
+    @DontCompile
+    public void test134_verifier(boolean warmup) {
+        try {
+            test134(true);
+            throw new RuntimeException("test134 failed: no exception thrown");
+        } catch (IllegalMonitorStateException ex) {
+            // Expected
+        }
+    }
 }


### PR DESCRIPTION
`LoadNode::Value` detects mark word loads and replaces them by `markWord::prototype()` which would strip inline/flat/null-free property bits. We need to use the prototype header from the klass. When writing tests, I've found an independent problem (due to a typo) in `Parse::do_monitor_enter()`.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8255045](https://bugs.openjdk.java.net/browse/JDK-8255045): [lworld] LoadNode::Value() use of markWord::prototype() may strip type bits


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/337/head:pull/337`
`$ git checkout pull/337`
