### PR TITLE
8261830: [lworld] [test] ArchiveRelocationTest compilation failure

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ArchiveRelocationTest.java
@@ -29,8 +29,8 @@
  * @comment JDK-8231610 Relocate the CDS archive if it cannot be mapped to the requested address
  * @bug 8231610
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @build HelloRelocation
- * @run driver ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
+ * @build Hello
+ * @run driver ClassFileInstaller -jar hello.jar Hello
  * @run driver ArchiveRelocationTest
  */
 
@@ -59,7 +59,7 @@ public class ArchiveRelocationTest {
         System.out.println("============================================================");
 
         String appJar = ClassFileInstaller.getJarPath("hello.jar");
-        String mainClass = "HelloRelocation";
+        String mainClass = "Hello";
         String forceRelocation = "-XX:ArchiveRelocationMode=1";
         String runRelocArg  = run_reloc  ? forceRelocation : "-showversion";
         String logArg = "-Xlog:cds=debug,cds+reloc=debug";
@@ -67,14 +67,12 @@ public class ArchiveRelocationTest {
         String nmtArg = "-XX:NativeMemoryTracking=detail";
 
         OutputAnalyzer out = TestCommon.dump(appJar,
-                                             TestCommon.list(mainClass,
-                                                             "HelloInlineClassApp",
-                                                             "HelloInlineClassApp$Point"),
-                                             unlockArg, dumpRelocArg, logArg, nmtArg);
+                TestCommon.list(mainClass),
+                unlockArg, logArg, nmtArg);
         out.shouldContain("Relocating archive from");
 
         TestCommon.run("-cp", appJar, unlockArg, runRelocArg, logArg,  mainClass)
-            .assertNormalExit(output -> {
+                .assertNormalExit(output -> {
                     if (run_reloc) {
                         output.shouldContain("Try to map archive(s) at an alternative address");
                     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
@@ -62,8 +62,7 @@ public class HelloDynamicInlineClass extends DynamicArchiveTestBase {
              "-Xlog:cds+dynamic=debug",
              "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                    output.shouldContain("Buffer-space to target-space delta")
-                           .shouldContain("Written dynamic archive 0x");
+                    output.shouldContain("Written dynamic archive 0x");
                 });
         run2(baseArchiveName, topArchiveName,
             "-Xlog:class+load",


### PR DESCRIPTION
Restore a missed merge to fix a compilation failure in ArchiveRelationTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261830](https://bugs.openjdk.java.net/browse/JDK-8261830): [lworld] [test] ArchiveRelocationTest compilation failure


### Reviewers
 * [Ioi Lam](https://openjdk.java.net/census#iklam) (@iklam - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/338/head:pull/338`
`$ git checkout pull/338`
