### PR TITLE
8264977: [lworld] A primitive class field by name val confuses javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4426,7 +4426,7 @@ public class Attr extends JCTree.Visitor {
                     // In this case, we have already made sure in
                     // visitSelect that qualifier expression is a type.
                     return syms.getClassField(site, types);
-                } else if (site.isPrimitiveClass() && resultInfo.pkind.contains(KindSelector.TYP) && (name == names.ref || name == names.val)) {
+                } else if (site.isPrimitiveClass() && isType(location) && resultInfo.pkind.contains(KindSelector.TYP) && (name == names.ref || name == names.val)) {
                     return site.tsym;
                 } else {
                     // We are seeing a plain identifier as selector.

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensNegativeTest.java
@@ -1,0 +1,43 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8264977
+ * @summary A primitive class field by name val confuses javac
+ * @compile/fail/ref=ValRefTokensNegativeTest.out -XDrawDiagnostics ValRefTokensNegativeTest.java
+ */
+
+public class ValRefTokensNegativeTest  {
+
+    ValRefTokensNegativeTest.ref aa = null;
+    static ValRefTokensNegativeTest.val bb = ValRefTokensNegativeTest.default;
+
+    EmptyValue empty = EmptyValue.default;
+
+    static class ValRefTokensTestWrapper {
+       ValRefTokensNegativeTest val = ValRefTokensNegativeTest.default;
+       ValRefTokensNegativeTest ref = ValRefTokensNegativeTest.default;
+    }
+
+    public EmptyValue test139(int x) {
+        ValRefTokensTestWrapper w = new ValRefTokensTestWrapper();
+        return x == 0 ? w.val.empty : w.ref.empty;
+    }
+
+    int valx() {
+        return EmptyValue.val.x;
+    }
+
+    int refx() {
+        return EmptyValue.ref.x;
+    }
+
+    static class EmptyValue {
+        static int x = 42;
+    }
+
+    public static void main(String [] args) {
+        if (new ValRefTokensNegativeTest().valx() != new ValRefTokensNegativeTest().refx())
+            throw new AssertionError("Broken");
+        if (new ValRefTokensNegativeTest().test139(0).x != new ValRefTokensNegativeTest().test139(1).x)
+            throw new AssertionError("Broken");
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensNegativeTest.out
@@ -1,0 +1,5 @@
+ValRefTokensNegativeTest.java:10:29: compiler.err.cant.resolve.location: kindname.class, ref, , , (compiler.misc.location: kindname.class, ValRefTokensNegativeTest, null)
+ValRefTokensNegativeTest.java:11:36: compiler.err.cant.resolve.location: kindname.class, val, , , (compiler.misc.location: kindname.class, ValRefTokensNegativeTest, null)
+ValRefTokensNegativeTest.java:26:26: compiler.err.cant.resolve.location: kindname.variable, val, , , (compiler.misc.location: kindname.class, ValRefTokensNegativeTest.EmptyValue, null)
+ValRefTokensNegativeTest.java:30:26: compiler.err.cant.resolve.location: kindname.variable, ref, , , (compiler.misc.location: kindname.class, ValRefTokensNegativeTest.EmptyValue, null)
+4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValRefTokensTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8264977
+ * @summary A primitive class field by name val confuses javac
+ * @run main ValRefTokensTest
+ */
+
+public primitive class ValRefTokensTest  {
+
+    ValRefTokensTest.ref aa = null;
+    static ValRefTokensTest.val bb = ValRefTokensTest.default;
+
+    EmptyValue empty = EmptyValue.default;
+
+    static primitive class ValRefTokensTestWrapper {
+       ValRefTokensTest val = ValRefTokensTest.default;
+       ValRefTokensTest ref = ValRefTokensTest.default;
+    }
+
+    public EmptyValue test139(int x) {
+        ValRefTokensTestWrapper w = new ValRefTokensTestWrapper();
+        return x == 0 ? w.val.empty : w.ref.empty;
+    }
+
+    int valx() {
+        return EmptyValue.val.x;
+    }
+
+    int refx() {
+        return EmptyValue.ref.x;
+    }
+
+    static primitive class EmptyValue {
+        static int x = 42;
+    }
+
+    public static void main(String [] args) {
+        if (new ValRefTokensTest().valx() != new ValRefTokensTest().refx())
+            throw new AssertionError("Broken");
+        if (new ValRefTokensTest().test139(0).x != new ValRefTokensTest().test139(1).x)
+            throw new AssertionError("Broken");
+    }
+}


### PR DESCRIPTION
More robust handling of .ref/.val tokens even as we wait for JDK-8244229 for the full solution

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264977](https://bugs.openjdk.java.net/browse/JDK-8264977): [lworld] A primitive class field by name val confuses javac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/380/head:pull/380` \
`$ git checkout pull/380`

Update a local copy of the PR: \
`$ git checkout pull/380` \
`$ git pull https://git.openjdk.java.net/valhalla pull/380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 380`

View PR using the GUI difftool: \
`$ git pr show -t 380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/380.diff">https://git.openjdk.java.net/valhalla/pull/380.diff</a>

</details>
