### PR TITLE
8258038: [AARCH64] [lworld] Fix inline type implementation

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3929,6 +3929,12 @@ encode %{
     // Set tmp to be (markWord of object | UNLOCK_VALUE).
     __ orr(tmp, disp_hdr, markWord::unlocked_value);
 
+    if (EnableValhalla) {
+      assert(!UseBiasedLocking, "Not compatible with biased-locking");
+      // Mask inline_type bit such that we go to the slow path if object is an inline type
+      __ andr(tmp, tmp, ~((int) markWord::inline_type_bit_in_place));
+    }
+
     // Initialize the box. (Must happen before we update the object mark!)
     __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
@@ -14970,9 +14976,9 @@ instruct MoveL2D_reg_reg(vRegD dst, iRegL src) %{
 // ============================================================================
 // clearing of an array
 
-instruct clearArray_reg_reg(iRegL_R11 cnt, iRegP_R10 base, iRegL val, Universe dummy, rFlagsReg cr)
+instruct clearArray_reg_reg_immL0(iRegL_R11 cnt, iRegP_R10 base, immL0 zero, Universe dummy, rFlagsReg cr)
 %{
-  match(Set dummy (ClearArray (Binary cnt base) val));
+  match(Set dummy (ClearArray (Binary cnt base) zero));
   effect(USE_KILL cnt, USE_KILL base, KILL cr);
 
   ins_cost(4 * INSN_COST);
@@ -14989,10 +14995,27 @@ instruct clearArray_reg_reg(iRegL_R11 cnt, iRegP_R10 base, iRegL val, Universe d
   ins_pipe(pipe_class_memory);
 %}
 
+instruct clearArray_reg_reg(iRegL_R11 cnt, iRegP_R10 base, iRegL val, Universe dummy, rFlagsReg cr)
+%{
+  predicate(((ClearArrayNode*)n)->word_copy_only());
+  match(Set dummy (ClearArray (Binary cnt base) val));
+  effect(USE_KILL cnt, USE_KILL base, KILL cr);
+
+  ins_cost(4 * INSN_COST);
+  format %{ "ClearArray $cnt, $base, $val" %}
+
+  ins_encode %{
+    __ fill_words($base$$Register, $cnt$$Register, $val$$Register);
+  %}
+
+  ins_pipe(pipe_class_memory);
+%}
+
 instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, Universe dummy, rFlagsReg cr)
 %{
   predicate((uint64_t)n->in(2)->get_long()
-            < (uint64_t)(BlockZeroingLowLimit >> LogBytesPerWord));
+            < (uint64_t)(BlockZeroingLowLimit >> LogBytesPerWord)
+            && !((ClearArrayNode*)n)->word_copy_only());
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL base);
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1898,12 +1898,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
 
-  __ verified_entry(C, 0);
-  __ bind(*_verified_entry);
-  // n.b. frame size includes space for return pc and rfp
-  const int framesize = C->output()->frame_size_in_bytes();
-  assert(framesize%(2*wordSize) == 0, "must preserve 2*wordSize alignment");
-
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
   __ nop();
@@ -1923,11 +1917,8 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ reinitialize_ptrue();
   }
 
-  int bangsize = C->output()->bang_size_in_bytes();
-  if (C->output()->need_stack_bang(bangsize))
-    __ generate_stack_overflow_check(bangsize);
-
-  __ build_frame(framesize);
+  __ verified_entry(C, 0);
+  __ bind(*_verified_entry);
 
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();

--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -208,6 +208,7 @@ NewInstanceStub::NewInstanceStub(LIR_Opr klass_reg, LIR_Opr result, ciInstanceKl
   _klass_reg = klass_reg;
   _info = new CodeEmitInfo(info);
   assert(stub_id == Runtime1::new_instance_id                 ||
+         stub_id == Runtime1::new_instance_no_inline_id       ||
          stub_id == Runtime1::fast_new_instance_id            ||
          stub_id == Runtime1::fast_new_instance_init_check_id,
          "need new_instance id");
@@ -253,7 +254,8 @@ void NewTypeArrayStub::emit_code(LIR_Assembler* ce) {
 
 // Implementation of NewObjectArrayStub
 
-NewObjectArrayStub::NewObjectArrayStub(LIR_Opr klass_reg, LIR_Opr length, LIR_Opr result, CodeEmitInfo* info, bool is_inline_type) {
+NewObjectArrayStub::NewObjectArrayStub(LIR_Opr klass_reg, LIR_Opr length, LIR_Opr result,
+                                       CodeEmitInfo* info, bool is_inline_type) {
   _klass_reg = klass_reg;
   _result = result;
   _length = length;
@@ -285,8 +287,8 @@ MonitorEnterStub::MonitorEnterStub(LIR_Opr obj_reg, LIR_Opr lock_reg, CodeEmitIn
 : MonitorAccessStub(obj_reg, lock_reg)
 {
   _info = new CodeEmitInfo(info);
-  _scratch_reg = scratch_reg;
   _throw_imse_stub = throw_imse_stub;
+  _scratch_reg = scratch_reg;
   if (_throw_imse_stub != NULL) {
     assert(_scratch_reg != LIR_OprFact::illegalOpr, "must be");
   }
@@ -299,11 +301,11 @@ void MonitorEnterStub::emit_code(LIR_Assembler* ce) {
   if (_throw_imse_stub != NULL) {
     // When we come here, _obj_reg has already been checked to be non-null.
     __ ldr(rscratch1, Address(_obj_reg->as_register(), oopDesc::mark_offset_in_bytes()));
-    __ mov(rscratch2, markWord::always_locked_pattern);
+    __ mov(rscratch2, markWord::inline_type_pattern);
     __ andr(rscratch1, rscratch1, rscratch2);
 
     __ cmp(rscratch1, rscratch2);
-    __ br(Assembler::NE, *_throw_imse_stub->entry());
+    __ br(Assembler::EQ, *_throw_imse_stub->entry());
   }
 
   ce->store_parameter(_obj_reg->as_register(),  1);

--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -287,8 +287,8 @@ MonitorEnterStub::MonitorEnterStub(LIR_Opr obj_reg, LIR_Opr lock_reg, CodeEmitIn
 : MonitorAccessStub(obj_reg, lock_reg)
 {
   _info = new CodeEmitInfo(info);
-  _throw_imse_stub = throw_imse_stub;
   _scratch_reg = scratch_reg;
+  _throw_imse_stub = throw_imse_stub;
   if (_throw_imse_stub != NULL) {
     assert(_scratch_reg != LIR_OprFact::illegalOpr, "must be");
   }

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -460,7 +460,7 @@ int LIR_Assembler::emit_unwind_handler() {
 
   // remove the activation and dispatch to the unwind handler
   __ block_comment("remove_frame and dispatch to the unwind handler");
-  int initial_framesize = initial_frame_size_in_bytes() + 2 * wordSize;
+  int initial_framesize = initial_frame_size_in_bytes();
   __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
   __ far_jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
@@ -527,7 +527,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   }
 
   // Pop the stack before the safepoint code
-  int initial_framesize = initial_frame_size_in_bytes() + 2 * wordSize;
+  int initial_framesize = initial_frame_size_in_bytes();
   __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -245,7 +245,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), needs_stack_repair(), NULL);
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
   //
@@ -460,7 +460,8 @@ int LIR_Assembler::emit_unwind_handler() {
 
   // remove the activation and dispatch to the unwind handler
   __ block_comment("remove_frame and dispatch to the unwind handler");
-  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
+  int initial_framesize = initial_frame_size_in_bytes() + 2 * wordSize;
+  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
   __ far_jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
   // Emit the slow path assembly
@@ -525,9 +526,9 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
     }
   }
 
-
   // Pop the stack before the safepoint code
-  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
+  int initial_framesize = initial_frame_size_in_bytes() + 2 * wordSize;
+  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {
     __ reserved_stack_check();
@@ -1065,10 +1066,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
     }
   } else if (type == T_ADDRESS && addr->disp() == oopDesc::klass_offset_in_bytes()) {
     if (UseCompressedClassPointers) {
-      __ andr(dest->as_register(), dest->as_register(), oopDesc::compressed_klass_mask());
       __ decode_klass_not_null(dest->as_register());
-    } else {
-      __   ubfm(dest->as_register(), dest->as_register(), 0, 63 - oopDesc::storage_props_nof_bits);
     }
   }
 }
@@ -1384,6 +1382,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
 
   assert_different_registers(obj, k_RInfo, klass_RInfo);
 
+  if (op->need_null_check()) {
     if (should_profile) {
       Label not_null;
       __ cbnz(obj, not_null);
@@ -1402,6 +1401,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
     } else {
       __ cbz(obj, *obj_is_null);
     }
+  }
 
   if (!k->is_loaded()) {
     klass2reg_with_patching(k_RInfo, op->info_for_patch());
@@ -1591,33 +1591,52 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
 }
 
 void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
-  // We are loading/storing an array that *may* be a flattened array (the declared type
-  // Object[], interface[], or VT?[]). If this array is flattened, take slow path.
+  // We are loading/storing from/to an array that *may* be flattened (the
+  // declared type is Object[], abstract[], interface[] or VT.ref[]).
+  // If this array is flattened, take the slow path.
 
-  __ load_storage_props(op->tmp()->as_register(), op->array()->as_register());
-  __ tst(op->tmp()->as_register(), ArrayStorageProperties::flattened_value);
-  __ br(Assembler::NE, *op->stub()->entry());
+  Register klass = op->tmp()->as_register();
+  if (UseArrayMarkWordCheck) {
+    __ test_flattened_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
+  } else {
+    __ load_klass(klass, op->array()->as_register());
+    __ ldrw(klass, Address(klass, Klass::layout_helper_offset()));
+    __ tst(klass, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ br(Assembler::NE, *op->stub()->entry());
+  }
   if (!op->value()->is_illegal()) {
-    // We are storing into the array.
+    // The array is not flattened, but it might be null-free. If we are storing
+    // a null into a null-free array, take the slow path (which will throw NPE).
     Label skip;
-    __ tst(op->tmp()->as_register(), ArrayStorageProperties::null_free_value);
-    __ br(Assembler::EQ, skip);
-    // The array is not flattened, but it is null_free. If we are storing
-    // a null, take the slow path (which will throw NPE).
-    __ cbz(op->value()->as_register(), *op->stub()->entry());
+    __ cbnz(op->value()->as_register(), skip);
+    if (UseArrayMarkWordCheck) {
+      __ test_null_free_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
+    } else {
+      __ tst(klass, Klass::_lh_null_free_bit_inplace);
+      __ br(Assembler::NE, *op->stub()->entry());
+    }
     __ bind(skip);
   }
-
 }
 
 void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
-  // This is called when we use aastore into a an array declared as "[LVT;",
-  // where we know VT is not flattened (due to FlatArrayElementMaxSize, etc).
-  // However, we need to do a NULL check if the actual array is a "[QVT;".
-
-  __ load_storage_props(op->tmp()->as_register(), op->array()->as_register());
-  __ mov(rscratch1, (uint64_t) ArrayStorageProperties::null_free_value);
-  __ cmp(op->tmp()->as_register(), rscratch1);
+  // We are storing into an array that *may* be null-free (the declared type is
+  // Object[], abstract[], interface[] or VT.ref[]).
+  if (UseArrayMarkWordCheck) {
+    Label test_mark_word;
+    Register tmp = op->tmp()->as_register();
+    __ ldr(tmp, Address(op->array()->as_register(), oopDesc::mark_offset_in_bytes()));
+    __ tst(tmp, markWord::unlocked_value);
+    __ br(Assembler::NE, test_mark_word);
+    __ load_prototype_header(tmp, op->array()->as_register());
+    __ bind(test_mark_word);
+    __ tst(tmp, markWord::nullfree_array_bit_in_place);
+  } else {
+    Register klass = op->tmp()->as_register();
+    __ load_klass(klass, op->array()->as_register());
+    __ ldr(klass, Address(klass, Klass::layout_helper_offset()));
+    __ tst(klass, Klass::_lh_null_free_bit_inplace);
+  }
 }
 
 void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op) {
@@ -1639,28 +1658,21 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
     __ cbz(right, L_oops_not_equal);
   }
 
-
   ciKlass* left_klass = op->left_klass();
   ciKlass* right_klass = op->right_klass();
 
-  // (2) Value object check -- if either of the operands is not a value object,
+  // (2) Inline type check -- if either of the operands is not a inline type,
   //     they are not substitutable. We do this only if we are not sure that the
-  //     operands are value objects
+  //     operands are inline type
   if ((left_klass == NULL || right_klass == NULL) ||// The klass is still unloaded, or came from a Phi node.
       !left_klass->is_inlinetype() || !right_klass->is_inlinetype()) {
-    Register tmp1  = rscratch1; /* op->tmp1()->as_register(); */
-    Register tmp2  = rscratch2; /* op->tmp2()->as_register(); */
-
-    __ mov(tmp1, (intptr_t)markWord::always_locked_pattern);
-
-    __ ldr(tmp2, Address(left, oopDesc::mark_offset_in_bytes()));
-    __ andr(tmp1, tmp1, tmp2);
-
-    __ ldr(tmp2, Address(right, oopDesc::mark_offset_in_bytes()));
-    __ andr(tmp1, tmp1, tmp2);
-
-    __ mov(tmp2, (intptr_t)markWord::always_locked_pattern);
-    __ cmp(tmp1, tmp2);
+    Register tmp1  = op->tmp1()->as_register();
+    __ mov(tmp1, markWord::inline_type_pattern);
+    __ ldr(rscratch1, Address(left, oopDesc::mark_offset_in_bytes()));
+    __ andr(tmp1, tmp1, rscratch1);
+    __ ldr(rscratch1, Address(right, oopDesc::mark_offset_in_bytes()));
+    __ andr(tmp1, tmp1, rscratch1);
+    __ cmp(tmp1, (u1)markWord::inline_type_pattern);
     __ br(Assembler::NE, L_oops_not_equal);
   }
 
@@ -1672,7 +1684,7 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
     Register left_klass_op = op->left_klass_op()->as_register();
     Register right_klass_op = op->right_klass_op()->as_register();
 
-    if (UseCompressedOops) {
+    if (UseCompressedClassPointers) {
       __ ldrw(left_klass_op,  Address(left,  oopDesc::klass_offset_in_bytes()));
       __ ldrw(right_klass_op, Address(right, oopDesc::klass_offset_in_bytes()));
       __ cmpw(left_klass_op, right_klass_op);
@@ -1694,21 +1706,14 @@ void LIR_Assembler::emit_opSubstitutabilityCheck(LIR_OpSubstitutabilityCheck* op
   move(op->equal_result(), op->result_opr());
   __ b(L_end);
 
-  // We've returned from the stub. op->result_opr() contains 0x0 IFF the two
+  // We've returned from the stub. R0 contains 0x0 IFF the two
   // operands are not substitutable. (Don't compare against 0x1 in case the
   // C compiler is naughty)
   __ bind(*op->stub()->continuation());
-
-  if (op->result_opr()->type() == T_LONG) {
-    __ cbzw(op->result_opr()->as_register(), L_oops_not_equal); // (call_stub() == 0x0) -> not_equal
-  } else {
-    __ cbz(op->result_opr()->as_register(), L_oops_not_equal); // (call_stub() == 0x0) -> not_equal
-  }
-
+  __ cbz(r0, L_oops_not_equal); // (call_stub() == 0x0) -> not_equal
   move(op->equal_result(), op->result_opr()); // (call_stub() != 0x0) -> equal
   // fall-through
   __ bind(L_end);
-
 }
 
 
@@ -2230,7 +2235,7 @@ void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
     bailout("trampoline stub overflow");
     return;
   }
-  add_call_info(code_offset(), op->info());
+  add_call_info(code_offset(), op->info(), op->maybe_return_as_fields());
 }
 
 
@@ -2240,7 +2245,7 @@ void LIR_Assembler::ic_call(LIR_OpJavaCall* op) {
     bailout("trampoline stub overflow");
     return;
   }
-  add_call_info(code_offset(), op->info());
+  add_call_info(code_offset(), op->info(), op->maybe_return_as_fields());
 }
 
 
@@ -2411,19 +2416,28 @@ void LIR_Assembler::store_parameter(jobject o,  int offset_from_rsp_in_words) {
   __ str(rscratch1, Address(sp, offset_from_rsp_in_bytes));
 }
 
-void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeStub* slow_path, bool is_dest) {
-  __ load_storage_props(tmp, obj);
-  if (is_dest) {
-    // We also take slow path if it's a null_free destination array, just in case the source array
-    // contains NULLs.
-    __ tst(tmp, ArrayStorageProperties::flattened_value | ArrayStorageProperties::null_free_value);
-  } else {
-    __ tst(tmp, ArrayStorageProperties::flattened_value);
+void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeStub* slow_path, bool is_dest, bool null_check) {
+  if (null_check) {
+    __ cbz(obj, *slow_path->entry());
   }
-  __ br(Assembler::NE, *slow_path->entry());
+  if (UseArrayMarkWordCheck) {
+    if (is_dest) {
+      __ test_null_free_array_oop(obj, tmp, *slow_path->entry());
+    } else {
+      __ test_flattened_array_oop(obj, tmp, *slow_path->entry());
+    }
+  } else {
+    __ load_klass(tmp, obj);
+    __ ldr(tmp, Address(tmp, Klass::layout_helper_offset()));
+    if (is_dest) {
+      // Take the slow path if it's a null_free destination array, in case the source array contains NULLs.
+      __ tst(tmp, Klass::_lh_null_free_bit_inplace);
+    } else {
+      __ tst(tmp, Klass::_lh_array_tag_vt_value_bit_inplace);
+    }
+    __ br(Assembler::NE, *slow_path->entry());
+  }
 }
-
-
 
 // This code replaces a call to arraycopy; no exception may
 // be thrown in this code, they must be thrown in the System.arraycopy
@@ -2450,16 +2464,6 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
     __ bind(*stub->continuation());
     return;
   }
