### PR TITLE
8266931: [lworld] [lw3] Test InlineTypeArrays.java fails because of incorrect instanceof behavior

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -862,7 +862,11 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
       k = SystemDictionary::find_instance_klass(ss.as_symbol(), class_loader, protection_domain);
     }
     if (k != NULL) {
-      k = k->array_klass_or_null(ndims);
+      if (class_name->is_Q_array_signature()) {
+        k = InlineKlass::cast(k)->null_free_inline_array_klass_or_null(ndims);
+      } else {
+        k = k->array_klass_or_null(ndims);
+      }
     }
   } else {
     k = find_instance_klass(class_name, class_loader, protection_domain);
@@ -1885,7 +1889,11 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     }
     // If element class already loaded, allocate array klass
     if (klass != NULL) {
-      klass = klass->array_klass_or_null(ndims);
+      if (class_name->is_Q_array_signature()) {
+        klass = InlineKlass::cast(klass)->null_free_inline_array_klass_or_null(ndims);
+      } else {
+        klass = klass->array_klass_or_null(ndims);
+      }
     }
   } else {
     MutexLocker mu(current, SystemDictionary_lock);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -65,7 +65,7 @@ public class InlineTypeArray {
     }
 
     void testClassForName() {
-        String arrayClsName = "[Lruntime.valhalla.inlinetypes.Point$ref;";
+        String arrayClsName = "[Lruntime.valhalla.inlinetypes.Point;";
         String qarrayClsName = "[Qruntime.valhalla.inlinetypes.Point;";
         try {
             // L-type..


### PR DESCRIPTION
Fix super types of null-free arrays of primitive classes ([LFoo; must be present in the list of super types of [QFoo;).

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8266931](https://bugs.openjdk.java.net/browse/JDK-8266931): [lworld] [lw3] Test InlineTypeArrays.java fails because of incorrect instanceof behavior


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/413/head:pull/413` \
`$ git checkout pull/413`

Update a local copy of the PR: \
`$ git checkout pull/413` \
`$ git pull https://git.openjdk.java.net/valhalla pull/413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 413`

View PR using the GUI difftool: \
`$ git pr show -t 413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/413.diff">https://git.openjdk.java.net/valhalla/pull/413.diff</a>

</details>
