### PR TITLE
8264216: [lworld] unknown.Class.default gives misleading compilation error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -38,7 +38,6 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.TreeVisitor;
 import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.*;
-import com.sun.tools.javac.code.Kinds.KindName;
 import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4894,10 +4894,10 @@ public class Attr extends JCTree.Visitor {
             site = capture(site); // Capture field access
 
         Symbol sym = switch (site.getTag()) {
-        		case WILDCARD -> throw new AssertionError(tree);
+                case WILDCARD -> throw new AssertionError(tree);
                 case PACKAGE -> {
-                	log.error(tree.pos, Errors.CantResolveLocation(Kinds.KindName.CLASS, site.tsym.getQualifiedName(), null, null,
-                			Fragments.Location(Kinds.typeKindName(env.enclClass.type), env.enclClass.type, null)));
+                    log.error(tree.pos, Errors.CantResolveLocation(Kinds.KindName.CLASS, site.tsym.getQualifiedName(), null, null,
+                            Fragments.Location(Kinds.typeKindName(env.enclClass.type), env.enclClass.type, null)));
                     yield syms.errSymbol;
                 }
                 case ERROR -> types.createErrorType(names._default, site.tsym, site).tsym;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -38,6 +38,7 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.TreeVisitor;
 import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.*;
+import com.sun.tools.javac.code.Kinds.KindName;
 import com.sun.tools.javac.code.Lint.LintCategory;
 import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
@@ -4888,12 +4889,17 @@ public class Attr extends JCTree.Visitor {
         }
 
         // Attribute the qualifier expression, and determine its symbol (if any).
-        Type site = attribTree(tree.clazz, env, new ResultInfo(KindSelector.TYP, Type.noType));
+        Type site = attribTree(tree.clazz, env, new ResultInfo(KindSelector.TYP_PCK, Type.noType));
         if (!pkind().contains(KindSelector.TYP_PCK))
             site = capture(site); // Capture field access
 
         Symbol sym = switch (site.getTag()) {
-                case PACKAGE, WILDCARD -> throw new AssertionError(tree);
+        		case WILDCARD -> throw new AssertionError(tree);
+                case PACKAGE -> {
+                	log.error(tree.pos, Errors.CantResolveLocation(Kinds.KindName.CLASS, site.tsym.getQualifiedName(), null, null,
+                			Fragments.Location(Kinds.typeKindName(env.enclClass.type), env.enclClass.type, null)));
+                    yield syms.errSymbol;
+                }
                 case ERROR -> types.createErrorType(names._default, site.tsym, site).tsym;
                 default -> new VarSymbol(STATIC, names._default, site, site.tsym);
         };

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.java
@@ -1,0 +1,14 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8264216
+ * @summary [lworld] unknown.Class.default gives misleading compilation error
+ * @compile/fail/ref=UnknownTypeDefault.out -Xlint:all -Werror -XDrawDiagnostics -XDdev UnknownTypeDefault.java
+ */
+
+public class UnknownTypeDefault {
+
+	public static void main(String [] args) {
+		Object d1 = Y.default;
+		Object d2 = y.Z.default;
+	}
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.java
@@ -7,8 +7,8 @@
 
 public class UnknownTypeDefault {
 
-	public static void main(String [] args) {
-		Object d1 = Y.default;
-		Object d2 = y.Z.default;
-	}
+    public static void main(String [] args) {
+        Object d1 = Y.default;
+        Object d2 = y.Z.default;
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.out
@@ -1,3 +1,3 @@
-UnknownTypeDefault.java:11:30: compiler.err.cant.resolve.location: kindname.class, Y, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
-UnknownTypeDefault.java:12:32: compiler.err.cant.resolve.location: kindname.class, y.Z, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
+UnknownTypeDefault.java:11:22: compiler.err.cant.resolve.location: kindname.class, Y, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
+UnknownTypeDefault.java:12:24: compiler.err.cant.resolve.location: kindname.class, y.Z, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnknownTypeDefault.out
@@ -1,0 +1,3 @@
+UnknownTypeDefault.java:11:30: compiler.err.cant.resolve.location: kindname.class, Y, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
+UnknownTypeDefault.java:12:32: compiler.err.cant.resolve.location: kindname.class, y.Z, null, null, (compiler.misc.location: kindname.class, UnknownTypeDefault, null)
+2 errors


### PR DESCRIPTION
Make the compilation error for `somepkgname.UnknownClass.default` as informative as `UnknownClass.default`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264216](https://bugs.openjdk.java.net/browse/JDK-8264216): [lworld] unknown.Class.default gives misleading compilation error


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/372/head:pull/372` \
`$ git checkout pull/372`

Update a local copy of the PR: \
`$ git checkout pull/372` \
`$ git pull https://git.openjdk.java.net/valhalla pull/372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 372`

View PR using the GUI difftool: \
`$ git pr show -t 372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/372.diff">https://git.openjdk.java.net/valhalla/pull/372.diff</a>

</details>
