### PR TITLE
javac support for Parametric VM, first stab

### DIFF
--- a/src/java.base/share/classes/java/lang/annotation/LinkageClass.java
+++ b/src/java.base/share/classes/java/lang/annotation/LinkageClass.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.annotation;
+
+/** Annotation used to define bind to a class parameter
+ */
+@Target(ElementType.METHOD)
+public @interface LinkageClass {
+    /** Indicates the value the class parameter will be specialized with
+     * @return the value the class parameter will be specialized with
+     */
+    String value();
+}

--- a/src/java.base/share/classes/java/lang/annotation/LinkageMethod.java
+++ b/src/java.base/share/classes/java/lang/annotation/LinkageMethod.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.annotation;
+
+/** Annotation used to define bind to a method parameter
+ */
+@Target(ElementType.METHOD)
+public @interface LinkageMethod {
+    /** Indicates the value the method parameter will be specialized with
+     * @return the value the method parameter will be specialized with
+     */
+    String value();
+}

--- a/src/java.base/share/classes/java/lang/annotation/ParamKind.java
+++ b/src/java.base/share/classes/java/lang/annotation/ParamKind.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.annotation;
+
+/** Enumerated class specifying the kind of the parameter for the {@code Parametric} annotation
+ */
+public enum ParamKind {
+    /** class parameter
+     */
+    CLASS,
+    /** method only parameters
+     */
+    METHOD_ONLY,
+    /** method and class parameters
+     */
+    METHOD_AND_CLASS;
+}

--- a/src/java.base/share/classes/java/lang/annotation/Parametric.java
+++ b/src/java.base/share/classes/java/lang/annotation/Parametric.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.annotation;
+
+/** Annotates elements that are to be parameterized
+ */
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface Parametric {
+    /**
+     * the id
+     * @return the id
+     */
+    String id();
+
+    /**
+     * the kind
+     * @return the kind
+     */
+    ParamKind kind() default ParamKind.CLASS;
+}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -66,7 +66,6 @@ import com.sun.tools.javac.util.JavacMessages;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
-import com.sun.tools.javac.util.Options;
 
 import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.*;
