### PR TITLE
8265720: [lworld] RedefineLeak.java is still problem listed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -162,7 +162,6 @@ runtime/ReservedStack/ReservedStackTest.java 8231031 generic-all
 
 # Valhalla TODO:
 runtime/CompressedOops/CompressedClassPointers.java 8210258 generic-all
-runtime/RedefineTests/RedefineLeak.java 8205032 generic-all
 runtime/SharedArchiveFile/BootAppendTests.java 8210258 generic-all
 runtime/SharedArchiveFile/CdsDifferentCompactStrings.java 8210258 generic-all
 runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java 8210258 generic-all


### PR DESCRIPTION
Trivial delisting

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265720](https://bugs.openjdk.java.net/browse/JDK-8265720): [lworld] RedefineLeak.java is still problem listed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/399/head:pull/399` \
`$ git checkout pull/399`

Update a local copy of the PR: \
`$ git checkout pull/399` \
`$ git pull https://git.openjdk.java.net/valhalla pull/399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 399`

View PR using the GUI difftool: \
`$ git pr show -t 399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/399.diff">https://git.openjdk.java.net/valhalla/pull/399.diff</a>

</details>
