### PR TITLE
Initial runtime arrays support for L or Q type

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -318,10 +318,14 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
                                                          protection_domain,
                                                          CHECK_NULL);
     if (k != NULL) {
-      if ((class_name->is_Q_array_signature() && !k->is_inline_klass())) {
-            THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), "L/Q mismatch on bottom type");
-          }
-      k = k->array_klass(ndims, CHECK_NULL);
+      if (class_name->is_Q_array_signature()) {
+        if (!k->is_inline_klass()) {
+          THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), "L/Q mismatch on bottom type");
+        }
+        k = InlineKlass::cast(k)->null_free_inline_array_klass(ndims, CHECK_NULL);
+      } else {
+        k = k->array_klass(ndims, CHECK_NULL);
+      }
     }
   } else {
     k = Universe::typeArrayKlassObj(t);

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -127,10 +127,10 @@ objArrayOop oopFactory::new_objArray(Klass* klass, int length, TRAPS) {
   }
 }
 
-arrayOop oopFactory::new_flatArray(Klass* klass, int length, TRAPS) {
-  assert(klass->is_inline_klass(), "Klass must be inline type");
+arrayOop oopFactory::new_flatArray(Klass* k, int length, TRAPS) {
+  InlineKlass* klass = InlineKlass::cast(k);
   // Request flattened, but we might not actually get it...either way "null-free" are the aaload/aastore semantics
-  Klass* array_klass = klass->array_klass(1, CHECK_NULL);
+  Klass* array_klass = klass->null_free_inline_array_klass(CHECK_NULL);
   assert(array_klass->is_null_free_array_klass(), "Expect a null-free array class here");
 
   arrayOop oop;

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -100,17 +100,16 @@ ArrayKlass::ArrayKlass(Symbol* name, KlassID id) :
     JFR_ONLY(INIT_ID(this);)
 }
 
-Symbol* ArrayKlass::create_element_klass_array_name(Klass* element_klass, TRAPS) {
+Symbol* ArrayKlass::create_element_klass_array_name(Klass* element_klass, bool qdesc, TRAPS) {
   ResourceMark rm(THREAD);
   Symbol* name = NULL;
-  bool is_qtype = element_klass->is_inline_klass();
   char *name_str = element_klass->name()->as_C_string();
   int len = element_klass->name()->utf8_length();
   char *new_str = NEW_RESOURCE_ARRAY(char, len + 4);
   int idx = 0;
   new_str[idx++] = JVM_SIGNATURE_ARRAY;
   if (element_klass->is_instance_klass()) { // it could be an array or simple type
-    if (is_qtype) {
+    if (qdesc) {
       new_str[idx++] = JVM_SIGNATURE_INLINE_TYPE;
     } else {
       new_str[idx++] = JVM_SIGNATURE_CLASS;

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -56,7 +56,7 @@ class ArrayKlass: public Klass {
   ArrayKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for cds"); }
 
   // Create array_name for element klass
-  static Symbol* create_element_klass_array_name(Klass* element_klass, TRAPS);
+  static Symbol* create_element_klass_array_name(Klass* element_klass, bool qdesc, TRAPS);
 
  public:
   // Instance variables

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -75,6 +75,15 @@ class InlineKlass: public InstanceKlass {
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(default_value_offset_offset());
   }
 
+  ArrayKlass* volatile* adr_null_free_inline_array_klasses() const {
+    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    return (ArrayKlass* volatile*) ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _null_free_inline_array_klasses));
+  }
+
+  ArrayKlass* null_free_inline_array_klasses() const {
+    return *adr_null_free_inline_array_klasses();
+  }
+
   address adr_alignment() const {
     assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _alignment));
@@ -129,15 +138,6 @@ class InlineKlass: public InstanceKlass {
   void cleanup_blobs();
 
  public:
-  // Returns the array class for the n'th dimension
-  virtual Klass* array_klass(int n, TRAPS);
-  virtual Klass* array_klass_or_null(int n);
-
-  // Returns the array class with this class as element type
-  virtual Klass* array_klass(TRAPS);
-  virtual Klass* array_klass_or_null();
-
-
   // Type testing
   bool is_inline_klass_slow() const        { return true; }
 
@@ -167,6 +167,19 @@ class InlineKlass: public InstanceKlass {
 
   bool contains_oops() const { return nonstatic_oop_map_count() > 0; }
   int nonstatic_oop_count();
+
+  // null free inline arrays...
+  //
+
+  // null free inline array klass, akin to InstanceKlass::array_klass()
+  // Returns the array class for the n'th dimension
+  Klass* null_free_inline_array_klass(int n, TRAPS);
+  Klass* null_free_inline_array_klass_or_null(int n);
+
+  // Returns the array class with this class as element type
+  Klass* null_free_inline_array_klass(TRAPS);
+  Klass* null_free_inline_array_klass_or_null();
+
 
   // General store methods
   //

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1574,7 +1574,8 @@ Klass* InstanceKlass::array_klass(int n, TRAPS) {
 
       // Check if update has already taken place
       if (array_klasses() == NULL) {
-        ObjArrayKlass* k = ObjArrayKlass::allocate_objArray_klass(class_loader_data(), 1, this, CHECK_NULL);
+        ObjArrayKlass* k = ObjArrayKlass::allocate_objArray_klass(class_loader_data(), 1, this,
+                                                                  false, false, CHECK_NULL);
         // use 'release' to pair with lock-free load
         release_set_array_klasses(k);
       }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -142,6 +142,7 @@ class InlineKlassFixedBlock {
   address* _pack_handler_jobject;
   address* _unpack_handler;
   int* _default_value_offset;
+  ArrayKlass** _null_free_inline_array_klasses;
   int _alignment;
   int _first_field_offset;
   int _exact_size_in_bytes;

--- a/src/hotspot/share/oops/objArrayKlass.hpp
+++ b/src/hotspot/share/oops/objArrayKlass.hpp
@@ -45,8 +45,8 @@ class ObjArrayKlass : public ArrayKlass {
   Klass* _bottom_klass;             // The one-dimensional type (InstanceKlass or TypeArrayKlass)
 
   // Constructor
-  ObjArrayKlass(int n, Klass* element_klass, Symbol* name);
-  static ObjArrayKlass* allocate(ClassLoaderData* loader_data, int n, Klass* k, Symbol* name, TRAPS);
+  ObjArrayKlass(int n, Klass* element_klass, Symbol* name, bool null_free);
+  static ObjArrayKlass* allocate(ClassLoaderData* loader_data, int n, Klass* k, Symbol* name, bool null_free, TRAPS);
  public:
   // For dummy objects
   ObjArrayKlass() {}
@@ -67,7 +67,8 @@ class ObjArrayKlass : public ArrayKlass {
 
   // Allocation
   static ObjArrayKlass* allocate_objArray_klass(ClassLoaderData* loader_data,
-                                                int n, Klass* element_klass, TRAPS);
+                                                int n, Klass* element_klass,
+                                                bool null_free, bool qdesc, TRAPS);
 
   objArrayOop allocate(int length, TRAPS);
   oop multi_allocate(int rank, jint* sizes, TRAPS);

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -187,7 +187,7 @@ Klass* TypeArrayKlass::array_klass(int n, TRAPS) {
 
       if (higher_dimension() == NULL) {
         Klass* oak = ObjArrayKlass::allocate_objArray_klass(
-              class_loader_data(), dim + 1, this, CHECK_NULL);
+              class_loader_data(), dim + 1, this, false, false, CHECK_NULL);
         ObjArrayKlass* h_ak = ObjArrayKlass::cast(oak);
         h_ak->set_lower_dimension(this);
         // use 'release' to pair with lock-free load


### PR DESCRIPTION
Added InlineKlass::null_free_inline_array_klass() akin to Klass::array_klass()
but specifically for Q class descriptors, with a separate chain for array klass
for Q-type arrays.

TODO: metadata visitor and cleanup for the new chain of Q-type array classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/411/head:pull/411` \
`$ git checkout pull/411`

Update a local copy of the PR: \
`$ git checkout pull/411` \
`$ git pull https://git.openjdk.java.net/valhalla pull/411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 411`

View PR using the GUI difftool: \
`$ git pr show -t 411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/411.diff">https://git.openjdk.java.net/valhalla/pull/411.diff</a>

</details>
