### PR TITLE
8266466: [lworld] Enhance javac to consume unified primitive class files generated under the option -XDunifiedValRefClass

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/api/JavacTrees.java
@@ -1216,7 +1216,7 @@ public class JavacTrees extends DocTrees {
             errorType.getKind() == TypeKind.ERROR) {
             return extraType2OriginalMap.computeIfAbsent(classType, tt ->
                     new ClassType(classType.getEnclosingType(), classType.typarams_field,
-                                  classType.tsym, classType.getMetadata(), classType.isReferenceProjection()) {
+                                  classType.tsym, classType.getMetadata(), classType.getFlavor()) {
                         @Override
                         public Type baseType() { return classType; }
                         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -52,6 +52,7 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.code.Kinds.Kind;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.comp.Annotate.AnnotationTypeMetadata;
 import com.sun.tools.javac.code.Type.*;
 import com.sun.tools.javac.comp.Attr;
@@ -1343,7 +1344,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             this(
                 flags,
                 name,
-                new ClassType(Type.noType, null, null),
+                new ClassType(Type.noType, null, null, TypeMetadata.EMPTY, Flavor.X_Typeof_X),
                 owner);
             this.type.tsym = this;
         }
@@ -1381,7 +1382,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                 erasure_field = new ClassType(types.erasure(type.getEnclosingType()),
                                               List.nil(), this,
                                               type.getMetadata(),
-                                              type.isReferenceProjection());
+                                              type.getFlavor());
             return erasure_field;
         }
 
@@ -1450,6 +1451,24 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                 flags_field |= (PUBLIC|STATIC);
                 this.type = new ErrorType(this, Type.noType);
                 throw ex;
+            } finally {
+                if (this.type != null && this.type.hasTag(CLASS)) {
+                    ClassType ct = (ClassType) this.type;
+                    if (ct.flavor == Flavor.X_Typeof_X) {
+                        // TODO: Discriminate between ref-val defaultness. ATM, we are blind to default favor
+                        ClassType ef = this.erasure_field != null && this.erasure_field.hasTag(CLASS) ?
+                                (ClassType) this.erasure_field : null;
+                        if ((this.flags_field & PRIMITIVE_CLASS) != 0) {
+                            ct.flavor = Flavor.Q_TypeOf_Q;
+                            if (ef != null)
+                                ef.flavor = Flavor.Q_TypeOf_Q;
+                        } else {
+                            ct.flavor = Flavor.L_TypeOf_L;
+                            if (ef != null)
+                                ef.flavor = Flavor.L_TypeOf_L;
+                        }
+                    }
+                }
             }
         }
 
@@ -1627,6 +1646,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                 classType.supertype_field = null;
                 classType.interfaces_field = null;
                 classType.all_interfaces_field = null;
