### PR TITLE
8267428: Several features lack the EnableValhalla guard

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3011,76 +3011,82 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   } else {
     if (is_static) {
       __ load_heap_oop(rax, field);
-      Label is_inline_type, uninitialized;
-      // Issue below if the static field has not been initialized yet
-      __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
-        // field is not an inline type
+      if (EnableValhalla) {
+        Label is_inline_type, uninitialized;
+        // Issue below if the static field has not been initialized yet
+        __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+          // field is not an inline type
+          __ push(atos);
+          __ jmp(Done);
+        // field is an inline type, must not return null even if uninitialized
+        __ bind(is_inline_type);
+           __ testptr(rax, rax);
+          __ jcc(Assembler::zero, uninitialized);
+            __ push(atos);
+            __ jmp(Done);
+          __ bind(uninitialized);
+            __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
+  #ifdef _LP64
+            Label slow_case, finish;
+            __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
+            __ jcc(Assembler::notEqual, slow_case);
+          __ get_default_value_oop(rcx, off, rax);
+          __ jmp(finish);
+          __ bind(slow_case);
+  #endif // LP64
+            __ call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_static_inline_type_field),
+                  obj, flags2);
+  #ifdef _LP64
+            __ bind(finish);
+  #endif // _LP64
+      }
+        __ verify_oop(rax);
         __ push(atos);
         __ jmp(Done);
-      // field is an inline type, must not return null even if uninitialized
-      __ bind(is_inline_type);
-        __ testptr(rax, rax);
-        __ jcc(Assembler::zero, uninitialized);
-          __ push(atos);
-          __ jmp(Done);
-        __ bind(uninitialized);
-          __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
-#ifdef _LP64
-          Label slow_case, finish;
-          __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
-          __ jcc(Assembler::notEqual, slow_case);
-        __ get_default_value_oop(rcx, off, rax);
-        __ jmp(finish);
-        __ bind(slow_case);
-#endif // LP64
-          __ call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::uninitialized_static_inline_type_field),
-                 obj, flags2);
-#ifdef _LP64
-          __ bind(finish);
-#endif // _LP64
-          __ verify_oop(rax);
-          __ push(atos);
-          __ jmp(Done);
     } else {
       Label is_inlined, nonnull, is_inline_type, rewrite_inline;
-      __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
-        // field is not an inline type
-        pop_and_check_object(obj);
-        __ load_heap_oop(rax, field);
-        __ push(atos);
-        if (rc == may_rewrite) {
-          patch_bytecode(Bytecodes::_fast_agetfield, bc, rbx);
-        }
-        __ jmp(Done);
-      __ bind(is_inline_type);
-        __ test_field_is_inlined(flags2, rscratch1, is_inlined);
-          // field is not inlined
-          __ movptr(rax, rcx);  // small dance required to preserve the klass_holder somewhere
-          pop_and_check_object(obj);
-          __ push(rax);
-          __ load_heap_oop(rax, field);
-          __ pop(rcx);
-          __ testptr(rax, rax);
-          __ jcc(Assembler::notZero, nonnull);
-            __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
-            __ get_inline_type_field_klass(rcx, flags2, rbx);
-            __ get_default_value_oop(rbx, rcx, rax);
-          __ bind(nonnull);
-          __ verify_oop(rax);
-          __ push(atos);
-          __ jmp(rewrite_inline);
-        __ bind(is_inlined);
-        // field is inlined
-          __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
-          pop_and_check_object(rax);
-          __ read_inlined_field(rcx, flags2, rbx, rax);
-          __ verify_oop(rax);
-          __ push(atos);
-      __ bind(rewrite_inline);
+      if (EnableValhalla) {
+        __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+      }
+      // field is not an inline type
+      pop_and_check_object(obj);
+      __ load_heap_oop(rax, field);
+      __ push(atos);
       if (rc == may_rewrite) {
-        patch_bytecode(Bytecodes::_fast_qgetfield, bc, rbx);
+        patch_bytecode(Bytecodes::_fast_agetfield, bc, rbx);
       }
       __ jmp(Done);
+      if (EnableValhalla) {
+        __ bind(is_inline_type);
+          __ test_field_is_inlined(flags2, rscratch1, is_inlined);
+            // field is not inlined
+            __ movptr(rax, rcx);  // small dance required to preserve the klass_holder somewhere
+            pop_and_check_object(obj);
+            __ push(rax);
+            __ load_heap_oop(rax, field);
+            __ pop(rcx);
+            __ testptr(rax, rax);
+            __ jcc(Assembler::notZero, nonnull);
+              __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
+              __ get_inline_type_field_klass(rcx, flags2, rbx);
+              __ get_default_value_oop(rbx, rcx, rax);
+            __ bind(nonnull);
+            __ verify_oop(rax);
+            __ push(atos);
+            __ jmp(rewrite_inline);
+          __ bind(is_inlined);
+          // field is inlined
+            __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
+            pop_and_check_object(rax);
+            __ read_inlined_field(rcx, flags2, rbx, rax);
+            __ verify_oop(rax);
+            __ push(atos);
+        __ bind(rewrite_inline);
+        if (rc == may_rewrite) {
+          patch_bytecode(Bytecodes::_fast_qgetfield, bc, rbx);
+        }
+        __ jmp(Done);
+      }
     }
   }
 
