### PR TITLE
8263440: [lworld] C2 compilation fails with "Error mixing types: byte and inlinetype[1]:{byte}"

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1218,6 +1218,7 @@ Type::Category Type::category() const {
     case Type::DoubleTop:
     case Type::DoubleCon:
     case Type::DoubleBot:
+    case Type::InlineType:
       return Category::Data;
     case Type::Memory:
       return Category::Memory;
@@ -1587,6 +1588,7 @@ const Type *TypeInt::xmeet( const Type *t ) const {
   case DoubleTop:
   case DoubleCon:
   case DoubleBot:
+  case InlineType:
   case Bottom:                  // Ye Olde Default
     return Type::BOTTOM;
   default:                      // All else is a mistake


### PR DESCRIPTION
Added missing handling of inline types to ideal node categorization `TypeInt::xmeet`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263440](https://bugs.openjdk.java.net/browse/JDK-8263440): [lworld] C2 compilation fails with "Error mixing types: byte and inlinetype[1]:{byte}"


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/366/head:pull/366`
`$ git checkout pull/366`
