### PR TITLE
CDS support for InlineKlass::null_free_array_klasses() & corrected modifiers

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -149,6 +149,11 @@ void FlatArrayKlass::initialize(TRAPS) {
   element_klass()->initialize(THREAD);
 }
 
+void FlatArrayKlass::metaspace_pointers_do(MetaspaceClosure* it) {
+  ArrayKlass::metaspace_pointers_do(it);
+  it->push(&_element_klass);
+}
+
 // Oops allocation...
 flatArrayOop FlatArrayKlass::allocate(int length, TRAPS) {
   check_array_allocation_length(length, max_elements(), CHECK_NULL);
@@ -424,6 +429,14 @@ GrowableArray<Klass*>* FlatArrayKlass::compute_secondary_supers(int num_extra_sl
     secondaries->push(array_super);
   }
   return secondaries;
+}
+
+jint FlatArrayKlass::compute_modifier_flags() const {
+  // The modifier for an flatArray is the same as its element
+  jint element_flags = element_klass()->compute_modifier_flags();
+
+  return (element_flags & (JVM_ACC_PUBLIC | JVM_ACC_PRIVATE | JVM_ACC_PROTECTED))
+                        | (JVM_ACC_ABSTRACT | JVM_ACC_FINAL);
 }
 
 void FlatArrayKlass::print_on(outputStream* st) const {

--- a/src/hotspot/share/oops/flatArrayKlass.hpp
+++ b/src/hotspot/share/oops/flatArrayKlass.hpp
@@ -91,6 +91,8 @@ class FlatArrayKlass : public ArrayKlass {
 
   oop protection_domain() const;
 
+  virtual void metaspace_pointers_do(MetaspaceClosure* iter);
+
   static jint array_layout_helper(InlineKlass* vklass); // layout helper for values
 
   // sizing
@@ -140,6 +142,8 @@ private:
   inline void oop_oop_iterate_elements_specialized_bounded(flatArrayOop a, OopClosureType* closure, void* low, void* high);
 
  public:
+  jint compute_modifier_flags() const;
+
   // Printing
   void print_on(outputStream* st) const;
   void print_value_on(outputStream* st) const;

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -129,6 +129,7 @@ class InlineKlass: public InstanceKlass {
   int first_field_offset_old();
 
   virtual void remove_unshareable_info();
+  virtual void remove_java_mirror();
   virtual void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS);
   virtual void metaspace_pointers_do(MetaspaceClosure* it);
 
@@ -140,6 +141,10 @@ class InlineKlass: public InstanceKlass {
  public:
   // Type testing
   bool is_inline_klass_slow() const        { return true; }
+
+  // Iterators
+  virtual void array_klasses_do(void f(Klass* k));
+  virtual void array_klasses_do(void f(Klass* k, TRAPS), TRAPS);
 
   // Casting from Klass*
   static InlineKlass* cast(Klass* k);


### PR DESCRIPTION
Filled in the initial L/Q array TODO missing items

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/415/head:pull/415` \
`$ git checkout pull/415`

Update a local copy of the PR: \
`$ git checkout pull/415` \
`$ git pull https://git.openjdk.java.net/valhalla pull/415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 415`

View PR using the GUI difftool: \
`$ git pr show -t 415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/415.diff">https://git.openjdk.java.net/valhalla/pull/415.diff</a>

</details>
