### PR TITLE
8267791: [lworld][lw3] Support compiler blackholes for inline types

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1927,6 +1927,27 @@ void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
       } else if (vt->is_InlineTypePtr()) {
         igvn.replace_node(vt, vt->get_oop());
       } else {
+        // Check if any users are blackholes. If so, rewrite them to use the individual
+        // components, instead of the inline type node that goes away.
+        for (DUIterator i = vt->outs(); vt->has_out(i); i++) {
+          if (vt->out(i)->is_Blackhole()) {
+            BlackholeNode* bh = vt->out(i)->as_Blackhole();
+
+            // Unlink the old input
+            int idx = bh->find_edge(vt);
+            assert(idx != -1, "The edge should be there");
+            bh->del_req(idx);
+            --i;
+
+            // Add the new inputs to the components
+            for (uint c = 0; c < vt->field_count(); c++) {
+              bh->add_req(vt->field_value(c));
+            }
+
+            // Node modified, record for IGVN
+            igvn.record_for_igvn(bh);
+          }
+        }
 #ifdef ASSERT
         for (DUIterator_Fast imax, i = vt->fast_outs(imax); i < imax; i++) {
           assert(vt->fast_out(i)->is_InlineTypeBase(), "Unexpected inline type user");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1941,7 +1941,7 @@ void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
             --i;
 
             if (vt->is_allocated(&igvn)) {
-              // Already has an allocation, blackhole that
+              // Already has the allocated instance, blackhole that
               bh->add_req(vt->get_oop());
             } else {
               // Not allocated yet, blackhole the components

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1928,7 +1928,7 @@ void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
         igvn.replace_node(vt, vt->get_oop());
       } else {
         // Check if any users are blackholes. If so, rewrite them to use either the
-        // allocated box, or individual components, instead of the inline type node
+        // allocated buffer, or individual components, instead of the inline type node
         // that goes away.
         for (DUIterator i = vt->outs(); vt->has_out(i); i++) {
           if (vt->out(i)->is_Blackhole()) {

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1354,7 +1354,9 @@ public:
 class BlackholeNode : public MemBarNode {
 public:
   BlackholeNode(Compile* C, int alias_idx, Node* precedent)
-    : MemBarNode(C, alias_idx, precedent) {}
+    : MemBarNode(C, alias_idx, precedent) {
+    init_class_id(Class_Blackhole);
+  }
   virtual int   Opcode() const;
   virtual uint ideal_reg() const { return 0; } // not matched in the AD file
   const RegMask &in_RegMask(uint idx) const {

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -668,6 +668,7 @@ public:
       DEFINE_CLASS_ID(MemBar,      Multi, 3)
         DEFINE_CLASS_ID(Initialize,       MemBar, 0)
         DEFINE_CLASS_ID(MemBarStoreStore, MemBar, 1)
+        DEFINE_CLASS_ID(Blackhole,        MemBar, 2)
 
     DEFINE_CLASS_ID(Mach,  Node, 1)
       DEFINE_CLASS_ID(MachReturn, Mach, 0)
@@ -845,6 +846,7 @@ public:
   DEFINE_CLASS_QUERY(ArrayCopy)
   DEFINE_CLASS_QUERY(BaseCountedLoop)
   DEFINE_CLASS_QUERY(BaseCountedLoopEnd)
+  DEFINE_CLASS_QUERY(Blackhole)
   DEFINE_CLASS_QUERY(Bool)
   DEFINE_CLASS_QUERY(BoxLock)
   DEFINE_CLASS_QUERY(Call)

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/BlackholeTest.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/BlackholeTest.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-package runtime.valhalla.inlinetypes;
+package compiler.valhalla.inlinetypes;
 
 /*
  * @test BlackholeTest
@@ -29,8 +29,8 @@ package runtime.valhalla.inlinetypes;
  * @run main/othervm
  *      -Xbatch
  *      -XX:+UnlockExperimentalVMOptions
- *      -XX:CompileCommand=blackhole,runtime/valhalla/inlinetypes/BlackholeTest.blackhole
- *      runtime.valhalla.inlinetypes.BlackholeTest
+ *      -XX:CompileCommand=blackhole,compiler/valhalla/inlinetypes/BlackholeTest.blackhole
+ *      compiler.valhalla.inlinetypes.BlackholeTest
  */
 
 public class BlackholeTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/BlackholeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/BlackholeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime.valhalla.inlinetypes;
+
+/*
+ * @test BlackholeTest
+ * @summary Check that blackholes work with inline types
+ * @run main/othervm
+ *      -Xbatch
+ *      -XX:+UnlockExperimentalVMOptions
+ *      -XX:CompileCommand=blackhole,runtime/valhalla/inlinetypes/BlackholeTest.blackhole
+ *      runtime.valhalla.inlinetypes.BlackholeTest
+ */
+
+public class BlackholeTest {
+    static primitive class MyValue {
+        int x = 0;
+    }
+
+    static MyValue v;
+
+    public static void main(String[] args) {
+        for (int c = 0; c < 5; c++) {
+            testNew();
+            testDefault();
+            testField();
+        }
+    }
+
+    private static void testNew() {
+        for (int c = 0; c < 100000; c++) {
+            blackhole(new MyValue());
+        }
+    }
+
+    private static void testDefault() {
+        for (int c = 0; c < 100000; c++) {
+            blackhole(MyValue.default);
+        }
+    }
+
+    private static void testField() {
+        for (int c = 0; c < 100000; c++) {
+            blackhole(v);
+        }
+    }
+
+    public static void blackhole(MyValue v) {
+        // Should be empty
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/BlackholeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/BlackholeTest.java
@@ -39,12 +39,14 @@ public class BlackholeTest {
     }
 
     static MyValue v;
+    static volatile MyValue vv;
 
     public static void main(String[] args) {
         for (int c = 0; c < 5; c++) {
             testNew();
             testDefault();
             testField();
+            testVolatileField();
         }
     }
 
@@ -63,6 +65,12 @@ public class BlackholeTest {
     private static void testField() {
         for (int c = 0; c < 100000; c++) {
             blackhole(v);
+        }
+    }
+
+    private static void testVolatileField() {
+        for (int c = 0; c < 100000; c++) {
+            blackhole(vv);
         }
     }
 


### PR DESCRIPTION
JDK-8259316 added the support for compiler blackholes. We need to check and implement the support for inline type arguments for them. I am sure we would find more wrinkles with nano-benchmarks, but insofar sample benchmark work as they should:

```
public class PrimitiveClasses {
    static primitive class Value {
        long x;
        long y;
        public Value(long x, long y) {
            this.x = x;
            this.y = y;
        }
    }

    [volatile] Value v = Value.default;

    @Benchmark
    public Value test() {
        return v;
    }
}
```

Before: crash on assert, `assert(vt->fast_out(i)->is_InlineTypeBase(), "Unexpected inline type user");`

After, generated code in non-`volatile` case shows blackhole of individual components:

```
$ java -Djmh.blackhole.mode=COMPILER -jar target/benchmarks.jar PrimitiveClasses -prof perfasm
...
....[Hottest Region 1]..............................................................................
c2, level 4, org.openjdk.jmh_generated.PrimitiveClasses_test_jmhTest::test_avgt_jmhStub, version 641 (39 bytes) 
...
         ↗  0x00007f67bcc8eee0:   mov    0x18(%r8),%r10        ; read and blackhole MyValue.x
  0.02%  │  0x00007f67bcc8eee4:   mov    0x10(%r8),%r11        ; read and blackhole MyValue.y
  0.10%  │  0x00007f67bcc8eee8:   movzbl 0x94(%r14),%r11d      ; read isDone
  0.10%  │  0x00007f67bcc8eef0:   mov    0x3b0(%r15),%r10      ; TL handshake
  2.79%  │  0x00007f67bcc8eef7:   add    $0x1,%rbp             ; ops++
         │  0x00007f67bcc8eefb:   test   %eax,(%r10)           ; TL handshake
 86.74%  │  0x00007f67bcc8eefe:   test   %r11d,%r11d           ; isDone?
  2.31%  ╰  0x00007f67bcc8ef01:   je     0x00007f67bcc8eee0    
```

And generated code in `volatile` case shows blackhole of the box (with the null-check):

```
          ↗   0x00007f3948c8db70:   shl    $0x3,%r10            ; unpack and blackhole MyValue
  0.02%   │↗  0x00007f3948c8db74:   movzbl 0x94(%r14),%r8d      ; read isDone
  0.68%   ││  0x00007f3948c8db7c:   mov    0x3b0(%r15),%r9      ; TL handshake
  0.72%   ││  0x00007f3948c8db83:   add    $0x1,%rbp            ; ops++
          ││  0x00007f3948c8db87:   test   %eax,(%r9)           ; TL handshake
 92.30%   ││  0x00007f3948c8db8a:   test   %r8d,%r8d            ; isDone?
         ╭││  0x00007f3948c8db8d:   jne    0x00007f3948c8dba4   
         │││  0x00007f3948c8db8f:   mov    0xc(%r11),%r10d      ; load "v" (MyValue box)
  0.35%  │││  0x00007f3948c8db93:   test   %r10d,%r10d          ; null check it
         │╰│  0x00007f3948c8db96:   jne    0x00007f3948c8db70   
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267791](https://bugs.openjdk.java.net/browse/JDK-8267791): [lworld][lw3] Support compiler blackholes for inline types


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/429/head:pull/429` \
`$ git checkout pull/429`

Update a local copy of the PR: \
`$ git checkout pull/429` \
`$ git pull https://git.openjdk.java.net/valhalla pull/429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 429`

View PR using the GUI difftool: \
`$ git pr show -t 429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/429.diff">https://git.openjdk.java.net/valhalla/pull/429.diff</a>

</details>
