### PR TITLE
8267503: [lworld] [lw3] NPE message thrown by checkcast is incorrect

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -1112,6 +1112,7 @@ int ExceptionMessageBuilder::get_NPE_null_slot(int bci) {
     case Bytecodes::_athrow:
     case Bytecodes::_monitorenter:
     case Bytecodes::_monitorexit:
+    case Bytecodes::_checkcast:
       return 0;
     case Bytecodes::_iaload:
     case Bytecodes::_faload:
@@ -1433,6 +1434,11 @@ void ExceptionMessageBuilder::print_NPE_failed_action(outputStream *os, int bci)
         os->print("Cannot invoke \"");
         print_method_name(os, _method, cp_index);
         os->print("\"");
+      } break;
+    case Bytecodes::_checkcast: {
+        int cp_index = Bytes::get_Java_u2(code_base + pos);
+        ConstantPool* cp = _method->constants();
+        os->print("Cannot cast to null-free type \"%s\"", cp->klass_at_noresolve(cp_index)->as_C_string());
       } break;
 
     default:


### PR DESCRIPTION
Please review those changes fixing the error message for NullPointerExceptions thrown by checkcast.

Without the fix:
java.lang.NullPointerException: There cannot be a NullPointerException at bci 23 of method void NPECheckcastTest.main(java.lang.String[])

With the fix:
java.lang.NullPointerException: Cannot cast to null-free type "QNPECheckcastTest$C1;" because "\<local2\>" is null

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267503](https://bugs.openjdk.java.net/browse/JDK-8267503): [lworld] [lw3] NPE message thrown by checkcast is incorrect


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/418/head:pull/418` \
`$ git checkout pull/418`

Update a local copy of the PR: \
`$ git checkout pull/418` \
`$ git pull https://git.openjdk.java.net/valhalla pull/418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 418`

View PR using the GUI difftool: \
`$ git pr show -t 418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/418.diff">https://git.openjdk.java.net/valhalla/pull/418.diff</a>

</details>
