### PR TITLE
8267818: [lworld] [AArch64] Shenandoah barrier set build warnings and register conflict

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -367,7 +367,7 @@ void ShenandoahBarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet d
 }
 
 void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                                             Address dst, Register val, Register tmp1, Register tmp2) {
+                                             Address dst, Register val, Register tmp1, Register tmp2, Register tmp3) {
   bool on_oop = is_reference_type(type);
   if (!on_oop) {
     BarrierSetAssembler::store_at(masm, decorators, type, dst, val, tmp1, tmp2);
@@ -392,7 +392,7 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet 
                                false /* expand_call */);
 
   if (val == noreg) {
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(r3, 0), noreg, noreg, noreg);
+    BarrierSetAssembler::store_at(masm, decorators, type, Address(r3, 0), noreg, noreg, noreg, noreg);
   } else {
     iu_barrier(masm, val, tmp1);
     // G1 barrier needs uncompressed oop for region cross check.
@@ -401,7 +401,7 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet 
       new_val = rscratch2;
       __ mov(new_val, val);
     }
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(r3, 0), val, noreg, noreg);
+    BarrierSetAssembler::store_at(masm, decorators, type, Address(r3, 0), val, noreg, noreg, noreg);
   }
 
 }

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.hpp
@@ -74,7 +74,7 @@ public:
   virtual void load_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                        Register dst, Address src, Register tmp1, Register tmp_thread);
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
-                        Address dst, Register val, Register tmp1, Register tmp2);
+                        Address dst, Register val, Register tmp1, Register tmp2, Register tmp3 = noreg);
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
   void cmpxchg_oop(MacroAssembler* masm, Register addr, Register expected, Register new_val,

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3306,7 +3306,7 @@ void TemplateTable::fast_accessfield(TosState state)
   switch (bytecode()) {
   case Bytecodes::_fast_qgetfield:
     {
-      Register index = r4, klass = r5, inline_klass = r6;
+      Register index = r4, klass = r5, inline_klass = r6, tmp = r7;
       Label is_inlined, nonnull, Done;
       __ test_field_is_inlined(r3, noreg /* temp */, is_inlined);
         // field is not inlined
@@ -3316,7 +3316,7 @@ void TemplateTable::fast_accessfield(TosState state)
           __ ldr(klass, Address(r2, in_bytes(ConstantPoolCache::base_offset() +
                                              ConstantPoolCacheEntry::f1_offset())));
           __ get_inline_type_field_klass(klass, index, inline_klass);
-          __ get_default_value_oop(inline_klass, rscratch1 /* temp */, r0);
+          __ get_default_value_oop(inline_klass, tmp /* temp */, r0);
         __ bind(nonnull);
         __ verify_oop(r0);
         __ b(Done);
@@ -3325,7 +3325,7 @@ void TemplateTable::fast_accessfield(TosState state)
         __ andw(index, r3, ConstantPoolCacheEntry::field_index_mask);
         __ ldr(klass, Address(r2, in_bytes(ConstantPoolCache::base_offset() +
                                            ConstantPoolCacheEntry::f1_offset())));
-        __ read_inlined_field(klass, index, r1, inline_klass /* temp */, r0);
+        __ read_inlined_field(klass, index, r1, tmp /* temp */, r0);
         __ verify_oop(r0);
       __ bind(Done);
     }


### PR DESCRIPTION
I get this warning when building with Shenandoah enabled on AArch64:

[...]/barrierSetAssembler_aarch64.hpp:47:16: warning: 'virtual void BarrierSetAssembler::store_at(MacroAssembler*, DecoratorSet, BasicType, Address, Register, Register, Register, Register)' was hidden [-Woverloaded-virtual]

BarrierSetAssembler::store_at() gained an extra tmp3 argument. (The 
same fix was already applied on x86.)

ShenahdoahBarrierSetAssembler::load_at() uses rscratch1 and rscratch2
internally but the interpreter _fast_qgetfield implementation passes
rscratch1 as a separate temporary via get_default_value_oop() which
causes an assert_different_registers() failure. Instead just allocate a
fresh temporary register and pass that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267818](https://bugs.openjdk.java.net/browse/JDK-8267818): [lworld] [AArch64] Shenandoah barrier set build warnings and register conflict


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/430/head:pull/430` \
`$ git checkout pull/430`

Update a local copy of the PR: \
`$ git checkout pull/430` \
`$ git pull https://git.openjdk.java.net/valhalla pull/430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 430`

View PR using the GUI difftool: \
`$ git pr show -t 430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/430.diff">https://git.openjdk.java.net/valhalla/pull/430.diff</a>

</details>
