### PR TITLE
8265118: [lworld] C1 should optimize inline type checkcasts

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2043,8 +2043,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
 }
 
 // Baseline version of withfield, allocate every time
-void GraphBuilder::withfield(int field_index)
-{
+void GraphBuilder::withfield(int field_index) {
   // Save the entire state and re-execute on deopt
   ValueStack* state_before = copy_state_before();
   state_before->set_should_reexecute(true);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -956,4 +956,21 @@ public class TestNullableInlineTypes extends InlineTypeTest {
         res = test39(false, testValue1, testValue1);
         Asserts.assertEquals(res, testValue1.x);
     }
+
+    // Test NPE when casting constant null to inline type
+    @Test()
+    public MyValue1 test40() throws Throwable {
+        Object NULL = null;
+        return (MyValue1)NULL;
+    }
+
+    @DontCompile
+    public void test40_verifier(boolean warmup) throws Throwable {
+        try {
+            test40();
+            throw new RuntimeException("NullPointerException expected");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package compiler.valhalla.inlinetypes;
+package runtime.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
 
@@ -30,7 +30,7 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile TestFieldTypeMismatchHelper.jasm
  * @compile TestFieldTypeMismatch.java
- * @run main/othervm compiler.valhalla.inlinetypes.TestFieldTypeMismatch
+ * @run main/othervm runtime.valhalla.inlinetypes.TestFieldTypeMismatch
  */
 
 final class MyValue {
@@ -46,7 +46,7 @@ public class TestFieldTypeMismatch {
         } catch(IncompatibleClassChangeError err) {
             exception = true;
             Asserts.assertEquals(err.getMessage(),
-                "Class compiler/valhalla/inlinetypes/TestFieldTypeMismatchHelper expects class compiler.valhalla.inlinetypes.MyValue to be an inline type, but it is not");
+                "Class runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper expects class runtime.valhalla.inlinetypes.MyValue to be an inline type, but it is not");
         }
         Asserts.assertTrue(exception);
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper.jasm
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper.jasm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,9 @@
  *
  */
 
-public class compiler/valhalla/inlinetypes/TestFieldTypeMismatchHelper version 61:0 {
+public class runtime/valhalla/inlinetypes/TestFieldTypeMismatchHelper version 61:0 {
 
-    Field field:"Qcompiler/valhalla/inlinetypes/MyValue;";
+    Field field:"Qruntime/valhalla/inlinetypes/MyValue;";
 
     public Method "<init>":"()V"
       stack 1 locals 1
@@ -37,7 +37,7 @@ public class compiler/valhalla/inlinetypes/TestFieldTypeMismatchHelper version 6
     public Method test:"()V" stack 2 locals 1 {
         aload_0;
         aconst_null;
-        putfield Field field:"Qcompiler/valhalla/inlinetypes/MyValue;";
+        putfield Field field:"Qruntime/valhalla/inlinetypes/MyValue;";
         return;
     }
 }


### PR DESCRIPTION
C1's `Canonicalizer::do_CheckCast` should optimize casts to inline klasses when types are known. 

I've added an additional test for null casts and fixed (unrelated) `TestFieldTypeMismatch.java` which was part of the wrong package.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265118](https://bugs.openjdk.java.net/browse/JDK-8265118): [lworld] C1 should optimize inline type checkcasts


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/383/head:pull/383` \
`$ git checkout pull/383`

Update a local copy of the PR: \
`$ git checkout pull/383` \
`$ git pull https://git.openjdk.java.net/valhalla pull/383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 383`

View PR using the GUI difftool: \
`$ git pr show -t 383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/383.diff">https://git.openjdk.java.net/valhalla/pull/383.diff</a>

</details>
