### PR TITLE
8261874: [lworld] Non-flattened array blocks scalarization of inline type

### DIFF
--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -307,6 +307,7 @@ class Compile : public Phase {
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
   bool                  _has_flattened_accesses; // Any known flattened array accesses?
   bool                  _flattened_accesses_share_alias; // Initially all flattened array share a single slice
+  bool                  _scalarize_in_safepoints; // Scalarize inline types in safepoint debug info
   uint                  _stress_seed;           // Seed for stress testing
 
   // Compilation environment.
@@ -602,6 +603,8 @@ class Compile : public Phase {
   void          set_flattened_accesses()         { _has_flattened_accesses = true; }
   bool          flattened_accesses_share_alias() const { return _flattened_accesses_share_alias; }
   void          set_flattened_accesses_share_alias(bool z) { _flattened_accesses_share_alias = z; }
+  bool          scalarize_in_safepoints() const { return _scalarize_in_safepoints; }
+  void          set_scalarize_in_safepoints(bool z) { _scalarize_in_safepoints = z; }
 
   // Support for scalarized inline type calling convention
   bool              has_scalarized_args() const  { return _method != NULL && _method->has_scalarized_args(); }

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -94,6 +94,8 @@ public:
 
   // Allocate all non-flattened inline type fields
   Node* allocate_fields(GraphKit* kit);
+
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------InlineTypeNode-------------------------------------

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -635,7 +635,11 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
       value = value_from_mem(mem, ctl, bt, ft, adr_type, alloc);
       if (value != NULL && ft->isa_narrowoop()) {
         assert(UseCompressedOops, "unexpected narrow oop");
-        value = transform_later(new DecodeNNode(value, value->get_ptr_type()));
+        if (value->is_EncodeP()) {
+          value = value->in(1);
+        } else {
+          value = transform_later(new DecodeNNode(value, value->get_ptr_type()));
+        }
       }
     }
     if (value != NULL) {
@@ -656,6 +660,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
   DEBUG_ONLY( Node* disq_node = NULL; )
   bool  can_eliminate = true;
 
+  Unique_Node_List worklist;
   Node* res = alloc->result_cast();
   const TypeOopPtr* res_type = NULL;
   if (res == NULL) {
@@ -664,6 +669,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
     NOT_PRODUCT(fail_eliminate = "Allocation does not have unique CheckCastPP";)
     can_eliminate = false;
   } else {
+    worklist.push(res);
     res_type = _igvn.type(res)->isa_oopptr();
     if (res_type == NULL) {
       NOT_PRODUCT(fail_eliminate = "Neither instance or array allocation";)
@@ -677,9 +683,9 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
     }
   }
 
-  if (can_eliminate && res != NULL) {
-    for (DUIterator_Fast jmax, j = res->fast_outs(jmax);
-                               j < jmax && can_eliminate; j++) {
+  while (can_eliminate && worklist.size() > 0) {
+    res = worklist.pop();
+    for (DUIterator_Fast jmax, j = res->fast_outs(jmax); j < jmax && can_eliminate; j++) {
       Node* use = res->fast_out(j);
 
       if (use->is_AddP()) {
@@ -730,6 +736,9 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
         }
       } else if (use->is_InlineType() && use->isa_InlineType()->get_oop() == res) {
         // ok to eliminate
+      } else if (use->is_InlineTypePtr() && use->isa_InlineTypePtr()->get_oop() == res) {
+        // Process users
+        worklist.push(use);
       } else if (use->Opcode() == Op_StoreX && use->in(MemNode::Address) == res) {
         // Store to mark word of inline type larval buffer
         assert(res_type->is_inlinetypeptr(), "Unexpected store to mark word");
@@ -765,7 +774,7 @@ bool PhaseMacroExpand::can_eliminate_allocation(AllocateNode *alloc, GrowableArr
         alloc->dump();
       else
         res->dump();
-    } else if (alloc->_is_scalar_replaceable) {
+    } else {
       tty->print("NotScalar (%s)", fail_eliminate);
       if (res == NULL)
         alloc->dump();
@@ -951,17 +960,18 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
 #endif
         return false;
       }
-      if (field_val->is_InlineType()) {
-        // Keep track of inline types to scalarize them later
-        value_worklist.push(field_val);
-      } else if (UseCompressedOops && field_type->isa_narrowoop()) {
+      if (UseCompressedOops && field_type->isa_narrowoop()) {
         // Enable "DecodeN(EncodeP(Allocate)) --> Allocate" transformation
         // to be able scalar replace the allocation.
         if (field_val->is_EncodeP()) {
           field_val = field_val->in(1);
-        } else {
+        } else if (!field_val->is_InlineTypeBase()) {
           field_val = transform_later(new DecodeNNode(field_val, field_val->get_ptr_type()));
         }
+      }
+      if (field_val->is_InlineTypeBase()) {
+        // Keep track of inline types to scalarize them later
+        value_worklist.push(field_val);
       }
       sfpt->add_req(field_val);
     }
@@ -980,8 +990,8 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
   // because Deoptimization::reassign_flat_array_elements needs field values.
   bool allow_oop = (klass == NULL) || !klass->is_flat_array_klass();
   for (uint i = 0; i < value_worklist.size(); ++i) {
-    Node* vt = value_worklist.at(i);
-    vt->as_InlineType()->make_scalar_in_safepoints(&_igvn, allow_oop);
+    InlineTypeBaseNode* vt = value_worklist.at(i)->as_InlineTypeBase();
+    vt->make_scalar_in_safepoints(&_igvn, allow_oop);
   }
   return true;
 }
@@ -2257,7 +2267,8 @@ void PhaseMacroExpand::inline_type_guard(Node** ctrl, LockNode* lock) {
 
   assert(unc->peek_monitor_box() == lock->box_node(), "wrong monitor");
   assert((obj_type->is_inlinetypeptr() && unc->peek_monitor_obj()->is_SafePointScalarObject()) ||
-         (unc->peek_monitor_obj() == lock->obj_node()), "wrong monitor");
+         (obj->is_InlineTypePtr() && obj->in(1) == unc->peek_monitor_obj()) ||
+         (obj == unc->peek_monitor_obj()), "wrong monitor");
 
   // pop monitor and push obj back on stack: we trap before the monitorenter
   unc->pop_monitor();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,9 +23,12 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283 8261037
+ * @bug 8260034 8260225 8260283 8261037 8261874
  * @summary Generated inline type tests.
- * @run main/othervm -Xbatch compiler.valhalla.inlinetypes.TestGenerated
+ * @run main/othervm -Xbatch
+ *                   compiler.valhalla.inlinetypes.TestGenerated
+ * @run main/othervm -Xbatch -XX:FlatArrayElementMaxSize=0
+ *                   compiler.valhalla.inlinetypes.TestGenerated
  */
 
 package compiler.valhalla.inlinetypes;
@@ -122,6 +125,17 @@ public class TestGenerated {
         return array[0].array == array[0].array;
     }
 
+    void test9(boolean b) {
+        MyValue1[] array = { new MyValue1() };
+        if (b) {
+            for (int i = 0; i < 10; ++i) {
+                if (array != array) {
+                    array = null;
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -137,6 +151,7 @@ public class TestGenerated {
             t.test6();
             t.test7(false);
             t.test8(array3);
+            t.test9(true);
         }
     }
 }


### PR DESCRIPTION
We hit an assert because an inline type is not scalarized in the debug info of a safepoint. The problem is that the inline type is stored in a non-flattened array which blocks scalarization. Once the non-flattened array is scalarized itself, the inline type could be scalarized as well but we don't keep track of its field values long enough (we remove the `InlineTypePtrNode` before macro expansion). The solution is to keep `InlineTypePtrNodes` until after macro expansion. I've also converted scalarization in safepoints into an ideal transformation, refactored related code and added the corresponding IR verification tests.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261874](https://bugs.openjdk.java.net/browse/JDK-8261874): [lworld] Non-flattened array blocks scalarization of inline type


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/342/head:pull/342`
`$ git checkout pull/342`