-
-  if (flags & LIR_OpArrayCopy::src_inlinetype_check) {
-    arraycopy_inlinetype_check(src, tmp, stub, false);
-  }
-
-  if (flags & LIR_OpArrayCopy::dst_inlinetype_check) {
-    arraycopy_inlinetype_check(dst, tmp, stub, true);
-  }
-
-
 
   // if we don't know anything, just go through the generic arraycopy
   if (default_type == NULL // || basic_type == T_OBJECT
@@ -2512,6 +2516,15 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
     __ bind(*stub->continuation());
     return;
+  }
+
+  // Handle inline type arrays
+  if (flags & LIR_OpArrayCopy::src_inlinetype_check) {
+    arraycopy_inlinetype_check(src, tmp, stub, false, (flags & LIR_OpArrayCopy::src_null_check));
+  }
+
+  if (flags & LIR_OpArrayCopy::dst_inlinetype_check) {
+    arraycopy_inlinetype_check(dst, tmp, stub, true, (flags & LIR_OpArrayCopy::dst_null_check));
   }
 
   assert(default_type != NULL && default_type->is_array_klass() && default_type->is_loaded(), "must be true at this point");
@@ -3074,7 +3087,24 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
 }
 
 void LIR_Assembler::emit_profile_inline_type(LIR_OpProfileInlineType* op) {
-  Unimplemented();
+  Register obj = op->obj()->as_register();
+  Register tmp = op->tmp()->as_pointer_register();
+  Address mdo_addr = as_Address(op->mdp()->as_address_ptr());
+  bool not_null = op->not_null();
+  int flag = op->flag();
+
+  Label not_inline_type;
+  if (!not_null) {
+    __ cbz(obj, not_inline_type);
+  }
+
+  __ test_oop_is_not_inline_type(obj, tmp, not_inline_type);
+
+  __ ldrb(rscratch1, mdo_addr);
+  __ orr(rscratch1, rscratch1, flag);
+  __ strb(rscratch1, mdo_addr);
+
+  __ bind(not_inline_type);
 }
 
 void LIR_Assembler::align_backward_branch_target() {
@@ -3215,6 +3245,10 @@ void LIR_Assembler::get_thread(LIR_Opr result_reg) {
   __ mov(result_reg->as_register(), rthread);
 }
 
+void LIR_Assembler::check_orig_pc() {
+  __ ldr(rscratch2, frame_map()->address_for_orig_pc_addr());
+  __ cmp(rscratch2, (u1)NULL_WORD);
+}
 
 void LIR_Assembler::peephole(LIR_List *lir) {
 #if 0

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -79,12 +79,13 @@ friend class ArrayCopyStub;
     _deopt_handler_size = 7 * NativeInstruction::instruction_size
   };
 
+  void arraycopy_inlinetype_check(Register obj, Register tmp, CodeStub* slow_path, bool is_dest, bool null_check);
+  void move(LIR_Opr src, LIR_Opr dst);
+
 public:
 
   void store_parameter(Register r, int offset_from_esp_in_words);
   void store_parameter(jint c,     int offset_from_esp_in_words);
   void store_parameter(jobject c,  int offset_from_esp_in_words);
-  void arraycopy_inlinetype_check(Register obj, Register tmp, CodeStub* slow_path, bool is_dest);
-  void move(LIR_Opr src, LIR_Opr dst);
 
 #endif // CPU_AARCH64_C1_LIRASSEMBLER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -181,7 +181,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
     if (large_disp != 0) {
       LIR_Opr tmp = new_pointer_register();
       if (Assembler::operand_valid_for_add_sub_immediate(large_disp)) {
-        __ add(tmp, tmp, LIR_OprFact::intptrConst(large_disp));
+        __ add(index, LIR_OprFact::intptrConst(large_disp), tmp);
         index = tmp;
       } else {
         __ move(tmp, LIR_OprFact::intptrConst(large_disp));

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -198,7 +198,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   }
 
   // at this point we either have base + index or base + displacement
-  if (large_disp == 0) {
+  if (large_disp == 0 && index->is_register()) {
     return new LIR_Address(base, index, type);
   } else {
     assert(Address::offset_ok_for_immed(large_disp, 0), "must be");
@@ -1157,26 +1157,28 @@ void LIRGenerator::do_NewInstance(NewInstance* x) {
   CodeEmitInfo* info = state_for(x, x->state());
   LIR_Opr reg = result_register_for(x->type());
   new_instance(reg, x->klass(), x->is_unresolved(),
-                       FrameMap::r2_oop_opr,
-                       FrameMap::r5_oop_opr,
-                       FrameMap::r4_oop_opr,
-                       LIR_OprFact::illegalOpr,
-                       FrameMap::r3_metadata_opr, info);
+               /* allow_inline */ false,
+               FrameMap::r2_oop_opr,
+               FrameMap::r5_oop_opr,
+               FrameMap::r4_oop_opr,
+               LIR_OprFact::illegalOpr,
+               FrameMap::r3_metadata_opr, info);
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);
 }
 
 void LIRGenerator::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
-  // Mapping to do_NewInstance (same code)
-  CodeEmitInfo* info = state_for(x, x->state());
+  // Mapping to do_NewInstance (same code) but use state_before for reexecution.
+  CodeEmitInfo* info = state_for(x, x->state_before());
   x->set_to_object_type();
   LIR_Opr reg = result_register_for(x->type());
-  new_instance(reg, x->klass(), x->is_unresolved(),
-             FrameMap::r2_oop_opr,
-             FrameMap::r5_oop_opr,
-             FrameMap::r4_oop_opr,
-             LIR_OprFact::illegalOpr,
-             FrameMap::r3_metadata_opr, info);
+  new_instance(reg, x->klass(), false,
+               /* allow_inline */ true,
+               FrameMap::r2_oop_opr,
+               FrameMap::r5_oop_opr,
+               FrameMap::r4_oop_opr,
+               LIR_OprFact::illegalOpr,
+               FrameMap::r3_metadata_opr, info);
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);
 
@@ -1419,7 +1421,12 @@ void LIRGenerator::do_If(If* x) {
     __ safepoint(LIR_OprFact::illegalOpr, state_for(x, x->state_before()));
   }
 
-  __ cmp(lir_cond(cond), left, right);
+  if (x->substitutability_check()) {
+    substitutability_check(x, *xin, *yin);
+  } else {
+    __ cmp(lir_cond(cond), left, right);
+  }
+
   // Generate branch profiling. Profiling code doesn't kill flags.
   profile_branch(x, cond);
   move_to_phi(x->state());

--- a/src/hotspot/cpu/aarch64/c1_LIR_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIR_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,5 +50,6 @@ void LIR_Address::verify() const {
   assert(index()->is_illegal() || index()->is_double_cpu() || index()->is_single_cpu(), "wrong index operand");
   assert(base()->type() == T_ADDRESS || base()->type() == T_OBJECT || base()->type() == T_LONG || base()->type() == T_METADATA,
          "wrong type for addresses");
+  assert(index()->is_illegal() || disp() == 0, "cannot set both index and displacement");
 }
 #endif // PRODUCT

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -94,9 +94,10 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // and mark it as unlocked
   orr(hdr, hdr, markWord::unlocked_value);
 
-  if (EnableValhalla && !UseBiasedLocking) {
+  if (EnableValhalla) {
+    assert(!UseBiasedLocking, "Not compatible with biased-locking");
     // Mask always_locked bit such that we go to the slow path if object is an inline type
-    andr(hdr, hdr, ~markWord::biased_lock_bit_in_place);
+    andr(hdr, hdr, ~markWord::inline_type_bit_in_place);
   }
 
   // save unlocked object header into the displaced header location on the stack
@@ -187,7 +188,8 @@ void C1_MacroAssembler::try_allocate(Register obj, Register var_size_in_bytes, i
 
 void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register len, Register t1, Register t2) {
   assert_different_registers(obj, klass, len);
-  if (UseBiasedLocking && !len->is_valid()) {
+  if (EnableValhalla) {
+    // Need to copy markWord::prototype header for klass
     assert_different_registers(obj, klass, len, t1, t2);
     ldr(t1, Address(klass, Klass::prototype_header_offset()));
   } else {
@@ -300,6 +302,7 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
 
   verify_oop(obj);
 }
+
 void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2, int header_size, int f, Register klass, Label& slow_case) {
   assert_different_registers(obj, len, t1, t2, klass);
 
@@ -345,9 +348,28 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
   cmp_klass(receiver, iCache, rscratch1);
 }
 
+void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_inc, bool needs_stack_repair) {
+#if 0
+  push(rbp);
+  if (PreserveFramePointer) {
+    mov(rbp, rsp);
+  }
+  decrement(rsp, frame_size_in_bytes);
+#endif
+  MacroAssembler::build_frame(frame_size_in_bytes + 2 * wordSize);
 
-void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes, bool needs_stack_repair, Label* verified_inline_entry_label) {
-  assert(bang_size_in_bytes >= framesize, "stack bang size incorrect");
+  if (needs_stack_repair) {
+    brk(1);
+    // Save stack increment (also account for fixed framesize and rbp)
+    assert((sp_inc & (StackAlignmentInBytes-1)) == 0, "stack increment not aligned");
+    int real_frame_size = sp_inc + frame_size_in_bytes + wordSize;
+    mov(rscratch1, real_frame_size);
+    str(rscratch1, Address(sp, frame_size_in_bytes - wordSize));
+  }
+}
+
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, bool needs_stack_repair, bool has_scalarized_args, Label* verified_inline_entry_label) {
+  assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before doing an enter().
   generate_stack_overflow_check(bang_size_in_bytes);
@@ -357,56 +379,29 @@ void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes, bool 
     bind(*verified_inline_entry_label);
   }
 
-  MacroAssembler::build_frame(framesize + 2 * wordSize);
+  MacroAssembler::build_frame(frame_size_in_bytes + 2 * wordSize);
 
   // Insert nmethod entry barrier into frame.
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->nmethod_entry_barrier(this);
 }
 
