### PR TITLE
8262128: [lworld] C1's ValueNumbering optimization does not correctly handle delayed accesses

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -265,6 +265,14 @@ ciType* LoadIndexed::declared_type() const {
   return ak->element_type();
 }
 
+intx LoadIndexed::hash_inline_access() const {
+  if (delayed() != NULL) {
+    return HASH2(_vt, delayed()->offset());
+  } else {
+    return HASH1(_vt);
+  }
+}
+
 bool StoreIndexed::is_exact_flattened_array_store() const {
   if (array()->is_loaded_flattened_array() && value()->as_Constant() == NULL && value()->declared_type() != NULL) {
     ciKlass* element_klass = array()->declared_type()->as_flat_array_klass()->element_klass();

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -265,14 +265,6 @@ ciType* LoadIndexed::declared_type() const {
   return ak->element_type();
 }
 
-intx LoadIndexed::hash_inline_access() const {
-  if (delayed() != NULL) {
-    return HASH2(_vt, delayed()->offset());
-  } else {
-    return HASH1(_vt);
-  }
-}
-
 bool StoreIndexed::is_exact_flattened_array_store() const {
   if (array()->is_loaded_flattened_array() && value()->as_Constant() == NULL && value()->declared_type() != NULL) {
     ciKlass* element_klass = array()->declared_type()->as_flat_array_klass()->element_klass();

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1015,8 +1015,10 @@ LEAF(LoadIndexed, AccessIndexed)
   DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
 
+  intx hash_inline_access() const;
+
   // generic
-  HASHING4(LoadIndexed, !should_profile(), type()->tag(), array()->subst(), index()->subst(), vt())
+  HASHING4(LoadIndexed, !should_profile(), type()->tag(), array()->subst(), index()->subst(), hash_inline_access())
 };
 
 class DelayedLoadIndexed : public CompilationResourceObj {
@@ -1037,10 +1039,10 @@ private:
     _offset += offset;
   }
 
-  LoadIndexed* load_instr() { return _load_instr; }
-  ValueStack* state_before() { return _state_before; }
-  ciField* field() { return _field; }
-  int offset() { return _offset; }
+  LoadIndexed* load_instr() const { return _load_instr; }
+  ValueStack* state_before() const { return _state_before; }
+  ciField* field() const { return _field; }
+  int offset() const { return _offset; }
 };
 
 LEAF(StoreIndexed, AccessIndexed)

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1015,10 +1015,8 @@ LEAF(LoadIndexed, AccessIndexed)
   DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
 
-  intx hash_inline_access() const;
-
   // generic
-  HASHING4(LoadIndexed, !should_profile(), type()->tag(), array()->subst(), index()->subst(), hash_inline_access())
+  HASHING4(LoadIndexed, delayed() == NULL && !should_profile(), type()->tag(), array()->subst(), index()->subst(), vt())
 };
 
 class DelayedLoadIndexed : public CompilationResourceObj {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2301,9 +2301,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
   } else if (x->delayed() != NULL) {
     assert(x->array()->is_loaded_flattened_array(), "must be");
     LIR_Opr result = rlock_result(x, x->delayed()->field()->type()->basic_type());
-    access_sub_element(array, index, result,
-                       x->delayed() == NULL ? 0 : x->delayed()->field(),
-                       x->delayed() == NULL ? 0 : x->delayed()->offset());
+    access_sub_element(array, index, result, x->delayed()->field(), x->delayed()->offset());
   } else if (x->array() != NULL && x->array()->is_loaded_flattened_array() &&
              x->array()->declared_type()->as_flat_array_klass()->element_klass()->as_inline_klass()->is_empty()) {
     // Load the default instance instead of reading the element

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283 8261037 8261874
+ * @bug 8260034 8260225 8260283 8261037 8261874 8262128
  * @summary Generated inline type tests.
  * @run main/othervm -Xbatch
  *                   compiler.valhalla.inlinetypes.TestGenerated
@@ -46,6 +46,11 @@ primitive class MyValue2 {
     int[] a = new int[1];
     int[] b = new int[6];
     int[] c = new int[5];
+}
+
+primitive class MyValue3 {
+    int[] intArray = new int[1];
+    float[] floatArray = new float[1];
 }
 
 public class TestGenerated {
@@ -136,11 +141,29 @@ public class TestGenerated {
         }
     }
 
+    int[] f6 = new int[1];
+
+    void test10(MyValue3[] array) {
+        float[] floatArray = array[0].floatArray;
+        if (f6 == f6) {
+            f6 = array[0].intArray;
+        }
+    }
+
+    void test11(MyValue3[] array) {
+        float[] floatArray = array[0].floatArray;
+        if (array[0].intArray[0] != 42) {
+            throw new RuntimeException("test11 failed");
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
         MyValue1[] array2 = new MyValue1[10];
         MyValue1[] array3 = { new MyValue1() };
+        MyValue3[] array4 = { new MyValue3() };
+        array4[0].intArray[0] = 42;
 
         for (int i = 0; i < 50_000; ++i) {
             t.test1(array1);
@@ -152,6 +175,8 @@ public class TestGenerated {
             t.test7(false);
             t.test8(array3);
             t.test9(true);
+            t.test10(array4);
+            t.test11(array4);
         }
     }
 }


### PR DESCRIPTION
C1's ValueNumbering optimization replaces an array+field load `array[0].intArray` by another non-equivalent array+field load `array[0].floatArray` because it does not handle delayed accesses. The hash value of `LoadIndexed` needs to take delayed accesses into account.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262128](https://bugs.openjdk.java.net/browse/JDK-8262128): [lworld] C1's ValueNumbering optimization does not correctly handle delayed accesses


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/345/head:pull/345`
`$ git checkout pull/345`
