### PR TITLE
8262746: [lworld] jcmd VM.class_print_layout crash due to NULL cld name

### DIFF
--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -630,7 +630,7 @@ void PrintClassLayout::print_class_layout(outputStream* st, char* class_name) {
     InstanceKlass* ik = InstanceKlass::cast(klass);
     int tab = 1;
     st->print_cr("Class %s [@%s]:", klass->name()->as_C_string(),
-        klass->class_loader_data()->name()->as_C_string());
+        klass->class_loader_data()->loader_name());
     ResourceMark rm;
     GrowableArray<FieldDesc>* fields = new (ResourceObj::C_HEAP, mtServiceability) GrowableArray<FieldDesc>(100, mtServiceability);
     for (FieldStream fd(ik, false, false); !fd.eos(); fd.next()) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package runtime.valhalla.inlinetypes;
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.JDKToolFinder;
+
+/*
+ * @test
+ * @summary Test the VM.class_print_layout command
+ * @library /test/lib
+ * @compile ClassPrintLayoutDcmd.java Point.java
+ * @run main/othervm runtime.valhalla.inlinetypes.ClassPrintLayoutDcmd
+ */
+
+public primitive class ClassPrintLayoutDcmd {
+    static primitive class Line {
+        Point p1, p2;
+        Line() {
+            this.p1 = this.p2 = Point.createPoint(0, 1);
+        }
+    }
+    static {
+        try {
+            Class.forName(Line.class.getName());
+        } catch(Throwable e) {
+            throw new RuntimeException("failed to find class");
+        }
+    }
+    static ProcessBuilder pb = new ProcessBuilder();
+
+    static void testCmd(String arg, int expectExitCode, String... expectStrings) throws Exception {
+        // Grab my own PID
+        String pid = Long.toString(ProcessTools.getProcessId());
+
+        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.class_print_layout", arg });
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(expectExitCode);
+        for (String expectString : expectStrings) {
+            output.shouldContain(expectString);
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        testCmd("foo/bar", 0, "");
+        testCmd("", 1, "IllegalArgumentException", "mandatory");
+        testCmd("java/lang/Object", 0, "java/lang/Object", "@bootstrap");
+        testCmd("java/lang/Class", 0, "java/lang/Class", "@bootstrap");
+        testCmd("runtime/valhalla/inlinetypes/ClassPrintLayoutDcmd$Line", 0, "@app", "p1", "p2");
+    }
+}


### PR DESCRIPTION
Hi, can I have a review of this one-line fix?

jcmd VM.class_print_layout crashes when printing classes which loaded by bootstrap loader since these classes has NULL class_loder_data()->name().

But actually, I wonder to know why we don't print the layout by modifications of existing functions in FieldLayoutBuilder::build_layout directly? It seems FieldLayoutBuilder can gather more complete layout information.

Thanks,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262746](https://bugs.openjdk.java.net/browse/JDK-8262746): [lworld] jcmd VM.class_print_layout crash due to NULL cld name


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/354/head:pull/354`
`$ git checkout pull/354`
