### PR TITLE
8262129: [lworld] C2 compilation fails with assert "can not use dead node"

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2705,13 +2705,15 @@ void PhaseMacroExpand::expand_mh_intrinsic_return(CallStaticJavaNode* call) {
   // Before any new projection is added:
   CallProjections* projs = call->extract_projections(true, true);
 
-  Node* ctl = new Node(1);
-  Node* mem = new Node(1);
-  Node* io = new Node(1);
-  Node* ex_ctl = new Node(1);
-  Node* ex_mem = new Node(1);
-  Node* ex_io = new Node(1);
-  Node* res = new Node(1);
+  // Create temporary hook nodes that will be replaced below.
+  // Add an input to prevent hook nodes from being dead.
+  Node* ctl = new Node(call);
+  Node* mem = new Node(ctl);
+  Node* io = new Node(ctl);
+  Node* ex_ctl = new Node(ctl);
+  Node* ex_mem = new Node(ctl);
+  Node* ex_io = new Node(ctl);
+  Node* res = new Node(ctl);
 
   Node* cast = transform_later(new CastP2XNode(ctl, res));
   Node* mask = MakeConX(0x1);


### PR DESCRIPTION
We hit an assert with `-XX:++VerifyIterativeGVN` because the hook nodes created by `PhaseMacroExpand::expand_mh_intrinsic_return` are dead. Similar to the mainline fix for [https://bugs.openjdk.java.net/browse/JDK-8238756](JDK-8238756), we have to add an input to these nodes.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262129](https://bugs.openjdk.java.net/browse/JDK-8262129): [lworld] C2 compilation fails with assert "can not use dead node"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/346/head:pull/346`
`$ git checkout pull/346`