-void C1_MacroAssembler::remove_frame(int framesize, bool needs_stack_repair) {
-
-  guarantee(needs_stack_repair == false, "Stack repair should not be true");
-
-  MacroAssembler::remove_frame(framesize + 2 * wordSize);
+void C1_MacroAssembler::verified_entry() {
+  // If we have to make this method not-entrant we'll overwrite its
+  // first instruction with a jump.  For this action to be legal we
+  // must ensure that this first instruction is a B, BL, NOP, BKPT,
+  // SVC, HVC, or SMC.  Make it a NOP.
+  nop();
+  if (C1Breakpoint) brk(1);
 }
 
-void C1_MacroAssembler::verified_inline_entry() {
-  if (C1Breakpoint || VerifyFPU || !UseStackBanging) {
-    // Verified Entry first instruction should be 5 bytes long for correct
-    // patching by patch_verified_entry().
-    //
-    // C1Breakpoint and VerifyFPU have one byte first instruction.
-    // Also first instruction will be one byte "push(rbp)" if stack banging
-    // code is not generated (see build_frame() above).
-    // For all these cases generate long instruction first.
-    nop();
-  }
-
-  nop();
-  // build frame
-  // verify_FPU(0, "method_entry");
-}
-
-int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int frame_size_in_bytes, int bang_size_in_bytes, Label& verified_inline_entry_label, bool is_inline_ro_entry) {
-  // This function required to support for InlineTypePassFieldsAsArgs
-  if (C1Breakpoint || VerifyFPU || !UseStackBanging) {
-    // Verified Entry first instruction should be 5 bytes long for correct
-    // patching by patch_verified_entry().
-    //
-    // C1Breakpoint and VerifyFPU have one byte first instruction.
-    // Also first instruction will be one byte "push(rbp)" if stack banging
-    // code is not generated (see build_frame() above).
-    // For all these cases generate long instruction first.
-    nop();
-  }
-
-  nop();
-  // verify_FPU(0, "method_entry");
-
+int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_inline_entry_label, bool is_inline_ro_entry) {
   assert(InlineTypePassFieldsAsArgs, "sanity");
+  // Make sure there is enough stack space for this method's activation.
+  assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
+  generate_stack_overflow_check(bang_size_in_bytes);
 
-  GrowableArray<SigEntry>* sig   = &ces->sig();
+  GrowableArray<SigEntry>* sig    = &ces->sig();
   GrowableArray<SigEntry>* sig_cc = is_inline_ro_entry ? &ces->sig_cc_ro() : &ces->sig_cc();
   VMRegPair* regs      = ces->regs();
   VMRegPair* regs_cc   = is_inline_ro_entry ? ces->regs_cc_ro() : ces->regs_cc();
@@ -418,27 +413,36 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   int args_passed = sig->length();
   int args_passed_cc = SigEntry::fill_sig_bt(sig_cc, sig_bt);
 
-  // Create a temp frame so we can call into runtime. It must be properly set up to accomodate GC.
-  int sp_inc = (args_on_stack - args_on_stack_cc) * VMRegImpl::stack_slot_size;
-  if (sp_inc > 0) {
+  // Check if we need to extend the stack for packing
+  int sp_inc = 0;
+  if (args_on_stack > args_on_stack_cc) {
+    // XXXNick: this is almost certainly wrong
+
+    brk(2);
+
+    // Two additional slots to account for return address
+    sp_inc = (args_on_stack + 2) * VMRegImpl::stack_slot_size;
     sp_inc = align_up(sp_inc, StackAlignmentInBytes);
+    // Save the return address, adjust the stack (make sure it is properly
+    // 16-byte aligned) and copy the return address to the new top of the stack.
+    // The stack will be repaired on return (see MacroAssembler::remove_frame).
+    //pop(r13);
     sub(sp, sp, sp_inc);
-  } else {
-    sp_inc = 0;
+    //push(r13);
   }
 
-  sub(sp, sp, frame_size_in_bytes);
-  if (sp_inc > 0) {
-    int real_frame_size = frame_size_in_bytes +
-           + wordSize  // pushed rbp
-           + wordSize  // returned address pushed by the stack extension code
-           + sp_inc;   // stack extension
-    mov(rscratch1, real_frame_size);
-    str(rscratch1, Address(sp, frame_size_in_bytes - wordSize));
-  }
+  // Create a temp frame so we can call into the runtime. It must be properly set up to accommodate GC.
+  build_frame_helper(frame_size_in_bytes, sp_inc, ces->c1_needs_stack_repair());
+
+  // Initialize orig_pc to detect deoptimization during buffering in below runtime call
+  str(zr, Address(sp, sp_offset_for_orig_pc));
+
+  // The runtime call might safepoint, make sure nmethod entry barrier is executed
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->nmethod_entry_barrier(this);
 
   // FIXME -- call runtime only if we cannot in-line allocate all the incoming inline type args.
-  mov(r1, (intptr_t) ces->method());
+  movptr(r1, (intptr_t)(ces->method()));
   if (is_inline_ro_entry) {
     far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::buffer_inline_args_no_receiver_id)));
   } else {
@@ -448,18 +452,18 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
 
   // Remove the temp frame
   add(sp, sp, frame_size_in_bytes);
+  //pop(rbp);
 
-  int n = shuffle_inline_args(true, is_inline_ro_entry, sig_cc,
-                              args_passed_cc, regs_cc,            // from
-                              args_passed, args_on_stack, regs);  // to
-  assert(sp_inc == n, "must be");
+  shuffle_inline_args(true, is_inline_ro_entry, sig_cc,
+                      args_passed_cc, args_on_stack_cc, regs_cc, // from
+                      args_passed, args_on_stack, regs,          // to
+                      sp_inc);
 
-  if (sp_inc != 0) {
-    // Do the stack banging here, and skip over the stack repair code in the
-    // verified_inline_entry (which has a different real_frame_size).
-    assert(sp_inc > 0, "stack should not shrink");
-    generate_stack_overflow_check(bang_size_in_bytes);
-    decrement(sp, frame_size_in_bytes);
+  if (ces->c1_needs_stack_repair()) {
+    // Create the real frame. Below jump will then skip over the stack banging and frame
+    // setup code in the verified_inline_entry (which has a different real_frame_size).
+    brk(3);
+    build_frame_helper(frame_size_in_bytes, sp_inc, true);
   }
 
   b(verified_inline_entry_label);

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -110,5 +110,7 @@ using MacroAssembler::null_check;
   void null_check(Register r, Label *Lnull = NULL) { MacroAssembler::null_check(r); }
 
   void load_parameter(int offset_in_words, Register reg);
+
+  void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
 
 #endif // CPU_AARCH64_C1_MACROASSEMBLER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,9 @@ public:
                        Register dst, Address src, Register tmp1, Register tmp_thread);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         Address dst, Register val, Register tmp1, Register tmp2, Register tmp3 = noreg);
+
+  virtual void value_copy(MacroAssembler* masm, DecoratorSet decorators,
+                          Register src, Register dst, Register value_klass);
 
   virtual void obj_equals(MacroAssembler* masm,
                           Register obj1, Register obj2);

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -266,6 +266,65 @@ void InterpreterMacroAssembler::get_method_counters(Register method,
   bind(has_counters);
 }
 
+void InterpreterMacroAssembler::allocate_instance(Register klass, Register new_obj,
+                                                  Register t1, Register t2,
+                                                  bool clear_fields, Label& alloc_failed) {
+  MacroAssembler::allocate_instance(klass, new_obj, t1, t2, clear_fields, alloc_failed);
+  {
+    SkipIfEqual skip_if(this, &DTraceAllocProbes, 0);
+    // Trigger dtrace event for fastpath
+    push(atos);
+    call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_object_alloc), new_obj);
+    pop(atos);
+  }
+}
+
+void InterpreterMacroAssembler::read_inlined_field(Register holder_klass,
+                                                   Register field_index, Register field_offset,
+                                                   Register temp, Register obj) {
+  Label alloc_failed, empty_value, done;
+  const Register src = field_offset;
+  const Register alloc_temp = rscratch1;
+  const Register dst_temp   = temp;
+  assert_different_registers(obj, holder_klass, field_index, field_offset, dst_temp);
+
+  // Grab the inline field klass
+  push(holder_klass);
+  const Register field_klass = holder_klass;
+  get_inline_type_field_klass(holder_klass, field_index, field_klass);
+
+  //check for empty value klass
+  test_klass_is_empty_inline_type(field_klass, dst_temp, empty_value);
+
+  // allocate buffer
+  push(obj); // save holder
+  allocate_instance(field_klass, obj, alloc_temp, dst_temp, false, alloc_failed);
+
+  // Have an oop instance buffer, copy into it
+  data_for_oop(obj, dst_temp, field_klass);
+  pop(alloc_temp);             // restore holder
+  lea(src, Address(alloc_temp, field_offset));
+  // call_VM_leaf, clobbers a few regs, save restore new obj
+  push(obj);
+  access_value_copy(IS_DEST_UNINITIALIZED, src, dst_temp, field_klass);
+  pop(obj);
+  pop(holder_klass);
+  b(done);
+
+  bind(empty_value);
+  get_empty_inline_type_oop(field_klass, dst_temp, obj);
+  pop(holder_klass);
+  b(done);
+
+  bind(alloc_failed);
+  pop(obj);
+  pop(holder_klass);
+  call_VM(obj, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_inlined_field),
+          obj, field_index, holder_klass);
+
+  bind(done);
+}
+
 // Load object from cpool->resolved_references(index)
 void InterpreterMacroAssembler::load_resolved_reference_at_index(
                                            Register result, Register index, Register tmp) {
@@ -312,19 +371,24 @@ void InterpreterMacroAssembler::load_resolved_method_at_index(int byte_no,
 // Kills:
 //      r2, r5
 void InterpreterMacroAssembler::gen_subtype_check(Register Rsub_klass,
-                                                  Label& ok_is_subtype) {
+                                                  Label& ok_is_subtype,
+                                                  bool profile) {
   assert(Rsub_klass != r0, "r0 holds superklass");
   assert(Rsub_klass != r2, "r2 holds 2ndary super array length");
   assert(Rsub_klass != r5, "r5 holds 2ndary super array scan ptr");
 
   // Profile the not-null value's klass.
-  profile_typecheck(r2, Rsub_klass, r5); // blows r2, reloads r5
+  if (profile) {
+    profile_typecheck(r2, Rsub_klass, r5); // blows r2, reloads r5
+  }
 
   // Do the check.
   check_klass_subtype(Rsub_klass, r0, r2, ok_is_subtype); // blows r2
 
   // Profile the failure of the check.
-  profile_typecheck_failed(r2); // blows r2
+  if (profile) {
+    profile_typecheck_failed(r2); // blows r2
+  }
 }
 
 // Java Expression Stack
@@ -790,14 +854,14 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg)
     // Load (object->mark() | 1) into swap_reg
     ldr(rscratch1, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
     orr(swap_reg, rscratch1, 1);
+    if (EnableValhalla) {
+      assert(!UseBiasedLocking, "Not compatible with biased-locking");
+      // Mask inline_type bit such that we go to the slow path if object is an inline type
+      andr(swap_reg, swap_reg, ~((int) markWord::inline_type_bit_in_place));
+    }
 
     // Save (object->mark() | 1) into BasicLock's displaced header
     str(swap_reg, Address(lock_reg, mark_offset));
-
-    if (EnableValhalla && !UseBiasedLocking) {
-      // For slow path is_always_locked, using biased, which is never natural for !UseBiasLocking
-      andr(swap_reg, swap_reg, ~((int) markWord::biased_lock_bit_in_place));
-    }
 
     assert(lock_offset == 0,
            "displached header must be first word in BasicObjectLock");
@@ -1152,7 +1216,7 @@ void InterpreterMacroAssembler::profile_taken_branch(Register mdp,
 }
 
 
-void InterpreterMacroAssembler::profile_not_taken_branch(Register mdp) {
+void InterpreterMacroAssembler::profile_not_taken_branch(Register mdp, bool acmp) {
   if (ProfileInterpreter) {
     Label profile_continue;
 
@@ -1164,7 +1228,7 @@ void InterpreterMacroAssembler::profile_not_taken_branch(Register mdp) {
 
     // The method data pointer needs to be updated to correspond to
     // the next bytecode
-    update_mdp_by_constant(mdp, in_bytes(BranchData::branch_data_size()));
+    update_mdp_by_constant(mdp, acmp ? in_bytes(ACmpData::acmp_data_size()) : in_bytes(BranchData::branch_data_size()));
     bind(profile_continue);
   }
 }
@@ -1523,6 +1587,85 @@ void InterpreterMacroAssembler::profile_switch_case(Register index,
                          index,
                          in_bytes(MultiBranchData::
                                   relative_displacement_offset()));
+
+    bind(profile_continue);
+  }
+}
+
+void InterpreterMacroAssembler::profile_array(Register mdp,
+                                              Register array,
+                                              Register tmp) {
+  if (ProfileInterpreter) {
+    Label profile_continue;
+
+    // If no method data exists, go to profile_continue.
+    test_method_data_pointer(mdp, profile_continue);
+
+    mov(tmp, array);
+    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayLoadStoreData::array_offset())));
+
+    Label not_flat;
+    test_non_flattened_array_oop(array, tmp, not_flat);
+
+    set_mdp_flag_at(mdp, ArrayLoadStoreData::flat_array_byte_constant());
+
+    bind(not_flat);
+
+    Label not_null_free;
+    test_non_null_free_array_oop(array, tmp, not_null_free);
+
+    set_mdp_flag_at(mdp, ArrayLoadStoreData::null_free_array_byte_constant());
+
+    bind(not_null_free);
+
+    bind(profile_continue);
+  }
+}
+
+void InterpreterMacroAssembler::profile_element(Register mdp,
+                                                Register element,
+                                                Register tmp) {
+  if (ProfileInterpreter) {
+    Label profile_continue;
+
+    // If no method data exists, go to profile_continue.
+    test_method_data_pointer(mdp, profile_continue);
+
+    mov(tmp, element);
+    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayLoadStoreData::element_offset())));
+
+    // The method data pointer needs to be updated.
+    update_mdp_by_constant(mdp, in_bytes(ArrayLoadStoreData::array_load_store_data_size()));
+
+    bind(profile_continue);
+  }
+}
+
+void InterpreterMacroAssembler::profile_acmp(Register mdp,
+                                             Register left,
+                                             Register right,
+                                             Register tmp) {
+  if (ProfileInterpreter) {
+    Label profile_continue;
+
+    // If no method data exists, go to profile_continue.
+    test_method_data_pointer(mdp, profile_continue);
+
+    mov(tmp, left);
+    profile_obj_type(tmp, Address(mdp, in_bytes(ACmpData::left_offset())));
+
+    Label left_not_inline_type;
+    test_oop_is_not_inline_type(left, tmp, left_not_inline_type);
+    set_mdp_flag_at(mdp, ACmpData::left_inline_type_byte_constant());
+    bind(left_not_inline_type);
+
+    mov(tmp, right);
+    profile_obj_type(tmp, Address(mdp, in_bytes(ACmpData::right_offset())));
+
+    Label right_not_inline_type;
+    test_oop_is_not_inline_type(right, tmp, right_not_inline_type);
+    set_mdp_flag_at(mdp, ACmpData::right_inline_type_byte_constant());
+    bind(right_not_inline_type);
 
     bind(profile_continue);
   }

--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "prims/jvmtiExport.hpp"
+#include "runtime/jfieldIDWorkaround.hpp"
 #include "runtime/safepoint.hpp"
 
 #define __ masm->
@@ -109,7 +110,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->try_resolve_jobject_in_native(masm, c_rarg0, robj, rscratch1, slow);
 
-  __ lsr(roffset, c_rarg2, 2);                // offset
+  __ lsr(roffset, c_rarg2, jfieldIDWorkaround::offset_shift);       // offset
   __ add(result, robj, roffset);
 
   assert(count < LIST_CAPACITY, "LIST_CAPACITY too small");

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -29,6 +29,7 @@
 #include "jvm.h"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "ci/ciInlineKlass.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
@@ -52,6 +53,7 @@
 #include "runtime/stubRoutines.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/powerOfTwo.hpp"
+#include "vmreg_aarch64.inline.hpp"
 #ifdef COMPILER1
 #include "c1/c1_LIRAssembler.hpp"
 #endif
@@ -938,6 +940,41 @@ void MacroAssembler::check_and_handle_earlyret(Register java_thread) { }
 
 void MacroAssembler::check_and_handle_popframe(Register java_thread) { }
 
+void MacroAssembler::get_default_value_oop(Register inline_klass, Register temp_reg, Register obj) {
+#ifdef ASSERT
+  {
+    Label done_check;
+    test_klass_is_inline_type(inline_klass, temp_reg, done_check);
+    stop("get_default_value_oop from non inline type klass");
+    bind(done_check);
+  }
+#endif
+  Register offset = temp_reg;
+  // Getting the offset of the pre-allocated default value
+  ldr(offset, Address(inline_klass, in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset())));
+  ldr(offset, Address(offset, in_bytes(InlineKlass::default_value_offset_offset())));
+
+  // Getting the mirror
+  ldr(obj, Address(inline_klass, in_bytes(Klass::java_mirror_offset())));
+  resolve_oop_handle(obj, inline_klass);
+
+  // Getting the pre-allocated default value from the mirror
+  Address field(obj, offset);
+  load_heap_oop(obj, field);
+}
+
+void MacroAssembler::get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj) {
+#ifdef ASSERT
+  {
+    Label done_check;
+    test_klass_is_empty_inline_type(inline_klass, temp_reg, done_check);
+    stop("get_empty_value from non-empty inline klass");
+    bind(done_check);
+  }
+#endif
+  get_default_value_oop(inline_klass, temp_reg, obj);
+}
+
 // Look up the method for a megamorphic invokeinterface call.
 // The target method is determined by <intf_klass, itable_index>.
 // The receiver klass is in recv_klass.
