### PR TITLE
8265973: [lworld] C2 compilation fails due to infinite loop in PhaseIterGVN::optimize

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -438,7 +438,9 @@ void Compile::disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_Lis
     }
   }
 
-  remove_useless_nodes(_macro_nodes,        useful); // remove useless macro and predicate opaq nodes
+  remove_useless_nodes(_macro_nodes,        useful); // remove useless macro nodes
+  remove_useless_nodes(_predicate_opaqs,    useful); // remove useless predicate opaque nodes
+  remove_useless_nodes(_skeleton_predicate_opaqs, useful);
   remove_useless_nodes(_expensive_nodes,    useful); // remove useless expensive nodes
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
   remove_useless_nodes(_inline_type_nodes,  useful); // remove useless inline type nodes

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -411,7 +411,7 @@ void Compile::remove_useless_node(Node* dead) {
 }
 
 // Disconnect all useless nodes by disconnecting those at the boundary.
-void Compile::remove_useless_nodes(Unique_Node_List &useful) {
+void Compile::disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_List* worklist) {
   uint next = 0;
   while (next < useful.size()) {
     Node *n = useful.at(next++);
@@ -434,7 +434,7 @@ void Compile::remove_useless_nodes(Unique_Node_List &useful) {
       }
     }
     if (n->outcnt() == 1 && n->has_special_unique_user()) {
-      record_for_igvn(n->unique_out());
+      worklist->push(n->unique_out());
     }
   }
 
@@ -442,6 +442,11 @@ void Compile::remove_useless_nodes(Unique_Node_List &useful) {
   remove_useless_nodes(_expensive_nodes,    useful); // remove useless expensive nodes
   remove_useless_nodes(_for_post_loop_igvn, useful); // remove useless node recorded for post loop opts IGVN pass
   remove_useless_nodes(_inline_type_nodes,  useful); // remove useless inline type nodes
+#ifdef ASSERT
+  if (_modified_nodes != NULL) {
+    _modified_nodes->remove_useless_nodes(useful.member_set());
+  }
+#endif
 
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->eliminate_useless_gc_barriers(useful, this);

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -943,7 +943,7 @@ class Compile : public Phase {
 
   void              identify_useful_nodes(Unique_Node_List &useful);
   void              update_dead_node_list(Unique_Node_List &useful);
-  void              remove_useless_nodes (Unique_Node_List &useful);
+  void              disconnect_useless_nodes(Unique_Node_List &useful, Unique_Node_List* worklist);
 
   void              remove_useless_node(Node* dead);
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -506,6 +506,9 @@ Node* InlineTypeBaseNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   if (phase->C->scalarize_in_safepoints() && can_reshape) {
     PhaseIterGVN* igvn = phase->is_IterGVN();
     make_scalar_in_safepoints(igvn);
+    if (outcnt() == 0) {
+      return NULL;
+    }
   }
   Node* oop = get_oop();
   if (oop->isa_InlineTypePtr()) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -425,7 +425,7 @@ PhaseRemoveUseless::PhaseRemoveUseless(PhaseGVN* gvn, Unique_Node_List* worklist
   worklist->remove_useless_nodes(_useful.member_set());
 
   // Disconnect 'useless' nodes that are adjacent to useful nodes
-  C->remove_useless_nodes(_useful);
+  C->disconnect_useless_nodes(_useful, worklist);
 }
 
 //=============================================================================
@@ -1930,6 +1930,13 @@ Node *PhaseCCP::transform( Node *n ) {
   new_node = transform_once(n);     // Check for constant
   _nodes.map( n->_idx, new_node );  // Flag as having been cloned
 
+  // Keep track of nodes that are reachable from the bottom
+  Unique_Node_List useful;
+  useful.push(new_node);
+  if (C->cached_top_node()) {
+    useful.push(C->cached_top_node());
+  }
+
   // Allocate stack of size _nodes.Size()/2 to avoid frequent realloc
   GrowableArray <Node *> trstack(C->live_nodes() >> 1);
 
@@ -1945,11 +1952,18 @@ Node *PhaseCCP::transform( Node *n ) {
           new_input = transform_once(input);   // Check for constant
           _nodes.map( input->_idx, new_input );// Flag as having been cloned
           trstack.push(new_input);
+          useful.push(new_input);
         }
         assert( new_input == clone->in(i), "insanity check");
       }
     }
   }
