### PR TITLE
8263568: [lworld] Fix residual reference to 'value'

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
@@ -205,6 +205,7 @@ public class AccessFlags {
             case ACC_VOLATILE:
                 return "volatile";
             case 0x100:
+                // ACC_NATIVE or ACC_PRIMITIVE
                 return (t == Kind.Class || t == Kind.InnerClass) ? "primitive" : "native";
             case ACC_ABSTRACT:
                 return "abstract";

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
@@ -205,7 +205,7 @@ public class AccessFlags {
             case ACC_VOLATILE:
                 return "volatile";
             case 0x100:
-                return (t == Kind.Class || t == Kind.InnerClass) ? "value" : t == Kind.Field ? "__Flattenable" : "native";
+                return (t == Kind.Class || t == Kind.InnerClass) ? "primitive" : "native";
             case ACC_ABSTRACT:
                 return "abstract";
             case ACC_STRICT:

--- a/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
@@ -46,7 +46,7 @@ public class QTypeTest {
                                             Paths.get(System.getProperty("test.classes"),
                                                 "QTypedValue.class").toString() };
         runCheck(params, new String [] {
-              "final value class QTypedValue",
+              "final primitive class QTypedValue",
               "  flags: (0x0130) ACC_FINAL, ACC_SUPER, ACC_PRIMITIVE",
               "  this_class: #1                          // QTypedValue",
               "   #1 = Class              #2             // QTypedValue",


### PR DESCRIPTION
javap tool is still outputting primitive type class modifiers as `value` class, it looks like we should tweak this.

(Actually, I'm wondering what's the meaning of 'native' for fields that annotated with ACC_PRIMITIVE in flagToModifier? Should we remove it and change the `case 0x100` to `case ACC_PRIMITIVE` so that IDE will help us find all references if we want to do some code refactor in the future?)


Thanks,
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263568](https://bugs.openjdk.java.net/browse/JDK-8263568): [lworld] Fix residual reference to 'value'


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer) ⚠️ Review applies to 5640dc868b3fc521cc1498b9fe9b8f0d373f9150
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/valhalla pull/368/head:pull/368`
`$ git checkout pull/368`

To update a local copy of the PR:
`$ git checkout pull/368`
`$ git pull https://git.openjdk.java.net/valhalla pull/368/head`