@@ -1405,6 +1442,7 @@ void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0) {
 }
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register arg_1) {
+  assert_different_registers(arg_1, c_rarg0);
   pass_arg0(this, arg_0);
   pass_arg1(this, arg_1);
   call_VM_leaf_base(entry_point, 2);
@@ -1412,6 +1450,8 @@ void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0, Register 
 
 void MacroAssembler::call_VM_leaf(address entry_point, Register arg_0,
                                   Register arg_1, Register arg_2) {
+  assert_different_registers(arg_1, c_rarg0);
+  assert_different_registers(arg_2, c_rarg0, c_rarg1);
   pass_arg0(this, arg_0);
   pass_arg1(this, arg_1);
   pass_arg2(this, arg_2);
@@ -1471,37 +1511,113 @@ void MacroAssembler::null_check(Register reg, int offset) {
   }
 }
 
-void MacroAssembler::test_klass_is_value(Register klass, Register temp_reg, Label& is_value) {
+void MacroAssembler::test_markword_is_inline_type(Register markword, Label& is_inline_type) {
+  assert_different_registers(markword, rscratch2);
+  andr(markword, markword, markWord::inline_type_mask_in_place);
+  mov(rscratch2, markWord::inline_type_pattern);
+  cmp(markword, rscratch2);
+  br(Assembler::EQ, is_inline_type);
+}
+
+void MacroAssembler::test_klass_is_inline_type(Register klass, Register temp_reg, Label& is_inline_type) {
   ldrw(temp_reg, Address(klass, Klass::access_flags_offset()));
   andr(temp_reg, temp_reg, JVM_ACC_INLINE);
-  cbnz(temp_reg, is_value);
+  cbnz(temp_reg, is_inline_type);
+}
+
+void MacroAssembler::test_oop_is_not_inline_type(Register object, Register tmp, Label& not_inline_type) {
+  cbz(object, not_inline_type);
+  const int is_inline_type_mask = markWord::inline_type_pattern;
+  ldr(tmp, Address(object, oopDesc::mark_offset_in_bytes()));
+  mov(rscratch1, is_inline_type_mask);
+  andr(tmp, tmp, rscratch1);
+  cmp(tmp, rscratch1);
+  br(Assembler::NE, not_inline_type);
+}
+
+void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register temp_reg, Label& is_empty_inline_type) {
+#ifdef ASSERT
+  {
+    Label done_check;
+    test_klass_is_inline_type(klass, temp_reg, done_check);
+    stop("test_klass_is_empty_inline_type with non inline type klass");
+    bind(done_check);
+  }
+#endif
+  ldrw(temp_reg, Address(klass, InstanceKlass::misc_flags_offset()));
+  andr(temp_reg, temp_reg, InstanceKlass::misc_flags_is_empty_inline_type());
+  cbnz(temp_reg, is_empty_inline_type);
 }
 
 void MacroAssembler::test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline) {
-  (void) temp_reg; // keep signature uniform with x86
-  tbnz(flags, ConstantPoolCacheEntry::is_inline_field_shift, is_inline);
+  assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
+  tbnz(flags, ConstantPoolCacheEntry::is_inline_type_shift, is_inline);
 }
 
 void MacroAssembler::test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline) {
-  (void) temp_reg; // keep signature uniform with x86
-  tbz(flags, ConstantPoolCacheEntry::is_inline_field_shift, not_inline);
+  assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
+  tbz(flags, ConstantPoolCacheEntry::is_inline_type_shift, not_inline);
 }
 
 void MacroAssembler::test_field_is_inlined(Register flags, Register temp_reg, Label& is_flattened) {
-  (void) temp_reg; // keep signature uniform with x86
-  tbnz(flags, ConstantPoolCacheEntry::is_flattened_field_shift, is_flattened);
+  assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
+  tbnz(flags, ConstantPoolCacheEntry::is_inlined_shift, is_flattened);
+}
+
+void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {
+  Label test_mark_word;
+  // load mark word
+  ldr(temp_reg, Address(oop, oopDesc::mark_offset_in_bytes()));
+  // check displaced
+  tst(temp_reg, markWord::unlocked_value);
+  br(Assembler::NE, test_mark_word);
+  // slow path use klass prototype
+  load_prototype_header(temp_reg, oop);
+
+  bind(test_mark_word);
+  andr(temp_reg, temp_reg, test_bit);
+  if (jmp_set) {
+    cbnz(temp_reg, jmp_label);
+  } else {
+    cbz(temp_reg, jmp_label);
+  }
 }
 
 void MacroAssembler::test_flattened_array_oop(Register oop, Register temp_reg, Label& is_flattened_array) {
-  load_storage_props(temp_reg, oop);
-  andr(temp_reg, temp_reg, ArrayStorageProperties::flattened_value);
-  cbnz(temp_reg, is_flattened_array);
+  test_oop_prototype_bit(oop, temp_reg, markWord::flat_array_bit_in_place, true, is_flattened_array);
+}
+
+void MacroAssembler::test_non_flattened_array_oop(Register oop, Register temp_reg,
+                                                  Label&is_non_flattened_array) {
+  test_oop_prototype_bit(oop, temp_reg, markWord::flat_array_bit_in_place, false, is_non_flattened_array);
 }
 
 void MacroAssembler::test_null_free_array_oop(Register oop, Register temp_reg, Label& is_null_free_array) {
-  load_storage_props(temp_reg, oop);
-  andr(temp_reg, temp_reg, ArrayStorageProperties::null_free_value);
-  cbnz(temp_reg, is_null_free_array);
+  test_oop_prototype_bit(oop, temp_reg, markWord::nullfree_array_bit_in_place, true, is_null_free_array);
+}
+
+void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_reg, Label&is_non_null_free_array) {
+  test_oop_prototype_bit(oop, temp_reg, markWord::nullfree_array_bit_in_place, false, is_non_null_free_array);
+}
+
+void MacroAssembler::test_flattened_array_layout(Register lh, Label& is_flattened_array) {
+  tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  br(Assembler::NE, is_flattened_array);
+}
+
+void MacroAssembler::test_non_flattened_array_layout(Register lh, Label& is_non_flattened_array) {
+  tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  br(Assembler::EQ, is_non_flattened_array);
+}
+
+void MacroAssembler::test_null_free_array_layout(Register lh, Label& is_null_free_array) {
+  tst(lh, Klass::_lh_null_free_bit_inplace);
+  br(Assembler::NE, is_null_free_array);
+}
+
+void MacroAssembler::test_non_null_free_array_layout(Register lh, Label& is_non_null_free_array) {
+  tst(lh, Klass::_lh_null_free_bit_inplace);
+  br(Assembler::EQ, is_non_null_free_array);
 }
 
 // MacroAssembler protected routines needed to implement
@@ -3826,12 +3942,11 @@ void MacroAssembler::load_metadata(Register dst, Register src) {
 }
 
 void MacroAssembler::load_klass(Register dst, Register src) {
-  load_metadata(dst, src);
   if (UseCompressedClassPointers) {
-    andr(dst, dst, oopDesc::compressed_klass_mask());
+    ldrw(dst, Address(src, oopDesc::klass_offset_in_bytes()));
     decode_klass_not_null(dst);
   } else {
-    ubfm(dst, dst, 0, 63 - oopDesc::storage_props_nof_bits);
+    ldr(dst, Address(src, oopDesc::klass_offset_in_bytes()));
   }
 }
 
@@ -3864,15 +3979,6 @@ void MacroAssembler::load_mirror(Register dst, Register method, Register tmp) {
   ldr(dst, Address(dst, ConstantPool::pool_holder_offset_in_bytes()));
   ldr(dst, Address(dst, mirror_offset));
   resolve_oop_handle(dst, tmp);
-}
-
-void MacroAssembler::load_storage_props(Register dst, Register src) {
-  load_metadata(dst, src);
-  if (UseCompressedClassPointers) {
-    asrw(dst, dst, oopDesc::narrow_storage_props_shift);
-  } else {
-    asr(dst, dst, oopDesc::wide_storage_props_shift);
-  }
 }
 
 void MacroAssembler::cmp_klass(Register oop, Register trial_klass, Register tmp) {
@@ -4224,6 +4330,46 @@ void MacroAssembler::access_store_at(BasicType type, DecoratorSet decorators,
   }
 }
 
