### PR TITLE
8264085: [lworld] C2 compilation fails with assert "inline type should be loaded"

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -274,6 +274,7 @@ void InlineTypeBaseNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKl
     Node* value = NULL;
     ciType* ft = field_type(i);
     if (ft->is_inlinetype() && ft->as_inline_klass()->is_empty()) {
+      // Loading from a field of an empty inline type. Just return the default instance.
       value = InlineTypeNode::make_default(kit->gvn(), ft->as_inline_klass());
     } else if (field_is_flattened(i)) {
       // Recursively load the flattened inline type field

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -273,13 +273,11 @@ void InlineTypeBaseNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKl
     int offset = holder_offset + field_offset(i);
     Node* value = NULL;
     ciType* ft = field_type(i);
-    if (field_is_flattened(i)) {
-      if (ft->as_inline_klass()->is_empty()) {
-        value = InlineTypeNode::make_default(kit->gvn(), ft->as_inline_klass());
-      } else {
-        // Recursively load the flattened inline type field
-        value = InlineTypeNode::make_from_flattened(kit, ft->as_inline_klass(), base, ptr, holder, offset, decorators);
-      }
+    if (ft->is_inlinetype() && ft->as_inline_klass()->is_empty()) {
+      value = InlineTypeNode::make_default(kit->gvn(), ft->as_inline_klass());
+    } else if (field_is_flattened(i)) {
+      // Recursively load the flattened inline type field
+      value = InlineTypeNode::make_from_flattened(kit, ft->as_inline_klass(), base, ptr, holder, offset, decorators);
     } else {
       const TypeOopPtr* oop_ptr = kit->gvn().type(base)->isa_oopptr();
       bool is_array = (oop_ptr->isa_aryptr() != NULL);
@@ -689,13 +687,13 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
     Node* value = field_value(i);
     if (value->is_InlineType()) {
       InlineTypeNode* vt = value->as_InlineType();
-      if (field_is_flattened(i)) {
-        if (!vt->inline_klass()->is_empty()) {
-          // Check inline type field load recursively
-          base = vt->is_loaded(phase, vk, base, offset - vt->inline_klass()->first_field_offset());
-          if (base == NULL) {
-            return NULL;
-          }
+      if (vt->inline_klass()->is_empty()) {
+        continue;
+      } else if (field_is_flattened(i)) {
+        // Check inline type field load recursively
+        base = vt->is_loaded(phase, vk, base, offset - vt->inline_klass()->first_field_offset());
+        if (base == NULL) {
+          return NULL;
         }
         continue;
       } else {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3711,4 +3711,25 @@ public class TestLWorld extends InlineTypeTest {
         Asserts.assertTrue(test138(rI, false));
         Asserts.assertTrue(test138(rI, true));
     }
+
+    static primitive class Test139Value {
+        Object obj = null;
+        MyValueEmpty empty = MyValueEmpty.default;
+    }
+
+    static primitive class Test139Wrapper {
+        Test139Value value = Test139Value.default;
+    }
+
+    @Test(failOn = ALLOC + LOAD + STORE + TRAP)
+    public MyValueEmpty test139() {
+        Test139Wrapper w = new Test139Wrapper();
+        return w.value.empty;
+    }
+
+    @DontCompile
+    public void test139_verifier(boolean warmup) {
+        MyValueEmpty empty = test139();
+        Asserts.assertEquals(empty, MyValueEmpty.default);
+    }
 }


### PR DESCRIPTION
We hit an assert because C2 fails to replace a load from a non-flattened, empty inline type field by the default oop.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264085](https://bugs.openjdk.java.net/browse/JDK-8264085): [lworld] C2 compilation fails with assert "inline type should be loaded"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/378/head:pull/378` \
`$ git checkout pull/378`

Update a local copy of the PR: \
`$ git checkout pull/378` \
`$ git pull https://git.openjdk.java.net/valhalla pull/378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 378`

View PR using the GUI difftool: \
`$ git pr show -t 378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/378.diff">https://git.openjdk.java.net/valhalla/pull/378.diff</a>

</details>
