### PR TITLE
8266709: [lworld] compiler/valhalla/inlinetypes/TestLWorldProfiling.java fails after merge

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeTest.java
@@ -108,10 +108,7 @@ import java.util.function.BooleanSupplier;
 public abstract class InlineTypeTest {
     protected static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
-    protected static final int COMP_LEVEL_ANY               = -2;
-    protected static final int COMP_LEVEL_ALL               = -2;
-    protected static final int COMP_LEVEL_AOT               = -1;
-    protected static final int COMP_LEVEL_NONE              =  0;
+    protected static final int COMP_LEVEL_ANY               = -1;
     protected static final int COMP_LEVEL_SIMPLE            =  1;     // C1
     protected static final int COMP_LEVEL_LIMITED_PROFILE   =  2;     // C1, invocation & backedge counters
     protected static final int COMP_LEVEL_FULL_PROFILE      =  3;     // C1, invocation & backedge counters + mdo


### PR DESCRIPTION
Compilation levels mirrored from `CompilerWhiteBoxTest.java` need to be updated after removal of AOT.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8266709](https://bugs.openjdk.java.net/browse/JDK-8266709): [lworld] compiler/valhalla/inlinetypes/TestLWorldProfiling.java fails after merge


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/405/head:pull/405` \
`$ git checkout pull/405`

Update a local copy of the PR: \
`$ git checkout pull/405` \
`$ git pull https://git.openjdk.java.net/valhalla pull/405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 405`

View PR using the GUI difftool: \
`$ git pr show -t 405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/405.diff">https://git.openjdk.java.net/valhalla/pull/405.diff</a>

</details>