+void MacroAssembler::access_value_copy(DecoratorSet decorators, Register src, Register dst,
+                                       Register inline_klass) {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->value_copy(this, decorators, src, dst, inline_klass);
+}
+
+void MacroAssembler::first_field_offset(Register inline_klass, Register offset) {
+  ldr(offset, Address(inline_klass, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+  ldrw(offset, Address(offset, InlineKlass::first_field_offset_offset()));
+}
+
+void MacroAssembler::data_for_oop(Register oop, Register data, Register inline_klass) {
+  // ((address) (void*) o) + vk->first_field_offset();
+  Register offset = (data == oop) ? rscratch1 : data;
+  first_field_offset(inline_klass, offset);
+  if (data == oop) {
+    add(data, data, offset);
+  } else {
+    lea(data, Address(oop, offset));
+  }
+}
+
+void MacroAssembler::data_for_value_array_index(Register array, Register array_klass,
+                                                Register index, Register data) {
+  assert_different_registers(array, array_klass, index);
+  assert_different_registers(rscratch1, array, index);
+
+  // array->base() + (index << Klass::layout_helper_log2_element_size(lh));
+  ldrw(rscratch1, Address(array_klass, Klass::layout_helper_offset()));
+
+  // Klass::layout_helper_log2_element_size(lh)
+  // (lh >> _lh_log2_element_size_shift) & _lh_log2_element_size_mask;
+  lsr(rscratch1, rscratch1, Klass::_lh_log2_element_size_shift);
+  andr(rscratch1, rscratch1, Klass::_lh_log2_element_size_mask);
+  lslv(index, index, rscratch1);
+
+  add(data, array, index);
+  add(data, data, arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE));
+}
+
 void MacroAssembler::resolve(DecoratorSet decorators, Register obj) {
   // Use stronger ACCESS_WRITE|ACCESS_READ by default.
   if ((decorators & (ACCESS_READ | ACCESS_WRITE)) == 0) {
@@ -4312,6 +4458,132 @@ Address MacroAssembler::constant_oop_address(jobject obj) {
 #endif
   int oop_index = oop_recorder()->find_index(obj);
   return Address((address)obj, oop_Relocation::spec(oop_index));
+}
+
+// Object / value buffer allocation...
+void MacroAssembler::allocate_instance(Register klass, Register new_obj,
+                                       Register t1, Register t2,
+                                       bool clear_fields, Label& alloc_failed)
+{
+  Label done, initialize_header, initialize_object, slow_case, slow_case_no_pop;
+  Register layout_size = t1;
+  assert(new_obj == r0, "needs to be r0, according to barrier asm eden_allocate");
+  assert_different_registers(klass, new_obj, t1, t2);
+
+#ifdef ASSERT
+  {
+    Label L;
+    ldrb(rscratch1, Address(klass, InstanceKlass::init_state_offset()));
+    cmpw(rscratch1, InstanceKlass::fully_initialized);
+    br(Assembler::EQ, L);
+    stop("klass not initialized");
+    bind(L);
+  }
+#endif
+
+  // get instance_size in InstanceKlass (scaled to a count of bytes)
+  ldrw(layout_size, Address(klass, Klass::layout_helper_offset()));
+  // test to see if it has a finalizer or is malformed in some way
+  tst(layout_size, Klass::_lh_instance_slow_path_bit);
+  br(Assembler::NE, slow_case_no_pop);
+
+  // Allocate the instance:
+  //  If TLAB is enabled:
+  //    Try to allocate in the TLAB.
+  //    If fails, go to the slow path.
+  //  Else If inline contiguous allocations are enabled:
+  //    Try to allocate in eden.
+  //    If fails due to heap end, go to slow path.
+  //
+  //  If TLAB is enabled OR inline contiguous is enabled:
+  //    Initialize the allocation.
+  //    Exit.
+  //
+  //  Go to slow path.
+  const bool allow_shared_alloc =
+    Universe::heap()->supports_inline_contig_alloc();
+
+  push(klass);
+
+  if (UseTLAB) {
+    tlab_allocate(new_obj, layout_size, 0, klass, t2, slow_case);
+    if (ZeroTLAB || (!clear_fields)) {
+      // the fields have been already cleared
+      b(initialize_header);
+    } else {
+      // initialize both the header and fields
+      b(initialize_object);
+    }
+  } else {
+    // Allocation in the shared Eden, if allowed.
+    //
+    eden_allocate(new_obj, layout_size, 0, t2, slow_case);
+  }
+
+  // If UseTLAB or allow_shared_alloc are true, the object is created above and
+  // there is an initialize need. Otherwise, skip and go to the slow path.
+  if (UseTLAB || allow_shared_alloc) {
+    if (clear_fields) {
+      // The object is initialized before the header.  If the object size is
+      // zero, go directly to the header initialization.
+      bind(initialize_object);
+      subs(layout_size, layout_size, sizeof(oopDesc));
+      br(Assembler::EQ, initialize_header);
+
+      // Initialize topmost object field, divide size by 8, check if odd and
+      // test if zero.
+      lsr(layout_size, layout_size, LogBytesPerLong); // divide by 2*oopSize and set carry flag if odd
+
+  #ifdef ASSERT
+      // make sure instance_size was multiple of 8
+      Label L;
+      // XXXNick: TODO
+      // Ignore partial flag stall after shrl() since it is debug VM
+      //jcc(Assembler::carryClear, L);
+      //stop("object size is not multiple of 2 - adjust this code");
+      //bind(L);
+      // must be > 0, no extra check needed here
+  #endif
+
+      // initialize remaining object fields: instance_size was a multiple of 8
+      {
+        Label loop;
+        Register base = t2;
+
+        // XXXNick: check this
+
+        add(base, new_obj, sizeof(oopDesc) - 1*oopSize);
+        bind(loop);
+        str(zr, Address(base, layout_size, Address::lsl(LogBytesPerLong)));
+        subs(layout_size, layout_size, 1);
+        br(Assembler::NE, loop);
+
+        //movptr(Address(new_obj, layout_size, Address::times_8, sizeof(oopDesc) - 1*oopSize), zero);
+        //NOT_LP64(movptr(Address(new_obj, layout_size, Address::times_8, sizeof(oopDesc) - 2*oopSize), zero));
+        //decrement(layout_size);
+        //jcc(Assembler::notZero, loop);
+      }
+    } // clear_fields
+
+    // initialize object header only.
+    bind(initialize_header);
+    pop(klass);
+    Register mark_word = t2;
+    ldr(mark_word, Address(klass, Klass::prototype_header_offset()));
+    str(mark_word, Address(new_obj, oopDesc::mark_offset_in_bytes ()));
+    store_klass_gap(new_obj, zr);  // zero klass gap for compressed oops
+    mov(t2, klass);         // preserve klass
+    store_klass(new_obj, t2);  // src klass reg is potentially compressed
+
+    b(done);
+  }
+
+  bind(slow_case);
+  pop(klass);
+  bind(slow_case_no_pop);
+  b(alloc_failed);
+
+  bind(done);
 }
 
 // Defines obj, preserves var_size_in_bytes, okay for t2 == var_size_in_bytes.
@@ -4423,6 +4695,19 @@ void MacroAssembler::verify_tlab() {
     ldp(rscratch2, rscratch1, Address(post(sp, 16)));
   }
 #endif
+}
+
+void MacroAssembler::get_inline_type_field_klass(Register klass, Register index, Register inline_klass) {
+  ldr(inline_klass, Address(klass, InstanceKlass::inline_type_field_klasses_offset()));
+#ifdef ASSERT
+  {
+    Label done;
+    cbnz(inline_klass, done);
+    stop("get_inline_type_field_klass contains no inline klass");
+    bind(done);
+  }
+#endif
+  ldr(inline_klass, Address(inline_klass, index, Address::lsl(3)));
 }
 
 // Writes to stack successive pages until offset reached to check for
@@ -5350,28 +5635,34 @@ void MacroAssembler::get_thread(Register dst) {
   pop(saved_regs, sp);
 }
 
+#ifdef COMPILER2
 // C2 compiled method's prolog code
 // Moved here from aarch64.ad to support Valhalla code belows
 void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
 
 // n.b. frame size includes space for return pc and rfp
-  const long framesize = C->frame_size_in_bytes();
+  const long framesize = C->output()->frame_size_in_bytes();
   assert(framesize % (2 * wordSize) == 0, "must preserve 2 * wordSize alignment");
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
   nop();
 
-  int bangsize = C->bang_size_in_bytes();
-  if (C->need_stack_bang(bangsize) && UseStackBanging)
+  int bangsize = C->output()->bang_size_in_bytes();
+  if (C->output()->need_stack_bang(bangsize))
      generate_stack_overflow_check(bangsize);
 
   build_frame(framesize);
+
+  if (C->needs_stack_repair()) {
+    Unimplemented();
+  }
 
   if (VerifyStackAtCalls) {
     Unimplemented();
   }
 }
+#endif // COMPILER2
 
 int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from_interpreter) {
   // An inline type might be returned. If fields are in registers we
@@ -5384,6 +5675,9 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
   int call_offset = -1;
 
   Label slow_case;
+
+  // XXXNick: this function needs updating
+  brk(1);
 
   // Try to allocate a new buffered inline type (from the heap)
   if (UseTLAB) {
@@ -5401,47 +5695,48 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
        ldrw(r14, Address(rscratch1 /*klass*/, Klass::layout_helper_offset()));
     }
 
-     ldr(r13, Address(rthread, in_bytes(JavaThread::tlab_top_offset())));
+    ldr(r13, Address(rthread, in_bytes(JavaThread::tlab_top_offset())));
 
-     // check whether we have space in TLAB,
-     // rscratch1 contains pointer to just allocated obj
-      lea(r14, Address(r13, r14));
-      ldr(rscratch1, Address(rthread, in_bytes(JavaThread::tlab_end_offset())));
+    // check whether we have space in TLAB,
+    // rscratch1 contains pointer to just allocated obj
+    lea(r14, Address(r13, r14));
+    ldr(rscratch1, Address(rthread, in_bytes(JavaThread::tlab_end_offset())));
 
-      cmp(r14, rscratch1);
-      br(Assembler::GT, slow_case);
+    cmp(r14, rscratch1);
+    br(Assembler::GT, slow_case);
 
-      // OK we have room in TLAB,
-      // Set new TLAB top
-      str(r14, Address(rthread, in_bytes(JavaThread::tlab_top_offset())));
+    // OK we have room in TLAB,
+    // Set new TLAB top
+    str(r14, Address(rthread, in_bytes(JavaThread::tlab_top_offset())));
 
-      // Set new class always locked
-      mov(rscratch1, (uint64_t) markWord::always_locked_prototype().value());
-      str(rscratch1, Address(r13, oopDesc::mark_offset_in_bytes()));
+#if 0
+    // Set new class always locked
+    mov(rscratch1, (uint64_t) markWord::always_locked_prototype().value());
+    str(rscratch1, Address(r13, oopDesc::mark_offset_in_bytes()));
+#endif
 
-      store_klass_gap(r13, zr);  // zero klass gap for compressed oops
-      if (vk == NULL) {
-        // store_klass corrupts rbx, so save it in rax for later use (interpreter case only).
-         mov(r0, r1);
-      }
+    store_klass_gap(r13, zr);  // zero klass gap for compressed oops
+    if (vk == NULL) {
+      // store_klass corrupts rbx, so save it in rax for later use (interpreter case only).
+      mov(r0, r1);
+    }
 
-      store_klass(r13, r1);  // klass
+    store_klass(r13, r1);  // klass
 
-      if (vk != NULL) {
-        // FIXME -- do the packing in-line to avoid the runtime call
-        mov(r0, r13);
-        far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
-      } else {
+    if (vk != NULL) {
+      // FIXME -- do the packing in-line to avoid the runtime call
+      mov(r0, r13);
+      far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
+    } else {
+      // We have our new buffered inline type, initialize its fields with an inline class specific handler
+      ldr(r1, Address(r0, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      ldr(r1, Address(r1, InlineKlass::pack_handler_offset()));
 
-        // We have our new buffered inline type, initialize its fields with an inline class specific handler
-        ldr(r1, Address(r0, InstanceKlass::adr_inlineklass_fixed_block_offset()));
-        ldr(r1, Address(r1, InlineKlass::pack_handler_offset()));
-
-        // Mov new class to r0 and call pack_handler
-        mov(r0, r13);
-        blr(r1);
-      }
-      b(skip);
+      // Mov new class to r0 and call pack_handler
+      mov(r0, r13);
+      blr(r1);
+    }
+    b(skip);
   }
 
   bind(slow_case);
@@ -5449,7 +5744,6 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
   // call. Some oop field may be live in some registers but we can't
   // tell. That runtime call will take care of preserving them
   // across a GC if there's one.
-
 
   if (from_interpreter) {
     super_call_VM_leaf(StubRoutines::store_inline_type_fields_to_buf());
@@ -5518,99 +5812,83 @@ bool MacroAssembler::move_helper(VMReg from, VMReg to, BasicType bt, RegState re
 }
 
 // Read all fields from an inline type oop and store the values in registers/stack slots
-bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, VMReg from, VMRegPair* regs_to,
-                                          int& to_index, RegState reg_state[]) {
-  Register fromReg = from->is_reg() ? from->as_Register() : noreg;
+bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index,
+                                          VMReg from, int& from_index, VMRegPair* to, int to_count, int& to_index,
+                                          RegState reg_state[]) {
   assert(sig->at(sig_index)._bt == T_VOID, "should be at end delimiter");
+  assert(from->is_valid(), "source must bevalid");
+  Register fromReg;
+  if (from->is_reg()) {
+    fromReg = from->as_Register();
+  } else {
+    int st_off = from->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
+    ldr(r10, Address(sp, st_off));
+    fromReg = r10;
+  }
 
-
-  int vt = 1;
+  ScalarizedInlineArgsStream stream(sig, sig_index, to, to_count, to_index, -1);
   bool done = true;
   bool mark_done = true;
-  do {
-    sig_index--;
-    BasicType bt = sig->at(sig_index)._bt;
-    if (bt == T_INLINE_TYPE) {
-      vt--;
-    } else if (bt == T_VOID &&
-               sig->at(sig_index-1)._bt != T_LONG &&
-               sig->at(sig_index-1)._bt != T_DOUBLE) {
-      vt++;
-    } else {
-      assert(to_index >= 0, "invalid to_index");
-      VMRegPair pair_to = regs_to[to_index--];
-      VMReg to = pair_to.first();
+  VMReg toReg;
+  BasicType bt;
+  while (stream.next(toReg, bt)) {
+    int off = sig->at(stream.sig_index())._offset;
+    assert(off > 0, "offset in object should be positive");
+    Address fromAddr = Address(fromReg, off);
 
-      if (bt == T_VOID) continue;
-
-      int idx = (int) to->value();
-      if (reg_state[idx] == reg_readonly) {
-         if (idx != from->value()) {
-           mark_done = false;
-         }
-         done = false;
-         continue;
-      } else if (reg_state[idx] == reg_written) {
-        continue;
-      } else {
-        assert(reg_state[idx] == reg_writable, "must be writable");
-        reg_state[idx] = reg_written;
-      }
-
-      if (fromReg == noreg) {
-        int st_off = from->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
-        ldr(rscratch2, Address(sp, st_off));
-        fromReg = rscratch2;
-      }
-
-      int off = sig->at(sig_index)._offset;
-      assert(off > 0, "offset in object should be positive");
-      bool is_oop = (bt == T_OBJECT || bt == T_ARRAY);
-
-      Address fromAddr = Address(fromReg, off);
-      bool is_signed = (bt != T_CHAR) && (bt != T_BOOLEAN);
-
-      if (!to->is_FloatRegister()) {
-
-        Register dst = to->is_stack() ? rscratch1 : to->as_Register();
-
-        if (is_oop) {
-          load_heap_oop(dst, fromAddr);
-        } else {
-          load_sized_value(dst, fromAddr, type2aelembytes(bt), is_signed);
-        }
-        if (to->is_stack()) {
-          int st_off = to->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
-          str(dst, Address(sp, st_off));
-        }
-      } else {
-        if (bt == T_DOUBLE) {
-          ldrd(to->as_FloatRegister(), fromAddr);
-        } else {
-          assert(bt == T_FLOAT, "must be float");
-          ldrs(to->as_FloatRegister(), fromAddr);
-        }
+    int idx = (int)toReg->value();
+    if (reg_state[idx] == reg_readonly) {
+     if (idx != from->value()) {
+       mark_done = false;
      }
-
+     done = false;
+     continue;
+    } else if (reg_state[idx] == reg_written) {
+      continue;
+    } else {
+      assert(reg_state[idx] == reg_writable, "must be writable");
+      reg_state[idx] = reg_written;
     }
 
-  } while (vt != 0);
+    if (!toReg->is_FloatRegister()) {
+      Register dst = toReg->is_stack() ? r13 : toReg->as_Register();
+      if (is_reference_type(bt)) {
+        load_heap_oop(dst, fromAddr);
+      } else {
+        bool is_signed = (bt != T_CHAR) && (bt != T_BOOLEAN);
+        load_sized_value(dst, fromAddr, type2aelembytes(bt), is_signed);
+      }
+      if (toReg->is_stack()) {
+        int st_off = toReg->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
+        str(dst, Address(sp, st_off));
+      }
+    } else if (bt == T_DOUBLE) {
+      ldrd(toReg->as_FloatRegister(), fromAddr);
+    } else {
+      assert(bt == T_FLOAT, "must be float");
+      ldrs(toReg->as_FloatRegister(), fromAddr);
+    }
+  }
+  sig_index = stream.sig_index();
+  to_index = stream.regs_index();
 
   if (mark_done && reg_state[from->value()] != reg_written) {
     // This is okay because no one else will write to that slot
     reg_state[from->value()] = reg_writable;
   }
+  from_index--;
   return done;
 }
 
 // Pack fields back into an inline type oop
 bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
-                                        VMReg to, VMRegPair* regs_from, int regs_from_count, int& from_index, RegState reg_state[]) {
+                                        VMRegPair* from, int from_count, int& from_index, VMReg to,
+                                        RegState reg_state[]) {
   assert(sig->at(sig_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
-  assert(to->is_valid(), "must be");
+  assert(to->is_valid(), "destination must be valid");
 
   if (reg_state[to->value()] == reg_written) {
-    skip_unpacked_fields(sig, sig_index, regs_from, regs_from_count, from_index);
+    skip_unpacked_fields(sig, sig_index, from, from_count, from_index);
     return true; // Already written
   }
 
@@ -5623,8 +5901,8 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
   Register val_obj = to->is_stack() ? val_obj_tmp : to->as_Register();
 
   if (reg_state[to->value()] == reg_readonly) {
-    if (!is_reg_in_unpacked_fields(sig, sig_index, to, regs_from, regs_from_count, from_index)) {
-      skip_unpacked_fields(sig, sig_index, regs_from, regs_from_count, from_index);
+    if (!is_reg_in_unpacked_fields(sig, sig_index, to, from, from_count, from_index)) {
+      skip_unpacked_fields(sig, sig_index, from, from_count, from_index);
       return false; // Not yet writable
     }
     val_obj = val_obj_tmp;
@@ -5633,47 +5911,39 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
   int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_INLINE_TYPE);
   load_heap_oop(val_obj, Address(val_array, index));
 
-  ScalarizedInlineArgsStream stream(sig, sig_index, regs_from, regs_from_count, from_index);
-  VMRegPair from_pair;
+  ScalarizedInlineArgsStream stream(sig, sig_index, from, from_count, from_index);
+  VMReg fromReg;
   BasicType bt;
-
-  while (stream.next(from_pair, bt)) {
+  while (stream.next(fromReg, bt)) {
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
-    bool is_oop = (bt == T_OBJECT || bt == T_ARRAY);
     size_t size_in_bytes = is_java_primitive(bt) ? type2aelembytes(bt) : wordSize;
-
-    VMReg from_r1 = from_pair.first();
-    VMReg from_r2 = from_pair.second();
 
     // Pack the scalarized field into the value object.
     Address dst(val_obj, off);
 
-    if (!from_r1->is_FloatRegister()) {
-      Register from_reg;
-      if (from_r1->is_stack()) {
-        from_reg = from_reg_tmp;
-        int ld_off = from_r1->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
-        load_sized_value(from_reg, Address(sp, ld_off), size_in_bytes, /* is_signed */ false);
+    if (!fromReg->is_FloatRegister()) {
+      Register src;
+      if (fromReg->is_stack()) {
+        src = from_reg_tmp;
+        int ld_off = fromReg->reg2stack() * VMRegImpl::stack_slot_size + wordSize;
+        load_sized_value(src, Address(sp, ld_off), size_in_bytes, /* is_signed */ false);
       } else {
-        from_reg = from_r1->as_Register();
+        src = fromReg->as_Register();
       }
-
-      if (is_oop) {
-        DecoratorSet decorators = IN_HEAP | ACCESS_WRITE;
-        store_heap_oop(dst, from_reg, tmp1, tmp2, tmp3, decorators);
+      assert_different_registers(dst.base(), src, tmp1, tmp2, tmp3, val_array);
+      if (is_reference_type(bt)) {
+        store_heap_oop(dst, src, tmp1, tmp2, tmp3, IN_HEAP | ACCESS_WRITE | IS_DEST_UNINITIALIZED);
       } else {
-        store_sized_value(dst, from_reg, size_in_bytes);
+        store_sized_value(dst, src, size_in_bytes);
       }
+    } else if (bt == T_DOUBLE) {
+      strd(fromReg->as_FloatRegister(), dst);
     } else {
-      if (from_r2->is_valid()) {
-        strd(from_r1->as_FloatRegister(), dst);
-      } else {
-        strs(from_r1->as_FloatRegister(), dst);
-      }
+      assert(bt == T_FLOAT, "must be float");
+      strs(fromReg->as_FloatRegister(), dst);
     }
-
-    reg_state[from_r1->value()] = reg_writable;
+    reg_state[fromReg->value()] = reg_writable;
   }
   sig_index = stream.sig_index();
   from_index = stream.regs_index();
@@ -5687,6 +5957,21 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
 
 VMReg MacroAssembler::spill_reg_for(VMReg reg) {
   return (reg->is_FloatRegister()) ? v0->as_VMReg() : r14->as_VMReg();
+}
+
+void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset) {
+  assert((initial_framesize & (StackAlignmentInBytes-1)) == 0, "frame size not aligned");
+  if (needs_stack_repair) {
+    brk(1);
+    // TODO: check this
+    ldr(rfp, Address(sp, initial_framesize));
+    ldr(rscratch1, Address(sp, sp_inc_offset));
+    mov(rscratch2, sp);
+    add(rscratch2, rscratch2, rscratch1);
+    mov(sp, rscratch2);
+  } else {
+    remove_frame(initial_framesize);
+  }
 }
 
 void MacroAssembler::cache_wb(Address line) {

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -608,7 +608,8 @@ static void gen_c2i_adapter(MacroAssembler *masm,
       // There is at least an inline type argument: we're coming from
       // compiled code so we have no buffers to back the inline types
       // Allocate the buffers here with a runtime call.
-      OopMap* map = RegisterSaver::save_live_registers(masm, 0, &frame_size_in_words);
+      RegisterSaver reg_save(false /* save_vectors */);
+      OopMap* map = reg_save.save_live_registers(masm, 0, &frame_size_in_words);
 
       frame_complete = __ offset();
       address the_pc = __ pc();
@@ -625,7 +626,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
       oop_maps->add_gc_map((int)(__ pc() - start), map);
       __ reset_last_Java_frame(false);
 
-      RegisterSaver::restore_live_registers(masm);
+      reg_save.restore_live_registers(masm);
 
       Label no_exception;
       __ ldr(r0, Address(rthread, Thread::pending_exception_offset()));
@@ -987,9 +988,8 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   // Scalarized c2i adapter with non-scalarized receiver (i.e., don't pack receiver)
   address c2i_inline_ro_entry = __ pc();
   if (regs_cc != regs_cc_ro) {
-    Label unused;
     gen_c2i_adapter(masm, sig_cc_ro, regs_cc_ro, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
-    skip_fixup = unused;
+    skip_fixup.reset();
   }
 
   // Scalarized c2i adapter
@@ -1021,11 +1021,11 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->c2i_entry_barrier(masm);
 
-  gen_c2i_adapter(masm, total_args_passed, comp_args_on_stack, sig_bt, regs, skip_fixup);
+  gen_c2i_adapter(masm, sig_cc, regs_cc, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, true);
 
   address c2i_unverified_inline_entry = c2i_unverified_entry;
 
- // Non-scalarized c2i adapter
+  // Non-scalarized c2i adapter
   address c2i_inline_entry = c2i_entry;
   if (regs != regs_cc) {
     Label inline_entry_skip_fixup;
@@ -1033,7 +1033,6 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
     gen_inline_cache_check(masm, inline_entry_skip_fixup);
 
     c2i_inline_entry = __ pc();
-    Label unused;
     gen_c2i_adapter(masm, sig, regs, inline_entry_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
   }
 
@@ -3341,6 +3340,7 @@ void OptoRuntime::generate_exception_blob() {
   // Set exception blob
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }
+#endif // COMPILER2
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   BufferBlob* buf = BufferBlob::create("inline types pack/unpack", 16 * K);
@@ -3354,6 +3354,15 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
 
   const Array<SigEntry>* sig_vk = vk->extended_sig();
   const Array<VMRegPair>* regs = vk->return_regs();
+
+  int pack_fields_jobject_off = __ offset();
+  // Resolve pre-allocated buffer from JNI handle.
+  // We cannot do this in generate_call_stub() because it requires GC code to be initialized.
+  __ ldr(r0, Address(r13, 0));
+  __ resolve_jobject(r0 /* value */,
+                     rthread /* thread */,
+                     r12 /* tmp */);
+  __ str(r0, Address(r13, 0));
 
   int pack_fields_off = __ offset();
 
@@ -3444,7 +3453,7 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
 
   __ flush();
 
-  return BufferedInlineTypeBlob::create(&buffer, pack_fields_off, unpack_fields_off);
+  return BufferedInlineTypeBlob::create(&buffer, pack_fields_off, pack_fields_jobject_off, unpack_fields_off);
 }
 
 // ---------------------------------------------------------------
@@ -3698,4 +3707,3 @@ void NativeInvokerGenerator::generate() {
 
   __ flush();
 }
-#endif // COMPILER2

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2104,6 +2104,14 @@ class StubGenerator: public StubCodeGenerator {
     __ eor(rscratch2, rscratch2, scratch_src_klass);
     __ cbnz(rscratch2, L_failed);
 
+    // Check for flat inline type array -> return -1
+    __ tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ br(Assembler::NE, L_failed);
+
+    // Check for null-free (non-flat) inline type array -> handle as object array
+    __ tst(lh, Klass::_lh_null_free_bit_inplace);
+    __ br(Assembler::NE, L_failed);
+
     //  if (!src->is_Array()) return -1;
     __ tbz(lh, 31, L_failed);  // i.e. (lh >= 0)
 
@@ -6818,7 +6826,6 @@ class StubGenerator: public StubCodeGenerator {
     oop_maps->add_gc_map(the_pc - start, map);
 
     __ reset_last_Java_frame(false);
-    __ maybe_isb();
 
     __ ldrd(j_farg7, f7_save);
     __ ldrd(j_farg6, f6_save);

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -328,6 +328,7 @@ void TemplateTable::ldc(bool wide)
   __ add(r3, r1, tags_offset);
   __ lea(r3, Address(r0, r3));
   __ ldarb(r3, r3);
+  __ andr(r3, r3, ~JVM_CONSTANT_QDescBit);
 
   // unresolved class - get the resolved class
   __ cmp(r3, (u1)JVM_CONSTANT_UnresolvedClass);
@@ -808,6 +809,7 @@ void TemplateTable::aaload()
   // r0: array
   // r1: index
   index_check(r0, r1); // leaves index in r1, kills rscratch1
+  __ profile_array(r2, r0, r4);
   if (UseFlatArray) {
     Label is_flat_array, done;
 
@@ -823,6 +825,7 @@ void TemplateTable::aaload()
     __ add(r1, r1, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
     do_oop_load(_masm, Address(r0, r1, Address::uxtw(LogBytesPerHeapOop)), r0, IS_ARRAY);
   }
+  __ profile_element(r2, r0, r4);
 }
 
 void TemplateTable::baload()
@@ -1109,49 +1112,52 @@ void TemplateTable::dastore() {
 }
 
 void TemplateTable::aastore() {
-  Label is_null, ok_is_subtype, done;
+  Label is_null, is_flat_array, ok_is_subtype, done;
   transition(vtos, vtos);
   // stack: ..., array, index, value
   __ ldr(r0, at_tos());    // value
   __ ldr(r2, at_tos_p1()); // index
   __ ldr(r3, at_tos_p2()); // array
 
-  Address element_address(r3, r4, Address::uxtw(LogBytesPerHeapOop));
-
   index_check(r3, r2);     // kills r1
 
-  // FIXME: Could we remove the line below?
+  __ profile_array(r4, r3, r5);
+  __ profile_element(r4, r0, r5);
+
   __ add(r4, r2, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
+  Address element_address(r3, r4, Address::uxtw(LogBytesPerHeapOop));
+  // Be careful not to clobber r4 below
 
   // do array store check - check for NULL value first
   __ cbz(r0, is_null);
 
-  Label  is_flat_array;
+  // Move array class to r5
+  __ load_klass(r5, r3);
+
   if (UseFlatArray) {
-    __ test_flattened_array_oop(r3, r8 /*temp*/, is_flat_array);
+    __ ldrw(r6, Address(r5, Klass::layout_helper_offset()));
+    __ test_flattened_array_layout(r6, is_flat_array);
   }
 
   // Move subklass into r1
   __ load_klass(r1, r0);
 
-  // Move superklass into r0
-  __ load_klass(r0, r3);
-  __ ldr(r0, Address(r0, ObjArrayKlass::element_klass_offset()));
+  // Move array element superklass into r0
+  __ ldr(r0, Address(r5, ObjArrayKlass::element_klass_offset()));
   // Compress array + index*oopSize + 12 into a single register.  Frees r2.
 
   // Generate subtype check.  Blows r2, r5
   // Superklass in r0.  Subklass in r1.
 
-  __ gen_subtype_check(r1, ok_is_subtype);
+  // is "r1 <: r0" ? (value subclass <: array element superclass)
+  __ gen_subtype_check(r1, ok_is_subtype, false);
 
   // Come here on failure
   // object is at TOS
   __ b(Interpreter::_throw_ArrayStoreException_entry);
 
-
   // Come here on success
   __ bind(ok_is_subtype);
-
 
   // Get the value we will store
   __ ldr(r0, at_tos());
@@ -1161,12 +1167,10 @@ void TemplateTable::aastore() {
 
   // Have a NULL in r0, r3=array, r2=index.  Store NULL at ary[idx]
   __ bind(is_null);
-  __ profile_null_seen(r2);
-
   if (EnableValhalla) {
     Label is_null_into_value_array_npe, store_null;
 
-    // No way to store null in flat array
+    // No way to store null in flat null-free array
     __ test_null_free_array_oop(r3, r8, is_null_into_value_array_npe);
     __ b(store_null);
 
@@ -1182,9 +1186,7 @@ void TemplateTable::aastore() {
 
   if (EnableValhalla) {
      Label is_type_ok;
-
-    // store non-null value
-    __ bind(is_flat_array);
+    __ bind(is_flat_array); // Store non-null value to flat
 
     // Simplistic type check...
     // r0 - value, r2 - index, r3 - array.
@@ -1192,32 +1194,35 @@ void TemplateTable::aastore() {
     // Profile the not-null value's klass.
     // Load value class
      __ load_klass(r1, r0);
-     __ profile_typecheck(r2, r1, r0); // blows r2, and r0
+
+    // Move element klass into r7
+     __ ldr(r7, Address(r5, ArrayKlass::element_klass_offset()));
 
     // flat value array needs exact type match
-    // is "r8 == r0" (value subclass == array element superclass)
+    // is "r1 == r7" (value subclass == array element superclass)
 
-    // Move element klass into r0
-
-     __ load_klass(r0, r3);
-
-     __ ldr(r0, Address(r0, ArrayKlass::element_klass_offset()));
-     __ cmp(r0, r1);
+     __ cmp(r7, r1);
      __ br(Assembler::EQ, is_type_ok);
 
-     __ profile_typecheck_failed(r2);
      __ b(ExternalAddress(Interpreter::_throw_ArrayStoreException_entry));
 
      __ bind(is_type_ok);
+    // r1: value's klass
+    // r3: array
+    // r5: array klass
+    __ test_klass_is_empty_inline_type(r1, r7, done);
 
-    // Reload from TOS to be safe, because of profile_typecheck that blows r2 and r0.
-    // FIXME: Should we really do it?
-     __ ldr(r1, at_tos());  // value
-     __ mov(r2, r3); // array, ldr(r2, at_tos_p2());
-     __ ldr(r3, at_tos_p1()); // index
-     __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::value_array_store), r1, r2, r3);
+    // calc dst for copy
+    __ ldrw(r7, at_tos_p1()); // index
+    __ data_for_value_array_index(r3, r5, r7, r7);
+
+    // ...and src for copy
+    __ ldr(r6, at_tos());  // value
+    __ data_for_oop(r6, r6, r1);
+
+    __ mov(r4, r1);  // Shuffle arguments to avoid conflict with c_rarg1
+    __ access_value_copy(IN_HEAP, r6, r7, r4);
   }
-
 
   // Pop stack arguments
   __ bind(done);
@@ -2034,8 +2039,10 @@ void TemplateTable::if_acmp(Condition cc) {
   Label taken, not_taken;
   __ pop_ptr(r1);
 
-  Register is_value_mask = rscratch1;
-  __ mov(is_value_mask, markWord::always_locked_pattern);
+  __ profile_acmp(r2, r1, r0, r4);
+
+  Register is_inline_type_mask = rscratch1;
+  __ mov(is_inline_type_mask, markWord::inline_type_pattern);
 
   if (EnableValhalla) {
     __ cmp(r1, r0);
@@ -2047,11 +2054,11 @@ void TemplateTable::if_acmp(Condition cc) {
 
     // and both are values ?
     __ ldr(r2, Address(r1, oopDesc::mark_offset_in_bytes()));
-    __ andr(r2, r2, is_value_mask);
+    __ andr(r2, r2, is_inline_type_mask);
     __ ldr(r4, Address(r0, oopDesc::mark_offset_in_bytes()));
-    __ andr(r4, r4, is_value_mask);
+    __ andr(r4, r4, is_inline_type_mask);
     __ andr(r2, r2, r4);
-    __ cmp(r2,  is_value_mask);
+    __ cmp(r2,  is_inline_type_mask);
     __ br(Assembler::NE, (cc == equal) ? not_taken : taken);
 
     // same value klass ?
@@ -2074,7 +2081,7 @@ void TemplateTable::if_acmp(Condition cc) {
   __ bind(taken);
   branch(false, false);
   __ bind(not_taken);
-  __ profile_not_taken_branch(r0);
+  __ profile_not_taken_branch(r0, true);
 }
 
 void TemplateTable::invoke_is_substitutable(Register aobj, Register bobj,
@@ -2424,10 +2431,10 @@ void TemplateTable::load_field_cp_cache_entry(Register obj,
   ByteSize cp_base_offset = ConstantPoolCache::base_offset();
   // Field offset
   __ ldr(off, Address(cache, in_bytes(cp_base_offset +
-                                          ConstantPoolCacheEntry::f2_offset())));
+                                      ConstantPoolCacheEntry::f2_offset())));
   // Flags
   __ ldrw(flags, Address(cache, in_bytes(cp_base_offset +
-                                           ConstantPoolCacheEntry::flags_offset())));
+                                         ConstantPoolCacheEntry::flags_offset())));
 
   // klass overwrite register
   if (is_static) {
@@ -2525,6 +2532,8 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   const Register cache = r2;
   const Register index = r3;
   const Register obj   = r4;
+  const Register klass = r5;
+  const Register inline_klass = r7;
   const Register off   = r19;
   const Register flags = r0;
   const Register raw_flags = r6;
@@ -2556,6 +2565,11 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
 
   Label Done, notByte, notBool, notInt, notShort, notChar,
               notLong, notFloat, notObj, notDouble;
+
+  if (!is_static) {
+    __ ldr(klass, Address(cache, in_bytes(ConstantPoolCache::base_offset() +
+                                          ConstantPoolCacheEntry::f1_offset())));
+  }
 
   // x86 uses a shift and mask or wings it with a shift plus assert
   // the mask is not needed. aarch64 just uses bitfield extract
@@ -2602,29 +2616,38 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
     }
     __ b(Done);
   } else { // Valhalla
-
     if (is_static) {
       __ load_heap_oop(r0, field);
-      Label is_inline, isUninitialized;
+      Label is_inline_type, uninitialized;
       // Issue below if the static field has not been initialized yet
-      __ test_field_is_inline_type(raw_flags, r8 /*temp*/, is_inline);
-        // Not inline case
+      __ test_field_is_inline_type(raw_flags, noreg /*temp*/, is_inline_type);
+        // field is not an inline type
         __ push(atos);
         __ b(Done);
-      // Inline case, must not return null even if uninitialized
-      __ bind(is_inline);
-        __ cbz(r0, isUninitialized);
+      // field is an inline type, must not return null even if uninitialized
+      __ bind(is_inline_type);
+        __ cbz(r0, uninitialized);
           __ push(atos);
           __ b(Done);
-        __ bind(isUninitialized);
+        __ bind(uninitialized);
           __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
+          Label slow_case, finish;
+          // XXXNick: fastpath not correct below
+          __ b(slow_case); __ brk(1);
+          __ ldrb(rscratch1, Address(klass /* XXX */, InstanceKlass::init_state_offset()));
+          __ cmp(rscratch1, (u1)InstanceKlass::fully_initialized);
+          __ br(Assembler::NE, slow_case);
+          __ get_default_value_oop(klass, off /* temp */, r0);
+        __ b(finish);
+        __ bind(slow_case);
           __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_static_inline_type_field), obj, raw_flags);
+          __ bind(finish);
           __ verify_oop(r0);
           __ push(atos);
           __ b(Done);
     } else {
-      Label isFlattened, isInitialized, is_inline, rewrite_inline;
-        __ test_field_is_inline_type(raw_flags, r8 /*temp*/, is_inline);
+      Label is_inlined, nonnull, is_inline_type, rewrite_inline;
+      __ test_field_is_inline_type(raw_flags, noreg /*temp*/, is_inline_type);
         // Non-inline field case
         __ load_heap_oop(r0, field);
         __ push(atos);
@@ -2632,26 +2655,28 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
           patch_bytecode(Bytecodes::_fast_agetfield, bc, r1);
         }
         __ b(Done);
-      __ bind(is_inline);
-        __ test_field_is_inlined(raw_flags, r8 /* temp */, isFlattened);
-         // Non-inline field case
+      __ bind(is_inline_type);
+        __ test_field_is_inlined(raw_flags, noreg /* temp */, is_inlined);
+         // field is not inlined
           __ load_heap_oop(r0, field);
-          __ cbnz(r0, isInitialized);
+          __ cbnz(r0, nonnull);
             __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
-            __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_inline_type_field), obj, raw_flags);
-          __ bind(isInitialized);
+            __ get_inline_type_field_klass(klass, raw_flags, inline_klass);
+            __ get_default_value_oop(inline_klass, klass /* temp */, r0);
+          __ bind(nonnull);
           __ verify_oop(r0);
           __ push(atos);
           __ b(rewrite_inline);
-        __ bind(isFlattened);
-          __ ldr(r10, Address(cache, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::f1_offset())));
+        __ bind(is_inlined);
+        // field is inlined
           __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
-          call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_flattened_field), obj, raw_flags, r10);
+          __ mov(r0, obj);
+          __ read_inlined_field(klass, raw_flags, off, inline_klass /* temp */, r0);
           __ verify_oop(r0);
           __ push(atos);
       __ bind(rewrite_inline);
       if (rc == may_rewrite) {
-         patch_bytecode(Bytecodes::_fast_qgetfield, bc, r1);
+        patch_bytecode(Bytecodes::_fast_qgetfield, bc, r1);
       }
       __ b(Done);
     }
@@ -2827,6 +2852,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   const Register flags = r0;
   const Register flags2 = r6;
   const Register bc    = r4;
+  const Register inline_klass = r5;
 
   resolve_cache_and_index(byte_no, cache, index, sizeof(u2));
   jvmti_post_field_mod(cache, index, is_static);
@@ -2902,19 +2928,18 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
       }
       __ b(Done);
      } else { // Valhalla
-
       __ pop(atos);
       if (is_static) {
-        Label not_inline;
-         __ test_field_is_not_inline_type(flags2, r8 /* temp */, not_inline);
+        Label is_inline_type;
+         __ test_field_is_not_inline_type(flags2, noreg /* temp */, is_inline_type);
          __ null_check(r0);
-         __ bind(not_inline);
+         __ bind(is_inline_type);
          do_oop_store(_masm, field, r0, IN_HEAP);
          __ b(Done);
       } else {
-        Label is_inline, isFlattened, rewrite_not_inline, rewrite_inline;
-        __ test_field_is_inline_type(flags2, r8 /*temp*/, is_inline);
-        // Not inline case
+        Label is_inline_type, is_inlined, rewrite_not_inline, rewrite_inline;
+        __ test_field_is_inline_type(flags2, noreg /*temp*/, is_inline_type);
+        // Not an inline type
         pop_and_check_object(obj);
         // Store into the field
         do_oop_store(_masm, field, r0, IN_HEAP);
@@ -2923,18 +2948,23 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
           patch_bytecode(Bytecodes::_fast_aputfield, bc, r19, true, byte_no);
         }
         __ b(Done);
-        // Implementation of the inline semantic
-        __ bind(is_inline);
+        // Implementation of the inline type semantic
+        __ bind(is_inline_type);
         __ null_check(r0);
-        __ test_field_is_inlined(flags2, r8 /*temp*/, isFlattened);
-        // Not inline case
+        __ test_field_is_inlined(flags2, noreg /*temp*/, is_inlined);
+        // field is not inlined
         pop_and_check_object(obj);
         // Store into the field
         do_oop_store(_masm, field, r0, IN_HEAP);
         __ b(rewrite_inline);
-        __ bind(isFlattened);
+        __ bind(is_inlined);
+        // field is inlined
         pop_and_check_object(obj);
-        call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::write_flattened_value), r0, off, obj);
+        assert_different_registers(r0, inline_klass, obj, off);
+        __ load_klass(inline_klass, r0);
+        __ data_for_oop(r0, r0, inline_klass);
+        __ add(obj, obj, off);
+        __ access_value_copy(IN_HEAP, r0, obj, inline_klass);
         __ bind(rewrite_inline);
         if (rc == may_rewrite) {
           patch_bytecode(Bytecodes::_fast_qputfield, bc, r19, true, byte_no);
@@ -3164,14 +3194,18 @@ void TemplateTable::fast_storefield(TosState state)
   switch (bytecode()) {
   case Bytecodes::_fast_qputfield: //fall through
    {
-      Label isFlattened, done;
+      Label is_inlined, done;
       __ null_check(r0);
-      __ test_field_is_flattened(r3, r8 /* temp */, isFlattened);
-      // No Flattened case
+      __ test_field_is_inlined(r3, noreg /* temp */, is_inlined);
+      // field is not inlined
       do_oop_store(_masm, field, r0, IN_HEAP);
       __ b(done);
-      __ bind(isFlattened);
-      call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::write_flattened_value), r0, r1, r2);
+      __ bind(is_inlined);
+      // field is inlined
+      __ load_klass(r4, r0);
+      __ data_for_oop(r0, r0, r4);
+      __ lea(rscratch1, field);
+      __ access_value_copy(IN_HEAP, r0, rscratch1, r4);
       __ bind(done);
     }
     break;
@@ -3274,26 +3308,26 @@ void TemplateTable::fast_accessfield(TosState state)
   switch (bytecode()) {
   case Bytecodes::_fast_qgetfield:
     {
-       Label isFlattened, isInitialized, Done;
-       // FIXME: We don't need to reload registers multiple times, but stay close to x86 code
-       __ ldrw(r9, Address(r2, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset())));
-       __ test_field_is_inlined(r9, r8 /* temp */, isFlattened);
-        // Non-flattened field case
-        __ mov(r9, r0);
+      Register index = r4, klass = r5, inline_klass = r6;
+      Label is_inlined, nonnull, Done;
+      __ test_field_is_inlined(r3, noreg /* temp */, is_inlined);
+        // field is not inlined
         __ load_heap_oop(r0, field);
-        __ cbnz(r0, isInitialized);
-          __ mov(r0, r9);
-          __ ldrw(r9, Address(r2, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset())));
-          __ andw(r9, r9, ConstantPoolCacheEntry::field_index_mask);
-          __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_instance_inline_type_field), r0, r9);
-        __ bind(isInitialized);
+        __ cbnz(r0, nonnull);
+          __ andw(index, r3, ConstantPoolCacheEntry::field_index_mask);
+          __ ldr(klass, Address(r2, in_bytes(ConstantPoolCache::base_offset() +
+                                             ConstantPoolCacheEntry::f1_offset())));
+          __ get_inline_type_field_klass(klass, index, inline_klass);
+          __ get_default_value_oop(inline_klass, rscratch1 /* temp */, r0);
+        __ bind(nonnull);
         __ verify_oop(r0);
         __ b(Done);
-      __ bind(isFlattened);
-        __ ldrw(r9, Address(r2, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset())));
-        __ andw(r9, r9, ConstantPoolCacheEntry::field_index_mask);
-        __ ldr(r3, Address(r2, in_bytes(ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::f1_offset())));
-        call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::read_flattened_field), r0, r9, r3);
+      __ bind(is_inlined);
+      // field is inlined
+        __ andw(index, r3, ConstantPoolCacheEntry::field_index_mask);
+        __ ldr(klass, Address(r2, in_bytes(ConstantPoolCache::base_offset() +
+                                           ConstantPoolCacheEntry::f1_offset())));
+        __ read_inlined_field(klass, index, r1, inline_klass /* temp */, r0);
         __ verify_oop(r0);
       __ bind(Done);
     }
@@ -3728,6 +3762,7 @@ void TemplateTable::_new() {
   __ get_unsigned_2_byte_index_at_bcp(r3, 1);
   Label slow_case;
   Label done;
+  Label is_not_value;
   Label initialize_header;
   Label initialize_object; // including clearing the fields
 
@@ -3745,95 +3780,22 @@ void TemplateTable::_new() {
   // get InstanceKlass
   __ load_resolved_klass_at_offset(r4, r3, r4, rscratch1);
 
+  __ ldrb(rscratch1, Address(r4, InstanceKlass::kind_offset()));
+  __ cmp(rscratch1, (u1)InstanceKlass::_kind_inline_type);
+  __ br(Assembler::NE, is_not_value);
+
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::throw_InstantiationError));
+
+  __ bind(is_not_value);
+
   // make sure klass is initialized & doesn't have finalizer
   // make sure klass is fully initialized
   __ ldrb(rscratch1, Address(r4, InstanceKlass::init_state_offset()));
   __ cmp(rscratch1, (u1)InstanceKlass::fully_initialized);
   __ br(Assembler::NE, slow_case);
 
-  // get instance_size in InstanceKlass (scaled to a count of bytes)
-  __ ldrw(r3,
-          Address(r4,
-                  Klass::layout_helper_offset()));
-  // test to see if it has a finalizer or is malformed in some way
-  __ tbnz(r3, exact_log2(Klass::_lh_instance_slow_path_bit), slow_case);
-
-  // Allocate the instance:
-  //  If TLAB is enabled:
-  //    Try to allocate in the TLAB.
-  //    If fails, go to the slow path.
-  //  Else If inline contiguous allocations are enabled:
-  //    Try to allocate in eden.
-  //    If fails due to heap end, go to slow path.
-  //
-  //  If TLAB is enabled OR inline contiguous is enabled:
-  //    Initialize the allocation.
-  //    Exit.
-  //
-  //  Go to slow path.
-  const bool allow_shared_alloc =
-    Universe::heap()->supports_inline_contig_alloc();
-
-  if (UseTLAB) {
-    __ tlab_allocate(r0, r3, 0, noreg, r1, slow_case);
-
-    if (ZeroTLAB) {
-      // the fields have been already cleared
-      __ b(initialize_header);
-    } else {
-      // initialize both the header and fields
-      __ b(initialize_object);
-    }
-  } else {
-    // Allocation in the shared Eden, if allowed.
-    //
-    // r3: instance size in bytes
-    if (allow_shared_alloc) {
-      __ eden_allocate(r0, r3, 0, r10, slow_case);
-    }
-  }
-
-  // If UseTLAB or allow_shared_alloc are true, the object is created above and
-  // there is an initialize need. Otherwise, skip and go to the slow path.
-  if (UseTLAB || allow_shared_alloc) {
-    // The object is initialized before the header.  If the object size is
-    // zero, go directly to the header initialization.
-    __ bind(initialize_object);
-    __ sub(r3, r3, sizeof(oopDesc));
-    __ cbz(r3, initialize_header);
-
-    // Initialize object fields
-    {
-      __ add(r2, r0, sizeof(oopDesc));
-      Label loop;
-      __ bind(loop);
-      __ str(zr, Address(__ post(r2, BytesPerLong)));
-      __ sub(r3, r3, BytesPerLong);
-      __ cbnz(r3, loop);
-    }
-
-    // initialize object header only.
-    __ bind(initialize_header);
-    if (UseBiasedLocking) {
-      __ ldr(rscratch1, Address(r4, Klass::prototype_header_offset()));
-    } else {
-      __ mov(rscratch1, (intptr_t)markWord::prototype().value());
-    }
-    __ str(rscratch1, Address(r0, oopDesc::mark_offset_in_bytes()));
-    __ store_klass_gap(r0, zr);  // zero klass gap for compressed oops
-    __ store_klass(r0, r4);      // store klass last
-
-    {
-      SkipIfEqual skip(_masm, &DTraceAllocProbes, false);
-      // Trigger dtrace event for fastpath
-      __ push(atos); // save the return value
-      __ call_VM_leaf(
-           CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_object_alloc), r0);
-      __ pop(atos); // restore the return value
-
-    }
-    __ b(done);
-  }
+  __ allocate_instance(r4, r0, r3, r1, true, slow_case);
+  __ b(done);
 
   // slow case
   __ bind(slow_case);