+
+  // Aggressively remove all useless nodes
+  C->update_dead_node_list(useful);
+  _worklist.remove_useless_nodes(useful.member_set());
+  C->disconnect_useless_nodes(useful, &_worklist);
+
   return new_node;
 }
 

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -567,7 +567,8 @@ protected:
 // Phase for performing global Conditional Constant Propagation.
 // Should be replaced with combined CCP & GVN someday.
 class PhaseCCP : public PhaseIterGVN {
-  Unique_Node_List _useful; // Nodes reachable from the bottom
+  GrowableArray<Node*> _trstack; // Stack for transform operation
+  Unique_Node_List _useful;      // Nodes reachable from the bottom
 
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node *transform_once( Node *n );

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -567,6 +567,8 @@ protected:
 // Phase for performing global Conditional Constant Propagation.
 // Should be replaced with combined CCP & GVN someday.
 class PhaseCCP : public PhaseIterGVN {
+  Unique_Node_List _useful; // Nodes reachable from the bottom
+
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node *transform_once( Node *n );
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -311,7 +311,7 @@ public class TestArrays extends InlineTypeTest {
     // Array load out of bounds (upper bound) at compile time
     @Test
     public int test12() {
-        int arraySize = Math.abs(rI) % 10;;
+        int arraySize = Math.abs(rI) % 10;
         MyValue1[] va = new MyValue1[arraySize];
 
         for (int i = 0; i < arraySize; i++) {
@@ -333,7 +333,7 @@ public class TestArrays extends InlineTypeTest {
     // Array load  out of bounds (lower bound) at compile time
     @Test
     public int test13() {
-        int arraySize = Math.abs(rI) % 10;;
+        int arraySize = Math.abs(rI) % 10;
         MyValue1[] va = new MyValue1[arraySize];
 
         for (int i = 0; i < arraySize; i++) {
@@ -381,7 +381,7 @@ public class TestArrays extends InlineTypeTest {
     // Array store out of bounds (upper bound) at compile time
     @Test
     public int test15() {
-        int arraySize = Math.abs(rI) % 10;;
+        int arraySize = Math.abs(rI) % 10;
         MyValue1[] va = new MyValue1[arraySize];
 
         try {
@@ -402,7 +402,7 @@ public class TestArrays extends InlineTypeTest {
     // Array store out of bounds (lower bound) at compile time
     @Test
     public int test16() {
-        int arraySize = Math.abs(rI) % 10;;
+        int arraySize = Math.abs(rI) % 10;
         MyValue1[] va = new MyValue1[arraySize];
 
         try {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -58,6 +58,14 @@ primitive class MyValue4 {
     int c = 8;
 }
 
+class MyValue4Wrapper {
+    public MyValue4.ref val;
+
+    public MyValue4Wrapper(MyValue4 val) {
+        this.val = val;
+    }
+}
+
 primitive class MyValue5 {
     int b = 2;
 }
@@ -219,6 +227,30 @@ public class TestGenerated {
         }
     }
 
+    void test15() {
+        MyValue4 val = new MyValue4();
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < 10; ++j) {
+                MyValue4[] array = new MyValue4[1];
+                for (int k = 0; k < 10; ++k) {
+                    array[0] = val;
+                    val = array[0];
+                }
+            }
+        }
+    }
+
+    void test16() {
+        MyValue4 val = MyValue4.default;
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < 10; ++j) {
+                val = (new MyValue4Wrapper(val)).val;
+                for (int k = 0; k < 10; ++k) {
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
         EmptyValue[] array1 = { new EmptyValue() };
@@ -243,6 +275,8 @@ public class TestGenerated {
             t.test12();
             t.test13(array5);
             t.test14(false, MyValue4.default);
+            t.test15();
+            t.test16();
         }
     }
 }


### PR DESCRIPTION
This is another instance of [JDK-8264586](https://bugs.openjdk.java.net/browse/JDK-8264586). The fix was not sufficient. The root cause is a subgraph that becomes unreachable from the bottom (but remains reachable from the top) after CCP removes a redundant null check. 

**Gory details:**
CCP has two phases. First, `PhaseCCP::analyze` visits all nodes and updates their types in `_types.map`. Then, `PhaseCCP::do_transform` only visits the nodes that are reachable from the bottom, updates their `bottom_type` and adds them to the IGVN worklist. During the second step, parts of the graph might be cut off (for example, due to a null-check that is found to be redundant) and the nodes of that subgraph are not visited. I.e., the following code is not executed:
https://github.com/openjdk/valhalla/blob/28a4ec0249fd86fe17f2b816c6f5f8eed31abfeb/src/hotspot/share/opto/phaseX.cpp#L1988-L1992

As a result, `LoadNodes` in the dead subgraph end up with types that are inconsistent with their bottom types. Since they are still reachable from the top, they will be processed by IGVN and then re-enqueued for IGVN indefinitely by this code:
https://github.com/openjdk/valhalla/blob/28a4ec0249fd86fe17f2b816c6f5f8eed31abfeb/src/hotspot/share/opto/memnode.cpp#L352-L358

The fix is to aggressively remove useless nodes after CCP. I'll consider upstreaming the fix after some bake time in Valhalla.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265973](https://bugs.openjdk.java.net/browse/JDK-8265973): [lworld] C2 compilation fails due to infinite loop in PhaseIterGVN::optimize


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.java.net/valhalla pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/397.diff">https://git.openjdk.java.net/valhalla/pull/397.diff</a>

</details>
