### PR TITLE
JDK-8265376: Prepare for javac change to do the member translation as described in SoV

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -605,6 +605,7 @@ public final class Class<T> implements java.io.Serializable,
     public Optional<Class<?>> referenceType() {
         if (isPrimitive()) return Optional.empty();
         if (isInterface() || isArray()) return Optional.of(this);
+        if (!isPrimitiveClass()) return Optional.of(this);
 
         Class<?>[] valRefTypes = getPrimitiveTypes();
         return valRefTypes.length == 2 ? Optional.of(valRefTypes[1]) : Optional.empty();

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -139,7 +139,9 @@ public class QTypeDescriptorTest {
     @Test(dataProvider = "descriptors")
     public static void testDescriptors(Class<?> defc, String name, Class<?>[] params, boolean found) throws Exception {
         try {
-            defc.getDeclaredMethod(name, params);
+            // TODO: methods are in the reference projection
+            Class<?> declaringClass = defc /* defc.referenceType().get() */;
+            declaringClass.getDeclaredMethod(name, params);
             if (!found) throw new AssertionError("Expected NoSuchMethodException");
         } catch (NoSuchMethodException e) {
             if (found) throw e;


### PR DESCRIPTION
This updates `test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java` and 
`test/jdk/valhalla/valuetypes/Reflection.java` tests to prepare for the javac
change to do the member translation as described in SoV (JDK-8244313).

It also fixes a bug in `Class::referenceType` to return this class if it's an
identity class.  This was uncovered by this test change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265376](https://bugs.openjdk.java.net/browse/JDK-8265376): Prepare for javac change to do the member translation as described in SoV


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/387/head:pull/387` \
`$ git checkout pull/387`

Update a local copy of the PR: \
`$ git checkout pull/387` \
`$ git pull https://git.openjdk.java.net/valhalla pull/387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 387`

View PR using the GUI difftool: \
`$ git pr show -t 387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/387.diff">https://git.openjdk.java.net/valhalla/pull/387.diff</a>

</details>