@@ -3912,6 +3874,7 @@ void TemplateTable::checkcast()
   __ add(rscratch1, r3, Array<u1>::base_offset_in_bytes());
   __ lea(r1, Address(rscratch1, r19));
   __ ldarb(r1, r1);
+  __ andr(r1, r1, ~JVM_CONSTANT_QDescBit);
   __ cmp(r1, (u1)JVM_CONSTANT_Class);
   __ br(Assembler::EQ, quicked);
 
@@ -3981,6 +3944,7 @@ void TemplateTable::instanceof() {
   __ add(rscratch1, r3, Array<u1>::base_offset_in_bytes());
   __ lea(r1, Address(rscratch1, r19));
   __ ldarb(r1, r1);
+  __ andr(r1, r1, ~JVM_CONSTANT_QDescBit);
   __ cmp(r1, (u1)JVM_CONSTANT_Class);
   __ br(Assembler::EQ, quicked);
 
@@ -4086,6 +4050,10 @@ void TemplateTable::monitorenter()
 
   __ resolve(IS_NOT_NULL, r0);
 
+  Label is_inline_type;
+  __ ldr(rscratch1, Address(r0, oopDesc::mark_offset_in_bytes()));
+  __ test_markword_is_inline_type(rscratch1, is_inline_type);
+
   const Address monitor_block_top(
         rfp, frame::interpreter_frame_monitor_block_top_offset * wordSize);
   const Address monitor_block_bot(
@@ -4175,6 +4143,11 @@ void TemplateTable::monitorenter()
   // The bcp has already been incremented. Just need to dispatch to
   // next instruction.
   __ dispatch_next(vtos);
+
+  __ bind(is_inline_type);
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address,
+                    InterpreterRuntime::throw_illegal_monitor_state_exception));
+  __ should_not_reach_here();
 }
 
 
