### PR TITLE
8266324: [lworld] [lw3] Component type of arrays of primitive objects incorrectly loaded at link time

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1005,7 +1005,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
       for (SignatureStream ss(m->signature()); !ss.is_done(); ss.next()) {
         if (ss.is_reference()) {
           if (ss.is_array()) {
-            ss.skip_array_prefix();
+            continue;
           }
           if (ss.type() == T_INLINE_TYPE) {
             Symbol* symb = ss.as_symbol();


### PR DESCRIPTION
Small fix to prevent the VM from loading component types of arrays of primitive objects at link time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8266324](https://bugs.openjdk.java.net/browse/JDK-8266324): [lworld] [lw3] Component type of arrays of primitive objects incorrectly loaded at link time


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)
 * [Lois Foltan](https://openjdk.java.net/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/396/head:pull/396` \
`$ git checkout pull/396`

Update a local copy of the PR: \
`$ git checkout pull/396` \
`$ git pull https://git.openjdk.java.net/valhalla pull/396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 396`

View PR using the GUI difftool: \
`$ git pr show -t 396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/396.diff">https://git.openjdk.java.net/valhalla/pull/396.diff</a>

</details>
