### PR TITLE
8262308: [lworld] Various small C2 fixes for bugs found by stress testing

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3100,7 +3100,7 @@ Node* GraphKit::type_check_receiver(Node* receiver, ciKlass* klass,
   Node* res = _gvn.transform(cast);
   if (recv_xtype->is_inlinetypeptr() && recv_xtype->inline_klass()->is_scalarizable()) {
     assert(!gvn().type(res)->maybe_null(), "receiver should never be null");
-    res = InlineTypeNode::make_from_oop(this, res, recv_xtype->inline_klass());
+    res = InlineTypeNode::make_from_oop(this, res, recv_xtype->inline_klass())->as_ptr(&gvn());
   }
 
   (*casted_receiver) = res;

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -245,7 +245,7 @@ void InlineTypeBaseNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allo
     vt->make_scalar_in_safepoints(igvn);
   }
   if (outcnt() == 0) {
-    igvn->remove_dead_node(this);
+    igvn->_worklist.push(this);
   }
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -133,7 +133,6 @@ public abstract class InlineTypeTest {
     private static final boolean PRINT_TIMES = Boolean.parseBoolean(System.getProperty("PrintTimes", "false"));
     private static final boolean COMPILE_COMMANDS = Boolean.parseBoolean(System.getProperty("CompileCommands", "true")) && !XCOMP;
     private static       boolean VERIFY_IR = Boolean.parseBoolean(System.getProperty("VerifyIR", "true")) && !XCOMP && !TEST_C1 && COMPILE_COMMANDS;
-    private static final boolean VERIFY_VM = Boolean.parseBoolean(System.getProperty("VerifyVM", "false"));
     private static final String SCENARIOS = System.getProperty("Scenarios", "");
     private static final String TESTLIST = System.getProperty("Testlist", "");
     private static final String EXCLUDELIST = System.getProperty("Exclude", "");
@@ -158,9 +157,6 @@ public abstract class InlineTypeTest {
         "-XX:CompileCommand=compileonly,compiler.valhalla.inlinetypes.*::*"};
     private static final String[] printFlags = {
         "-XX:+PrintCompilation", "-XX:+PrintIdeal", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintOptoAssembly"};
-    private static final String[] verifyFlags = {
-        "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerifyOops", "-XX:+VerifyStack", "-XX:+VerifyLastFrame",
-        "-XX:+VerifyBeforeGC", "-XX:+VerifyAfterGC", "-XX:+VerifyDuringGC", "-XX:+VerifyAdapterSharing"};
 
     protected static final int InlineTypePassFieldsAsArgsOn = 0x1;
     protected static final int InlineTypePassFieldsAsArgsOff = 0x2;
@@ -455,7 +451,7 @@ public abstract class InlineTypeTest {
             }
         }
         // Each VM is launched with flags in this order, so the later ones can override the earlier one:
-        //     VERIFY_IR/VERIFY_VM flags specified below
+        //     VERIFY_IR flags specified below
         //     vmInputArgs, which consists of:
         //        @run options
         //        getVMParameters()
@@ -468,9 +464,6 @@ public abstract class InlineTypeTest {
             cmds = concat(cmds, printFlags);
             // Always trap for exception throwing to not confuse IR verification
             cmds = concat(cmds, "-XX:-OmitStackTraceInFastThrow");
-        }
-        if (VERIFY_VM) {
-            cmds = concat(cmds, verifyFlags);
         }
         cmds = concat(cmds, vmInputArgs);
         cmds = concat(cmds, defaultFlags);


### PR DESCRIPTION
More testing with stress flags enabled revealed the following bugs:
- We should not call `remove_dead_node` from `InlineTypeBaseNode::Ideal`. Instead, we should just make sure the dead node is on the IGVN worklist to be removed. I've also removed the `VerifyVM` option from the framework. Such flags can be added manually or via the CI job definitions.
- `PhaseMacroExpand::process_users_of_allocation` needs to handle `InlineTypePtrNodes` because we now keep them until after macro expansion.
- `GraphKit::type_check_receiver` should create a `InlineTypePtrNode` instead of a `InlineTypeNode` because it operates on pointers. 

I have a job definition file with all these stress flags enabled that I will integrate separately soon.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262308](https://bugs.openjdk.java.net/browse/JDK-8262308): [lworld] Various small C2 fixes for bugs found by stress testing


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/351/head:pull/351`
`$ git checkout pull/351`
