### PR TITLE
8265726: [lworld] C2 compilation fails with assert "uses must be dominated by definitions"

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1249,12 +1249,9 @@ void PhaseCFG::verify() const {
           assert(def_block || def->is_Con(), "must have block; constants for debug info ok");
           // Verify that all definitions dominate their uses (except for virtual
           // instructions merging multiple definitions).
-          // TODO re-enable
-          /*
           assert(n->is_Root() || n->is_Region() || n->is_Phi() || n->is_MachMerge() ||
                  def_block->dominates(block),
                  "uses must be dominated by definitions");
-          */
           // Verify that instructions in the block are in correct order.
           // Uses must follow their definition if they are at the same block.
           // Mostly done to check that MachSpillCopy nodes are placed correctly

--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -314,7 +314,7 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
       }
       // Block of memory-op input
       Block* inb = get_block_for_node(mach->in(j));
-      if (mach->in(j)->is_Con() && inb == get_block_for_node(mach)) {
+      if (mach->in(j)->is_Con() && mach->in(j)->req() == 1 && inb == get_block_for_node(mach)) {
         // Ignore constant loads scheduled in the same block (we can simply hoist them as well)
         continue;
       }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2831,6 +2831,9 @@ void PhaseMacroExpand::expand_mh_intrinsic_return(CallStaticJavaNode* call) {
   _igvn.replace_in_uses(projs->catchall_catchproj, ex_r);
   _igvn.replace_in_uses(projs->catchall_memproj, ex_mem_phi);
   _igvn.replace_in_uses(projs->catchall_ioproj, ex_io_phi);
+  // The CatchNode should not use the ex_io_phi. Re-connect it to the catchall_ioproj.
+  Node* cn = projs->fallthrough_catchproj->in(0);
+  _igvn.replace_input_of(cn, 1, projs->catchall_ioproj);
 
   _igvn.replace_node(ctl, projs->fallthrough_catchproj);
   _igvn.replace_node(mem, projs->fallthrough_memproj);


### PR DESCRIPTION
We hit an assert during `PhaseCFG` because the Phi input to a CatchNode does not dominate. The problem is in `PhaseMacroExpand::expand_mh_intrinsic_return` where we rewire projection nodes to merge the state of the slow call in. 

Here's the `invokeBasic` call before macro expansion:
![BeforeMacroExpand](https://user-images.githubusercontent.com/5312595/115862604-9b8e9700-a434-11eb-862f-eee42bcf0504.png)
And after macro expansion:
![AfterMacroExpand](https://user-images.githubusercontent.com/5312595/115862618-a1847800-a434-11eb-8bd1-fa01d5f518fc.png)
The input of the CatchNode was accidentally replaced by the Phi merging the exception IO from both calls.

The fix is to re-connect the CatchNode.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265726](https://bugs.openjdk.java.net/browse/JDK-8265726): [lworld] C2 compilation fails with assert "uses must be dominated by definitions"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/391/head:pull/391` \
`$ git checkout pull/391`

Update a local copy of the PR: \
`$ git checkout pull/391` \
`$ git pull https://git.openjdk.java.net/valhalla pull/391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 391`

View PR using the GUI difftool: \
`$ git pr show -t 391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/391.diff">https://git.openjdk.java.net/valhalla/pull/391.diff</a>

</details>
