### PR TITLE
8267710: [lworld][lw3] Hook AlwaysAtomicAccesses to primitive classes atomicity rules

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -652,7 +652,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
         InlineKlass* vk = InlineKlass::cast(klass);
         bool too_big_to_flatten = (InlineFieldMaxFlatSize >= 0 &&
                                    (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
-        bool too_atomic_to_flatten = vk->is_declared_atomic();
+        bool too_atomic_to_flatten = vk->is_declared_atomic() || AlwaysAtomicAccesses;
         bool too_volatile_to_flatten = fs.access_flags().is_volatile();
         if (vk->is_naturally_atomic()) {
           too_atomic_to_flatten = false;

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -753,7 +753,7 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
         InlineKlass* vk = InlineKlass::cast(klass);
         bool too_big_to_flatten = (InlineFieldMaxFlatSize >= 0 &&
                                    (vk->size_helper() * HeapWordSize) > InlineFieldMaxFlatSize);
-        bool too_atomic_to_flatten = vk->is_declared_atomic();
+        bool too_atomic_to_flatten = vk->is_declared_atomic() || AlwaysAtomicAccesses;
         bool too_volatile_to_flatten = fs.access_flags().is_volatile();
         if (vk->is_naturally_atomic()) {
           too_atomic_to_flatten = false;


### PR DESCRIPTION
`AlwaysAtomicAccesses` was added in JDK 9 to aid the research in the costs of requiring the always-atomic accesses. It would be nice to hook it up to current Valhalla code that handles explicitly declared atomic primitive classes.

Testing:
 - [x] ad-hoc jcstress tests with lworld and `-XX:(-|+)AlwaysAtomicAccesses`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267710](https://bugs.openjdk.java.net/browse/JDK-8267710): [lworld][lw3] Hook AlwaysAtomicAccesses to primitive classes atomicity rules


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/427/head:pull/427` \
`$ git checkout pull/427`

Update a local copy of the PR: \
`$ git checkout pull/427` \
`$ git pull https://git.openjdk.java.net/valhalla pull/427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 427`

View PR using the GUI difftool: \
`$ git pr show -t 427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/427.diff">https://git.openjdk.java.net/valhalla/pull/427.diff</a>

</details>
