### PR TITLE
8263441: [lworld] TestUnloadedInlineTypeField fails due to unexpected compilation level

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -34,6 +34,7 @@ import jdk.test.lib.Asserts;
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox jdk.test.lib.Platform
  * @run main/othervm/timeout=120 -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
  *                               -XX:+UnlockExperimentalVMOptions -XX:+WhiteBoxAPI
+ *                               -XX:PerMethodRecompilationCutoff=-1 -XX:PerBytecodeRecompilationCutoff=-1
  *                               compiler.valhalla.inlinetypes.InlineTypeTest
  *                               compiler.valhalla.inlinetypes.TestUnloadedInlineTypeField
  */


### PR DESCRIPTION
Some of the unit tests trigger frequent recompilation that may lead to test failures because the `PerMethodRecompilationCutoff` is reached for the test method. The fix is to disable `PerMethodRecompilationCutoff` and `PerBytecodeRecompilationCutoff`.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263441](https://bugs.openjdk.java.net/browse/JDK-8263441): [lworld] TestUnloadedInlineTypeField fails due to unexpected compilation level


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/374/head:pull/374` \
`$ git checkout pull/374`

Update a local copy of the PR: \
`$ git checkout pull/374` \
`$ git pull https://git.openjdk.java.net/valhalla pull/374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 374`

View PR using the GUI difftool: \
`$ git pr show -t 374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/374.diff">https://git.openjdk.java.net/valhalla/pull/374.diff</a>

</details>
