### PR TITLE
8261956: [type-restrictions] Support RestrictedMethod in the interpreter

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3954,7 +3954,6 @@ void TemplateTable::prepare_invoke(int byte_no,
   const bool is_invokehandle     = code == Bytecodes::_invokehandle;
   const bool is_invokevirtual    = code == Bytecodes::_invokevirtual;
   const bool is_invokespecial    = code == Bytecodes::_invokespecial;
-  const bool is_invokestatic     = code == Bytecodes::_invokestatic;
   const bool load_receiver       = (recv  != noreg);
   const bool save_flags          = (flags != noreg);
   assert(load_receiver == (code != Bytecodes::_invokestatic && code != Bytecodes::_invokedynamic), "");

--- a/src/hotspot/cpu/x86/templateTable_x86.hpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.hpp
@@ -45,4 +45,6 @@
 
   static void invoke_is_substitutable(Register aobj, Register bobj, Label& is_subst, Label& not_subst);
 
+  static void restricted_method_check(Register method);
+
 #endif // CPU_X86_TEMPLATETABLE_X86_HPP

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2681,6 +2681,10 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
   bool runtime_invisible_parameter_annotations_exists = false;
   const u1* annotation_default = NULL;
   int annotation_default_length = 0;
+  bool has_restricted_method_attribute = false;
+  const u1* restricted_param_types_start = NULL;
+  u2 restricted_return_type_index = 0;
+  u1 restricted_num_params = 0;
 
   // Parse code and exceptions attribute
   u2 method_attributes_count = cfs->get_u2_fast();
@@ -3017,6 +3021,29 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
           assert(runtime_invisible_type_annotations != NULL, "null invisible type annotations");
         }
         cfs->skip_u1(method_attribute_length, CHECK_NULL);
+      } else if (method_attribute_name == vmSymbols::tag_restricted_method()) {
+        const u1* const current_start = cfs->current();
+
+        // RestrictedMethod_attribute {
+        //   u2 name_index;
+        //   u4 length;
+        //   u1 num_params;
+        //   u2 restricted_param_type[num_params];
+        //   u2 restricted_return_type;
+        // }
+
+        has_restricted_method_attribute = true;
+        cfs->guarantee_more(1, CHECK_NULL);  // num_params
+        restricted_num_params = cfs->get_u1_fast();
+        guarantee_property((int)method_attribute_length == restricted_num_params * 2 + 3,
+                          "Invalid RestrictedMethod attribute length %u in class file %s",
+                          method_attribute_length,
+                          CHECK_NULL);
+
+        restricted_param_types_start = cfs->current();
+        cfs->skip_u2_fast(restricted_num_params);
+        cfs->guarantee_more(2, CHECK_NULL);  // restricted_return_type
+        restricted_return_type_index = cfs->get_u2_fast();
       } else {
         // Skip unknown attributes
         cfs->skip_u1(method_attribute_length, CHECK_NULL);
@@ -3056,6 +3083,10 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
       runtime_visible_type_annotations_length +
            runtime_invisible_type_annotations_length,
       annotation_default_length,
+      // RestrictedMethod atribute requires a more complex protocol because num_params can be zeo
+      // but the attribute still be there because of a restricted return value
+      // So -1 is passed if the attribute is absent, otherwise num_params is passed
+      has_restricted_method_attribute ? restricted_num_params : -1 ,
       0);
 
   Method* const m = Method::allocate(_loader_data,
@@ -3158,6 +3189,18 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
                           annotation_default,
                           annotation_default_length,
                           CHECK_NULL);