@@ -3392,14 +3398,18 @@ void TemplateTable::putfield_or_static_helper(int byte_no, bool is_static, Rewri
       __ pop(atos);
       if (is_static) {
         Label is_inline_type;
-        __ test_field_is_not_inline_type(flags2, rscratch1, is_inline_type);
-        __ null_check(rax);
-        __ bind(is_inline_type);
+        if (EnableValhalla) {
+          __ test_field_is_not_inline_type(flags2, rscratch1, is_inline_type);
+          __ null_check(rax);
+          __ bind(is_inline_type);
+        }
         do_oop_store(_masm, field, rax);
         __ jmp(Done);
       } else {
         Label is_inline_type, is_inlined, rewrite_not_inline, rewrite_inline;
-        __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+        if (EnableValhalla) {
+          __ test_field_is_inline_type(flags2, rscratch1, is_inline_type);
+        }
         // Not an inline type
         pop_and_check_object(obj);
         // Store into the field
@@ -3409,28 +3419,30 @@ void TemplateTable::putfield_or_static_helper(int byte_no, bool is_static, Rewri
           patch_bytecode(Bytecodes::_fast_aputfield, bc, rbx, true, byte_no);
         }
         __ jmp(Done);
-        // Implementation of the inline type semantic
-        __ bind(is_inline_type);
-        __ null_check(rax);
-        __ test_field_is_inlined(flags2, rscratch1, is_inlined);
-        // field is not inlined
-        pop_and_check_object(obj);
-        // Store into the field
-        do_oop_store(_masm, field, rax);
-        __ jmp(rewrite_inline);
-        __ bind(is_inlined);
-        // field is inlined
-        pop_and_check_object(obj);
-        assert_different_registers(rax, rdx, obj, off);
-        __ load_klass(rdx, rax, rscratch1);
-        __ data_for_oop(rax, rax, rdx);
-        __ addptr(obj, off);
-        __ access_value_copy(IN_HEAP, rax, obj, rdx);
-        __ bind(rewrite_inline);
-        if (rc == may_rewrite) {
-          patch_bytecode(Bytecodes::_fast_qputfield, bc, rbx, true, byte_no);
+        if (EnableValhalla) {
+          // Implementation of the inline type semantic
+          __ bind(is_inline_type);
+          __ null_check(rax);
+          __ test_field_is_inlined(flags2, rscratch1, is_inlined);
+          // field is not inlined
+          pop_and_check_object(obj);
+          // Store into the field
+          do_oop_store(_masm, field, rax);
+          __ jmp(rewrite_inline);
+          __ bind(is_inlined);
+          // field is inlined
+          pop_and_check_object(obj);
+          assert_different_registers(rax, rdx, obj, off);
+          __ load_klass(rdx, rax, rscratch1);
+          __ data_for_oop(rax, rax, rdx);
+          __ addptr(obj, off);
+          __ access_value_copy(IN_HEAP, rax, obj, rdx);
+          __ bind(rewrite_inline);
+          if (rc == may_rewrite) {
+            patch_bytecode(Bytecodes::_fast_qputfield, bc, rbx, true, byte_no);
+          }
+          __ jmp(Done);
         }
-        __ jmp(Done);
       }
     }
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -996,7 +996,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
 
   // Could it be possible to do the following processing only if the
   // class uses inline types?
-  {
+  if (EnableValhalla) {
     ResourceMark rm(THREAD);
     for (int i = 0; i < methods()->length(); i++) {
       Method* m = methods()->at(i);


### PR DESCRIPTION
Add if(EnableValhalla) guards around:
  - injection of the IdentityObject interface
  - iteration over fields to pre-load primitive class fields
  - iteration of method arguments to eagerly load primitive class arguments
  - support for flattened and null-free fields in the interpreter

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267428](https://bugs.openjdk.java.net/browse/JDK-8267428): Several features lack the EnableValhalla guard


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/417/head:pull/417` \
`$ git checkout pull/417`

Update a local copy of the PR: \
`$ git checkout pull/417` \
`$ git pull https://git.openjdk.java.net/valhalla pull/417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 417`

View PR using the GUI difftool: \
`$ git pr show -t 417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/417.diff">https://git.openjdk.java.net/valhalla/pull/417.diff</a>

</details>
