### PR TITLE
8262747: [lworld] C1 compilation fails when PinAllInstructions is turned on

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1755,7 +1755,11 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
     __ branch(lir_cond_notEqual, L_end->label());
     set_in_conditional_code(true);
     Constant* default_value = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
-    __ move(load_constant(default_value), result);
+    if (default_value->is_pinned()) {
+      __ move(LIR_OprFact::value_type(default_value->type()), result);
+    } else {
+      __ move(load_constant(default_value), result);
+    }
     __ branch_destination(L_end->label());
     set_in_conditional_code(false);
   }
@@ -2159,7 +2163,11 @@ void LIRGenerator::do_LoadField(LoadField* x) {
     __ branch(lir_cond_notEqual, L_end->label());
     set_in_conditional_code(true);
     Constant* default_value = new Constant(new InstanceConstant(inline_klass->default_instance()));
-    __ move(load_constant(default_value), result);
+    if (default_value->is_pinned()) {
+      __ move(LIR_OprFact::value_type(default_value->type()), result);
+    } else {
+      __ move(load_constant(default_value), result);
+    }
     __ branch_destination(L_end->label());
     set_in_conditional_code(false);
   }
@@ -2309,7 +2317,11 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
     ciInlineKlass* elem_klass = x->array()->declared_type()->as_flat_array_klass()->element_klass()->as_inline_klass();
     LIR_Opr result = rlock_result(x, x->elt_type());
     Constant* default_value = new Constant(new InstanceConstant(elem_klass->default_instance()));
-    __ move(load_constant(default_value), result);
+    if (default_value->is_pinned()) {
+      __ move(LIR_OprFact::value_type(default_value->type()), result);
+    } else {
+      __ move(load_constant(default_value), result);
+    }
   } else {
     LIR_Opr result = rlock_result(x, x->elt_type());
     LoadFlattenedArrayStub* slow_path = NULL;


### PR DESCRIPTION
When turning on the -XX:+PinAllInstructions, C1 hits the following assertion:

````
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/qingfeng.yy/valhalla/src/hotspot/share/c1/c1_LIRGenerator.cpp:1524), pid=81974, tid=81994
#  assert(!x->is_pinned()) failed: only for unpinned constants
...
Stack: [0x00007fc0771fa000,0x00007fc0772fb000],  sp=0x00007fc0772f89f0,  free space=1018k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x65de6c]  LIRGenerator::load_constant(Constant*)+0x2a
V  [libjvm.so+0x65ee4b]  LIRGenerator::access_sub_element(LIRItem&, LIRItem&, LIR_OprDesc*&, ciField*, int)+0x319
V  [libjvm.so+0x66209c]  LIRGenerator::do_LoadIndexed(LoadIndexed*)+0x846
V  [libjvm.so+0x6277c4]  LoadIndexed::visit(InstructionVisitor*)+0x2e
V  [libjvm.so+0x6586ae]  LIRGenerator::do_root(Instruction*)+0xfc
V  [libjvm.so+0x65856e]  LIRGenerator::block_do(BlockBegin*)+0x7c
V  [libjvm.so+0x62696d]  BlockList::iterate_forward(BlockClosure*)+0x5d
V  [libjvm.so+0x61ee24]  IR::iterate_linear_scan_order(BlockClosure*)+0x2e
V  [libjvm.so+0x5ee90b]  Compilation::emit_lir()+0x95
V  [libjvm.so+0x5ef140]  Compilation::compile_java_method()+0x21e
V  [libjvm.so+0x5ef4af]  Compilation::compile_method()+0x107
V  [libjvm.so+0x5efd05]  Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*, bool, DirectiveSet*)+0x3bb
V  [libjvm.so+0x5f3baf]  Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*)+0xd9
V  [libjvm.so+0x81a938]  CompileBroker::invoke_compiler_on_method(CompileTask*)+0x88a
V  [libjvm.so+0x81956b]  CompileBroker::compiler_thread_loop()+0x3df
V  [libjvm.so+0x83bef1]  CompilerThread::thread_entry(JavaThread*, Thread*)+0x69
V  [libjvm.so+0x12fd598]  JavaThread::thread_main_inner()+0x14c
V  [libjvm.so+0x12fd444]  JavaThread::run()+0x11e
V  [libjvm.so+0x12fa630]  Thread::call_run()+0x180
V  [libjvm.so+0x1028936]  thread_native_entry(Thread*)+0x1e4
````

The root cause of this crash is because LIRGenerator::access_sub_element() uses LIRGenerator::load_constant() to load the default value of a primitive class type(constant) into a register, load_constant requires unpinned constant instr, so it unquestionably crashes when PinAllInstructions is enabled.

This problem also occurred in many places under `test/hotspot/jtreg/compiler/valhalla`. After applying this patch, they all passed with slowdebug build.

Thanks,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262747](https://bugs.openjdk.java.net/browse/JDK-8262747): [lworld] C1 compilation fails when PinAllInstructions is turned on


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/355/head:pull/355`
`$ git checkout pull/355`
