### PR TITLE
8262025: [lworld] C2 should optimize acmp of the same inline type

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2176,6 +2176,12 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
     return;
   }
 
+  // Check for equality before potentially allocating
+  if (left == right) {
+    do_if(btest, makecon(TypeInt::CC_EQ));
+    return;
+  }
+
   // Allocate inline type operands and re-execute on deoptimization
   if (left->is_InlineType()) {
     PreserveReexecuteState preexecs(this);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3645,4 +3645,70 @@ public class TestLWorld extends InlineTypeTest {
             // Expected
         }
     }
+
+    // Test that acmp of the same inline object is removed
+    @Test(failOn = ALLOC + LOAD + STORE + NULL_CHECK_TRAP + TRAP)
+    public static boolean test135() {
+        MyValue1 val = MyValue1.createWithFieldsInline(rI, rL);
+        return val == val;
+    }
+
+    @DontCompile
+    public void test135_verifier(boolean warmup) {
+        Asserts.assertTrue(test135());
+    }
+
+    // Same as test135 but with .ref
+    @Test(failOn = ALLOC + LOAD + STORE + NULL_CHECK_TRAP + TRAP)
+    public static boolean test136(boolean b) {
+        MyValue1.ref val = MyValue1.createWithFieldsInline(rI, rL);
+        if (b) {
+            val = null;
+        }
+        return val == val;
+    }
+
+    @DontCompile
+    public void test136_verifier(boolean warmup) {
+        Asserts.assertTrue(test136(false));
+        Asserts.assertTrue(test136(true));
+    }
+
+    static final primitive class SimpleInlineType {
+        final int x;
+        public SimpleInlineType(int x) {
+            this.x = x;
+        }
+    }
+
+    // Test that acmp of different inline objects with same content is removed
+    @Test(failOn = ALLOC + LOAD + STORE + NULL_CHECK_TRAP + TRAP)
+    public static boolean test137(int i) {
+        SimpleInlineType val1 = new SimpleInlineType(i);
+        SimpleInlineType val2 = new SimpleInlineType(i);
+        return val1 == val2;
+    }
+
+    @DontCompile
+    public void test137_verifier(boolean warmup) {
+        Asserts.assertTrue(test137(rI));
+    }
+
+    // Same as test137 but with .ref
+    @Test(failOn = ALLOC + LOAD + STORE + NULL_CHECK_TRAP + TRAP)
+    public static boolean test138(int i, boolean b) {
+        SimpleInlineType.ref val1 = new SimpleInlineType(i);
+        SimpleInlineType.ref val2 = new SimpleInlineType(i);
+        if (b) {
+            val1 = null;
+            val2 = null;
+        }
+        return val1 == val2;
+    }
+
+    @DontCompile
+    public void test138_verifier(boolean warmup) {
+        Asserts.assertTrue(test138(rI, false));
+        Asserts.assertTrue(test138(rI, true));
+    }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
@@ -173,6 +173,7 @@ public class Ifacmp {
                     if (a != b) throw new RuntimeException("Substitutability test failed" + a + " != " + b);
                 }
             }
+            System.gc();
         } while (ref.get() != null);
     }
 


### PR DESCRIPTION
I've noticed that a simple `val == val` where `val` is an inline type is not optimized by C2. The reason is that we are buffering the inline type operands before applying optimizations. The fix is to simply check for equality before that.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262025](https://bugs.openjdk.java.net/browse/JDK-8262025): [lworld] C2 should optimize acmp of the same inline type


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/343/head:pull/343`
`$ git checkout pull/343`
