### PR TITLE
8262831: [lworld] C2 compilation fails with assert "should be addp but is Phi"

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3922,6 +3922,12 @@ intptr_t InitializeNode::can_capture_store(StoreNode* st, PhaseGVN* phase, bool 
                 // the store control then we cannot capture the store.
                 assert(!n->is_Store(), "2 stores to same slice on same control?");
                 Node* base = other_adr;
+                if (base->is_Phi()) {
+                  // In rare case, base may be a PhiNode and it may reads
+                  // the same memory slice between InitializeNode and store.
+                  failed = true;
+                  break;
+                }
                 assert(base->is_AddP(), "should be addp but is %s", base->Name());
                 base = base->in(AddPNode::Base);
                 if (base != NULL) {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3923,7 +3923,7 @@ intptr_t InitializeNode::can_capture_store(StoreNode* st, PhaseGVN* phase, bool 
                 assert(!n->is_Store(), "2 stores to same slice on same control?");
                 Node* base = other_adr;
                 if (base->is_Phi()) {
-                  // In rare case, base may be a PhiNode and it may reads
+                  // In rare case, base may be a PhiNode and it may read
                   // the same memory slice between InitializeNode and store.
                   failed = true;
                   break;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283 8261037 8261874 8262128
+ * @bug 8260034 8260225 8260283 8261037 8261874 8262128 8262831
  * @summary Generated inline type tests.
  * @run main/othervm -Xbatch
  *                   compiler.valhalla.inlinetypes.TestGenerated
@@ -56,6 +56,10 @@ primitive class MyValue3 {
 primitive class MyValue4 {
     short b = 2;
     int c = 8;
+}
+
+primitive class MyValue5 {
+    int b = 2;
 }
 
 public class TestGenerated {
@@ -182,12 +186,31 @@ public class TestGenerated {
         return f;
     }
 
+    int test13_iField;
+    MyValue5 test13_c;
+    MyValue5 test13_t;
+
+    void test13(MyValue5[] array) {
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < 10; ++j) {
+                test13_iField = 6;
+            }
+            for (int j = 0; j < 2; ++j) {
+                test13_iField += array[0].b;
+            }
+            MyValue5[] array2 = {new MyValue5()};
+            test13_c = array[0];
+            array2[0] = test13_t;
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
         MyValue1[] array2 = new MyValue1[10];
         MyValue1[] array3 = { new MyValue1() };
         MyValue3[] array4 = { new MyValue3() };
+        MyValue5[] array5 = { new MyValue5() };
         array4[0].intArray[0] = 42;
 
         for (int i = 0; i < 50_000; ++i) {
@@ -203,6 +226,7 @@ public class TestGenerated {
             t.test10(array4);
             t.test11(array4);
             t.test12();
+            t.test13(array5);
         }
     }
 }


### PR DESCRIPTION
Hi,

Can I have a review of this bug fix?

The following test case is crashed at `(5)`:
```
   void test(MyValue[] array) {
        for (int i = 0; i < 10; ++i) {
            for (int j = 0; j < 10; ++j) {                                (1)
                iField = 6;					                   (2)
            }									  (3)
            for (int j = 0; j < 2; ++j) {
                iField += array[0].b;
            }
            MyValue[] array2 = {new MyValue()};           (4)
            c = array[0];						  (5) // hit the assertion
            array2[0] = t;						  (6)
        }
    }
```
I did some investigations. C2 wants to check whether there are other Mem nodes between `(4)` and `(6)` that read or write the array2, because it hopes to merge `(4)` and `(6)` into an InitializeNode. If it finds that there are any reads or writes, such as LoadI in `(5)`, then its Address input must be an AddPNode. But in fact, it may be a PhiNode, so an assertion is hit.

![crash1](https://user-images.githubusercontent.com/5010047/112446079-c977b180-8d8a-11eb-9d75-3c0dd7487e58.jpg)

Why does PhiNode appear on (5) as the input of LoadINode? Because the loop unrolling (PhaseIdealLoop::do_unroll) occurred in `(1)-(3)`, it produced a cloned node of the parameter array(not as straightforward as I said, actually it's a CastPPNode which produced via extra steps), and then the parameter array and the cloned nodes were merged, thus a PhiNode node appeared.

![crash2](https://user-images.githubusercontent.com/5010047/112446126-d5637380-8d8a-11eb-834e-7b62d03acd25.jpg)

Thanks Tobias for pointing out that this scenario is not reproducible in mainline JDK because we can't perform such aggressive scalarization for non-inline types. So we'd better fix it in Valhalla for now.

Thanks!
Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262831](https://bugs.openjdk.java.net/browse/JDK-8262831): [lworld] C2 compilation fails with assert "should be addp but is Phi"


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to 57704eafd9744621f53ea9be7f02f0e9b4cf6709


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/371/head:pull/371` \
`$ git checkout pull/371`

Update a local copy of the PR: \
`$ git checkout pull/371` \
`$ git pull https://git.openjdk.java.net/valhalla pull/371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 371`

View PR using the GUI difftool: \
`$ git pr show -t 371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/371.diff">https://git.openjdk.java.net/valhalla/pull/371.diff</a>

</details>
