### PR TITLE
8264586: [lworld] C2 compilation fails due to infinite loop in PhaseIterGVN::optimize

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1955,9 +1955,6 @@ static bool return_val_keeps_allocations_alive(Node* ret_val) {
 }
 
 void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
-  if (_inline_type_nodes.length() == 0) {
-    return;
-  }
   // Make sure that the return value does not keep an otherwise unused allocation alive
   if (tf()->returns_inline_type_as_fields()) {
     Node* ret = NULL;
@@ -1977,6 +1974,9 @@ void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
         igvn.remove_dead_node(ret_val);
       }
     }
+  }
+  if (_inline_type_nodes.length() == 0) {
+    return;
   }
   if (remove) {
     // Remove inline type nodes

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -3361,13 +3361,8 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           memnode_worklist.append_if_missing(use);
         }
       } else if (use->Opcode() == Op_Return) {
-        assert(_compile->tf()->returns_inline_type_as_fields(), "must return an inline type");
-        // Get InlineKlass by removing the tag bit from the metadata pointer
-        Node* klass = use->in(TypeFunc::Parms);
-        intptr_t ptr = igvn->type(klass)->isa_rawptr()->get_con();
-        clear_nth_bit(ptr, 0);
-        assert(Metaspace::contains((void*)ptr), "should be klass");
-        assert(((InlineKlass*)ptr)->contains_oops(), "returned inline type must contain a reference field");
+        // Allocation is referenced by field of returned inline type
+        assert(_compile->tf()->returns_inline_type_as_fields(), "EA: unexpected reference by ReturnNode");
       } else {
         uint op = use->Opcode();
         if ((op == Op_StrCompressedCopy || op == Op_StrInflatedCopy) &&

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -168,6 +168,8 @@ private:
     }
   }
 
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+
 public:
   virtual int Opcode() const;
 };

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2377,6 +2377,8 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     if (is_store) {
       const Type* val_t = _gvn.type(val);
       if (!val_t->isa_inlinetype() || val_t->inline_klass() != inline_klass) {
+        set_map(old_map);
+        set_sp(old_sp);
         return false;
       }
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -204,6 +204,21 @@ public class TestGenerated {
         }
     }
 
+    void test14(boolean b, MyValue4 val) {
+        for (int i = 0; i < 10; ++i) {
+            if (b) {
+                val = MyValue4.default;
+            }
+            MyValue4[] array = new MyValue4[1];
+            array[0] = val;
+
+            for (int j = 0; j < 5; ++j) {
+                for (int k = 0; k < 5; ++k) {
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -227,6 +242,7 @@ public class TestGenerated {
             t.test11(array4);
             t.test12();
             t.test13(array5);
+            t.test14(false, MyValue4.default);
         }
     }
 }


### PR DESCRIPTION
The problem is an `InlineTypePtrNode` that becomes dead after CCP removes a redundant null check and then keeps several other nodes alive. Since we don't run any loop opts anymore after CCP, the dead subgraph is not removed and the dead nodes are also not re-processed by `PhaseCCP::transform_once` to update their bottom types. As a result, two `LoadNodes` only used by a `ValueTypePtrNode` end up with types that are inconsistent with their bottom types and are re-enqueued for IGVN indefinitely by this code:
https://github.com/openjdk/valhalla/blob/28a4ec0249fd86fe17f2b816c6f5f8eed31abfeb/src/hotspot/share/opto/memnode.cpp#L352-L358

I think we should aggressively remove `InlineTypePtrNodes` if they are no longer needed to keep track of the individual field values. I've added an Ideal transformation to take care of that.

The patch also includes a fix for an unrelated "Control flow was added although the intrinsic bailed out" failure and some cleanup/refactoring.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264586](https://bugs.openjdk.java.net/browse/JDK-8264586): [lworld] C2 compilation fails due to infinite loop in PhaseIterGVN::optimize


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/377/head:pull/377` \
`$ git checkout pull/377`

Update a local copy of the PR: \
`$ git checkout pull/377` \
`$ git pull https://git.openjdk.java.net/valhalla pull/377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 377`

View PR using the GUI difftool: \
`$ git pr show -t 377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/377.diff">https://git.openjdk.java.net/valhalla/pull/377.diff</a>

</details>