+
+  // Copy RestrictedMethod attribute if present
+  if (has_restricted_method_attribute) {
+    m->set_restricted_method(true);
+    *(m->constMethod()->restricted_num_params_addr()) = restricted_num_params;
+    *(m->constMethod()->restricted_return_type_index_addr()) = restricted_return_type_index;
+    u2* cursor = m->constMethod()->restricted_param_type_start();
+    for (int i = 0; i < restricted_num_params; i++) {
+      cursor[i] = Bytes::get_Java_u2((address)restricted_param_types_start);
+      restricted_param_types_start +=2;
+    }
+  }
 
   if (name == vmSymbols::finalize_method_name() &&
       signature == vmSymbols::void_method_signature()) {

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -191,6 +191,7 @@
   template(tag_bootstrap_methods,                     "BootstrapMethods")                         \
   template(tag_permitted_subclasses,                  "PermittedSubclasses")                      \
   template(tag_restricted_field,                      "RestrictedField")                          \
+  template(tag_restricted_method,                     "RestrictedMethod")                         \
                                                                                                   \
   /* exception klasses: at least all exceptions thrown by the VM have entries here */             \
   template(java_lang_ArithmeticException,             "java/lang/ArithmeticException")            \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -569,11 +569,10 @@ JRT_END
 JRT_ENTRY(void, InterpreterRuntime::restricted_return_value_check(JavaThread* thread, oopDesc* obj))
   LastFrameAccessor last_frame(thread);
   assert(last_frame.bytecode().code() == Bytecodes::_areturn, "Only areturn should have such checks");
-  Method* caller = last_frame.method();
-  constantPoolHandle cph(THREAD, caller->constants());
-  Method* callee = last_frame.cache_entry()->method_if_resolved(cph);
-  if (callee->constMethod()->has_restricted_method()) {
-    Klass* k = callee->restricted_return_value();
+  Method* method = last_frame.method();
+  constantPoolHandle cph(THREAD, method->constants());
+  if (method->constMethod()->has_restricted_method()) {
+    Klass* k = method->restricted_return_value();
     if (k != NULL && !obj->klass()->is_subtype_of(k)) {
       THROW(vmSymbols::java_lang_IncompatibleClassChangeError());
     }

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -552,7 +552,7 @@ JRT_ENTRY(void, InterpreterRuntime::restricted_parameter_checks(JavaThread* thre
       sizes[i] = parameter_type_word_count(ss.type());
       i++;
     }
-    int tos_idx = (int)last_frame.get_frame().interpreter_frame_expression_stack_size() - 1;
+    int tos_idx = (int)last_frame.get_frame().interpreter_frame_expression_stack_size() - 3;
     for (int i = arg_count - 1; i >=0; --i) {
       Klass* k = callee->restricted_param_type_at(i);
       if (k != NULL) {

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -75,6 +75,9 @@ class InterpreterRuntime: AllStatic {
   static jboolean is_substitutable(JavaThread* thread, oopDesc* aobj, oopDesc* bobj);
   static void check_restricted_type(JavaThread* thread);
 
+  static void restricted_parameter_checks(JavaThread* thread);
+  static void restricted_return_value_check(JavaThread* thread, oopDesc* obj);
+
   // Quicken instance-of and check-cast bytecodes
   static void    quicken_io_cc(JavaThread* thread);
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1031,6 +1031,10 @@ bool InstanceKlass::link_class_impl(TRAPS) {
           }
         }
       }
+      // Loadding classes of restricted parameters
+      if (m->constMethod()->has_restricted_method()) {
+        m->resolve_restricted_types(CHECK_false);
+      }
     }
   }
 
@@ -1255,6 +1259,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
       THROW_OOP(e());
     }
   }
+
 
   // Step 8
   // Initialize classes of inline fields

--- a/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/IncompleteKnowledgeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/IncompleteKnowledgeTest.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Asserts;
  * @test
  * @summary Testing accessing flattened field from class with no knowledge of the type restriction
  * @library /test/lib
- * @compile  -XDflattenWithTypeRestrictions SimpleTest.java IncompleteKnowledgeTest.java
+ * @compile SimpleTest.java IncompleteKnowledgeTest.java
  * @run main/othervm -Xverify:none -Xcomp runtime.valhalla.typerestrictions.IncompleteKnowledgeTest
  */
 public class IncompleteKnowledgeTest {

--- a/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/RestrictedMethodTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/RestrictedMethodTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.typerestrictions;
+
+import java.lang.invoke.RestrictedType;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @summary Testing type restrictions on method arguments and return value
+ * @library /test/lib
+ * @compile RestrictedMethodTest.java
+ * @run main/othervm -Xint runtime.valhalla.typerestrictions.RestrictedMethodTest
+ */
+
+interface RMInterface {
+  default public void imethod(@RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o) {
+    System.out.println("imethod says "+o);
+  }
+}
+
+public class RestrictedMethodTest implements RMInterface {
+  static inline class Point {
+    int x = 0;
+    int y = 0;
+  }
+
+  void oneRestrictedArgument(@RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o) {
+    System.out.println("oneRestrictedArgument says " + o);
+  }
+
+  void twoRestrictedArguments(@RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o0,
+                             @RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o1) {
+    System.out.println("twoRestrictedArguments says " + o0 + " " + o1);
+  }
+
+  void secondArgumentRestricted(long l, @RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o) {
+    System.out.println("secondArgumentRestricted says " + l + " " + o);
+  }
+
+  static void staticWithOneRestrictedArgument(@RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object o) {
+    System.out.println("staticWithOneRestrictedArgument says " + o);
+  }
+
+  static @RestrictedType("Qruntime/valhalla/typerestrictions/RestrictedMethodTest$Point;") Object restrictedReturnValue(Object o) {
+    System.out.println("Returning "+o);
+    return o;
+  }
+
+  static void testRMInterface(RMInterface i) {
+    Point p = new Point();
+    Throwable result = null;
+    try {
+      i.imethod(p);
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+      i.imethod(new Object());
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectICC(result);
+    result = null;
+  }
+  static void expectICC(Throwable t) {
+    Asserts.assertNotNull(t, "An error should have been thrown");
+    Asserts.assertTrue(t instanceof java.lang.IncompatibleClassChangeError, "Wrong error type");
+  }
+
+  static void expectNoError(Throwable t) {
+    Asserts.assertNull(t, "No Error should have been thrown");
+  }
+  public static void main(String[] args) {
+    Point p = new Point();
+    RestrictedMethodTest test = new RestrictedMethodTest();
+    Throwable result = null;
+    try {
+      test.oneRestrictedArgument(p);
+    }  catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+        test.oneRestrictedArgument(new Object());
+    } catch(Throwable t) {
+        result = t;
+    }
+    expectICC(result);
+    result = null;
+    try {
+      test.twoRestrictedArguments(p, new Point());
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+      test.twoRestrictedArguments(new Object(), new Point());
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectICC(result);
+    result = null;
+    try {
+      test.twoRestrictedArguments(p, new Object());
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectICC(result);
+    result = null;
+    try {
+      test.secondArgumentRestricted(42L, p);
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+      test.secondArgumentRestricted(42L, new String("Duke"));
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectICC(result);
+    result = null;
+    // Is code robust againt null receiver?
+    RestrictedMethodTest test2 = null;
+    try {
+        test2.oneRestrictedArgument(new Object());
+    } catch(Throwable t) {
+        result = t;
+    }
+    Asserts.assertNotNull(result, "An NPE should have been thrown");
+    Asserts.assertTrue(result instanceof java.lang.NullPointerException, "Wrong exception type");
+    result = null;
+    try {
+      staticWithOneRestrictedArgument(p);
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+        staticWithOneRestrictedArgument(new Object());
+    } catch(Throwable t) {
+        result = t;
+    }
+    expectICC(result);
+    result = null;
+    testRMInterface(test);
+    try {
+      restrictedReturnValue(new Point());
+    } catch(Throwable t) {
+      result = t;
+    }
+    expectNoError(result);
+    try {
+        restrictedReturnValue(new Object());
+    } catch(Throwable t) {
+        result = t;
+    }
+    expectICC(result);
+    result = null;
+  }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/SimpleTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/TypeRestrictions/SimpleTest.java
@@ -29,7 +29,7 @@ import jdk.test.lib.Asserts;
  * @test
  * @summary Simple test about type restrictions
  * @library /test/lib
- * @compile  -XDflattenWithTypeRestrictions SimpleTest.java
+ * @compile SimpleTest.java
  * @run main/othervm -Xint runtime.valhalla.typerestrictions.SimpleTest
  */
 public class SimpleTest {


### PR DESCRIPTION
Please review these changes adding support for RestrictedMethod in the interpreter.
Types restrictions are enforced in the following bytecodes:
  - invokevirtual
  - invokestatic
  - invokespecial
  - invokeinterface
  
The changeset also includes a small fix to prevent previous type restrictions related tests to fail.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261956](https://bugs.openjdk.java.net/browse/JDK-8261956): [type-restrictions] Support RestrictedMethod in the interpreter


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer) ⚠️ Review applies to 6b0face9d8385968266ad1db22e9e34afa8bd354
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/341/head:pull/341`
`$ git checkout pull/341`
