### PR TITLE
8262748: [lworld] print out reason information for Deoptimize instruction

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2058,7 +2058,7 @@ void GraphBuilder::withfield(int field_index)
   Value obj = apop();
 
   if (!holder->is_loaded()) {
-    apush(append_split(new Deoptimize(state_before)));
+    apush(append_split(new Deoptimize(holder, state_before)));
     return;
   }
 
@@ -2492,7 +2492,7 @@ void GraphBuilder::default_value(int klass_index) {
     ciInlineKlass* vk = klass->as_inline_klass();
     apush(append(new Constant(new InstanceConstant(vk->default_instance()))));
   } else {
-    apush(append_split(new Deoptimize(copy_state_before())));
+    apush(append_split(new Deoptimize(klass, copy_state_before())));
   }
 }
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -1520,9 +1520,15 @@ LEAF(NewMultiArray, NewArray)
 };
 
 LEAF(Deoptimize, StateSplit)
+private:
+  ciKlass*    _klass;
+
  public:
-  Deoptimize(ValueStack* state_before)
-  : StateSplit(objectType, state_before) {}
+  Deoptimize(ciKlass* klass, ValueStack* state_before)
+  : StateSplit(objectType, state_before), _klass(klass) {}
+
+  // accessors
+  ciKlass* klass() const                         { return _klass; }
 };
 
 BASE(TypeCheck, StateSplit)

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -542,7 +542,9 @@ void InstructionPrinter::do_NewMultiArray(NewMultiArray* x) {
 }
 
 void InstructionPrinter::do_Deoptimize(Deoptimize* x) {
-  output()->print("deoptimize");
+  output()->print("deoptimize [unloaded=");
+  print_klass(x->klass());
+  output()->print("] ");
 }
 
 void InstructionPrinter::do_MonitorEnter(MonitorEnter* x) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2346,6 +2346,9 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
 }
 
 void LIRGenerator::do_Deoptimize(Deoptimize* x) {
+  // This happens only when a class X uses the withfield/defaultvalue bytecode
+  // to refer to an inline class V, where V has not yet been loaded/resolved.
+  // This is not a common case. Let's just deoptimize.
   CodeEmitInfo* info = state_for(x, x->state_before());
   CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                       Deoptimization::Reason_unloaded,


### PR DESCRIPTION
The instruction printer only tells that there is a deoptimization instruction, but not indicates they are deoptimized due to which class is not loaded.

```
Java
----
static void test1(Object[] arr) {
	TestValue v = TestValue.default;
	arr[0] = v;
}
HIR(OLD)
---
. 0    2    a2     deoptimize
. 5    1    i3     0
. 7    0    a4     a1[i3] := a2 (L) [rc] What's the type of a2?
. 8    0    v5     return
HIR(NEW)
---
. 0    2    a2     deoptimize [unloaded=Test$TestValue]
. 5    1    i3     0
. 7    0    a4     a1[i3] := a2 (L) [rc]
. 8    0    v5     return
```

In addition, I restore some comments on LIRGenerator::do_Deoptimize, I'm not sure whether these comments were removed deliberately or accidentally, so please let me know if I did wrong. 

Thanks!
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262748](https://bugs.openjdk.java.net/browse/JDK-8262748): [lworld] print out reason information for Deoptimize instruction


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/356/head:pull/356`
`$ git checkout pull/356`
