### PR TITLE
8262287: [lworld] C2 compilation fails with assert "should have been removed from the graph"

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1064,10 +1064,14 @@ void PhiNode::verify_adr_type(bool recursive) const {
   if (Node::in_dump())               return;  // muzzle asserts when printing
 
   assert((_type == Type::MEMORY) == (_adr_type != NULL), "adr_type for memory phis only");
+  // Flat array element shouldn't get their own memory slice until flattened_accesses_share_alias is cleared.
+  // It could be the graph has no loads/stores and flattened_accesses_share_alias is never cleared. EA could still
+  // creates per element Phis but that wouldn't be a problem as there are no memory accesses for that array.
   assert(_adr_type == NULL || _adr_type->isa_aryptr() == NULL ||
          _adr_type->is_aryptr()->is_known_instance() ||
          !_adr_type->is_aryptr()->is_flat() ||
-         !Compile::current()->flattened_accesses_share_alias() || _adr_type == TypeAryPtr::INLINES, "");
+         !Compile::current()->flattened_accesses_share_alias() ||
+         _adr_type == TypeAryPtr::INLINES, "flat array element shouldn't get its own slice yet");
 
   if (!VerifyAliases)       return;  // verify thoroughly only if requested
 

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1064,6 +1064,10 @@ void PhiNode::verify_adr_type(bool recursive) const {
   if (Node::in_dump())               return;  // muzzle asserts when printing
 
   assert((_type == Type::MEMORY) == (_adr_type != NULL), "adr_type for memory phis only");
+  assert(_adr_type == NULL || _adr_type->isa_aryptr() == NULL ||
+         _adr_type->is_aryptr()->is_known_instance() ||
+         !_adr_type->is_aryptr()->is_flat() ||
+         !Compile::current()->flattened_accesses_share_alias() || _adr_type == TypeAryPtr::INLINES, "");
 
   if (!VerifyAliases)       return;  // verify thoroughly only if requested
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4028,6 +4028,9 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
           int off_in_vt = field->offset() - vk->first_field_offset();
           const TypePtr* adr_type = arytype->with_field_offset(off_in_vt)->add_offset(Type::OffsetBot);
           int fieldidx = C->get_alias_index(adr_type, true);
+          // Pass NULL for init_out. Having per flat array element field memory edges as uses of the Initialize node
+          // can result in per flat array field Phis to be created which confuses the logic of
+          // Compile::adjust_flattened_array_access_aliases().
           hook_memory_on_init(*this, fieldidx, minit_in, NULL);
         }
         C->set_flattened_accesses_share_alias(true);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3962,7 +3962,9 @@ static void hook_memory_on_init(GraphKit& kit, int alias_idx,
 
   Node* prevmem = kit.memory(alias_idx);
   init_in_merge->set_memory_at(alias_idx, prevmem);
-  kit.set_memory(init_out_raw, alias_idx);
+  if (init_out_raw != NULL) {
+    kit.set_memory(init_out_raw, alias_idx);
+  }
 }
 
 //---------------------------set_output_for_allocation-------------------------
@@ -4026,7 +4028,7 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
           int off_in_vt = field->offset() - vk->first_field_offset();
           const TypePtr* adr_type = arytype->with_field_offset(off_in_vt)->add_offset(Type::OffsetBot);
           int fieldidx = C->get_alias_index(adr_type, true);
-          hook_memory_on_init(*this, fieldidx, minit_in, minit_out);
+          hook_memory_on_init(*this, fieldidx, minit_in, NULL);
         }
         C->set_flattened_accesses_share_alias(true);
         hook_memory_on_init(*this, C->get_alias_index(TypeAryPtr::INLINES), minit_in, minit_out);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1218,6 +1218,7 @@ Type::Category Type::category() const {
     case Type::DoubleTop:
     case Type::DoubleCon:
     case Type::DoubleBot:
+    case Type::InlineType:
       return Category::Data;
     case Type::Memory:
       return Category::Memory;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -53,6 +53,11 @@ primitive class MyValue3 {
     float[] floatArray = new float[1];
 }
 
+primitive class MyValue4 {
+    short b = 2;
+    int c = 8;
+}
+
 public class TestGenerated {
     EmptyValue f1 = new EmptyValue();
     EmptyValue f2 = new EmptyValue();
@@ -157,6 +162,26 @@ public class TestGenerated {
         }
     }
 
+    MyValue4[] d = {new MyValue4()};
+    MyValue4 e;
+    byte f;
+    byte test12() {
+        MyValue4 i = new MyValue4();
+        for (int j = 0; j < 6; ++j) {
+            MyValue4[] k = {};
+            if (i.b < 0101)
+                i = e;
+            for (int l = 0; l < 9; ++l) {
+                MyValue4 m = new MyValue4();
+                i = m;
+            }
+        }
+        if (d[0].c > 1)
+            for (int n = 0; n < 7; ++n)
+                ;
+        return f;
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -177,6 +202,7 @@ public class TestGenerated {
             t.test9(true);
             t.test10(array4);
             t.test11(array4);
+            t.test12();
         }
     }
 }


### PR DESCRIPTION
hook_memory_on_init() sets up memory edges so stores can be captured
at an allocation. To do that, it adds extra edges for each field after
and before the InitializeNode. This also happens for flat arrays
eventhough until Compile::adjust_flattened_array_access_aliases() runs
there's a single slice for all fields of a flat array element. The
extra edges added after the InitalizeNode can cause PhiNodes to be
created for each fields of the array element which confuses
Compile::adjust_flattened_array_access_aliases() (because it expects
no Phi for individual fields until it runs). I don't think the memory
edges out of the InitializeNode are needed as
Compile::adjust_flattened_array_access_aliases() should create
them. So I propose not adding them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262287](https://bugs.openjdk.java.net/browse/JDK-8262287): [lworld] C2 compilation fails with assert "should have been removed from the graph"


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/361/head:pull/361`
`$ git checkout pull/361`
