### PR TITLE
8265615: [lworld] docs-jdk-api-javadoc target fails with un-escaped angle bracket

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultValueTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/DefaultValueTree.java
@@ -29,9 +29,9 @@ package com.sun.source.tree;
  * A tree node for a {@code default} instance initializion expression.
  *
  * For example:
- * <pre>
+ * <pre>{@code
  *   Optional<String>.default
- * </pre>
+ * }</pre>
  *
  * @jls todo
  *


### PR DESCRIPTION
Escape code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265615](https://bugs.openjdk.java.net/browse/JDK-8265615): [lworld] docs-jdk-api-javadoc target fails with un-escaped angle bracket


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/388/head:pull/388` \
`$ git checkout pull/388`

Update a local copy of the PR: \
`$ git checkout pull/388` \
`$ git pull https://git.openjdk.java.net/valhalla pull/388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 388`

View PR using the GUI difftool: \
`$ git pr show -t 388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/388.diff">https://git.openjdk.java.net/valhalla/pull/388.diff</a>

</details>