+                classType.flavor = Flavor.X_Typeof_X;
             }
             clearAnnotationMetadata();
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1454,19 +1454,9 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             } finally {
                 if (this.type != null && this.type.hasTag(CLASS)) {
                     ClassType ct = (ClassType) this.type;
-                    if (ct.flavor == Flavor.X_Typeof_X) {
-                        // TODO: Discriminate between ref-val defaultness. ATM, we are blind to default favor
-                        ClassType ef = this.erasure_field != null && this.erasure_field.hasTag(CLASS) ?
-                                (ClassType) this.erasure_field : null;
-                        if ((this.flags_field & PRIMITIVE_CLASS) != 0) {
-                            ct.flavor = Flavor.Q_TypeOf_Q;
-                            if (ef != null)
-                                ef.flavor = Flavor.Q_TypeOf_Q;
-                        } else {
-                            ct.flavor = Flavor.L_TypeOf_L;
-                            if (ef != null)
-                                ef.flavor = Flavor.L_TypeOf_L;
-                        }
+                    ct.flavor = ct.flavor.metamorphose((this.flags_field & PRIMITIVE_CLASS) != 0);
+                    if (this.erasure_field != null && this.erasure_field.hasTag(CLASS)) {
+                        ((ClassType) this.erasure_field).flavor = ct.flavor;
                     }
                 }
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -35,6 +35,7 @@ import java.util.function.Predicate;
 import javax.lang.model.type.*;
 
 import com.sun.tools.javac.code.Symbol.*;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.code.TypeMetadata.Entry;
 import com.sun.tools.javac.code.Types.TypeMapping;
 import com.sun.tools.javac.code.Types.UniqueType;
@@ -241,6 +242,14 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     }
 
     /**
+     * Return the `flavor' associated with a ClassType.
+     * @see ClassType.Flavor
+     */
+    public Flavor getFlavor() {
+        throw new AssertionError("Unexpected call to getFlavor() on a Type that is not a ClassType: " + this);
+    }
+
+    /**
      * @return true IFF the receiver is a reference projection of an inline type and false
      * for primitives or plain references
      */
@@ -286,7 +295,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             List<Type> typarams = t.getTypeArguments();
             List<Type> typarams1 = visit(typarams, s);
             if (outer1 == outer && typarams1 == typarams) return t;
-            else return new ClassType(outer1, typarams1, t.tsym, t.metadata, t.isReferenceProjection()) {
+            else return new ClassType(outer1, typarams1, t.tsym, t.metadata, t.getFlavor()) {
                 @Override
                 protected boolean needsStripping() {
                     return true;
@@ -1017,6 +1026,61 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     public static class ClassType extends Type implements DeclaredType, LoadableConstant,
                                                           javax.lang.model.type.ErrorType {
 
+        /**
+         * The 'flavor' of a ClassType indicates its reference/primitive projectionness
+         * viewed against the default nature of the associated class.
+         */
+        public enum Flavor {
+
+            /**
+             * Classic reference type. Also reference projection type of a reference-favoring aka
+             * reference-default primitive class type
+             */
+            L_TypeOf_L,
+
+            /**
+             * Reference projection type of a primitive-favoring aka primitive-default
+             * plain vanilla primitive class type,
+             */
+            L_TypeOf_Q,
+
+            /**
+             * Value projection type of a primitive-favoring aka primitive-default
+             * plain vanilla primitive class type,
+             */
+            Q_TypeOf_Q,
+
+            /**
+             * Value projection type of a reference-favoring aka
+             * reference-default primitive class type
+             */
+            Q_TypeOf_L,
+
+            /**
+             * Reference projection type of a class type of an as yet unknown default provenance, 'X' will be
+             * discovered to be 'L' or 'Q' in "due course" and mutated suitably.
+             */
+            L_TypeOf_X,
+
+            /**
+             * Value projection type of a class type of an as yet unknown default provenance, 'X' will be
+             * discovered to be 'L' or 'Q' in "due course" and mutated suitably.
+             */
+            Q_TypeOf_X,
+
+            /**
+             *  As yet unknown projection type of an as yet unknown default provenance class.
+             */
+            X_Typeof_X,
+
+            /**
+             *  An error type - we don't care to discriminate them any further.
+             */
+             E_Typeof_X;
+
+            // We don't seem to need X_Typeof_L or X_Typeof_Q so far.
+        }
+
         /** The enclosing type of this type. If this is the type of an inner
          *  class, outer_field refers to the type of its enclosing
          *  instance class, in all other cases it refers to noType.
@@ -1050,28 +1114,27 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         */
         public ClassType projection;
 
-        /** Is this class type a reference projection of a primitive class type ?
+        /** Is this L of default {L, Q, X} or Q of default {L, Q, X} ?
          */
-        private boolean isReferenceProjection;
+        public Flavor flavor;
 
+        /*
+         * Use of this constructor is kinda sorta deprecated, use the other constructor
+         * that forces the call site to consider and include the class type flavor.
+         */
         public ClassType(Type outer, List<Type> typarams, TypeSymbol tsym) {
-            this(outer, typarams, tsym, TypeMetadata.EMPTY, false);
+            this(outer, typarams, tsym, TypeMetadata.EMPTY, Flavor.L_TypeOf_L);
         }
 
         public ClassType(Type outer, List<Type> typarams, TypeSymbol tsym,
-                         TypeMetadata metadata) {
-            this(outer, typarams, tsym, metadata, false);
-        }
-
-        public ClassType(Type outer, List<Type> typarams, TypeSymbol tsym,
-                         TypeMetadata metadata, boolean isReferenceProjection) {
+                         TypeMetadata metadata, Flavor flavor) {
             super(tsym, metadata);
-            this.outer_field = outer != null && outer.isReferenceProjection() ? outer.valueProjection() : outer;
+            this.outer_field = outer;
             this.typarams_field = typarams;
             this.allparams_field = null;
             this.supertype_field = null;
             this.interfaces_field = null;
-            this.isReferenceProjection = isReferenceProjection;
+            this.flavor = flavor;
         }
 
         public int poolTag() {
@@ -1080,7 +1143,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         @Override
         public ClassType cloneWithMetadata(TypeMetadata md) {
-            return new ClassType(outer_field, typarams_field, tsym, md, isReferenceProjection) {
+            return new ClassType(outer_field, typarams_field, tsym, md, flavor) {
                 @Override
                 public Type baseType() { return ClassType.this.baseType(); }
             };
@@ -1098,7 +1161,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         public Type constType(Object constValue) {
             final Object value = constValue;
-            return new ClassType(getEnclosingType(), typarams_field, tsym, metadata, isReferenceProjection) {
+            return new ClassType(getEnclosingType(), typarams_field, tsym, metadata, flavor) {
                     @Override
                     public Object constValue() {
                         return value;
@@ -1125,6 +1188,12 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                 buf.append(className(tsym, true));
             }
 
+            boolean isReferenceProjection;
+            try {
+                isReferenceProjection = isReferenceProjection();
+            } catch (CompletionFailure cf) {
+                isReferenceProjection = false; // handle missing types gracefully.
+            }
             if (isReferenceProjection) {
                 buf.append('.');
                 buf.append(tsym.name.table.names.ref);
@@ -1171,6 +1240,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                 return s;
             }
 
+        public Flavor getFlavor() {
+            return flavor;
+        }
+
         @DefinedBy(Api.LANGUAGE_MODEL)
         public List<Type> getTypeArguments() {
             if (typarams_field == null) {
@@ -1187,11 +1260,14 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         @DefinedBy(Api.LANGUAGE_MODEL)
         public Type getEnclosingType() {
+            if (outer_field != null && outer_field.isReferenceProjection()) {
+                outer_field = outer_field.valueProjection();
+            }
             return outer_field;
         }
 
         public void setEnclosingType(Type outer) {
-            outer_field = outer != null && outer.isReferenceProjection() ? outer.valueProjection() : outer;
+            outer_field = outer;
         }
 
         public List<Type> allparams() {
@@ -1220,12 +1296,19 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
 
         @Override
         public boolean isPrimitiveClass() {
-            return !isReferenceProjection && tsym != null && tsym.isPrimitiveClass();
+            return !isReferenceProjection() && tsym != null && tsym.isPrimitiveClass();
         }
 
         @Override
         public boolean isReferenceProjection() {
-            return isReferenceProjection;
+            if (flavor == Flavor.L_TypeOf_X) {
+                if (tsym != null && tsym.isPrimitiveClass()) {
+                    flavor = Flavor.L_TypeOf_Q;
+                } else {
+                    flavor = Flavor.L_TypeOf_L;
+                }
+            }
+            return flavor == Flavor.L_TypeOf_Q;
         }
 
         @Override
@@ -1236,7 +1319,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             if (projection !=  null)
                 return projection;
 
-            projection = new ClassType(outer_field, typarams_field, tsym, getMetadata(), false);
+            projection = new ClassType(outer_field, typarams_field, tsym, getMetadata(), Flavor.Q_TypeOf_Q);
             projection.allparams_field = allparams_field;
             projection.supertype_field = supertype_field;
 
@@ -1256,7 +1339,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             if (projection != null)
                 return projection;
 
-            projection = new ClassType(outer_field, typarams_field, tsym, getMetadata(), true);
+            projection = new ClassType(outer_field, typarams_field, tsym, getMetadata(), Flavor.L_TypeOf_Q);
             projection.allparams_field = allparams_field;
             projection.supertype_field = supertype_field;
 
@@ -1314,7 +1397,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     public static class ErasedClassType extends ClassType {
         public ErasedClassType(Type outer, TypeSymbol tsym,
                                TypeMetadata metadata) {
-            super(outer, List.nil(), tsym, metadata, false);
+            super(outer, List.nil(), tsym, metadata, tsym.type.getFlavor());
         }
 
         @Override
@@ -2479,21 +2562,20 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
 
         public ErrorType(Type originalType, TypeSymbol tsym) {
-            super(noType, List.nil(), null);
-            this.tsym = tsym;
+            super(noType, List.nil(), tsym, TypeMetadata.EMPTY, Flavor.E_Typeof_X);
             this.originalType = (originalType == null ? noType : originalType);
         }
 
         private ErrorType(Type originalType, TypeSymbol tsym,
-                          TypeMetadata metadata) {
-            super(noType, List.nil(), null, metadata);
+                          TypeMetadata metadata, Flavor flavor) {
+            super(noType, List.nil(), null, metadata, flavor);
             this.tsym = tsym;
             this.originalType = (originalType == null ? noType : originalType);
         }
 
         @Override
         public ErrorType cloneWithMetadata(TypeMetadata md) {
-            return new ErrorType(originalType, tsym, md) {
+            return new ErrorType(originalType, tsym, md, getFlavor()) {
                 @Override
                 public Type baseType() { return ErrorType.this.baseType(); }
             };

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -627,7 +627,7 @@ public class TypeAnnotations {
                     } else {
                         ClassType ret = new ClassType(t.getEnclosingType().accept(this, s),
                                                       t.typarams_field, t.tsym,
-                                                      t.getMetadata(), t.isReferenceProjection());
+                                                      t.getMetadata(), t.getFlavor());
                         ret.all_interfaces_field = t.all_interfaces_field;
                         ret.allparams_field = t.allparams_field;
                         ret.interfaces_field = t.interfaces_field;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -43,6 +43,7 @@ import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.code.TypeMetadata.Annotations;
 import com.sun.tools.javac.code.Types.FunctionDescriptorLookupError;
 import com.sun.tools.javac.comp.ArgumentAttr.LocalCacheContext;
@@ -2619,7 +2620,7 @@ public class Attr extends JCTree.Visitor {
                                 syms.boundClass)),
                         restype.tsym,
                         restype.getMetadata(),
-                        restype.isReferenceProjection());
+                        restype.getFlavor());
             } else if (msym != null &&
                     msym.owner == syms.arrayClass &&
                     methodName == names.clone &&
@@ -2821,7 +2822,7 @@ public class Attr extends JCTree.Visitor {
                             clazztype.tsym.type.getTypeArguments(),
                                                clazztype.tsym,
                                                clazztype.getMetadata(),
-                                               clazztype.isReferenceProjection());
+                                               clazztype.getFlavor());
 
                 Env<AttrContext> diamondEnv = localEnv.dup(tree);
                 diamondEnv.info.selectSuper = cdef != null || tree.classDeclRemoved();
@@ -4546,6 +4547,7 @@ public class Attr extends JCTree.Visitor {
                 // except for three situations:
                 owntype = sym.type;
                 if (owntype.hasTag(CLASS)) {
+                    Assert.check(owntype.getFlavor() != Flavor.X_Typeof_X);
                     chk.checkForBadAuxiliaryClassAccess(tree.pos(), env, (ClassSymbol)sym);
                     Type ownOuter = owntype.getEnclosingType();
 
@@ -4553,7 +4555,7 @@ public class Attr extends JCTree.Visitor {
                     // is requested via the .ref notation, then adjust the computed type to
                     // reflect this.
                     if (owntype.isPrimitiveClass() && tree.hasTag(SELECT) && ((JCFieldAccess) tree).name == names.ref) {
-                        owntype = new ClassType(owntype.getEnclosingType(), owntype.getTypeArguments(), (TypeSymbol)sym, owntype.getMetadata(), true);
+                        owntype = new ClassType(owntype.getEnclosingType(), owntype.getTypeArguments(), (TypeSymbol)sym, owntype.getMetadata(), Flavor.L_TypeOf_Q);
                     }
 
                     // (b) If the symbol's type is parameterized, erase it
@@ -4583,7 +4585,7 @@ public class Attr extends JCTree.Visitor {
                         if (normOuter != ownOuter)
                             owntype = new ClassType(
                                 normOuter, List.nil(), owntype.tsym,
-                                owntype.getMetadata(), owntype.isReferenceProjection());
+                                owntype.getMetadata(), owntype.getFlavor());
                     }
                 }
                 break;
@@ -4994,7 +4996,7 @@ public class Attr extends JCTree.Visitor {
                     }
                 }
                 owntype = new ClassType(clazzOuter, actuals, clazztype.tsym,
-                                        clazztype.getMetadata(), clazztype.isReferenceProjection());
+                                        clazztype.getMetadata(), clazztype.getFlavor());
             } else {
                 if (formals.length() != 0) {
                     log.error(tree.pos(),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.code.Kinds.KindSelector;
 import com.sun.tools.javac.code.Scope.*;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.main.Option.PkgInfo;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
@@ -474,6 +475,12 @@ public class Enter extends JCTree.Visitor {
         c.clearAnnotationMetadata();
 
         ClassType ct = (ClassType)c.type;
+        // TODO: Discriminate between ref-val defaultness. ATM, we are blind to default favor
+        if ((c.flags_field & PRIMITIVE_CLASS) != 0) {
+            ct.flavor = Flavor.Q_TypeOf_Q;
+        } else {
+            ct.flavor = Flavor.L_TypeOf_L;
+        }
         if (owner.kind != PCK && (c.flags_field & STATIC) == 0) {
             // We are seeing a local or inner class.
             // Set outer_field of this class to closest enclosing class

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -475,12 +475,8 @@ public class Enter extends JCTree.Visitor {
         c.clearAnnotationMetadata();
 
         ClassType ct = (ClassType)c.type;
-        // TODO: Discriminate between ref-val defaultness. ATM, we are blind to default favor
-        if ((c.flags_field & PRIMITIVE_CLASS) != 0) {
-            ct.flavor = Flavor.Q_TypeOf_Q;
-        } else {
-            ct.flavor = Flavor.L_TypeOf_L;
-        }
+        ct.flavor = ct.flavor.metamorphose((c.flags_field & PRIMITIVE_CLASS) != 0);
+
         if (owner.kind != PCK && (c.flags_field & STATIC) == 0) {
             // We are seeing a local or inner class.
             // Set outer_field of this class to closest enclosing class

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3722,7 +3722,7 @@ public class Resolve {
                 List<Type> typeargtypes, MethodResolutionPhase maxPhase) {
             super(referenceTree, names.init, site, argtypes, typeargtypes, maxPhase);
             if (site.isRaw()) {
-                this.site = new ClassType(site.getEnclosingType(), site.tsym.type.getTypeArguments(), site.tsym, site.getMetadata(), site.isReferenceProjection());
+                this.site = new ClassType(site.getEnclosingType(), site.tsym.type.getTypeArguments(), site.tsym, site.getMetadata(), site.getFlavor());
                 needsInference = true;
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -663,7 +663,7 @@ public class ClassReader {
                         flavor = L_TypeOf_Q;
                     } else {
                         // We are seeing QFoo; or LFoo; The name itself does not shine any light on default val-refness
-                        flavor = prefix == 'L' ? Flavor.L_TypeOf_X : Flavor.L_TypeOf_X;
+                        flavor = prefix == 'L' ? Flavor.L_TypeOf_X : Flavor.Q_TypeOf_X;
                     }
                     t = flavor == L_TypeOf_Q ? enterPrimitiveClass(name) : enterClass(name);
                     outer = new ClassType(outer, List.nil(), t, TypeMetadata.EMPTY, flavor);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -44,6 +44,7 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.code.Source.Feature;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.comp.Annotate;
 import com.sun.tools.javac.comp.Annotate.AnnotationTypeCompleter;
 import com.sun.tools.javac.code.*;
@@ -70,6 +71,8 @@ import static com.sun.tools.javac.code.Kinds.Kind.*;
 
 import com.sun.tools.javac.code.Scope.LookupKind;
 
+import static com.sun.tools.javac.code.Type.ClassType.Flavor.L_TypeOf_Q;
+import static com.sun.tools.javac.code.Type.ClassType.Flavor.Q_TypeOf_Q;
 import static com.sun.tools.javac.code.TypeTag.ARRAY;
 import static com.sun.tools.javac.code.TypeTag.CLASS;
 import static com.sun.tools.javac.code.TypeTag.TYPEVAR;
@@ -535,13 +538,14 @@ public class ClassReader {
     /** Convert class signature to type, where signature is implicit.
      */
     Type classSigToType() {
-        if (signature[sigp] != 'L' && signature[sigp] != 'Q')
+        byte prefix = signature[sigp];
+        if (prefix != 'L' && prefix != 'Q')
             throw badClassFile("bad.class.signature",
                                Convert.utf2string(signature, sigp, 10));
         sigp++;
         Type outer = Type.noType;
         Name name;
-        boolean requireProjection;
+        ClassType.Flavor flavor;
         int startSbp = sbp;
 
         while (true) {
@@ -554,15 +558,24 @@ public class ClassReader {
                         sbp - startSbp);
                 if (allowPrimitiveClasses && name.toString().endsWith("$ref")) {
                     name = name.subName(0, name.length() - 4);
-                    requireProjection = true;
+                    Assert.check(prefix == 'L');
+                    flavor = L_TypeOf_Q;
                 } else {
-                    requireProjection = false;
+                    // We are seeing QFoo; or LFoo; The name itself does not shine any light on default val-refness
+                    flavor = prefix == 'L' ? Flavor.L_TypeOf_X : Flavor.Q_TypeOf_X;
                 }
-                ClassSymbol t = enterClass(name);
+                ClassSymbol t = flavor == L_TypeOf_Q ? enterPrimitiveClass(name) : enterClass(name);
                 try {
-                    return (outer == Type.noType) ?
-                            requireProjection ? t.erasure(types).referenceProjection() : t.erasure(types) :
-                        new ClassType(outer, List.nil(), t, TypeMetadata.EMPTY, requireProjection);
+                    if (outer == Type.noType) {
+                        ClassType et = (ClassType) t.erasure(types);
+                        if (flavor == L_TypeOf_Q) {
+                            return et.referenceProjection();
+                        } else {
+                            // Todo: This spews out more objects than before, i.e no reuse with identical flavor
+                            return new ClassType(et.getEnclosingType(), List.nil(), et.tsym, et.getMetadata(), flavor);
+                        }
+                    }
+                    return new ClassType(outer, List.nil(), t, TypeMetadata.EMPTY, flavor);
                 } finally {
                     sbp = startSbp;
                 }
@@ -574,12 +587,14 @@ public class ClassReader {
                         sbp - startSbp);
                 if (allowPrimitiveClasses && name.toString().endsWith("$ref")) {
                     name = name.subName(0, name.length() - 4);
-                    requireProjection = true;
+                    Assert.check(prefix == 'L');
+                    flavor = L_TypeOf_Q;
                 } else {
-                    requireProjection = false;
+                    // We are seeing QFoo; or LFoo; The name itself does not shine any light on default val-refness
+                    flavor = prefix == 'L' ? Flavor.L_TypeOf_X : Flavor.Q_TypeOf_X;
                 }
-                ClassSymbol t = enterClass(name);
-                outer = new ClassType(outer, sigToTypes('>'), t, TypeMetadata.EMPTY, requireProjection) {
+                ClassSymbol t = flavor == L_TypeOf_Q ? enterPrimitiveClass(name) : enterClass(name);
+                outer = new ClassType(outer, sigToTypes('>'), t, TypeMetadata.EMPTY, flavor) {
                         boolean completed = false;
                         @Override @DefinedBy(Api.LANGUAGE_MODEL)
                         public Type getEnclosingType() {
@@ -644,12 +659,14 @@ public class ClassReader {
                             sbp - startSbp);
                     if (allowPrimitiveClasses && name.toString().endsWith("$ref")) {
                         name = name.subName(0, name.length() - 4);
-                        requireProjection = true;
+                        Assert.check(prefix == 'L');
+                        flavor = L_TypeOf_Q;
                     } else {
-                        requireProjection = false;
+                        // We are seeing QFoo; or LFoo; The name itself does not shine any light on default val-refness
+                        flavor = prefix == 'L' ? Flavor.L_TypeOf_X : Flavor.L_TypeOf_X;
                     }
-                    t = enterClass(name);
-                    outer = new ClassType(outer, List.nil(), t, TypeMetadata.EMPTY, requireProjection);
+                    t = flavor == L_TypeOf_Q ? enterPrimitiveClass(name) : enterClass(name);
+                    outer = new ClassType(outer, List.nil(), t, TypeMetadata.EMPTY, flavor);
                 }
                 signatureBuffer[sbp++] = (byte)'$';
                 continue;
@@ -2504,6 +2521,26 @@ public class ClassReader {
         return syms.enterClass(currentModule, name);
     }
 
+    /**
+     * Special routine to enter a class that we conclude must be a primitive class from naming convention
+     * E.g, if we see LFoo$ref in descriptors, we discern that to be the reference projection of the primitive
+     * class Foo
+     */
+    protected ClassSymbol enterPrimitiveClass(Name name) {
+        ClassSymbol c = enterClass(name);
+        noticePrimitiveClass(c);
+        return c;
+    }
+
+    private void noticePrimitiveClass(ClassSymbol c) {
+        ClassType ct = (ClassType) c.type;
+        ct.flavor = Q_TypeOf_Q;
+        if (c.erasure_field != null) {
+            ClassType ef = (ClassType) c.erasure_field;
+            ef.flavor = Q_TypeOf_Q;
+        }
+    }
+
     protected ClassSymbol enterClass(Name name, TypeSymbol owner) {
         return syms.enterClass(currentModule, name, owner);
     }
@@ -2612,6 +2649,9 @@ public class ClassReader {
                     ((ClassType)member.type).setEnclosingType(outer.type);
                     if (member.erasure_field != null)
                         ((ClassType)member.erasure_field).setEnclosingType(types.erasure(outer.type));
+                }
+                if ((flags & PRIMITIVE_CLASS) != 0) {
+                    noticePrimitiveClass(member); // Do we care to do this ?
                 }
                 if (c == outer) {
                     member.flags_field = flags;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2534,10 +2534,9 @@ public class ClassReader {
 
     private void noticePrimitiveClass(ClassSymbol c) {
         ClassType ct = (ClassType) c.type;
-        ct.flavor = Q_TypeOf_Q;
+        ct.flavor = ct.flavor.metamorphose(true);
         if (c.erasure_field != null) {
-            ClassType ef = (ClassType) c.erasure_field;
-            ef.flavor = Q_TypeOf_Q;
+            ((ClassType) c.erasure_field).flavor = ct.flavor;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -43,6 +43,7 @@ import com.sun.tools.javac.code.Directive.*;
 import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.code.Types.SignatureGenerator.InvalidSignatureException;
 import com.sun.tools.javac.comp.Check;
 import com.sun.tools.javac.file.PathFileObject;
@@ -1543,7 +1544,11 @@ public class ClassWriter extends ClassFile {
             ClassType projectedType;
 
             ClassType ct = (ClassType) c.type;
-            projectedType = new ClassType(ct.getEnclosingType(), ct.typarams_field, null, ct.getMetadata(), false);
+            /* Note, the class type associated with the Primitive$ref.class is NOT a reference projection type. A reference projection
+             * type gets created by using Primitive.ref notation in the source file or while reading in a descriptor of such a type
+             * from the class file. Here we are generating the Primitive$ref.class for the VM's benefit and it is a reference class.
+             */
+            projectedType = new ClassType(ct.getEnclosingType(), ct.typarams_field, null, ct.getMetadata(), Flavor.L_TypeOf_L);
             projectedType.allparams_field = ct.allparams_field;
             projectedType.supertype_field = ct.supertype_field;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
@@ -274,7 +274,7 @@ public class JavacTypes implements javax.lang.model.util.Types {
             }
             // TODO: Would like a way to check that type args match formals.
 
-            return (DeclaredType) new Type.ClassType(outer, targs.toList(), sym);
+            return (DeclaredType) new Type.ClassType(outer, targs.toList(), sym, TypeMetadata.EMPTY, sym.type.getFlavor());
         }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -58,6 +58,7 @@ import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.ClassType;
+import com.sun.tools.javac.code.Type.ClassType.Flavor;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Check;
@@ -1343,7 +1344,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
                         Kinds.Kind symKind = cs.kind;
                         cs.reset();
                         if (symKind == ERR) {
-                            cs.type = new ClassType(cs.type.getEnclosingType(), null, cs);
+                            cs.type = new ClassType(cs.type.getEnclosingType(), null, cs, TypeMetadata.EMPTY, Flavor.X_Typeof_X);
                         }
                         if (cs.isCompleted()) {
                             cs.completer = initialCompleter;

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConsumeUnifiedClass.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConsumeUnifiedClass.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266466
+ * @summary Enhance javac to consume unified primitive class files
+ * @compile -XDunifiedValRefClass -XDallowWithFieldOperator Point.java Rectangle.java
+ * @compile/fail/ref=ConsumeUnifiedClass.out -XDrawDiagnostics ConsumeUnifiedClass.java
+ */
+
+public primitive class ConsumeUnifiedClass {
+    public static void main(String [] args) {
+        Rectangle r = new Rectangle(null, null); // Check method type decoding, should error
+        r = Rectangle.from(null, null); // OK.
+        Rectangle.origin = null; // Check field type decoding, should error
+        Rectangle.origin = Point.makePoint(0, 0); // OK
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConsumeUnifiedClass.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConsumeUnifiedClass.out
@@ -1,0 +1,3 @@
+ConsumeUnifiedClass.java:36:23: compiler.err.cant.apply.symbol: kindname.constructor, Rectangle, Point,Point, compiler.misc.type.null,compiler.misc.type.null, kindname.class, Rectangle, (compiler.misc.no.conforming.assignment.exists: (compiler.misc.inconvertible.types: compiler.misc.type.null, Point))
+ConsumeUnifiedClass.java:38:28: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, Point)
+2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
@@ -28,9 +28,9 @@ public primitive class Rectangle {
     Point topLeft, bottomRight;
 
     static Point origin;
- 
+
     static Rectangle from (Point.ref topLeft, Point.ref bottomRight) {
-        return new Rectangle(topLeft, bottomRight);     
+        return new Rectangle(topLeft, bottomRight);
     }
 
     Rectangle (Point topLeft, Point bottomRight) {

--- a/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public primitive class Rectangle {
+
+    Point topLeft, bottomRight;
+
+    static Point origin;
+ 
+    static Rectangle from (Point.ref topLeft, Point.ref bottomRight) {
+        return new Rectangle(topLeft, bottomRight);     
+    }
+
+    Rectangle (Point topLeft, Point bottomRight) {
+        this.topLeft = topLeft;
+        this.bottomRight = bottomRight;
+    }
+}


### PR DESCRIPTION
Post the integration of https://bugs.openjdk.java.net/browse/JDK-8244227,
the constructor of ClassType, takes a boolean isReferenceProjection as an additional
parameter. Till now, it was feasible to upfront decide at the time of constructing
a class type whether the proposed type is supposed to be a reference projection or not.

This is no longer possible under the unified class file generation scheme we are
moving to. When we see LFoo; in field/method signatures/descriptors, we don't know
whether the type is Foo.ref of a primitive class Foo or a plain old reference type.

Likewise when we see QFoo; we have an ambiguity whether this is the primitive class
type Foo or is Foo.val type of a ref-default primitive class Foo. Till a class is
fully built ("completed"), we don't know whether it is a primitive class and if so,
what its ref-val defaultness is.

Completing class Foo every time we see a type descriptor LFoo; or QFoo; is wasteful
of resources. Nor is it possible as it is, since it would call for the ClassReader's
code to be reentered even as some other class is being read in: So the proposed patch
implements an incremental piece meal augmentation of attributes.

I suggest the review be started with Type.java in ClassType#Flavor enumeration to gather
a high level picture of the abstractions put in place to characterize a class type in
an incremental basis. After Type.java, Attr.java, ClassReader.java and Symbol.java in
that order provide a good order for review.

Please note, while this patch puts together the infrastructure and layes the groundwork
for modelling ref-default classes and thereby enable VBC migration work, such work will
arrive separately at a later time.

As of now javac knows only about primitive class and their reference projections and
plain old reference types. There is no notion of ref-val defaultness yet, Nor a way
to declare them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8266466](https://bugs.openjdk.java.net/browse/JDK-8266466): [lworld] Enhance javac to consume unified primitive class files generated under the option -XDunifiedValRefClass


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/421/head:pull/421` \
`$ git checkout pull/421`

Update a local copy of the PR: \
`$ git checkout pull/421` \
`$ git pull https://git.openjdk.java.net/valhalla pull/421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 421`

View PR using the GUI difftool: \
`$ git pr show -t 421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/421.diff">https://git.openjdk.java.net/valhalla/pull/421.diff</a>

</details>
