### PR TITLE
8263566: [lworld] Skip generate_return_value_stubs when InlineTypeReturnedAsFields is disabled

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -6914,10 +6914,12 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_dcos = generate_dsin_dcos(/* isCos = */ true);
     }
 
-    StubRoutines::_load_inline_type_fields_in_regs =
+    if (InlineTypeReturnedAsFields) {
+      StubRoutines::_load_inline_type_fields_in_regs =
          generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::load_inline_type_fields_in_regs), "load_inline_type_fields_in_regs", false);
-    StubRoutines::_store_inline_type_fields_to_buf =
+      StubRoutines::_store_inline_type_fields_to_buf =
          generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::store_inline_type_fields_to_buf), "store_inline_type_fields_to_buf", true);
+    }
 
     // Safefetch stubs.
     generate_safefetch("SafeFetch32", sizeof(int),     &StubRoutines::_safefetch32_entry,

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6886,9 +6886,12 @@ address generate_avx_ghash_processBlocks() {
     StubRoutines::_forward_exception_entry = generate_forward_exception();
 
     // Generate these first because they are called from other stubs
-    StubRoutines::_load_inline_type_fields_in_regs = generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::load_inline_type_fields_in_regs), "load_inline_type_fields_in_regs", false);
-    StubRoutines::_store_inline_type_fields_to_buf = generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::store_inline_type_fields_to_buf), "store_inline_type_fields_to_buf", true);
-
+    if (InlineTypeReturnedAsFields) {
+      StubRoutines::_load_inline_type_fields_in_regs =
+        generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::load_inline_type_fields_in_regs), "load_inline_type_fields_in_regs", false);
+      StubRoutines::_store_inline_type_fields_to_buf =
+        generate_return_value_stub(CAST_FROM_FN_PTR(address, SharedRuntime::store_inline_type_fields_to_buf), "store_inline_type_fields_to_buf", true);
+    }
     StubRoutines::_call_stub_entry = generate_call_stub(StubRoutines::_call_stub_return_address);
 
     // is referenced by megamorphic call


### PR DESCRIPTION
This is a trivial change. When InlineTypeReturnedAsFields is turned off, we can skip generating related stub routines, which would reduce C heap occupancy and start VM faster through slightly.

Testing:
x86: all valhalla related tests with release mode
aarch64: none

Best regards,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263566](https://bugs.openjdk.java.net/browse/JDK-8263566): [lworld] Skip generate_return_value_stubs when InlineTypeReturnedAsFields is disabled


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/valhalla pull/367/head:pull/367`
`$ git checkout pull/367`
