### PR TITLE
8262863: [lworld] C2 should keep track of the oop even if an inline type is returned as fields

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2374,7 +2374,7 @@ encode %{
       __ int3();
       __ bind(L);
     }
-    if (tf()->returns_inline_type_as_fields()) {
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
       // An inline type is returned as fields in multiple registers.
       // Rax either contains an oop if the inline type is buffered or a pointer
       // to the corresponding InlineKlass with the lowest bit set to 1. Zero rax

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2374,6 +2374,18 @@ encode %{
       __ int3();
       __ bind(L);
     }
+    if (tf()->returns_inline_type_as_fields()) {
+      // An inline type is returned as fields in multiple registers.
+      // Rax either contains an oop if the inline type is buffered or a pointer
+      // to the corresponding InlineKlass with the lowest bit set to 1. Zero rax
+      // if the lowest bit is set to allow C2 to use the oop after null checking.
+      // rax &= (rax & 1) - 1
+      C2_MacroAssembler _masm(&cbuf);
+      __ movptr(rscratch1, rax);
+      __ andptr(rscratch1, 0x1);
+      __ subptr(rscratch1, 0x1);
+      __ andptr(rax, rscratch1);
+    }
   %}
 
 %}

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1101,7 +1101,6 @@ bool LIR_OpJavaCall::maybe_return_as_fields(ciInlineKlass** vk_ret) const {
         // (RAX on x64, with LSB set to 1) and we need to allocate an inline
         // type instance of that type and initialize it with other values being
         // returned (in other registers).
-        // type.
         if (vk_ret != NULL) {
           *vk_ret = NULL;
         }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2019,7 +2019,10 @@ void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes
 
   // Replace the result with the new result if it exists and is used
   if (callprojs->resproj[0] != NULL && result != NULL) {
-    assert(callprojs->nb_resproj == 1, "unexpected number of results");
+    // If the inlined code is dead, the result projections for an inline type returned as
+    // fields have not been replaced. They will go away once the call is replaced by TOP below.
+    assert(callprojs->nb_resproj == 1 || (call->tf()->returns_inline_type_as_fields() && stopped()),
+           "unexpected number of results");
     C->gvn_replace_by(callprojs->resproj[0], result);
   }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1897,7 +1897,7 @@ Node* GraphKit::set_results_for_java_call(CallJavaNode* call, bool separate_io_p
     // Return of multiple values (inline type fields): we create a
     // InlineType node, each field is a projection from the call.
     ciInlineKlass* vk = call->method()->return_type()->as_inline_klass();
-    uint base_input = TypeFunc::Parms + 1;
+    uint base_input = TypeFunc::Parms;
     ret = InlineTypeNode::make_from_multi(this, call, vk, base_input, false);
   } else {
     ret = _gvn.transform(new ProjNode(call, TypeFunc::Parms));

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -708,9 +708,10 @@ class GraphKit : public Phase {
       assert(!recv_type->maybe_null(), "should never be null");
       InlineTypeNode* vt = InlineTypeNode::make_from_oop(this, n, recv_type->inline_klass());
       set_argument(0, vt);
-      if (replace_value && !Compile::current()->inlining_incrementally()) {
+      if (replace_value && is_Parse()) {
         // Only replace in map if we are not incrementally inlining because we
         // share a map with the caller which might expect the inline type as oop.
+        assert(!Compile::current()->inlining_incrementally(), "sanity");
         replace_in_map(n, vt);
       }
       n = vt;

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -621,6 +621,11 @@ InlineTypeNode* InlineTypeNode::make_from_flattened(GraphKit* kit, ciInlineKlass
 
 InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi, ciInlineKlass* vk, uint& base_input, bool in) {
   InlineTypeNode* vt = make_uninitialized(kit->gvn(), vk);
+  if (!in) {
+    // Keep track of the oop. The returned inline type might already be buffered.
+    Node* oop = kit->gvn().transform(new ProjNode(multi, base_input++));
+    vt->set_oop(oop);
+  }
   vt->initialize_fields(kit, multi, base_input, in);
   return kit->gvn().transform(vt)->as_InlineType();
 }

--- a/src/hotspot/share/opto/replacednodes.cpp
+++ b/src/hotspot/share/opto/replacednodes.cpp
@@ -145,6 +145,7 @@ void ReplacedNodes::apply(Compile* C, Node* ctl) {
       enqueue_use(initial, use, work);
       bool replace = true;
       // Check that this use is dominated by ctl. Go ahead with the replacement if it is.
+      DEBUG_ONLY(uint loop_count = 0);
       while (work.size() != 0 && replace) {
         Node* n = work.pop();
         if (use->outcnt() == 0) {
@@ -174,6 +175,7 @@ void ReplacedNodes::apply(Compile* C, Node* ctl) {
             enqueue_use(n, n->out(k), work);
           }
         }
+        assert(loop_count++ < K, "infinite loop in ReplacedNodes::apply");
       }
       if (replace) {
         bool is_in_table = C->initial_gvn()->hash_delete(use);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2115,8 +2115,7 @@ const TypeTuple *TypeTuple::make_range(ciSignature* sig, bool ret_vt_fields) {
   case T_INLINE_TYPE:
     if (ret_vt_fields) {
       uint pos = TypeFunc::Parms;
-      field_array[pos] = TypePtr::BOTTOM;
-      pos++;
+      field_array[pos++] = get_const_type(return_type);
       collect_inline_fields(return_type->as_inline_klass(), field_array, pos);
     } else {
       field_array[TypeFunc::Parms] = get_const_type(return_type)->join_speculative(TypePtr::NOTNULL);


### PR DESCRIPTION
If an inline type is returned, its fields are passed in registers if possible. The first register (rax) either contains a pointer to the InlineKlass to allow buffering in interpreted or C1 compiled callers or an oop if the inline type has already been buffered. Currently, a C2 compiled caller completely ignores the first register and just uses the field values returned in the other registers.

With this patch, C2 checks if an oop is returned and keeps track of it to avoid unnecessary re-buffering. This significantly boosts performance of cases were inlining fails and the callee is interpreted, C1 compiled or had to buffer the inline type for another reason (for example, due a store to a non-flattened field/array).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262863](https://bugs.openjdk.java.net/browse/JDK-8262863): [lworld] C2 should keep track of the oop even if an inline type is returned as fields


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/357/head:pull/357`
`$ git checkout pull/357`
