### PR TITLE
First set of changes to initiate the transition to the L/Q model

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -532,7 +532,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
 
   ciMethod* method = compilation()->method();
   ciType* return_type = method->return_type();
-  if (InlineTypeReturnedAsFields && return_type->is_inlinetype()) {
+  if (InlineTypeReturnedAsFields && return_type->is_inlinetype() && return_type->is_null_free()) {
     ciInlineKlass* vk = return_type->as_inline_klass();
     if (vk->can_be_returned_as_fields()) {
 #ifndef _LP64

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2739,20 +2739,20 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
   jcc(Assembler::notZero, is_empty_inline_type);
 }
 
-void MacroAssembler::test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline_type) {
+void MacroAssembler::test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free_inline_type) {
   movl(temp_reg, flags);
-  shrl(temp_reg, ConstantPoolCacheEntry::is_inline_type_shift);
+  shrl(temp_reg, ConstantPoolCacheEntry::is_null_free_inline_type_shift);
   andl(temp_reg, 0x1);
   testl(temp_reg, temp_reg);
-  jcc(Assembler::notZero, is_inline_type);
+  jcc(Assembler::notZero, is_null_free_inline_type);
 }
 
-void MacroAssembler::test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline_type) {
+void MacroAssembler::test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free_inline_type) {
   movl(temp_reg, flags);
-  shrl(temp_reg, ConstantPoolCacheEntry::is_inline_type_shift);
+  shrl(temp_reg, ConstantPoolCacheEntry::is_null_free_inline_type_shift);
   andl(temp_reg, 0x1);
   testl(temp_reg, temp_reg);
-  jcc(Assembler::zero, not_inline_type);
+  jcc(Assembler::zero, not_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_inlined(Register flags, Register temp_reg, Label& is_inlined) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -116,8 +116,8 @@ class MacroAssembler: public Assembler {
   // get_default_value_oop with extra assertion for empty inline klass
   void get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj);
 
-  void test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline);
-  void test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline);
+  void test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free);
+  void test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free);
   void test_field_is_inlined(Register flags, Register temp_reg, Label& is_inlined);
 
   // Check oops for special arrays, i.e. flattened and/or null-free

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3011,14 +3011,14 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   } else {
     if (is_static) {
       __ load_heap_oop(rax, field);
-      Label is_inline_type, uninitialized;
+      Label is_null_free_inline_type, uninitialized;
       // Issue below if the static field has not been initialized yet
-      __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
-        // field is not an inline type
+      __ test_field_is_null_free_inline_type(flags2, rscratch1, is_null_free_inline_type);
+        // field is not a null free inline type
         __ push(atos);
         __ jmp(Done);
-      // field is an inline type, must not return null even if uninitialized
-      __ bind(is_inline_type);
+      // field is a null free inline type, must not return null even if uninitialized
+      __ bind(is_null_free_inline_type);
         __ testptr(rax, rax);
         __ jcc(Assembler::zero, uninitialized);
           __ push(atos);
@@ -3043,7 +3043,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
           __ jmp(Done);
     } else {
       Label is_inlined, nonnull, is_inline_type, rewrite_inline;
-      __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+      __ test_field_is_null_free_inline_type(flags2, rscratch1, is_inline_type);
         // field is not an inline type
         pop_and_check_object(obj);
         __ load_heap_oop(rax, field);
@@ -3392,14 +3392,14 @@ void TemplateTable::putfield_or_static_helper(int byte_no, bool is_static, Rewri
       __ pop(atos);
       if (is_static) {
         Label is_inline_type;
-        __ test_field_is_not_inline_type(flags2, rscratch1, is_inline_type);
+        __ test_field_is_not_null_free_inline_type(flags2, rscratch1, is_inline_type);
         __ null_check(rax);
         __ bind(is_inline_type);
         do_oop_store(_masm, field, rax);
         __ jmp(Done);
       } else {
         Label is_inline_type, is_inlined, rewrite_not_inline, rewrite_inline;
-        __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+        __ test_field_is_null_free_inline_type(flags2, rscratch1, is_inline_type);
         // Not an inline type
         pop_and_check_object(obj);
         // Store into the field

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -669,7 +669,8 @@ void Canonicalizer::do_CheckCast      (CheckCast*       x) {
       }
     }
     // checkcast of null returns null for non-inline klasses
-    if (!x->klass()->is_inlinetype() && obj->as_Constant() && obj->type()->as_ObjectType()->constant_value()->is_null_object()) {
+    if (!x->klass()->is_inlinetype() && x->is_null_free()
+        && obj->as_Constant() && obj->type()->as_ObjectType()->constant_value()->is_null_object()) {
       set_canonical(obj);
     }
   }

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1074,7 +1074,7 @@ void LIR_OpJavaCall::emit_code(LIR_Assembler* masm) {
 
 bool LIR_OpJavaCall::maybe_return_as_fields(ciInlineKlass** vk_ret) const {
   if (InlineTypeReturnedAsFields &&
-      (method()->signature()->returns_inline_type() ||
+      (method()->signature()->returns_null_free_inline_type() ||
        method()->is_method_handle_intrinsic())) {
     ciType* return_type = method()->return_type();
     if (return_type->is_inlinetype()) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2055,7 +2055,7 @@ bool LIRGenerator::inline_type_field_access_prolog(AccessField* x, CodeEmitInfo*
   bool could_be_flat = !x->is_static() && x->needs_patching();
   // Deoptimize if we load from a static field with an unloaded type because we need
   // the default value if the field is null.
-  bool could_be_null = x->is_static() && x->as_LoadField() != NULL && !field->type()->is_loaded();
+  bool could_be_null = x->is_static() && x->as_LoadField() != NULL && !field->type()->unwrap()->is_loaded();
   assert(!could_be_null || !field->holder()->is_loaded(), "inline type field should be loaded");
   if (could_be_flat || could_be_null) {
     assert(x->needs_patching(), "no deopt required");
@@ -2137,7 +2137,7 @@ void LIRGenerator::do_LoadField(LoadField* x) {
   if (field->signature()->is_Q_signature()) {
     // Load from non-flattened inline type field requires
     // a null check to replace null with the default value.
-    ciInlineKlass* inline_klass = field->type()->as_inline_klass();
+    ciInlineKlass* inline_klass = field->type()->unwrap()->as_inline_klass();
     assert(inline_klass->is_loaded(), "field klass must be loaded");
 
     ciInstanceKlass* holder = field->holder();

--- a/src/hotspot/share/ci/ciClassList.hpp
+++ b/src/hotspot/share/ci/ciClassList.hpp
@@ -60,6 +60,7 @@ class   ciMethod;
 class   ciMethodData;
 class     ciReceiverTypeData;  // part of ciMethodData
 class   ciType;
+class    ciWrapper;
 class    ciReturnAddress;
 class    ciKlass;
 class     ciInstanceKlass;
@@ -116,6 +117,7 @@ friend class ciReplay;                 \
 friend class ciTypeArray;              \
 friend class ciType;                   \
 friend class ciReturnAddress;          \
+friend class  ciWrapper;               \
 friend class ciKlass;                  \
 friend class ciInstanceKlass;          \
 friend class ciInlineKlass;            \

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -602,7 +602,7 @@ ciKlass* ciEnv::get_klass_by_index(const constantPoolHandle& cpool,
 // ciEnv::is_inline_klass
 //
 // Check if the klass is an inline klass.
-bool ciEnv::is_inline_klass(const constantPoolHandle& cpool, int index) {
+bool ciEnv::has_Q_signature(const constantPoolHandle& cpool, int index) {
   GUARDED_VM_ENTRY(return cpool->klass_name_at(index)->is_Q_signature();)
 }
 

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -135,7 +135,7 @@ private:
   ciMethod*  get_method_by_index(const constantPoolHandle& cpool,
                                  int method_index, Bytecodes::Code bc,
                                  ciInstanceKlass* loading_klass);
-  bool       is_inline_klass(const constantPoolHandle& cpool,
+  bool       has_Q_signature(const constantPoolHandle& cpool,
                              int klass_index);
 
   // Implementation methods for loading and constant pool access.
@@ -472,6 +472,10 @@ public:
   void dump_replay_data(outputStream* out);
   void dump_replay_data_unsafe(outputStream* out);
   void dump_compile_data(outputStream* out);
+
+  ciWrapper* make_null_free_wrapper(ciType* type) {
+    return _factory->make_null_free_wrapper(type);
+  }
 };
 
 #endif // SHARE_CI_CIENV_HPP

--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -50,6 +50,7 @@ private:
   int              _offset;
   bool             _is_constant;
   bool             _is_flattened;
+  bool             _is_null_free;
   ciMethod*        _known_to_link_with_put;
   ciInstanceKlass* _known_to_link_with_get;
   ciConstant       _constant_value;
@@ -177,6 +178,7 @@ public:
   bool is_volatile             () const { return flags().is_volatile(); }
   bool is_transient            () const { return flags().is_transient(); }
   bool is_flattened            () const { return _is_flattened; }
+  bool is_null_free            () const { return _is_null_free; }
 
   // The field is modified outside of instance initializer methods
   // (or class/initializer methods if the field is static).

--- a/src/hotspot/share/ci/ciMetadata.hpp
+++ b/src/hotspot/share/ci/ciMetadata.hpp
@@ -60,6 +60,7 @@ class ciMetadata: public ciBaseObject {
   virtual bool is_flat_array_klass() const  { return false; }
   virtual bool is_obj_array_klass() const   { return false; }
   virtual bool is_type_array_klass() const  { return false; }
+  virtual bool is_wrapper() const           { return false; }
   virtual bool flatten_array() const        { return false; }
   virtual void dump_replay_data(outputStream* st) { /* do nothing */ }
 
@@ -110,6 +111,10 @@ class ciMetadata: public ciBaseObject {
   ciInlineKlass*           as_inline_klass() {
     assert(is_inlinetype(), "bad cast");
     return (ciInlineKlass*)this;
+  }
+  ciWrapper*               as_wrapper() {
+    assert(is_wrapper(), "bad cast");
+    return (ciWrapper*)this;
   }
 
   Metadata* constant_encoding() { return _metadata; }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -629,6 +629,12 @@ ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
   return new_ret_addr;
 }
 
+ciWrapper* ciObjectFactory::make_null_free_wrapper(ciType* type) {
+  ciWrapper* wrapper = new (arena()) ciWrapper(type, /* null_free */ true);
+  init_ident_of(wrapper);
+  return wrapper;
+}
+
 // ------------------------------------------------------------------
 // ciObjectFactory::init_ident_of
 void ciObjectFactory::init_ident_of(ciBaseObject* obj) {

--- a/src/hotspot/share/ci/ciObjectFactory.hpp
+++ b/src/hotspot/share/ci/ciObjectFactory.hpp
@@ -139,6 +139,8 @@ public:
 
   ciReturnAddress* get_return_address(int bci);
 
+  ciWrapper* make_null_free_wrapper(ciType* type);
+
   GrowableArray<ciMetadata*>* get_ci_metadata() { return &_ci_metadata; }
   // RedefineClasses support
   void metadata_do(MetadataClosure* f);

--- a/src/hotspot/share/ci/ciSignature.cpp
+++ b/src/hotspot/share/ci/ciSignature.cpp
@@ -64,6 +64,9 @@ ciSignature::ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpo
       _return_type = type;
       break;
     }
+    if (type->is_inlinetype() && ss.has_Q_descriptor()) {
+      type = env->make_null_free_wrapper(type);
+    }
     _types.append(type);
     size += type->size();
   }
@@ -72,7 +75,7 @@ ciSignature::ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpo
 
 // ------------------------------------------------------------------
 // ciSignature::returns_inline_type
-bool ciSignature::returns_inline_type() const {
+bool ciSignature::returns_null_free_inline_type() const {
   GUARDED_VM_ENTRY(return get_symbol()->is_Q_method_signature();)
 }
 

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -57,7 +57,7 @@ public:
 
   ciType*   return_type() const                  { return _return_type; }
   ciType*   type_at(int index) const             { return _types.at(index); }
-  bool      returns_inline_type() const;
+  bool      returns_null_free_inline_type() const;
 
   int       size() const                         { return _size; }
   int       count() const                        { return _types.length(); }

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -196,10 +196,10 @@ ciKlass* ciBytecodeStream::get_klass(bool& will_link) {
 // ciBytecodeStream::is_inline_klass
 //
 // Check if the klass is an inline klass.
-bool ciBytecodeStream::is_inline_klass() const {
+bool ciBytecodeStream::has_Q_signature() const {
   VM_ENTRY_MARK;
   constantPoolHandle cpool(THREAD, _method->get_Method()->constants());
-  return CURRENT_ENV->is_inline_klass(cpool, get_klass_index());
+  return CURRENT_ENV->has_Q_signature(cpool, get_klass_index());
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -219,7 +219,7 @@ public:
   // or checkcast, get the referenced klass.
   ciKlass* get_klass(bool& will_link);
   int get_klass_index() const;
-  bool is_inline_klass() const;
+  bool has_Q_signature() const;
 
   // If this bytecode is one of the ldc variants, get the referenced
   // constant.  Do not attempt to resolve it, since that would require

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -35,6 +35,7 @@ class ciType : public ciMetadata {
   CI_PACKAGE_ACCESS
   friend class ciKlass;
   friend class ciReturnAddress;
+  friend class ciWrapper;
 
 private:
   BasicType _basic_type;
@@ -71,6 +72,9 @@ public:
   bool is_type() const                      { return true; }
   bool is_classless() const                 { return is_primitive_type(); }
 
+  virtual ciType*     unwrap()              { return this; }
+  virtual bool is_null_free() const        { return false; }
+
   const char* name();
   virtual void print_name_on(outputStream* st);
   void print_name() {
@@ -104,6 +108,37 @@ public:
   int  bci() { return _bci; }
 
   static ciReturnAddress* make(int bci);
+};
+
+// ciWrapper
+//
+// This class wraps another type to carry additional information like nullability.
+// Should only be instantiated and used by ciTypeFlow and ciSignature.
+class ciWrapper : public ciType {
+  CI_PACKAGE_ACCESS
+
+private:
+  ciType* _type;
+  bool _null_free;
+
+  ciWrapper(ciType* type, bool null_free) : ciType(type->basic_type()) {
+    assert(type->is_inlinetype()
+          // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
+          || (type->is_instance_klass() && !type->is_loaded()),
+          "should only be used for inline types");
+    _type = type;
+    _null_free = null_free;
+  }
+
+  const char* type_string() { return "ciWrapper"; }
+
+  void print_impl(outputStream* st) { _type->print_impl(st); }
+
+public:
+  bool    is_wrapper() const { return true; }
+
+  ciType*     unwrap()       { return _type; }
+  bool is_null_free() const { return _null_free; }
 };
 
 #endif // SHARE_CI_CITYPE_HPP

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -598,7 +598,7 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
   if (!will_link) {
-    if (str->is_inline_klass()) {
+    if (str->has_Q_signature()) {
       trap(str, klass,
            Deoptimization::make_trap_request
            (Deoptimization::Reason_unloaded,

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5879,7 +5879,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   if (ik->is_inline_klass()) nfields++;
   for (int i = 0; i < nfields; i++) {
     if (((ik->field_access_flags(i) & JVM_ACC_STATIC) == 0)) {
-      if (ik->field_is_inline_type(i)) {
+      if (ik->field_is_null_free_inline_type(i)) {
         Symbol* klass_name = ik->field_signature(i)->fundamental_name(CHECK);
         // Inline classes for instance fields must have been pre-loaded
         // Inline classes for static fields might not have been loaded yet

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -318,8 +318,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
                                                          protection_domain,
                                                          CHECK_NULL);
     if (k != NULL) {
-      if ((class_name->is_Q_array_signature() && !k->is_inline_klass()) ||
-          (!class_name->is_Q_array_signature() && k->is_inline_klass())) {
+      if ((class_name->is_Q_array_signature() && !k->is_inline_klass())) {
             THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), "L/Q mismatch on bottom type");
           }
       k = k->array_klass(ndims, CHECK_NULL);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -350,7 +350,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ConstantPoolCa
       field_vk->write_inlined_field(new_value_h(), offset, vt_oop, CHECK_(return_offset));
     } else { // not inlined
       oop voop = *(oop*)f.interpreter_frame_expression_stack_at(tos_idx);
-      if (voop == NULL && cp_entry->is_inline_type()) {
+      if (voop == NULL && cp_entry->is_null_free_inline_type()) {
         THROW_(vmSymbols::java_lang_NullPointerException(), return_offset);
       }
       assert(voop == NULL || oopDesc::is_oop(voop),"checking argument");
@@ -380,6 +380,7 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_inline_type_field(JavaT
   // If the class is being initialized, the default value is returned.
   instanceHandle mirror_h(THREAD, (instanceOop)mirror);
   InstanceKlass* klass = InstanceKlass::cast(java_lang_Class::as_Klass(mirror));
+  assert(klass->field_signature(index)->is_Q_signature(), "Sanity check");
   if (klass->is_being_initialized() && klass->is_reentrant_initialization(THREAD)) {
     int offset = klass->field_offset(index);
     Klass* field_k = klass->get_inline_type_field_klass_or_null(index);
@@ -956,7 +957,7 @@ void InterpreterRuntime::resolve_get_put(JavaThread* current, Bytecodes::Code by
     info.access_flags().is_final(),
     info.access_flags().is_volatile(),
     info.is_inlined(),
-    info.is_inline_type()
+    info.signature()->is_Q_signature() && info.is_inline_type()
   );
 }
 

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -137,17 +137,17 @@ void ConstantPoolCacheEntry::set_field(Bytecodes::Code get_code,
                                        bool is_final,
                                        bool is_volatile,
                                        bool is_inlined,
-                                       bool is_inline_type) {
+                                       bool is_null_free_inline_type) {
   set_f1(field_holder);
   set_f2(field_offset);
   assert((field_index & field_index_mask) == field_index,
          "field index does not fit in low flag bits");
-  assert(!is_inlined || is_inline_type, "Sanity check");
+  assert(!is_inlined || is_null_free_inline_type, "Sanity check");
   set_field_flags(field_type,
                   ((is_volatile ? 1 : 0) << is_volatile_shift) |
                   ((is_final    ? 1 : 0) << is_final_shift) |
                   ((is_inlined  ? 1 : 0) << is_inlined_shift) |
-                  ((is_inline_type ? 1 : 0) << is_inline_type_shift),
+                  ((is_null_free_inline_type ? 1 : 0) << is_null_free_inline_type_shift),
                   field_index);
   set_bytecode_1(get_code);
   set_bytecode_2(put_code);

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -77,7 +77,7 @@ class PSPromotionManager;
 //
 // The flags after TosState have the following interpretation:
 // bit 27: 0 for fields, 1 for methods
-// I  flag true if field is an inline type (must never be null)
+// I  flag true if field is a null free inline type (must never be null)
 // i  flag true if field is inlined
 // f  flag true if field is marked final
 // v  flag true if field is volatile (only for fields)
@@ -186,7 +186,7 @@ class ConstantPoolCacheEntry {
     is_field_entry_shift       = 26,  // (F) is it a field or a method?
     has_local_signature_shift  = 25,  // (S) does the call site have a per-site signature (sig-poly methods)?
     has_appendix_shift         = 24,  // (A) does the call site have an appendix argument?
-    is_inline_type_shift       = 24,  // (I) is the type of the field an inline type (must never be null)
+    is_null_free_inline_type_shift = 24,  // (I) is the field a null free inline type (must never be null)
     is_forced_virtual_shift    = 23,  // (I) is the interface reference forced to virtual mode?
     is_inlined_shift           = 23,  // (i) is the field inlined?
     is_final_shift             = 22,  // (f) is the field or method final?
@@ -229,7 +229,7 @@ class ConstantPoolCacheEntry {
     bool            is_final,                    // the field is final
     bool            is_volatile,                 // the field is volatile
     bool            is_inlined,                  // the field is inlined
-    bool            is_inline_type               // the field is an inline type (must never be null)
+    bool            is_null_free_inline_type     // the field is an inline type (must never be null)
   );
 
  private:
@@ -362,7 +362,7 @@ class ConstantPoolCacheEntry {
   bool is_field_entry() const                    { return (_flags & (1 << is_field_entry_shift))    != 0; }
   bool is_long() const                           { return flag_state() == ltos; }
   bool is_double() const                         { return flag_state() == dtos; }
-  bool is_inline_type() const                    { return (_flags & (1 << is_inline_type_shift))       != 0; }
+  bool is_null_free_inline_type() const          { return (_flags & (1 << is_null_free_inline_type_shift)) != 0; }
   TosState flag_state() const                    { assert((uint)number_of_states <= (uint)tos_state_mask+1, "");
                                                    return (TosState)((_flags >> tos_state_shift) & tos_state_mask); }
   void set_indy_resolution_failed();

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -161,7 +161,7 @@ static inline bool is_class_loader(const Symbol* class_name,
   return false;
 }
 
-bool InstanceKlass::field_is_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_INLINE_TYPE; }
+bool InstanceKlass::field_is_null_free_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_INLINE_TYPE; }
 
 // private: called to verify that k is a static member of this nest.
 // We know that k is an instance class in the same package and hence the
@@ -2891,7 +2891,7 @@ const char* InstanceKlass::signature_name() const {
 
   // Add L or Q as type indicator
   int dest_index = 0;
-  dest[dest_index++] = is_inline_klass() ? JVM_SIGNATURE_INLINE_TYPE : JVM_SIGNATURE_CLASS;
+  dest[dest_index++] = JVM_SIGNATURE_CLASS;
 
   // Add the actual class name
   for (int src_index = 0; src_index < src_length; ) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -555,7 +555,7 @@ class InstanceKlass: public Klass {
   Symbol* field_name        (int index) const { return field(index)->name(constants()); }
   Symbol* field_signature   (int index) const { return field(index)->signature(constants()); }
   bool    field_is_inlined(int index) const { return field(index)->is_inlined(); }
-  bool    field_is_inline_type(int index) const;
+  bool    field_is_null_free_inline_type(int index) const;
 
   // Number of Java declared fields
   int java_fields_count() const           { return (int)_java_fields_count; }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -76,7 +76,7 @@ void Parse::do_checkcast() {
   // then the checkcast does nothing.
   const TypeOopPtr *tp = _gvn.type(obj)->isa_oopptr();
   if (!will_link || (tp && tp->klass() && !tp->klass()->is_loaded())) {
-    assert(!iter().is_inline_klass(), "Inline type should be loaded");
+    assert(!iter().has_Q_signature(), "Inline type should be loaded");
     if (C->log() != NULL) {
       if (!will_link) {
         C->log()->elem("assert_null reason='checkcast' klass='%d'",

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -523,6 +523,10 @@ class SignatureStream : public StackObj {
     return true;
   }
 
+  bool has_Q_descriptor() const {
+    return has_envelope() && (_signature->char_at(_begin) == JVM_SIGNATURE_INLINE_TYPE);
+  }
+
   // return the symbol for chars in symbol_begin()..symbol_end()
   Symbol* as_symbol() {
     return find_symbol();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -139,7 +139,7 @@ public class Types {
         noWarnings = new Warner(null);
         Options options = Options.instance(context);
         allowValueBasedClasses = options.isSet("allowValueBasedClasses");
-        splitPrimitiveClass = options.isUnset("unifiedValRefClass");
+        splitPrimitiveClass = false ; // options.isUnset("unifiedValRefClass"); // Temporarely forcing the default
     }
     // </editor-fold>
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
@@ -144,7 +144,7 @@ public class InlineTypesTest {
         String sig = "()Q" + inlineClass.getName() + ";";
         final String methodSignature = sig.replace('.', '/');
         final String fieldQSignature = "Q" + inlineClass.getName().replace('.', '/') + ";";
-        final String fieldLSignature = "L" + inlineClass.getName().replace('.', '/') + "$ref;";
+        final String fieldLSignature = "L" + inlineClass.getName().replace('.', '/') + ";";
         System.out.println(methodSignature);
         MethodHandle fromExecStackToFields = InstructionHelper.loadCode(
                 LOOKUP,


### PR DESCRIPTION
Here's a first set of changes to migrate the code base to the L/Q model again.
Changes are in the runtime, the interpreter, CI and C1.
The changeset also activates the mode in javac that generates a single class file per primitive class (instead of two).
Changes allow a reasonable number of test in runtime/valhalla/inlinetypes to pass with -XX:TieredStopAtLevel=1 but some tests are failing, mainly because of missing changes in array code and C2.

Fred
