### PR TITLE
8267559: [lworld] [lw3] NPE thrown when attempting to write null to a null-free array has incorrect error message

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -1173,7 +1173,13 @@ int ExceptionMessageBuilder::get_NPE_null_slot(int bci) {
 
 bool ExceptionMessageBuilder::print_NPE_cause(outputStream* os, int bci, int slot) {
   if (print_NPE_cause0(os, bci, slot, _max_cause_detail, false, " because \"")) {
-    os->print("\" is null");
+    address code_base = _method->constMethod()->code_base();
+    Bytecodes::Code code = Bytecodes::java_code_at(_method, code_base + bci);
+    if (code == Bytecodes::_aastore) {
+      os->print("\" is null or is a null-free array and there's an attempt to store null in it");
+    } else {
+      os->print("\" is null");
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
Please review this small fix in the error message of the NullPointerException thrown when trying to write null on a null-free array.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267559](https://bugs.openjdk.java.net/browse/JDK-8267559): [lworld] [lw3] NPE thrown when attempting to write null to a null-free array has incorrect error message


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/422/head:pull/422` \
`$ git checkout pull/422`

Update a local copy of the PR: \
`$ git checkout pull/422` \
`$ git pull https://git.openjdk.java.net/valhalla pull/422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 422`

View PR using the GUI difftool: \
`$ git pr show -t 422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/422.diff">https://git.openjdk.java.net/valhalla/pull/422.diff</a>

</details>
