### PR TITLE
8267698: [lworld] [lw3] runtime\exceptionMsgs\NullPointerException\NullPointerExceptionTest.java test fails because of new error message

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/NullPointerExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/NullPointerExceptionTest.java
@@ -304,7 +304,7 @@ public class NullPointerExceptionTest {
         } catch (NullPointerException e) {
             checkMessage(e, "oa1[0] = new Object();", e.getMessage(),
                          "Cannot store to object array because " +
-                         (hasDebugInfo ? "\"oa1\"" : "\"<local3>\"") + " is null");
+                         (hasDebugInfo ? "\"oa1\"" : "\"<local3>\"") + " is null or is a null-free array and there's an attempt to store null in it");
         }
         // bastore (boolean)
         try {


### PR DESCRIPTION
Fix test to recognize the new exception message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267698](https://bugs.openjdk.java.net/browse/JDK-8267698): [lworld] [lw3] runtime\exceptionMsgs\NullPointerException\NullPointerExceptionTest.java test fails because of new error message


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.java.net/valhalla pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/426.diff">https://git.openjdk.java.net/valhalla/pull/426.diff</a>

</details>
