### PR TITLE
8264414: [lworld] [AArch64] TestBufferTearing.java fails with C1

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -323,6 +323,10 @@ void InterpreterMacroAssembler::read_inlined_field(Register holder_klass,
           obj, field_index, holder_klass);
 
   bind(done);
+
+  // Ensure the stores to copy the inline field contents are visible
+  // before any subsequent store that publishes this reference.
+  membar(Assembler::StoreStore);
 }
 
 // Load object from cpool->resolved_references(index)

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1617,7 +1617,7 @@ void GraphBuilder::method_return(Value x, bool ignore_return) {
 
   // The conditions for a memory barrier are described in Parse::do_exits().
   bool need_mem_bar = false;
-  if (method()->is_object_constructor() &&
+  if ((method()->is_object_constructor() || method()->is_static_init_factory()) &&
        (scope()->wrote_final() ||
          (AlwaysSafeConstructors && scope()->wrote_fields()) ||
          (support_IRIW_for_not_multiple_copy_atomic_cpu && scope()->wrote_volatile()))) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearingC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearingC1.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+/**
+ * @test TestBufferTearingC1
+ * @key randomness
+ * @summary Additional tests for C1 missing barriers when buffering inline types.
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=-1 -XX:FlatArrayElementMaxSize=0
+ *                   -XX:TieredStopAtLevel=1
+ *                   compiler.valhalla.inlinetypes.TestBufferTearingC1
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=0 -XX:FlatArrayElementMaxSize=-1
+ *                   -XX:TieredStopAtLevel=1
+ *                   compiler.valhalla.inlinetypes.TestBufferTearingC1
+ */
+
+primitive class Point {
+    public final int x, y;
+
+    public Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+primitive class Rect {
+    public final Point a, b;
+
+    public Rect(Point a, Point b) {
+        this.a = a;
+        this.b = b;
+    }
+}
+
+public class TestBufferTearingC1 {
+
+    public static Point[] points = new Point[] { new Point(1, 1) };
+    public static Point point = new Point(1, 1);
+
+    static volatile boolean running = true;
+
+    public static void writePoint(int iter) {
+        Rect r = new Rect(new Point(iter, iter), new Point(iter + 1, iter + 1));
+        point = points[0];  // Indexed load of flattened array (when FlatArrayElementMaxSize != 0)
+        points[0] = r.a;    // Load from flattened field (when InlineFieldMaxFlatSize != 0)
+    }
+
+    private static void checkMissingBarrier() {
+        while (running) {
+            // When FlatArrayElementMaxSize == 0 the "buffered" reference
+            // created by the load from the flattened field `r.a' will be
+            // stored directly in the array at `points[0]'.  It should not be
+            // possible to read through this reference and see the
+            // intermediate zero-initialised state of the object (i.e. there
+            // should be a store-store barrier after copying the flattened
+            // field contents before the store that publishes it).
+            if (points[0].x == 0 || points[0].y == 0) {
+                throw new IllegalStateException();
+            }
+
+            // Similarly, when InlineFieldMaxFlatSize == 0 the buffered
+            // reference created by the indexed load from the flattened array
+            // `points[0]' will be stored directly in the field `points'.  It
+            // should not be possible to read through this reference and see
+            // the intermediate zero-initialised state of the object.
+            if (point.x == 0 || point.y == 0) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread[] threads = new Thread[10];
+        for (int i = 0; i < 10; i++) {
+            threads[i] = new Thread(TestBufferTearingC1::checkMissingBarrier);
+            threads[i].start();
+        }
+
+        for (int i = 1; i < 1_000_000; i++) {
+            writePoint(i);
+        }
+
+        running = false;
+
+        for (int i = 0; i < 10; i++) {
+            threads[i].join();
+        }
+    }
+}


### PR DESCRIPTION
We see failures like this on AArch64 when MyValue.incrementAndCheck() is
compiled with C1:

  java.lang.RuntimeException: Inconsistent field values: expected 0 to equal 675128
        at jdk.test.lib.Asserts.fail(Asserts.java:594)
        at jdk.test.lib.Asserts.assertEquals(Asserts.java:205)
        at jdk.test.lib.Asserts.assertEQ(Asserts.java:178)
        at compiler.valhalla.inlinetypes.MyValue.incrementAndCheck(TestBufferTearing.java:81)
        at compiler.valhalla.inlinetypes.TestBufferTearing$Runner.run(TestBufferTearing.java:124)

The barrier that is usually inserted on return from a method that wrote
final fields should be sufficient to prevent another thread seeing the
zero-initialised intermediate state.  However this barrier isn't
inserted at the moment because method()->is_object_constructor() is
false for primitive class constructors.

C2 has a similar guard around the memory barrier in Parse::do_exits().
I'm not sure if that needs amending as well but I've not seen any
failures due to it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264414](https://bugs.openjdk.java.net/browse/JDK-8264414): [lworld] [AArch64] TestBufferTearing.java fails with C1


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/376/head:pull/376` \
`$ git checkout pull/376`

Update a local copy of the PR: \
`$ git checkout pull/376` \
`$ git pull https://git.openjdk.java.net/valhalla pull/376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 376`

View PR using the GUI difftool: \
`$ git pr show -t 376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/376.diff">https://git.openjdk.java.net/valhalla/pull/376.diff</a>

</details>