@@ -4186,6 +4159,18 @@ void TemplateTable::monitorexit()
   __ null_check(r0);
 
   __ resolve(IS_NOT_NULL, r0);
+
+  const int is_inline_type_mask = markWord::inline_type_pattern;
+  Label has_identity;
+  __ ldr(rscratch1, Address(r0, oopDesc::mark_offset_in_bytes()));
+  __ mov(rscratch2, is_inline_type_mask);
+  __ andr(rscratch1, rscratch1, rscratch2);
+  __ cmp(rscratch1, rscratch2);
+  __ br(Assembler::NE, has_identity);
+  __ call_VM(noreg, CAST_FROM_FN_PTR(address,
+                     InterpreterRuntime::throw_illegal_monitor_state_exception));
+  __ should_not_reach_here();
+  __ bind(has_identity);
 
   const Address monitor_block_top(
         rfp, frame::interpreter_frame_monitor_block_top_offset * wordSize);

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2632,9 +2632,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
         __ bind(uninitialized);
           __ andw(raw_flags, raw_flags, ConstantPoolCacheEntry::field_index_mask);
           Label slow_case, finish;
-          // XXXNick: fastpath not correct below
-          __ b(slow_case); __ brk(1);
-          __ ldrb(rscratch1, Address(klass /* XXX */, InstanceKlass::init_state_offset()));
+          __ ldrb(rscratch1, Address(cache, InstanceKlass::init_state_offset()));
           __ cmp(rscratch1, (u1)InstanceKlass::fully_initialized);
           __ br(Assembler::NE, slow_case);
           __ get_default_value_oop(klass, off /* temp */, r0);

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,9 +139,13 @@ int MacroAssembler::unpack_inline_args(Compile* C, bool receiver_only) {
     // 16-byte aligned) and copy the return address to the new top of the stack.
     // The stack will be repaired on return (see MacroAssembler::remove_frame).
     assert(sp_inc > 0, "sanity");
+#ifdef X86
     pop(r13);
     subptr(rsp, sp_inc);
     push(r13);
+#else
+    Unimplemented();
+#endif
   }
   shuffle_inline_args(false, receiver_only, sig,
                       args_passed, args_on_stack, regs,           // from

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1727,14 +1727,8 @@ LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& inde
   }
 #endif
 
