### PR TITLE
8266712: [lworld] compiler/loopstripmining/DeadNodesInOuterLoopAtLoopCloning.java fails after merge

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1144,7 +1144,7 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
       // LoadVector/StoreVector needs additional check to ensure the types match.
       if (store_Opcode() == Op_StoreVector) {
         const TypeVect*  in_vt = st->as_StoreVector()->vect_type();
-        const TypeVect* out_vt = as_LoadVector()->vect_type();
+        const TypeVect* out_vt = is_Load() ? as_LoadVector()->vect_type() : as_StoreVector()->vect_type();
         if (in_vt != out_vt) {
           return NULL;
         }


### PR DESCRIPTION
[JDK-8189802](https://bugs.openjdk.java.net/browse/JDK-8189802) weakened the conditions for calling `can_see_stored_value` from `StoreNode::Identity` (see http://hg.openjdk.java.net/valhalla/valhalla/rev/b826402f953a#l16.35). New code added by [JDK-8263972](https://bugs.openjdk.java.net/browse/JDK-8263972) needs to be adjusted accordingly.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8266712](https://bugs.openjdk.java.net/browse/JDK-8266712): [lworld] compiler/loopstripmining/DeadNodesInOuterLoopAtLoopCloning.java fails after merge


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/406/head:pull/406` \
`$ git checkout pull/406`

Update a local copy of the PR: \
`$ git checkout pull/406` \
`$ git pull https://git.openjdk.java.net/valhalla pull/406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 406`

View PR using the GUI difftool: \
`$ git pr show -t 406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/406.diff">https://git.openjdk.java.net/valhalla/pull/406.diff</a>

</details>