@@ -225,6 +224,9 @@ public class Symtab {
     public final Type identityObjectType;
     public final Type primitiveObjectType;
     public final Type valueBasedType;
+    public final Type parametricType;
+    public final Type linkageClassType;
+    public final Type linkageMethodType;
 
     /** The symbol representing the length field of an array.
      */
@@ -601,6 +603,9 @@ public class Symtab {
         identityObjectType = enterClass("java.lang.IdentityObject");
         primitiveObjectType = enterClass("java.lang.PrimitiveObject");
         valueBasedType = enterClass("jdk.internal.ValueBased");
+        parametricType = enterClass("java.lang.annotation.Parametric");
+        linkageClassType = enterClass("java.lang.annotation.LinkageClass");
+        linkageMethodType = enterClass("java.lang.annotation.LinkageMethod");
 
         synthesizeEmptyInterfaceIfMissing(autoCloseableType);
         synthesizeEmptyInterfaceIfMissing(cloneableType);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassFile.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassFile.java
@@ -85,6 +85,8 @@ public class ClassFile {
     public final static int CONSTANT_InvokeDynamic = 18;
     public final static int CONSTANT_Module = 19;
     public final static int CONSTANT_Package = 20;
+    public final static int CONSTANT_Parameter = 21;
+    public final static int CONSTANT_Linkage = 22;
 
     public final static int REF_getField = 1;
     public final static int REF_getStatic = 2;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1277,6 +1277,17 @@ public class ClassReader {
                     }
                 }
             },
+            new AttributeReader(names.Parametric, V61, CLASS_OR_MEMBER_ATTRIBUTE) {
+                @Override
+                protected boolean accepts(AttributeKind kind) {
+                    return super.accepts(kind);
+                }
+                protected void read(Symbol sym, int attrLen) {
+                    // just read the info, nothing to do for now
+                    nextChar();
+                    nextChar();
+                }
+            },
         };
 
         for (AttributeReader r: readers)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -874,6 +874,10 @@ public class ClassWriter extends ClassFile {
         int alenIdx = writeAttr(names.Parametric);
         int kind = 1; // the default
         Attribute.Compound c = sym.attribute(syms.parametricType.tsym);
+        // let's extract the id from the annotation
+        Attribute idValue = c.member(names.id);
+
+        // now, let's extract the kind from the annotation
         Attribute value = c.member(names.kind);
         if (value != null && value instanceof Attribute.Enum) {
             Name kindName = ((Attribute.Enum)value).value.name;
@@ -884,7 +888,7 @@ public class ClassWriter extends ClassFile {
                 default -> throw new AssertionError("unexpected kind");
             };
         }
-        databuf.appendChar(poolWriter.putParameter(kind));
+        databuf.appendChar(poolWriter.putParameter(idValue.getValue().toString(), kind));
         databuf.appendChar(0);
         endAttr(alenIdx);
         return 1;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -217,6 +217,7 @@ public class Code {
         this.syms = syms;
         this.types = types;
         this.poolWriter = poolWriter;
+        this.poolWriter.currentMethSymbol = meth;
         this.debugCode = debugCode;
         this.stackMap = stackMap;
         switch (stackMap) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -129,7 +129,7 @@ public class Gen extends JCTree.Visitor {
         genCrt = options.isSet(XJCOV);
         debugCode = options.isSet("debug.code");
         disableVirtualizedPrivateInvoke = options.isSet("disableVirtualizedPrivateInvoke");
-        poolWriter = new PoolWriter(types, names);
+        poolWriter = new PoolWriter(types, names, syms, log, options.isSet("supportParametricVM"));
 
         // ignore cldc because we cannot have both stackmap formats
         this.stackMap = StackMapFormat.JSR202;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
@@ -228,9 +228,15 @@ public interface PoolConstant {
      */
     final class Parameter implements PoolConstant {
 
+        String id;
         final int kind;
 
         Parameter(int kind) {
+            this.kind = kind;
+        }
+
+        Parameter(String id, int kind) {
+            this.id = id;
             this.kind = kind;
         }
 
@@ -241,7 +247,7 @@ public interface PoolConstant {
 
         @Override
         public Object poolKey(Types types) {
-            return Integer.valueOf(kind);
+            return id;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
@@ -25,6 +25,7 @@
 
 package com.sun.tools.javac.jvm;
 
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.code.Types.UniqueType;
@@ -219,6 +220,59 @@ public interface PoolConstant {
         @Override
         public Object poolKey(Types types) {
             return new Pair<>(name, new UniqueType(type, types));
+        }
+    }
+
+    /**
+     * A pool constant implementation describing a parameter pool entry.
+     */
+    final class Parameter implements PoolConstant {
+
+        final int kind;
+
+        Parameter(int kind) {
+            this.kind = kind;
+        }
+
+        @Override
+        public int poolTag() {
+            return ClassFile.CONSTANT_Parameter;
+        }
+
+        @Override
+        public Object poolKey(Types types) {
+            return Integer.valueOf(kind);
+        }
+    }
+
+    /**
+     * A pool constant implementation describing a linkage pool entry.
+     */
+    final class Linkage implements PoolConstant {
+
+        final Object parameter;
+        // could be symbol or type
+        final Object reference;
+        final boolean isClassReference;
+
+        Linkage(Object parameter, Object reference, boolean isClassReference) {
+            this.parameter = parameter;
+            this.reference = reference;
+            this.isClassReference = isClassReference;
+        }
+
+        @Override
+        public int poolTag() {
+            return ClassFile.CONSTANT_Linkage;
+        }
+
+        @Override
+        public Object poolKey(Types types) {
+            return new Pair<>(parameter, reference);
+        }
+
+        public boolean hasClassReference() {
+            return isClassReference;
         }
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -314,8 +314,8 @@ public class PoolWriter {
     /**
      * Puts a parameter into the pool and returns its index.
      */
-    int putParameter(int kind) {
-        return pool.writeIfNeeded(new Parameter(kind));
+    int putParameter(String id, int kind) {
+        return pool.writeIfNeeded(new Parameter(id, kind));
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -25,6 +25,7 @@
 
 package com.sun.tools.javac.jvm;
 
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Kinds.Kind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
@@ -32,18 +33,23 @@ import com.sun.tools.javac.code.Symbol.DynamicMethodSymbol;
 import com.sun.tools.javac.code.Symbol.MethodHandleSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
+import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ConstantPoolQType;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.jvm.ClassWriter.PoolOverflow;
 import com.sun.tools.javac.jvm.ClassWriter.StringOverflow;
+import com.sun.tools.javac.jvm.PoolConstant.Linkage;
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant;
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant.BasicConstant;
 import com.sun.tools.javac.jvm.PoolConstant.Dynamic;
 import com.sun.tools.javac.jvm.PoolConstant.Dynamic.BsmKey;
 import com.sun.tools.javac.jvm.PoolConstant.NameAndType;
+import com.sun.tools.javac.jvm.PoolConstant.Parameter;
+import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.ByteBuffer;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
 
@@ -51,9 +57,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.sun.tools.javac.code.Kinds.Kind.TYP;
 import static com.sun.tools.javac.code.TypeTag.ARRAY;
@@ -85,6 +93,12 @@ public class PoolWriter {
 
     private final Names names;
 
+    private final Symtab syms;
+
+    private final Log log;
+
+    private final boolean supportParametricVM;
+
     /** Pool helper **/
     final WriteablePoolHelper pool;
 
@@ -97,18 +111,34 @@ public class PoolWriter {
     /** The list of entries in the BootstrapMethods attribute. */
     Map<BsmKey, Integer> bootstrapMethods = new LinkedHashMap<>();
 
-    public PoolWriter(Types types, Names names) {
+    // current symbol for which the code is being generated
+    Symbol.MethodSymbol currentMethSymbol;
+
+    public PoolWriter(Types types, Names names, Symtab syms, Log log, boolean supportParametricVM) {
         this.types = types;
         this.names = names;
+        this.syms = syms;
+        this.log = log;
         this.signatureGen = new SharedSignatureGenerator(types);
         this.pool = new WriteablePoolHelper();
+        this.supportParametricVM = supportParametricVM;
     }
 
     /**
      * Puts a class symbol into the pool and return its index.
      */
     int putClass(ClassSymbol csym) {
-        return putClass(csym.type);
+        Attribute.Compound parametricAnno = csym.attribute(syms.parametricType.tsym);
+        if (supportParametricVM &&
+                parametricAnno != null &&
+                enclMethodHasLinkageAnno() &&
+                !referencesBeingLinked.contains(csym)) {
+            int linkageIndex = generateLinkage(types.erasure(csym.type), parametricAnno);
+            if (linkageIndex > 0) {
+                return linkageIndex;
+            }
+        }
+        return pool.writeIfNeeded(types.erasure(csym.type));
     }
 
     /**
@@ -116,6 +146,16 @@ public class PoolWriter {
      * or an array type.
      */
     int putClass(Type t) {
+        Attribute.Compound parametricAnno = t.tsym.attribute(syms.parametricType.tsym);
+        if (supportParametricVM &&
+                parametricAnno != null &&
+                enclMethodHasLinkageAnno() &&
+                !referencesBeingLinked.contains(t)) {
+            int linkageIndex = generateLinkage(t, parametricAnno);
+            if (linkageIndex > 0) {
+                return linkageIndex;
+            }
+        }
         return pool.writeIfNeeded(types.erasure(t));
     }
 
@@ -124,15 +164,99 @@ public class PoolWriter {
      * or an array type.
      */
     int putClass(ConstantPoolQType t) {
+        // still need to check here if linkage is necessary
         return pool.writeIfNeeded(t);
     }
+
+    Set<Object> referencesBeingLinked = new HashSet<>();
 
     /**
      * Puts a member reference into the constant pool. Valid members are either field or method symbols.
      */
     int putMember(Symbol s) {
+        Attribute.Compound parametricAnno = s.attribute(syms.parametricType.tsym);
+        if (supportParametricVM &&
+                parametricAnno != null &&
+                enclMethodHasLinkageAnno() &&
+                !referencesBeingLinked.contains(s)) {
+            int linkageIndex = generateLinkage(s, parametricAnno);
+            if (linkageIndex > 0) {
+                return linkageIndex;
+            }
+        }
         return pool.writeIfNeeded(s);
     }
+
+    // where
+        boolean enclMethodHasLinkageAnno() {
+            return currentMethSymbol != null && (currentMethSymbol.attribute(syms.linkageMethodType.tsym) != null ||
+                    currentMethSymbol.attribute(syms.linkageClassType.tsym) != null);
+        }
+
+        /* this method will try to generate a Linkage that will eventually be written into the constant pool
+         * if it can't find all the needed information it will bail out, and return -1, to inform the caller
+         * to generate the corresponding legacy entry. If successful it will return the index of the corresponding
+         * Linkage_info constant in the constant pool
+         */
+        int generateLinkage(Object s, Attribute.Compound parametricAnno) {
+            // the referred element is parametric
+            if (!supportParametricVM) return -1;
+            Name kindName = names.CLASS;
+            Attribute value = parametricAnno.member(names.kind);
+            if (value != null && value instanceof Attribute.Enum) {
+                kindName = ((Attribute.Enum)value).value.name;
+            }
+
+            // let's find out if the enclosing method has any linkage annotations
+            String linkageMethodValueStr = null;
+            Attribute.Compound linkageMethodAnno = currentMethSymbol.attribute(syms.linkageMethodType.tsym);
+            if (linkageMethodAnno != null) {
+                Attribute linkageMethodValue = linkageMethodAnno.member(names.value);
+                if (linkageMethodValue != null && linkageMethodValue instanceof Attribute.Constant) {
+                    linkageMethodValueStr = linkageMethodValue.getValue().toString();
+                }
+                if (linkageMethodValueStr == null) {
+                    log.printRawLines("LinkageMethod annotation without value");
+                    return -1;
+                }
+            }
+            String linkageClassValueStr = null;
+            Attribute.Compound linkageClassAnno = currentMethSymbol.attribute(syms.linkageClassType.tsym);
+            if (linkageClassAnno != null) {
+                Attribute linkageClassValue = linkageClassAnno.member(names.value);
+                if (linkageClassValue != null && linkageClassValue instanceof Attribute.Constant) {
+                    linkageClassValueStr = linkageClassValue.getValue().toString();
+                }
+                if (linkageClassValueStr == null) {
+                    log.printRawLines("LinkageClass annotation without value");
+                    return -1;
+                }
+            }
+            if (kindName == names.METHOD_ONLY) {
+                if (linkageMethodValueStr == null) {
+                    // bail out
+                    return -1;
+                }
+                referencesBeingLinked.add(s);
+                return pool.writeIfNeeded(new Linkage(linkageMethodValueStr, s, false));
+            } else if (kindName == names.CLASS) {
+                if (linkageClassValueStr == null) {
+                    // bail out
+                    return -1;
+                }
+                referencesBeingLinked.add(s);
+                return pool.writeIfNeeded(new Linkage(linkageClassValueStr, s, s instanceof Type));
+            } else if (kindName == names.METHOD_AND_CLASS) {
+                if (linkageMethodValueStr == null) {
+                    // bail out
+                    return -1;
+                }
+                referencesBeingLinked.add(s);
+                return pool.writeIfNeeded(new Linkage(linkageMethodValueStr, s, s instanceof Type));
+            }
+            log.printRawLines("could not generate Linkage_info constant");
+            return -1;
+        }
 
     /**
      * Puts a dynamic reference into the constant pool and return its index.
@@ -210,6 +334,13 @@ public class PoolWriter {
      */
     int putNameAndType(Symbol s) {
         return pool.writeIfNeeded(new NameAndType(s.name, descriptorType(s)));
+    }
+
+    /**
+     * Puts a parameter into the pool and returns its index.
+     */
+    int putParameter(int kind) {
+        return pool.writeIfNeeded(new Parameter(kind));
     }
 
     /**
@@ -380,6 +511,9 @@ public class PoolWriter {
                     if (ct.hasTag(CLASS)) {
                         enterInner((ClassSymbol)ct.tsym);
                     }
+                    if (referencesBeingLinked.contains(c)) {
+                        referencesBeingLinked.remove(c);
+                    }
                     break;
                 }
                 case ClassFile.CONSTANT_Utf8: {
@@ -401,6 +535,9 @@ public class PoolWriter {
                     poolbuf.appendByte(tag);
                     poolbuf.appendChar(putClass((ClassSymbol)sym.owner));
                     poolbuf.appendChar(putNameAndType(sym));
+                    if (referencesBeingLinked.contains(c)) {
+                        referencesBeingLinked.remove(c);
+                    }
                     break;
                 }
                 case ClassFile.CONSTANT_Package: {
@@ -473,6 +610,24 @@ public class PoolWriter {
                     poolbuf.appendByte(tag);
                     poolbuf.appendChar(makeBootstrapEntry(d));
                     poolbuf.appendChar(putNameAndType(d));
+                    break;
+                }
+                case ClassFile.CONSTANT_Parameter: {
+                    Parameter p = (Parameter) c;
+                    poolbuf.appendByte(tag);
+                    poolbuf.appendByte(p.kind);
+                    poolbuf.appendChar(0);
+                    break;
+                }
+                case ClassFile.CONSTANT_Linkage: {
+                    Linkage l = (Linkage) c;
+                    poolbuf.appendByte(tag);
+                    poolbuf.appendChar(putConstant(l.parameter));
+                    if (l.hasClassReference()) {
+                        poolbuf.appendChar(putClass((Type)l.reference));
+                    } else {
+                        poolbuf.appendChar(putMember((Symbol)l.reference));
+                    }
                     break;
                 }
                 default:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -229,6 +229,7 @@ public class Names {
 
     // valhalla
     // Parametric annotation
+    public final Name id;
     public final Name kind;
     public final Name METHOD_ONLY;
     public final Name METHOD_AND_CLASS;
@@ -415,6 +416,7 @@ public class Names {
         sealed = fromString("sealed");
 
         // valhalla
+        id = fromString("id");
         kind = fromString("kind");
         METHOD_ONLY = fromString("METHOD_ONLY");
         METHOD_AND_CLASS = fromString("METHOD_AND_CLASS");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -166,6 +166,7 @@ public class Names {
     public final Name Value;
     public final Name Varargs;
     public final Name PermittedSubclasses;
+    public final Name Parametric;
 
     // members of java.lang.annotation.ElementType
     public final Name ANNOTATION_TYPE;
@@ -225,6 +226,12 @@ public class Names {
     // sealed types
     public final Name permits;
     public final Name sealed;
+
+    // valhalla
+    // Parametric annotation
+    public final Name kind;
+    public final Name METHOD_ONLY;
+    public final Name METHOD_AND_CLASS;
 
     public final Name.Table table;
 
@@ -352,6 +359,7 @@ public class Names {
         Value = fromString("Value");
         Varargs = fromString("Varargs");
         PermittedSubclasses = fromString("PermittedSubclasses");
+        Parametric = fromString("Parametric");
 
         // members of java.lang.annotation.ElementType
         ANNOTATION_TYPE = fromString("ANNOTATION_TYPE");
@@ -405,6 +413,11 @@ public class Names {
         // sealed types
         permits = fromString("permits");
         sealed = fromString("sealed");
+
+        // valhalla
+        kind = fromString("kind");
+        METHOD_ONLY = fromString("METHOD_ONLY");
+        METHOD_AND_CLASS = fromString("METHOD_AND_CLASS");
     }
 
     protected Name.Table createTable(Options options) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -60,6 +60,7 @@ public abstract class Attribute {
     public static final String ModuleTarget             = "ModuleTarget";
     public static final String NestHost                 = "NestHost";
     public static final String NestMembers              = "NestMembers";
+    public static final String Parametric               = "Parametric";
     public static final String Record                   = "Record";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
     public static final String RuntimeInvisibleAnnotations = "RuntimeInvisibleAnnotations";
@@ -136,6 +137,7 @@ public abstract class Attribute {
             standardAttributes.put(ModuleTarget,      ModuleTarget_attribute.class);
             standardAttributes.put(NestHost, NestHost_attribute.class);
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
+            standardAttributes.put(Parametric, Parametric_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
             standardAttributes.put(RuntimeInvisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations_attribute.class);
@@ -203,6 +205,7 @@ public abstract class Attribute {
         R visitModuleTarget(ModuleTarget_attribute attr, P p);
         R visitNestHost(NestHost_attribute attr, P p);
         R visitNestMembers(NestMembers_attribute attr, P p);
+        R visitParametric(Parametric_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);
         R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassTranslator.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassTranslator.java
@@ -44,6 +44,8 @@ import com.sun.tools.classfile.ConstantPool.CONSTANT_NameAndType_info;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_Package_info;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_String_info;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_Utf8_info;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Parameter_info;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Linkage_info;
 import com.sun.tools.classfile.ConstantPool.CPInfo;
 
 /**
@@ -423,6 +425,34 @@ public class ClassTranslator
                 info2 = info;
             else
                 info2 = new CONSTANT_NameAndType_info(cp2, info.name_index, info.type_index);
+            translations.put(info, info2);
+        }
+        return info;
+    }
+
+    @Override
+    public CPInfo visitParameter(CONSTANT_Parameter_info info, Map<Object, Object> translations) {
+        CONSTANT_Parameter_info info2 = (CONSTANT_Parameter_info) translations.get(info);
+        if (info2 == null) {
+            ConstantPool cp2 = translate(info.cp, translations);
+            if (cp2 == info.cp)
+                info2 = info;
+            else
+                info2 = new CONSTANT_Parameter_info(cp2, info.parameter_kind, info.bootstrap_method_attr_index);
+            translations.put(info, info2);
+        }
+        return info;
+    }
+
+    @Override
+    public CPInfo visitLinkage(CONSTANT_Linkage_info info, Map<Object, Object> translations) {
+        CONSTANT_Linkage_info info2 = (CONSTANT_Linkage_info) translations.get(info);
+        if (info2 == null) {
+            ConstantPool cp2 = translate(info.cp, translations);
+            if (cp2 == info.cp)
+                info2 = info;
+            else
+                info2 = new CONSTANT_Linkage_info(cp2, info.parameter_index, info.reference_index);
             translations.put(info, info2);
         }
         return info;

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -349,6 +349,20 @@ public class ClassWriter {
             out.writeShort(info.name_and_type_index);
             return 1;
         }
+
+        @Override
+        public Integer visitParameter(CONSTANT_Parameter_info info, ClassOutputStream out) {
+            out.writeByte(info.parameter_kind.tag);
+            out.writeShort(info.bootstrap_method_attr_index);
+            return 1;
+        }
+
+        @Override
+        public Integer visitLinkage(CONSTANT_Linkage_info info, ClassOutputStream out) {
+            out.writeShort(info.parameter_index);
+            out.writeShort(info.reference_index);
+            return 1;
+        }
     }
 
     /**
@@ -650,6 +664,13 @@ public class ClassWriter {
                 for (Attribute componentAttr: info.attributes)
                     write(componentAttr, out);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitParametric(Parametric_attribute attr, ClassOutputStream out) {
+            out.writeShort(attr.parameter_index);
+            out.writeShort(attr.type_index);
             return null;
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Dependencies.java
@@ -713,6 +713,14 @@ public class Dependencies {
                 return null;
             }
 
+            public Void visitParameter(CONSTANT_Parameter_info info, Void p) {
+                return null;
+            }
+
+            public Void visitLinkage(CONSTANT_Linkage_info info, Void p) {
+                return null;
+            }
+
             public Void visitNameAndType(CONSTANT_NameAndType_info info, Void p) {
                 try {
                     new Signature(info.type_index).getType(constant_pool).accept(this, null);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Parametric_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Parametric_attribute.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+import com.sun.tools.classfile.Attribute.Visitor;
+
+/**
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+public class Parametric_attribute extends Attribute {
+    Parametric_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        parameter_index = cr.readUnsignedShort();
+        type_index = cr.readUnsignedShort();
+    }
+
+    public Parametric_attribute(int name_index, int parameter_index, int type_index) {
+        super(name_index, 2);
+        this.parameter_index = parameter_index;
+        this.type_index = type_index;
+    }
+
+    @Override
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitParametric(this, data);
+    }
+
+    public final int parameter_index;
+    public final int type_index;
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ReferenceFinder.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ReferenceFinder.java
@@ -200,6 +200,10 @@ public final class ReferenceFinder {
         public Boolean visitUtf8(CONSTANT_Utf8_info info, ConstantPool cpool) {
             return false;
         }
+
+        public Boolean visitParameter(CONSTANT_Parameter_info info, ConstantPool cpool) { return false; }
+
+        public Boolean visitLinkage(CONSTANT_Linkage_info info, ConstantPool cpool) { return false; }
     };
 
     private Instruction.KindVisitor<Integer, List<Integer>> codeVisitor =

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -60,6 +60,7 @@ import com.sun.tools.classfile.ModuleResolution_attribute;
 import com.sun.tools.classfile.ModuleTarget_attribute;
 import com.sun.tools.classfile.NestHost_attribute;
 import com.sun.tools.classfile.NestMembers_attribute;
+import com.sun.tools.classfile.Parametric_attribute;
 import com.sun.tools.classfile.Record_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleParameterAnnotations_attribute;
@@ -894,6 +895,12 @@ public class AttributeWriter extends BasicWriter
         } catch (ConstantPoolException ex) {
             throw new AssertionError(ex);
         }
+        return null;
+    }
+
+    @Override
+    public Void visitParametric(Parametric_attribute attr, Void ignore) {
+        println("Parametric: #" + attr.parameter_index + ":" + attr.type_index);
         return null;
     }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
@@ -170,6 +170,20 @@ public class ConstantWriter extends BasicWriter {
                 return 1;
             }
 
+            public Integer visitParameter(CONSTANT_Parameter_info info, Void p) {
+                print(info.parameter_kind + ":" + info.bootstrap_method_attr_index);
+                tab();
+                println("// " + stringValue(info));
+                return 1;
+            }
+
+            public Integer visitLinkage(CONSTANT_Linkage_info info, Void p) {
+                print("#" + info.parameter_index + ":#" + info.reference_index);
+                tab();
+                println("// " + stringValue(info));
+                return 1;
+            }
+
         };
         println("Constant pool:");
         indent(+1);
@@ -257,6 +271,10 @@ public class ConstantWriter extends BasicWriter {
                 return "Dynamic";
             case CONSTANT_NameAndType:
                 return "NameAndType";
+            case CONSTANT_Parameter:
+                return "Parameter";
+            case CONSTANT_Linkage:
+                return "Linkage";
             default:
                 return "(unknown tag " + tag + ")";
         }
@@ -473,6 +491,20 @@ public class ConstantWriter extends BasicWriter {
                 }
             }
             return sb.toString();
+        }
+
+        public String visitParameter(CONSTANT_Parameter_info info, Void p) {
+            return info.parameter_kind + ":" + info.bootstrap_method_attr_index;
+        }
+
+        public String visitLinkage(CONSTANT_Linkage_info info, Void p) {
+            try {
+                ClassFile classFile = classWriter.getClassFile();
+                return stringValue(classFile.constant_pool.get(info.parameter_index)) + ":" +
+                        stringValue(classFile.constant_pool.get(info.reference_index));
+            } catch (ConstantPoolException e) {
+                return report(e);
+            }
         }
 
         String visitRef(CPRefInfo info, Void p) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeprscan/scan/CPSelector.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeprscan/scan/CPSelector.java
@@ -120,4 +120,14 @@ class CPSelector implements ConstantPool.Visitor<Void,CPEntries> {
     public Void visitUtf8(ConstantPool.CONSTANT_Utf8_info info, CPEntries p) {
         return null;
     }
+
+    @Override
+    public Void visitParameter(ConstantPool.CONSTANT_Parameter_info info, CPEntries p) {
+        return null;
+    }
+
+    @Override
+    public Void visitLinkage(ConstantPool.CONSTANT_Linkage_info info, CPEntries p) {
+        return null;
+    }
 }


### PR DESCRIPTION
This patch is the initial support for Parametric VM in javac. This is the first iteration of the prototype, so still a work in progress. In order to test the new code users need to pass the hidden option: `-XDsupportParametricVM` to javac. See the examples below for an illustration of the bytecode the compiler can generate now. Lets assume we have the following class annotated with the `@Parametric` annotation:

```
import java.lang.annotation.*;

@Parametric(id="PAIR")
class Pair<X, Y> {
    @Parametric(id="PAIR")
    X fst;
    @Parametric(id="PAIR")
    Y snd;

    Pair(X fst, Y snd) {
        this.fst = fst;
        this.snd = snd;
    }

    Pair<Y, X> swap() {
        return new Pair<>(snd, fst);
    }

    @Parametric(id="make", kind=ParamKind.METHOD_ONLY)
    static <U, W> Pair<U, W> make(U fst, W snd) {
        return new Pair<>(fst, snd);
    }

    @Parametric(id="setFst", kind=ParamKind.METHOD_AND_CLASS)
    <Z> Pair<Z, Y> setFst(Z newFst) {
        return null;
    }
}
```

After compilation this class will contain the following new entries in the constant pool:

```
#22 = Parameter          CLASS:0        // CLASS:0
#37 = Parameter          METHOD_ONLY:0  // METHOD_ONLY:0
#44 = Parameter          METHOD_AND_CLASS:0 // METHOD_AND_CLASS:0
```
also there will be several elements with the new attribute `Parametric` which will appear in both fields, the `Pair` class per-se and methods: `make` and `setFst`.

Let's now assume we define a Client willing to use class `Pair`, it will need to define values to bound to the "holes" defined in class `Pair` using the `Parametric` annotation. For this class Client should use annotations `@LinkageClass` and or `@LinkageMethod` depending on the kind of hole in class `Pair` it is intending to bound to. Let's define class `Client` as:

```
import java.lang.annotation.*;

class Client {
    @LinkageClass("linkageClass")
    void linkClassParams() {
        Pair<String, Integer> psi = new Pair<>("first", 2);
    }

    @LinkageClass("linkageClass")
    void linkClassParamsFieldAccess(Pair<String, Integer> psi) {
        psi.fst = "field";
    }


    @LinkageMethod("linkageMethod1")
    void linkMethodParams(Pair<String, Integer> psi) {
        Pair<String, Integer> pair = Pair.make("hello", 1);
    }

    @LinkageClass("linkageClass")
    @LinkageMethod("linkageMethod2")
    void linkClassAndMethodParams(Pair<String, Integer> psi) {
        Pair<String, Integer> pss = psi.setFst("b");
    }
}
```

again compiling this class with the hidden option `-XDsupportParametricVM` we can find these new entries in the CP:

```
   #7 = Linkage            #8:#9          // linkageClass:Pair
   #8 = String             #10            // linkageClass
   #9 = Class              #11            // Pair
```

this Linkage CP entry is referred from method: `linkClassParams` as:

```
  void linkClassParams();
    descriptor: ()V
    flags: (0x0000)
    Code:
      stack=4, locals=2, args_size=1
         0: new           #7                  // Linkage linkageClass:Pair
```

also:

```
  #25 = Linkage            #8:#26         // linkageClass:Pair.fst:Ljava/lang/Object;
  #26 = Fieldref           #7.#27         // Pair.fst:Ljava/lang/Object;
  #27 = NameAndType        #28:#29        // fst:Ljava/lang/Object;
```

referred from method: `linkClassParamsFieldAccess` the bytecode looks like:

```
  void linkClassParamsFieldAccess(Pair<java.lang.String, java.lang.Integer>);
    descriptor: (LPair;)V
    flags: (0x0000)
    Code:
      stack=2, locals=2, args_size=2
         0: aload_1
         1: ldc           #23                 // String field
         3: putfield      #25                 // Linkage linkageClass:Pair.fst:Ljava/lang/Object;
         6: return
```

also:

```
  #32 = Linkage            #33:#34        // linkageMethod1:Pair.make:(Ljava/lang/Object;Ljava/lang/Object;)LPair;
  #33 = String             #35            // linkageMethod1
  #34 = Methodref          #9.#36         // Pair.make:(Ljava/lang/Object;Ljava/lang/Object;)LPair;
```

this time referred by method: `linkMethodParams` with bytecode:

```
  void linkMethodParams(Pair<java.lang.String, java.lang.Integer>);
    descriptor: (LPair;)V
    flags: (0x0000)
    Code:
      stack=2, locals=3, args_size=2
         0: ldc           #30                 // String hello
         2: iconst_1
         3: invokestatic  #14                 // Method java/lang/Integer.valueOf:(I)Ljava/lang/Integer;
         6: invokestatic  #32                 // Linkage linkageMethod1:Pair.make:(Ljava/lang/Object;Ljava/lang/Object;)LPair;
         9: astore_2
        10: return
```

and finally:

```
  #41 = Linkage            #42:#43        // linkageMethod2:Pair.setFst:(Ljava/lang/Object;)LPair;
  #42 = String             #44            // linkageMethod2
  #43 = Methodref          #7.#45         // Pair.setFst:(Ljava/lang/Object;)LPair;
```

in this last example it can be seen that Methodref at #43 is also pointing to #7 which, as commented above, is another Linkage_info entry in the CP.

TIA, for the feedback and comments,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/364/head:pull/364`
`$ git checkout pull/364`