-#ifdef AARCH64
-  // XXXNick: remove this hack - call generate_address() instead?
-  __ add(index_op, LIR_OprFact::intptrConst(array_header_size), index_op);
-  array_header_size = 0;
-#endif
-
   LIR_Opr elm_op = new_pointer_register();
-  LIR_Address* elm_address = new LIR_Address(array.result(), index_op, array_header_size, T_ADDRESS);
+  LIR_Address* elm_address = generate_address(array.result(), index_op, 0, array_header_size, T_ADDRESS);
   __ leal(LIR_OprFact::address(elm_address), elm_op);
   return elm_op;
 }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1727,6 +1727,12 @@ LIR_Opr LIRGenerator::get_and_load_element_address(LIRItem& array, LIRItem& inde
   }
 #endif
 
+#ifdef AARCH64
+  // XXXNick: remove this hack - call generate_address() instead?
+  __ add(index_op, LIR_OprFact::intptrConst(array_header_size), index_op);
+  array_header_size = 0;
+#endif
+
   LIR_Opr elm_op = new_pointer_register();
   LIR_Address* elm_address = new LIR_Address(array.result(), index_op, array_header_size, T_ADDRESS);
   __ leal(LIR_OprFact::address(elm_address), elm_op);


### PR DESCRIPTION
This patch updates the original AArch64 lworld port from December 2019 to match the x86 C1/C2/interpreter changes since then. It doesn't support InlineTypePassFieldsAsArgs or InlineTypeReturnedAsFields: this can be added later.

Known issues:

* compiler/valhalla/inlinetypes/TestLWorld test9 fails with an internal C2 error:

```
  #  Internal Error (/home/nicgas01/valhalla/src/hotspot/share/opto/buildOopMap.cpp:360), pid=2011, tid=2025
  #  assert(false) failed: there should be a oop in OopMap instead of a live raw oop at safepoint
```

  I haven't investigated this but it doesn't seem to be related to any of the platform specific code. I'll make a separate JBS issue for it.

* compiler/valhalla/inlinetypes/TestArrays.java and TestNullableArrays.java fail some sub-tests with:

```
  stderr: [OpenJDK 64-Bit Server VM warning: InlineTypePassFieldsAsArgs is not supported on this platform
  OpenJDK 64-Bit Server VM warning: InlineTypeReturnedAsFields is not supported on this platform
  Exception in thread "main" java.lang.RuntimeException: Graph for 'TestNullableArrays::test1' contains different number of match nodes (expected 1 but got 0):
  : expected 1 to equal 0
  	at jdk.test.lib.Asserts.fail(Asserts.java:594)
  	at jdk.test.lib.Asserts.assertEquals(Asserts.java:205)
  	at jdk.test.lib.Asserts.assertEQ(Asserts.java:178)
  	at compiler.valhalla.inlinetypes.InlineTypeTest.parseOutput(InlineTypeTest.java:600)
  	at compiler.valhalla.inlinetypes.InlineTypeTest.execute_vm(InlineTypeTest.java:482)
  	at compiler.valhalla.inlinetypes.InlineTypeTest.run(InlineTypeTest.java:436)
  	at compiler.valhalla.inlinetypes.TestNullableArrays.main(TestNullableArrays.java:58)
  ]
```

  I think this is related to not implementing passing/returning fields.

* compiler/valhalla/inlinetypes/TestBufferTearing.java fails intermittently. I haven't investigated this and will make a separate JBS issue for it.

This patch includes two changes that I also submitted to openjdk/jdk:
* https://github.com/openjdk/jdk/commit/f7e0a09802f74
* https://github.com/openjdk/jdk/commit/be67aaabe63a

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8258038](https://bugs.openjdk.java.net/browse/JDK-8258038): [AARCH64] [lworld] Fix inline type implementation


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/valhalla pull/353/head:pull/353`
`$ git checkout pull/353`

To update a local copy of the PR:
`$ git checkout pull/353`
`$ git pull https://git.openjdk.java.net/valhalla pull/353/head`
