### PR TITLE
8267672: [lworld] A couple of cleanups to Unified class file generation scheme

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Printer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Printer.java
@@ -234,7 +234,13 @@ public abstract class Printer implements Type.Visitor<String, Locale>, Symbol.Vi
             buf.append(printAnnotations(t));
             buf.append(className(t, true, locale));
         }
-        if (t.isReferenceProjection()) {
+        boolean isReferenceProjection;
+        try {
+            isReferenceProjection = t.isReferenceProjection();
+        } catch (CompletionFailure cf) {
+            isReferenceProjection = false; // handle missing types gracefully.
+        }
+        if (isReferenceProjection) {
             buf.append('.');
             buf.append(t.tsym.name.table.names.ref);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -1140,7 +1140,7 @@ public class Lower extends TreeTranslator {
                 // Convert type idents to
                 // <flat name> or <package name> . <flat name>
                 Name flatname = Convert.shortName(sym.flatName());
-                if (requireReferenceProjection) {
+                if (types.splitPrimitiveClass && requireReferenceProjection) {
                     flatname = flatname.append('$', names.ref);
                 }
                 while (base != null &&


### PR DESCRIPTION
Minor cleanups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267672](https://bugs.openjdk.java.net/browse/JDK-8267672): [lworld] A couple of cleanups to Unified class file generation scheme


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/425/head:pull/425` \
`$ git checkout pull/425`

Update a local copy of the PR: \
`$ git checkout pull/425` \
`$ git pull https://git.openjdk.java.net/valhalla pull/425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 425`

View PR using the GUI difftool: \
`$ git pr show -t 425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/425.diff">https://git.openjdk.java.net/valhalla/pull/425.diff</a>

</details>
