### PR TITLE
8262231: [lworld] C2 compilation fails with assert "user must call transfer_exceptions_into_jvms"

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -134,16 +134,7 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
     return kit.transfer_exceptions_into_jvms();
   }
   // The intrinsic bailed out
-#ifdef ASSERT
-  if (ctrl != kit.control()) {
-    ctrl->dump(0);
-    tty->print_cr("####");
-    kit.control()->dump(3);
-    assert(false, "control flow added");
-  }
-  // TODO just use this
-  //assert(ctrl == kit.control(), "Control flow was added although we bailed out");
-#endif
+  assert(ctrl == kit.control(), "Control flow was added although we bailed out");
   if (jvms->has_method()) {
     // Not a root compile.
     const char* msg;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -109,9 +109,7 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
 #endif
   ciMethod* callee = kit.callee();
   const int bci    = kit.bci();
-#ifdef ASSERT
-  Node* ctrl = kit.control();
-#endif
+
   // Try to inline the intrinsic.
   if ((CheckIntrinsics ? callee->intrinsic_candidate() : true) &&
       kit.try_to_inline(_last_predicate)) {
@@ -133,8 +131,8 @@ JVMState* LibraryIntrinsic::generate(JVMState* jvms) {
     C->print_inlining_update(this);
     return kit.transfer_exceptions_into_jvms();
   }
+
   // The intrinsic bailed out
-  assert(ctrl == kit.control(), "Control flow was added although we bailed out");
   if (jvms->has_method()) {
     // Not a root compile.
     const char* msg;


### PR DESCRIPTION
When running with `-XX:PerMethodSpecTrapLimit=0 -XX:PerMethodTrapLimit=0`, we hit an assert because the unsafe access intrinsic adds an exception to the `GraphKit` state but then bails out and therefore does not transfer that exception into the `JVMState`. In general, we should only modify the graph once we are sure we won't bail out from intrinsification. I've added an assert that catches this even without any VM flags and fixed all affected intrinsics.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262231](https://bugs.openjdk.java.net/browse/JDK-8262231): [lworld] C2 compilation fails with assert "user must call transfer_exceptions_into_jvms"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/348/head:pull/348`
`$ git checkout pull/348`
