### PR TITLE
8264895: [lworld] assert(!InstanceKlass::cast(receiver_klass)->is_not_initialized()) failed: receiver_klass must be initialized

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2488,7 +2488,8 @@ void GraphBuilder::new_instance(int klass_index) {
 void GraphBuilder::default_value(int klass_index) {
   bool will_link;
   ciKlass* klass = stream()->get_klass(will_link);
-  if (!stream()->is_unresolved_klass() && klass->is_inlinetype()) {
+  if (!stream()->is_unresolved_klass() && klass->is_inlinetype() &&
+      klass->as_inline_klass()->is_initialized()) {
     ciInlineKlass* vk = klass->as_inline_klass();
     apush(append(new Constant(new InstanceConstant(vk->default_instance()))));
   } else {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,12 @@ public class TestLWorld extends InlineTypeTest {
     }
 
     public static void main(String[] args) throws Throwable {
+        // Make sure Test140Value is loaded but not linked
+        Class<?> class1 = Test140Value.class;
+        // Make sure Test141Value is linked but not initialized
+        Class<?> class2 = Test141Value.class;
+        class2.getDeclaredFields();
+
         TestLWorld test = new TestLWorld();
         test.run(args, MyValue1.class, MyValue2.class, MyValue2Inline.class, MyValue3.class,
                  MyValue3Inline.class, Test51Value.class);
@@ -3731,5 +3737,47 @@ public class TestLWorld extends InlineTypeTest {
     public void test139_verifier(boolean warmup) {
         MyValueEmpty empty = test139();
         Asserts.assertEquals(empty, MyValueEmpty.default);
+    }
+
+    // Test calling a method on a loaded but not linked inline type
+    final primitive class Test140Value {
+        final int x = 42;
+        public int get() {
+            return x;
+        }
+    }
+
+    @Test
+    @Warmup(0)
+    public int test140() {
+        Test140Value vt = Test140Value.default;
+        return vt.get();
+    }
+
+    @DontCompile
+    public void test140_verifier(boolean warmup) {
+        int result = test140();
+        Asserts.assertEquals(result, 0);
+    }
+
+    // Test calling a method on a linked but not initialized inline type
+    final primitive class Test141Value {
+        final int x = 42;
+        public int get() {
+            return x;
+        }
+    }
+
+    @Test
+    @Warmup(0)
+    public int test141() {
+        Test141Value vt = Test141Value.default;
+        return vt.get();
+    }
+
+    @DontCompile
+    public void test141_verifier(boolean warmup) {
+        int result = test141();
+        Asserts.assertEquals(result, 0);
     }
 }


### PR DESCRIPTION
We hit an assert during call resolution of C1 compiled code because the receiver klass is not linked/initialized. This can happen because C1 compiled code does not initialize the inline class at defaultvalue and call resolution does not expect uninitialized klasses (for non-inline classes, the receiver is either null or initialized).

The fix is to deoptimize at defaultvalue for now and add support for runtime patching later with [JDK-8265067](https://bugs.openjdk.java.net/browse/JDK-8265067).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264895](https://bugs.openjdk.java.net/browse/JDK-8264895): [lworld] assert(!InstanceKlass::cast(receiver_klass)->is_not_initialized()) failed: receiver_klass must be initialized


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/382/head:pull/382` \
`$ git checkout pull/382`

Update a local copy of the PR: \
`$ git checkout pull/382` \
`$ git pull https://git.openjdk.java.net/valhalla pull/382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 382`

View PR using the GUI difftool: \
`$ git pr show -t 382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/382.diff">https://git.openjdk.java.net/valhalla/pull/382.diff</a>

</details>
