### PR TITLE
8263900: [lworld] Make .default a separate node type in the parser.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultExpressionTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultExpressionTree.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.source.tree;
+
+/**
+ * A tree node for a {@code default} instance initializion expression.
+ *
+ * For example:
+ * <pre>
+ *   Optional<String>.default
+ * </pre>
+ *
+ * @jls todo
+ *
+ * @since valhalla
+ */
+public interface DefaultExpressionTree extends ExpressionTree {
+
+    /**
+     * Returns the name of the class of the instance being initialized.
+     * @return the name
+     */
+    ExpressionTree getClazz();
+
+}

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultValueTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultValueTree.java
@@ -37,12 +37,12 @@ package com.sun.source.tree;
  *
  * @since valhalla
  */
-public interface DefaultExpressionTree extends ExpressionTree {
+public interface DefaultValueTree extends ExpressionTree {
 
     /**
      * Returns the name of the class of the instance being initialized.
      * @return the name
      */
-    ExpressionTree getClazz();
+    ExpressionTree getType();
 
 }

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
@@ -254,6 +254,13 @@ public interface Tree {
         SWITCH_EXPRESSION(SwitchExpressionTree.class),
 
         /**
+         * Used for instances of {@link DefaultExpressionTree}.
+         *
+         * @since valhalla
+         */
+        DEFAULT_EXPRESSION(DefaultExpressionTree.class),
+
+        /**
          * Used for instances of {@link SynchronizedTree}.
          */
         SYNCHRONIZED(SynchronizedTree.class),

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/Tree.java
@@ -254,11 +254,11 @@ public interface Tree {
         SWITCH_EXPRESSION(SwitchExpressionTree.class),
 
         /**
-         * Used for instances of {@link DefaultExpressionTree}.
+         * Used for instances of {@link DefaultValueTree}.
          *
          * @since valhalla
          */
-        DEFAULT_EXPRESSION(DefaultExpressionTree.class),
+        DEFAULT_VALUE(DefaultValueTree.class),
 
         /**
          * Used for instances of {@link SynchronizedTree}.

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
@@ -170,6 +170,14 @@ public interface TreeVisitor<R,P> {
     R visitContinue(ContinueTree node, P p);
 
     /**
+     * Visits a DefaultExpression node.
+     * @param node the node being visited
+     * @param p a parameter value
+     * @return a result value
+     */
+    R visitDefaultExpression(DefaultExpressionTree node, P p);
+
+    /**
      * Visits a DoWhileTree node.
      * @param node the node being visited
      * @param p a parameter value

--- a/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/TreeVisitor.java
@@ -170,12 +170,12 @@ public interface TreeVisitor<R,P> {
     R visitContinue(ContinueTree node, P p);
 
     /**
-     * Visits a DefaultExpression node.
+     * Visits a DefaultValue node.
      * @param node the node being visited
      * @param p a parameter value
      * @return a result value
      */
-    R visitDefaultExpression(DefaultExpressionTree node, P p);
+    R visitDefaultValue(DefaultValueTree node, P p);
 
     /**
      * Visits a DoWhileTree node.

--- a/src/jdk.compiler/share/classes/com/sun/source/util/SimpleTreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/SimpleTreeVisitor.java
@@ -307,6 +307,18 @@ public class SimpleTreeVisitor <R,P> implements TreeVisitor<R,P> {
      * @return  the result of {@code defaultAction}
      */
     @Override
+    public R visitDefaultExpression(DefaultExpressionTree node, P p) {
+        return defaultAction(node, p);
+    }
+
+    /**
+     * {@inheritDoc} This implementation calls {@code defaultAction}.
+     *
+     * @param node {@inheritDoc}
+     * @param p {@inheritDoc}
+     * @return  the result of {@code defaultAction}
+     */
+    @Override
     public R visitSynchronized(SynchronizedTree node, P p) {
         return defaultAction(node, p);
     }

--- a/src/jdk.compiler/share/classes/com/sun/source/util/SimpleTreeVisitor.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/SimpleTreeVisitor.java
@@ -307,7 +307,7 @@ public class SimpleTreeVisitor <R,P> implements TreeVisitor<R,P> {
      * @return  the result of {@code defaultAction}
      */
     @Override
-    public R visitDefaultExpression(DefaultExpressionTree node, P p) {
+    public R visitDefaultValue(DefaultValueTree node, P p) {
         return defaultAction(node, p);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -393,6 +393,19 @@ public class TreeScanner<R,P> implements TreeVisitor<R,P> {
      * @return the result of scanning
      */
     @Override
+    public R visitDefaultExpression(DefaultExpressionTree node, P p) {
+        R r = scan(node.getClazz(), p);
+        return r;
+    }
+
+    /**
+     * {@inheritDoc} This implementation scans the children in left to right order.
+     *
+     * @param node  {@inheritDoc}
+     * @param p  {@inheritDoc}
+     * @return the result of scanning
+     */
+    @Override
     public R visitSynchronized(SynchronizedTree node, P p) {
         R r = scan(node.getExpression(), p);
         r = scanAndReduce(node.getBlock(), p, r);

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -393,9 +393,8 @@ public class TreeScanner<R,P> implements TreeVisitor<R,P> {
      * @return the result of scanning
      */
     @Override
-    public R visitDefaultExpression(DefaultExpressionTree node, P p) {
-        R r = scan(node.getClazz(), p);
-        return r;
+    public R visitDefaultValue(DefaultValueTree node, P p) {
+        return scan(node.getType(), p);
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4461,7 +4461,7 @@ public class Attr extends JCTree.Visitor {
                 return types.createErrorType(name, site.tsym, site).tsym;
             default:
                 // The qualifier expression is of a primitive type -- only
-                // .class and .default is allowed for these.
+                // .class is allowed for these.
                 if (name == names._class) {
                     // In this case, we have already made sure in Select that
                     // qualifier expression is a type.
@@ -4881,7 +4881,7 @@ public class Attr extends JCTree.Visitor {
         }
     }
 
-    public void visitDefaultExpression(JCDefaultExpression tree) {
+    public void visitDefaultValue(JCDefaultValue tree) {
         if (!allowPrimitiveClasses) {
             log.error(DiagnosticFlag.SOURCE_LEVEL, tree.pos(),
                     Feature.PRIMITIVE_CLASSES.error(sourceName));
@@ -4892,7 +4892,6 @@ public class Attr extends JCTree.Visitor {
         if (!pkind().contains(KindSelector.TYP_PCK))
             site = capture(site); // Capture field access
 
-        Symbol sitesym = TreeInfo.symbol(tree.clazz);
         Symbol sym = switch (site.getTag()) {
                 case PACKAGE, WILDCARD -> throw new AssertionError(tree);
                 case ERROR -> types.createErrorType(names._default, site.tsym, site).tsym;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4254,12 +4254,8 @@ public class Attr extends JCTree.Visitor {
         // Determine the expected kind of the qualifier expression.
         KindSelector skind = KindSelector.NIL;
         if (tree.name == names._this || tree.name == names._super ||
-                tree.name == names._class || tree.name == names._default)
+                tree.name == names._class)
         {
-            if (tree.name == names._default && !allowPrimitiveClasses) {
-                log.error(DiagnosticFlag.SOURCE_LEVEL, tree.pos(),
-                        Feature.PRIMITIVE_CLASSES.error(sourceName));
-            }
             skind = KindSelector.TYP;
         } else {
             if (pkind().contains(KindSelector.PCK))
@@ -4281,15 +4277,10 @@ public class Attr extends JCTree.Visitor {
             while (elt.hasTag(ARRAY))
                 elt = ((ArrayType)elt).elemtype;
             if (elt.hasTag(TYPEVAR)) {
-                if (tree.name == names._default) {
-                    result = check(tree, litType(BOT).constType(null),
-                            KindSelector.VAL, resultInfo);
-                } else {
-                    log.error(tree.pos(), Errors.TypeVarCantBeDeref);
-                    result = tree.type = types.createErrorType(tree.name, site.tsym, site);
-                    tree.sym = tree.type.tsym;
-                    return;
-                }
+                log.error(tree.pos(), Errors.TypeVarCantBeDeref);
+                result = tree.type = types.createErrorType(tree.name, site.tsym, site);
+                tree.sym = tree.type.tsym;
+                return;
             }
         }
 
@@ -4433,9 +4424,7 @@ public class Attr extends JCTree.Visitor {
                     // In this case, we have already made sure in
                     // visitSelect that qualifier expression is a type.
                     return syms.getClassField(site, types);
-                } else if (name == names._default) {
-                    return new VarSymbol(STATIC, names._default, site, site.tsym);
-                } else if (name == names.ref && site.isPrimitiveClass() && resultInfo.pkind.contains(KindSelector.TYP)) {
+               } else if (name == names.ref && site.isPrimitiveClass() && resultInfo.pkind.contains(KindSelector.TYP)) {
                     return site.tsym.referenceProjection();
                 } else if (name == names.val && site.isPrimitiveClass() && resultInfo.pkind.contains(KindSelector.TYP)) {
                     return site.tsym;
@@ -4448,10 +4437,6 @@ public class Attr extends JCTree.Visitor {
             case WILDCARD:
                 throw new AssertionError(tree);
             case TYPEVAR:
-                if (name == names._default) {
-                    // Be sure to return the default value before examining bounds
-                    return new VarSymbol(STATIC, names._default, site, site.tsym);
-                }
                 // Normally, site.getUpperBound() shouldn't be null.
                 // It should only happen during memberEnter/attribBase
                 // when determining the super type which *must* be
@@ -4481,8 +4466,6 @@ public class Attr extends JCTree.Visitor {
                     // In this case, we have already made sure in Select that
                     // qualifier expression is a type.
                     return syms.getClassField(site, types);
-                } else if (name == names._default) {
-                    return new VarSymbol(STATIC, names._default, site, site.tsym);
                 } else {
                     log.error(pos, Errors.CantDeref(site));
                     return syms.errSymbol;
@@ -4896,6 +4879,30 @@ public class Attr extends JCTree.Visitor {
             log.report(errDiag);
             return types.createErrorType(site);
         }
+    }
+
+    public void visitDefaultExpression(JCDefaultExpression tree) {
+        if (!allowPrimitiveClasses) {
+            log.error(DiagnosticFlag.SOURCE_LEVEL, tree.pos(),
+                    Feature.PRIMITIVE_CLASSES.error(sourceName));
+        }
+
+        // Attribute the qualifier expression, and determine its symbol (if any).
+        Type site = attribTree(tree.clazz, env, new ResultInfo(KindSelector.TYP, Type.noType));
+        if (!pkind().contains(KindSelector.TYP_PCK))
+            site = capture(site); // Capture field access
+
+        Symbol sitesym = TreeInfo.symbol(tree.clazz);
+        Symbol sym = switch (site.getTag()) {
+                case PACKAGE, WILDCARD -> throw new AssertionError(tree);
+                case ERROR -> types.createErrorType(names._default, site.tsym, site).tsym;
+                default -> new VarSymbol(STATIC, names._default, site, site.tsym);
+        };
+
+        if (site.hasTag(TYPEVAR) && sym.kind != ERR) {
+            site = types.skipTypeVars(site, true);
+        }
+        result = checkId(tree, site, sym, env, resultInfo);
     }
 
     public void visitLiteral(JCLiteral tree) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/CRTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/CRTable.java
@@ -33,7 +33,6 @@ import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.tree.JCTree.*;
 import com.sun.tools.javac.tree.EndPosTable;
-import com.sun.tools.javac.tree.JCTree.JCSwitchExpression;
 
 /** This class contains the CharacterRangeTable for some method
  *  and the hashtable for mapping trees or lists of trees to their
@@ -365,6 +364,13 @@ implements CRTFlags {
             result = sr;
         }
 
+        @Override
+        public void visitDefaultValue(JCDefaultValue tree) {
+            SourceRange sr = new SourceRange(startPos(tree), endPos(tree));
+            sr.mergeWith(csp(tree.clazz));
+            result = sr;
+        }
+        
         public void visitIf(JCIf tree) {
             SourceRange sr = new SourceRange(startPos(tree), endPos(tree));
             sr.mergeWith(csp(tree.cond));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/CRTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/CRTable.java
@@ -370,7 +370,7 @@ implements CRTFlags {
             sr.mergeWith(csp(tree.clazz));
             result = sr;
         }
-        
+
         public void visitIf(JCIf tree) {
             SourceRange sr = new SourceRange(startPos(tree), endPos(tree));
             sr.mergeWith(csp(tree.cond));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2348,16 +2348,6 @@ public class Gen extends JCTree.Visitor {
             code.emitLdc((LoadableConstant)checkDimension(tree.pos(), tree.selected.type));
             result = items.makeStackItem(pt);
             return;
-        } else if (tree.name == names._default) {
-            if (tree.type.asElement().isPrimitiveClass()) {
-                code.emitop2(defaultvalue, checkDimension(tree.pos(), tree.type), PoolWriter::putClass);
-            } else if (tree.type.isReference()) {
-                code.emitop0(aconst_null);
-            } else {
-                code.emitop0(zero(Code.typecode(tree.type)));
-            }
-            result = items.makeStackItem(tree.type);
-            return;
         }
 
         Symbol ssym = TreeInfo.symbol(tree.selected);
@@ -2412,6 +2402,18 @@ public class Gen extends JCTree.Visitor {
                 }
             }
         }
+    }
+
+    public void visitDefaultExpression(JCDefaultExpression tree) {
+        if (tree.type.asElement().isPrimitiveClass()) {
+            code.emitop2(defaultvalue, checkDimension(tree.pos(), tree.type), PoolWriter::putClass);
+        } else if (tree.type.isReference()) {
+            code.emitop0(aconst_null);
+        } else {
+            code.emitop0(zero(Code.typecode(tree.type)));
+        }
+        result = items.makeStackItem(tree.type);
+        return;
     }
 
     public boolean isInvokeDynamic(Symbol sym) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2404,7 +2404,7 @@ public class Gen extends JCTree.Visitor {
         }
     }
 
-    public void visitDefaultExpression(JCDefaultExpression tree) {
+    public void visitDefaultValue(JCDefaultValue tree) {
         if (tree.type.asElement().isPrimitiveClass()) {
             code.emitop2(defaultvalue, checkDimension(tree.pos(), tree.type), PoolWriter::putClass);
         } else if (tree.type.isReference()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
@@ -200,7 +200,8 @@ public class TransValues extends TreeTranslator {
                     // Synthesize code to allocate factory "product" via: V $this = V.default;
                     Assert.check(symbol.type.getParameterTypes().size() == 0);
                     final JCExpression type = make.Type(currentClass.type);
-                    rhs = make.Select(type, new VarSymbol(STATIC, names._default, currentClass.type, currentClass.sym));
+                    rhs = make.DefaultExpression(type);
+                    rhs.type = currentClass.type;
                 } else {
                     // This must be a chained call of form `this(args)'; Mutate it into a factory invocation i.e V $this = V.init(args);
                     Assert.check(TreeInfo.name(TreeInfo.firstConstructorCall(tree).meth) == names._this);
@@ -335,7 +336,7 @@ public class TransValues extends TreeTranslator {
            V.ref.member to V.member
         */
         fieldAccess.selected = translate(fieldAccess.selected);
-        if (fieldAccess.name != names._class && fieldAccess.name != names._default) {  // TODO: this and super ??
+        if (fieldAccess.name != names._class) {  // TODO: this and super ??
             Symbol sym = TreeInfo.symbol(fieldAccess);
             Symbol sitesym = TreeInfo.symbol(fieldAccess.selected);
             TypeSymbol selectedType = fieldAccess.selected.type.tsym;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransValues.java
@@ -200,7 +200,7 @@ public class TransValues extends TreeTranslator {
                     // Synthesize code to allocate factory "product" via: V $this = V.default;
                     Assert.check(symbol.type.getParameterTypes().size() == 0);
                     final JCExpression type = make.Type(currentClass.type);
-                    rhs = make.DefaultExpression(type);
+                    rhs = make.DefaultValue(type);
                     rhs.type = currentClass.type;
                 } else {
                     // This must be a chained call of form `this(args)'; Mutate it into a factory invocation i.e V $this = V.init(args);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1357,7 +1357,7 @@ public class JavacParser implements Parser {
                             case DEFAULT:
                                 if (typeArgs != null) return illegal();
                                 selectExprMode();
-                                t = to(F.at(pos).Select(t, names._default));
+                                t = to(F.at(pos).DefaultExpression(t));
                                 nextToken();
                                 break loop;
                             case CLASS:
@@ -1434,7 +1434,7 @@ public class JavacParser implements Parser {
                             while (token.kind == DOT) {
                                 nextToken();
                                 if (token.kind == DEFAULT) {
-                                    t =  toP(F.at(token.pos).Select(t, names._default));
+                                    t =  toP(F.at(token.pos).DefaultExpression(t));
                                     nextToken();
                                     selectExprMode();
                                     return term3Rest(t, typeArgs);
@@ -2277,7 +2277,11 @@ public class JavacParser implements Parser {
                 // taking care to handle some interior dimension(s) being annotated.
                 if ((tag == TYPEARRAY && TreeInfo.containsTypeAnnotation(t)) || tag == ANNOTATED_TYPE)
                     syntaxError(token.pos, Errors.NoAnnotationsOnDotClass);
-                t = toP(F.at(pos).Select(t, selector == CLASS ? names._class : names._default));
+                if (selector == CLASS) {
+                    t = toP(F.at(pos).Select(t, names._class));
+                } else {
+                    t = toP(F.at(pos).DefaultExpression(t));
+                }
             }
         } else if ((mode & TYPE) != 0) {
             if (token.kind != COLCOL) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1357,7 +1357,7 @@ public class JavacParser implements Parser {
                             case DEFAULT:
                                 if (typeArgs != null) return illegal();
                                 selectExprMode();
-                                t = to(F.at(pos).DefaultExpression(t));
+                                t = to(F.at(pos).DefaultValue(t));
                                 nextToken();
                                 break loop;
                             case CLASS:
@@ -1434,7 +1434,7 @@ public class JavacParser implements Parser {
                             while (token.kind == DOT) {
                                 nextToken();
                                 if (token.kind == DEFAULT) {
-                                    t =  toP(F.at(token.pos).DefaultExpression(t));
+                                    t =  toP(F.at(token.pos).DefaultValue(t));
                                     nextToken();
                                     selectExprMode();
                                     return term3Rest(t, typeArgs);
@@ -2280,7 +2280,7 @@ public class JavacParser implements Parser {
                 if (selector == CLASS) {
                     t = toP(F.at(pos).Select(t, names._class));
                 } else {
-                    t = toP(F.at(pos).DefaultExpression(t));
+                    t = toP(F.at(pos).DefaultValue(t));
                 }
             }
         } else if ((mode & TYPE) != 0) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -253,6 +253,10 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
          */
         SELECT,
 
+        /** Default expressions, of type DefaultExpressionTree.
+         */
+        DEFAULT_EXPRESSION,
+
         /** Member references, of type Reference.
          */
         REFERENCE,
@@ -1355,6 +1359,32 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         @Override
         public Tag getTag() {
             return CASE;
+        }
+    }
+
+    /**
+     * A "Identifier<TA1, TA2>.default" construction.
+     */
+    public static class JCDefaultExpression extends JCPolyExpression implements DefaultExpressionTree {
+        public JCExpression clazz;
+
+        protected JCDefaultExpression(JCExpression clazz) {
+            this.clazz = clazz;
+        }
+        @Override
+        public void accept(Visitor v) { v.visitDefaultExpression(this); }
+
+        @DefinedBy(Api.COMPILER_TREE)
+        public Kind getKind() { return Kind.DEFAULT_EXPRESSION; }
+        @Override @DefinedBy(Api.COMPILER_TREE)
+        public ExpressionTree getClazz() { return clazz; }
+        @Override @DefinedBy(Api.COMPILER_TREE)
+        public <R,D> R accept(TreeVisitor<R,D> v, D d) {
+            return v.visitDefaultExpression(this, d);
+        }
+        @Override
+        public Tag getTag() {
+            return DEFAULT_EXPRESSION;
         }
     }
 
@@ -3209,6 +3239,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         JCSwitchExpression SwitchExpression(JCExpression selector, List<JCCase> cases);
         JCCase Case(CaseTree.CaseKind caseKind, List<JCExpression> pat,
                     List<JCStatement> stats, JCTree body);
+        JCDefaultExpression DefaultExpression(JCExpression type);
         JCSynchronized Synchronized(JCExpression lock, JCBlock body);
         JCTry Try(JCBlock body, List<JCCatch> catchers, JCBlock finalizer);
         JCTry Try(List<JCTree> resources,
@@ -3287,6 +3318,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public void visitLabelled(JCLabeledStatement that)   { visitTree(that); }
         public void visitSwitch(JCSwitch that)               { visitTree(that); }
         public void visitCase(JCCase that)                   { visitTree(that); }
+        public void visitDefaultExpression(JCDefaultExpression that) { visitTree(that); }
         public void visitSwitchExpression(JCSwitchExpression that)               { visitTree(that); }
         public void visitSynchronized(JCSynchronized that)   { visitTree(that); }
         public void visitTry(JCTry that)                     { visitTree(that); }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -253,9 +253,9 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
          */
         SELECT,
 
-        /** Default expressions, of type DefaultExpressionTree.
+        /** Default values, of type DefaultValueTree.
          */
-        DEFAULT_EXPRESSION,
+        DEFAULT_VALUE,
 
         /** Member references, of type Reference.
          */
@@ -1365,26 +1365,26 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
     /**
      * A "Identifier<TA1, TA2>.default" construction.
      */
-    public static class JCDefaultExpression extends JCPolyExpression implements DefaultExpressionTree {
+    public static class JCDefaultValue extends JCPolyExpression implements DefaultValueTree {
         public JCExpression clazz;
 
-        protected JCDefaultExpression(JCExpression clazz) {
+        protected JCDefaultValue(JCExpression clazz) {
             this.clazz = clazz;
         }
         @Override
-        public void accept(Visitor v) { v.visitDefaultExpression(this); }
+        public void accept(Visitor v) { v.visitDefaultValue(this); }
 
         @DefinedBy(Api.COMPILER_TREE)
-        public Kind getKind() { return Kind.DEFAULT_EXPRESSION; }
+        public Kind getKind() { return Kind.DEFAULT_VALUE; }
         @Override @DefinedBy(Api.COMPILER_TREE)
-        public ExpressionTree getClazz() { return clazz; }
+        public JCExpression getType() { return clazz; }
         @Override @DefinedBy(Api.COMPILER_TREE)
         public <R,D> R accept(TreeVisitor<R,D> v, D d) {
-            return v.visitDefaultExpression(this, d);
+            return v.visitDefaultValue(this, d);
         }
         @Override
         public Tag getTag() {
-            return DEFAULT_EXPRESSION;
+            return DEFAULT_VALUE;
         }
     }
 
@@ -3239,7 +3239,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         JCSwitchExpression SwitchExpression(JCExpression selector, List<JCCase> cases);
         JCCase Case(CaseTree.CaseKind caseKind, List<JCExpression> pat,
                     List<JCStatement> stats, JCTree body);
-        JCDefaultExpression DefaultExpression(JCExpression type);
+        JCDefaultValue DefaultValue(JCExpression type);
         JCSynchronized Synchronized(JCExpression lock, JCBlock body);
         JCTry Try(JCBlock body, List<JCCatch> catchers, JCBlock finalizer);
         JCTry Try(List<JCTree> resources,
@@ -3318,7 +3318,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public void visitLabelled(JCLabeledStatement that)   { visitTree(that); }
         public void visitSwitch(JCSwitch that)               { visitTree(that); }
         public void visitCase(JCCase that)                   { visitTree(that); }
-        public void visitDefaultExpression(JCDefaultExpression that) { visitTree(that); }
+        public void visitDefaultValue(JCDefaultValue that) { visitTree(that); }
         public void visitSwitchExpression(JCSwitchExpression that)               { visitTree(that); }
         public void visitSynchronized(JCSynchronized that)   { visitTree(that); }
         public void visitTry(JCTry that)                     { visitTree(that); }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -743,7 +743,7 @@ public class Pretty extends JCTree.Visitor {
         }
     }
 
-    public void visitDefaultExpression(JCDefaultExpression tree) {
+    public void visitDefaultValue(JCDefaultValue tree) {
         try {
             printExpr(tree.clazz, TreeInfo.postfixPrec);
             print(".default");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -743,6 +743,15 @@ public class Pretty extends JCTree.Visitor {
         }
     }
 
+    public void visitDefaultExpression(JCDefaultExpression tree) {
+        try {
+            printExpr(tree.clazz, TreeInfo.postfixPrec);
+            print(".default");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     public void visitDoLoop(JCDoWhileLoop tree) {
         try {
             print("do ");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
@@ -199,6 +199,13 @@ public class TreeCopier<P> implements TreeVisitor<JCTree,P> {
     }
 
     @DefinedBy(Api.COMPILER_TREE)
+    public JCTree visitDefaultExpression(DefaultExpressionTree node, P p) {
+        JCDefaultExpression t = (JCDefaultExpression) node;
+        JCExpression clazz = copy(t.clazz, p);
+        return M.at(t.pos).DefaultExpression(clazz);
+    }
+
+    @DefinedBy(Api.COMPILER_TREE)
     public JCTree visitDoWhileLoop(DoWhileLoopTree node, P p) {
         JCDoWhileLoop t = (JCDoWhileLoop) node;
         JCStatement body = copy(t.body, p);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
@@ -199,10 +199,10 @@ public class TreeCopier<P> implements TreeVisitor<JCTree,P> {
     }
 
     @DefinedBy(Api.COMPILER_TREE)
-    public JCTree visitDefaultExpression(DefaultExpressionTree node, P p) {
-        JCDefaultExpression t = (JCDefaultExpression) node;
+    public JCTree visitDefaultValue(DefaultValueTree node, P p) {
+        JCDefaultValue t = (JCDefaultValue) node;
         JCExpression clazz = copy(t.clazz, p);
-        return M.at(t.pos).DefaultExpression(clazz);
+        return M.at(t.pos).DefaultValue(clazz);
     }
 
     @DefinedBy(Api.COMPILER_TREE)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -487,8 +487,8 @@ public class TreeInfo {
             }
             case CONDEXPR:
                 return getStartPos(((JCConditional) tree).cond);
-            case DEFAULT_EXPRESSION:
-                return getStartPos(((JCDefaultExpression) tree).clazz);
+            case DEFAULT_VALUE:
+                return getStartPos(((JCDefaultValue) tree).clazz);
             case EXEC:
                 return getStartPos(((JCExpressionStatement) tree).expr);
             case INDEXED:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -487,6 +487,8 @@ public class TreeInfo {
             }
             case CONDEXPR:
                 return getStartPos(((JCConditional) tree).cond);
+            case DEFAULT_EXPRESSION:
+                return getStartPos(((JCDefaultExpression) tree).clazz);
             case EXEC:
                 return getStartPos(((JCExpressionStatement) tree).expr);
             case INDEXED:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -298,8 +298,8 @@ public class TreeMaker implements JCTree.Factory {
         return tree;
     }
 
-    public JCDefaultExpression DefaultExpression(JCExpression type) {
-        JCDefaultExpression tree = new JCDefaultExpression(type);
+    public JCDefaultValue DefaultValue(JCExpression type) {
+        JCDefaultValue tree = new JCDefaultValue(type);
         tree.pos = pos;
         return tree;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -298,6 +298,12 @@ public class TreeMaker implements JCTree.Factory {
         return tree;
     }
 
+    public JCDefaultExpression DefaultExpression(JCExpression type) {
+        JCDefaultExpression tree = new JCDefaultExpression(type);
+        tree.pos = pos;
+        return tree;
+    }
+
     public JCSwitchExpression SwitchExpression(JCExpression selector, List<JCCase> cases) {
         JCSwitchExpression tree = new JCSwitchExpression(selector, cases);
         tree.pos = pos;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
@@ -186,6 +186,10 @@ public class TreeScanner extends Visitor {
         scan(tree.stats);
     }
 
+    public void visitDefaultExpression(JCDefaultExpression tree) {
+        scan(tree.clazz);
+    }
+
     public void visitSwitchExpression(JCSwitchExpression tree) {
         scan(tree.selector);
         scan(tree.cases);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeScanner.java
@@ -186,7 +186,7 @@ public class TreeScanner extends Visitor {
         scan(tree.stats);
     }
 
-    public void visitDefaultExpression(JCDefaultExpression tree) {
+    public void visitDefaultValue(JCDefaultValue tree) {
         scan(tree.clazz);
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
@@ -380,6 +380,11 @@ public class TreeTranslator extends JCTree.Visitor {
         result = tree;
     }
 
+    public void visitDefaultExpression(JCDefaultExpression tree) {
+        tree.clazz = translate(tree.clazz);
+        result = tree;
+    }
+
     public void visitReference(JCMemberReference tree) {
         tree.expr = translate(tree.expr);
         result = tree;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
@@ -380,7 +380,7 @@ public class TreeTranslator extends JCTree.Visitor {
         result = tree;
     }
 
-    public void visitDefaultExpression(JCDefaultExpression tree) {
+    public void visitDefaultValue(JCDefaultValue tree) {
         tree.clazz = translate(tree.clazz);
         result = tree;
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/UncheckedDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UncheckedDefault.java
@@ -11,4 +11,10 @@ public primitive class UncheckedDefault<E> {
     public static void main(String [] args) {
         UncheckedDefault<String> foo = UncheckedDefault.default;
     }
+
+    public E makeDefault() {
+        E e = E.default;
+        return e;
+    }
+
 }


### PR DESCRIPTION
To prepare for making .default a poly expression and to implement further logic, .default-expressions should be split off as a separate AST node.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263900](https://bugs.openjdk.java.net/browse/JDK-8263900): [lworld] Make .default a separate node type in the parser.


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/valhalla pull/370/head:pull/370`
`$ git checkout pull/370`

To update a local copy of the PR:
`$ git checkout pull/370`
`$ git pull https://git.openjdk.java.net/valhalla pull/370/head`
