### PR TITLE
8267846: [lworld] JIT support for the L/Q model (step 1)

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -513,10 +513,8 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   assert(result->is_illegal() || !result->is_single_cpu() || result->as_register() == r0, "word returns are in r0,");
 
   ciMethod* method = compilation()->method();
-
-  ciType* return_type = method->return_type();
-  if (InlineTypeReturnedAsFields && return_type->is_inlinetype()) {
-    ciInlineKlass* vk = return_type->as_inline_klass();
+  if (InlineTypeReturnedAsFields && method->signature()->returns_null_free_inline_type()) {
+    ciInlineKlass* vk = method->return_type()->as_inline_klass();
     if (vk->can_be_returned_as_fields()) {
       address unpack_handler = vk->unpack_handler();
       assert(unpack_handler != NULL, "must be");

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -531,9 +531,8 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   }
 
   ciMethod* method = compilation()->method();
-  ciType* return_type = method->return_type();
-  if (InlineTypeReturnedAsFields && return_type->is_inlinetype() && return_type->is_null_free()) {
-    ciInlineKlass* vk = return_type->as_inline_klass();
+  if (InlineTypeReturnedAsFields && method->signature()->returns_null_free_inline_type()) {
+    ciInlineKlass* vk = method->return_type()->as_inline_klass();
     if (vk->can_be_returned_as_fields()) {
 #ifndef _LP64
       Unimplemented();

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -662,15 +662,14 @@ void Canonicalizer::do_CheckCast      (CheckCast*       x) {
                           klass->as_instance_klass()->is_interface();
       // Interface casts can't be statically optimized away since verifier doesn't
       // enforce interface types in bytecode.
-      if (!is_interface && klass->is_subtype_of(x->klass())) {
+      if (!is_interface && klass->is_subtype_of(x->klass()) && (!x->is_null_free() || obj->is_null_free())) {
         assert(!x->klass()->is_inlinetype() || x->klass() == klass, "Inline klasses can't have subtypes");
         set_canonical(obj);
         return;
       }
     }
-    // checkcast of null returns null for non-inline klasses
-    if (!x->klass()->is_inlinetype() && x->is_null_free()
-        && obj->as_Constant() && obj->type()->as_ObjectType()->constant_value()->is_null_object()) {
+    // checkcast of null returns null for non null-free klasses
+    if (!x->is_null_free() && obj->is_null_obj()) {
       set_canonical(obj);
     }
   }
@@ -684,7 +683,7 @@ void Canonicalizer::do_InstanceOf     (InstanceOf*      x) {
       return;
     }
     // instanceof null returns false
-    if (obj->as_Constant() && obj->type()->as_ObjectType()->constant_value()->is_null_object()) {
+    if (obj->as_Constant() && obj->is_null_obj()) {
       set_constant(0);
     }
   }

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1844,9 +1844,9 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         assert(!field->is_stable() || !field_value.is_null_or_zero(),
                "stable static w/ default value shouldn't be a constant");
         constant = make_constant(field_value, field);
-      } else if (field_type == T_INLINE_TYPE && field->type()->is_null_free() && field->type()->unwrap()->as_inline_klass()->is_empty()) {
+      } else if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty()) {
         // Loading from a field of an empty inline type. Just return the default instance.
-        constant = new Constant(new InstanceConstant(field->type()->unwrap()->as_inline_klass()->default_instance()));
+        constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
       }
       if (constant != NULL) {
         push(type, append(constant));
@@ -1869,7 +1869,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
-      if (field_type == T_INLINE_TYPE && field->type()->unwrap()->as_inline_klass()->is_empty()) {
+      if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty()) {
         // Storing to a field of an empty inline type. Ignore.
         break;
       }
@@ -1887,18 +1887,18 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (!has_pending_field_access() && !has_pending_load_indexed()) {
         obj = apop();
         ObjectType* obj_type = obj->type()->as_ObjectType();
-        if (field_type == T_INLINE_TYPE && field->type()->is_null_free() && field->type()->unwrap()->as_inline_klass()->is_empty()) {
+        if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty()) {
           // Loading from a field of an empty inline type. Just return the default instance.
           null_check(obj);
-          constant = new Constant(new InstanceConstant(field->type()->unwrap()->as_inline_klass()->default_instance()));
+          constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
         } else if (field->is_constant() && !field->is_flattened() && obj_type->is_constant() && !PatchALot) {
           ciObject* const_oop = obj_type->constant_value();
           if (!const_oop->is_null_object() && const_oop->is_loaded()) {
             ciConstant field_value = field->constant_value_of(const_oop);
             if (field_value.is_valid()) {
-              if (field->signature()->is_Q_signature() && field_value.is_null_or_zero()) {
+              if (field->is_null_free() && field_value.is_null_or_zero()) {
                 // Non-flattened inline type field. Replace null by the default value.
-                constant = new Constant(new InstanceConstant(field->type()->unwrap()->as_inline_klass()->default_instance()));
+                constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
               } else {
                 constant = make_constant(field_value, field);
               }
@@ -1985,7 +1985,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               set_pending_field_access(dfa);
             }
           } else {
-            ciInlineKlass* inline_klass = field->type()->unwrap()->as_inline_klass();
+            ciInlineKlass* inline_klass = field->type()->as_inline_klass();
             scope()->set_wrote_final();
             scope()->set_wrote_fields();
             bool need_membar = false;
@@ -2042,7 +2042,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         Value mask = append(new Constant(new IntConstant(1)));
         val = append(new LogicOp(Bytecodes::_iand, val, mask));
       }
-      if (field_type == T_INLINE_TYPE && field->type()->is_null_free() && field->type()->unwrap()->as_inline_klass()->is_empty()) {
+      if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty()) {
         // Storing to a field of an empty inline type. Ignore.
         null_check(obj);
       } else if (!field->is_flattened()) {
@@ -2053,7 +2053,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
         }
       } else {
         assert(!needs_patching, "Can't patch flattened inline type field access");
-        ciInlineKlass* inline_klass = field->type()->unwrap()->as_inline_klass();
+        ciInlineKlass* inline_klass = field->type()->as_inline_klass();
         copy_inline_content(inline_klass, val, inline_klass->first_field_offset(), obj, offset, state_before, field);
       }
       break;
@@ -2129,7 +2129,7 @@ void GraphBuilder::withfield(int field_index) {
   }
   if (field_modify->is_flattened()) {
     assert(!needs_patching, "Can't patch flattened inline type field access");
-    ciInlineKlass* vk = field_modify->type()->unwrap()->as_inline_klass();
+    ciInlineKlass* vk = field_modify->type()->as_inline_klass();
     if (!vk->is_empty()) {
       copy_inline_content(vk, val, vk->first_field_offset(), new_instance, offset_modify, state_before, field_modify);
     }
@@ -2478,7 +2478,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   }
 
   Invoke* result = new Invoke(code, result_type, recv, args, target, state_before,
-                              declared_signature->return_type()->is_null_free());
+                              declared_signature->returns_null_free_inline_type());
   // push result
   append_split(result);
 
@@ -3579,7 +3579,7 @@ ValueStack* GraphBuilder::state_at_entry() {
     // don't allow T_ARRAY to propagate into locals types
     if (is_reference_type(basic_type)) basic_type = T_OBJECT;
     ValueType* vt = as_ValueType(basic_type);
-    state->store_local(idx, new Local(type, vt, idx, false, type->is_null_free()));
+    state->store_local(idx, new Local(type, vt, idx, false, sig->is_null_free_at(i)));
     idx += type->size();
   }
 

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -866,7 +866,7 @@ LEAF(LoadField, AccessField)
             ciInlineKlass* inline_klass = NULL, Value default_value = NULL )
   : AccessField(obj, offset, field, is_static, state_before, needs_patching)
   {
-    set_null_free(field->signature()->is_Q_signature());
+    set_null_free(field->is_null_free());
   }
 
   ciType* declared_type() const;

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1747,13 +1747,13 @@ void LIRGenerator::access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& r
                      elm_item, LIR_OprFact::intConst(sub_offset), result,
                      NULL, NULL);
 
-  if (field->signature()->is_Q_signature()) {
-    assert(field->type()->unwrap()->as_inline_klass()->is_loaded(), "Must be");
+  if (field->is_null_free()) {
+    assert(field->type()->as_inline_klass()->is_loaded(), "Must be");
     LabelObj* L_end = new LabelObj();
     __ cmp(lir_cond_notEqual, result, LIR_OprFact::oopConst(NULL));
     __ branch(lir_cond_notEqual, L_end->label());
     set_in_conditional_code(true);
-    Constant* default_value = new Constant(new InstanceConstant(field->type()->unwrap()->as_inline_klass()->default_instance()));
+    Constant* default_value = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
     if (default_value->is_pinned()) {
       __ move(LIR_OprFact::value_type(default_value->type()), result);
     } else {
@@ -1773,7 +1773,7 @@ void LIRGenerator::access_flattened_array(bool is_load, LIRItem& array, LIRItem&
 
   ciInlineKlass* elem_klass = NULL;
   if (field != NULL) {
-    elem_klass = field->type()->unwrap()->as_inline_klass();
+    elem_klass = field->type()->as_inline_klass();
   } else {
     elem_klass = array.value()->declared_type()->as_flat_array_klass()->element_klass()->as_inline_klass();
   }
@@ -2046,7 +2046,7 @@ LIR_Opr LIRGenerator::access_atomic_add_at(DecoratorSet decorators, BasicType ty
 bool LIRGenerator::inline_type_field_access_prolog(AccessField* x, CodeEmitInfo* info) {
   ciField* field = x->field();
   assert(!field->is_flattened(), "Flattened field access should have been expanded");
-  if (!field->signature()->is_Q_signature()) {
+  if (!field->is_null_free()) {
     return true; // Not an inline type field
   }
   // Deoptimize if the access is non-static and requires patching (holder not loaded
@@ -2055,7 +2055,7 @@ bool LIRGenerator::inline_type_field_access_prolog(AccessField* x, CodeEmitInfo*
   bool could_be_flat = !x->is_static() && x->needs_patching();
   // Deoptimize if we load from a static field with an unloaded type because we need
   // the default value if the field is null.
-  bool could_be_null = x->is_static() && x->as_LoadField() != NULL && !field->type()->unwrap()->is_loaded();
+  bool could_be_null = x->is_static() && x->as_LoadField() != NULL && !field->type()->is_loaded();
   assert(!could_be_null || !field->holder()->is_loaded(), "inline type field should be loaded");
   if (could_be_flat || could_be_null) {
     assert(x->needs_patching(), "no deopt required");
@@ -2134,10 +2134,10 @@ void LIRGenerator::do_LoadField(LoadField* x) {
                  info ? new CodeEmitInfo(info) : NULL, info);
 
   ciField* field = x->field();
-  if (field->signature()->is_Q_signature()) {
+  if (field->is_null_free()) {
     // Load from non-flattened inline type field requires
     // a null check to replace null with the default value.
-    ciInlineKlass* inline_klass = field->type()->unwrap()->as_inline_klass();
+    ciInlineKlass* inline_klass = field->type()->as_inline_klass();
     assert(inline_klass->is_loaded(), "field klass must be loaded");
 
     ciInstanceKlass* holder = field->holder();
@@ -3051,11 +3051,6 @@ ciKlass* LIRGenerator::profile_type(ciMethodData* md, int md_base_offset, int md
       }
     }
     do_update = exact_klass == NULL || ciTypeEntries::valid_ciklass(profiled_k) != exact_klass;
-  }
-
-  // Inline types can't be null
-  if (exact_klass != NULL && exact_klass->is_inlinetype()) {
-    do_null = false;
   }
 
   if (!do_null && !do_update) {

--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -102,27 +102,22 @@ bool ciArrayKlass::is_leaf_type() {
 // ciArrayKlass::base_element_type
 //
 // What type is obtained when this array is indexed as many times as possible?
-ciArrayKlass* ciArrayKlass::make(ciType* element_type) {
+ciArrayKlass* ciArrayKlass::make(ciType* element_type, bool null_free) {
   if (element_type->is_primitive_type()) {
     return ciTypeArrayKlass::make(element_type->basic_type());
   } else {
-    return make(element_type->as_klass(), element_type->is_null_free());
-  }
-}
-
-ciArrayKlass* ciArrayKlass::make(ciKlass* klass, bool null_free) {
-  if (null_free && klass->is_loaded()) {
-    GUARDED_VM_ENTRY(
-      EXCEPTION_CONTEXT;
-      Klass* ak = InlineKlass::cast(klass->get_Klass())->null_free_inline_array_klass(THREAD);
-      if (HAS_PENDING_EXCEPTION) {
-        CLEAR_PENDING_EXCEPTION;
-      } else if (ak != NULL && ak->is_flatArray_klass()) {
-        return ciFlatArrayKlass::make(klass);
-      }
-    )
-    return ciObjArrayKlass::make(klass, true);
-  } else {
+    ciKlass* klass = element_type->as_klass();
+    if (null_free && klass->is_loaded()) {
+      GUARDED_VM_ENTRY(
+        EXCEPTION_CONTEXT;
+        Klass* ak = InlineKlass::cast(klass->get_Klass())->null_free_inline_array_klass(THREAD);
+        if (HAS_PENDING_EXCEPTION) {
+          CLEAR_PENDING_EXCEPTION;
+        } else if (ak != NULL && ak->is_flatArray_klass()) {
+          return ciFlatArrayKlass::make(klass);
+        }
+      )
+    }
     return ciObjArrayKlass::make(klass, null_free);
   }
 }

--- a/src/hotspot/share/ci/ciArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciArrayKlass.hpp
@@ -59,11 +59,12 @@ public:
   // The one-level type of the array elements.
   virtual ciKlass* element_klass() { return NULL; }
 
-  static ciArrayKlass* make(ciType* element_type);
-  static ciArrayKlass* make(ciKlass* klass, bool null_free);
+  static ciArrayKlass* make(ciType* klass, bool null_free = false);
 
   int array_header_in_bytes();
   ciInstance* component_mirror_instance() const;
+
+  virtual bool is_elem_null_free() const { return false; }
 };
 
 #endif // SHARE_CI_CIARRAYKLASS_HPP

--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -98,12 +98,7 @@ ciField::ciField(ciInstanceKlass* klass, int index) :
     bool ignore;
     // This is not really a class reference; the index always refers to the
     // field's type signature, as a symbol.  Linkage checks do not apply.
-    ciType* type = ciEnv::current(THREAD)->get_klass_by_index(cpool, sig_index, ignore, klass);
-    if (signature->is_Q_signature()) {
-      _type = ciEnv::current(THREAD)->make_null_free_wrapper(type);
-    } else {
-      _type = type;
-    }
+    _type = ciEnv::current(THREAD)->get_klass_by_index(cpool, sig_index, ignore, klass);
   } else {
     _type = ciType::make(field_type);
   }
@@ -381,12 +376,6 @@ ciType* ciField::compute_type() {
 
 ciType* ciField::compute_type_impl() {
   ciKlass* type = CURRENT_ENV->get_klass_by_name_impl(_holder, constantPoolHandle(), _signature, false);
-  ciType* rtype;
-  if (_signature->is_Q_signature()) {
-    rtype = CURRENT_ENV->make_null_free_wrapper(type);
-  } else {
-    rtype = type;
-  }
   if (!type->is_primitive_type() && is_shared()) {
     // We must not cache a pointer to an unshared type, in a shared field.
     bool type_is_also_shared = false;
@@ -398,12 +387,11 @@ ciType* ciField::compute_type_impl() {
       // Currently there is no 'shared' query for array types.
       type_is_also_shared = !ciObjectFactory::is_initialized();
     }
-    if (!type_is_also_shared) {
-      return rtype;              // Bummer.
-    }
+    if (!type_is_also_shared)
+      return type;              // Bummer.
   }
-  _type = rtype;
-  return rtype;
+  _type = type;
+  return type;
 }
 
 

--- a/src/hotspot/share/ci/ciFlatArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciFlatArrayKlass.hpp
@@ -84,6 +84,8 @@ public:
   virtual bool can_be_inline_array_klass() {
     return true;
   }
+
+  virtual bool is_elem_null_free() const { return true; }
 };
 
 

--- a/src/hotspot/share/ci/ciObjArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.hpp
@@ -38,6 +38,7 @@ class ciObjArrayKlass : public ciArrayKlass {
 private:
   ciKlass* _element_klass;
   ciKlass* _base_element_klass;
+  bool     _null_free;
 
 protected:
   ciObjArrayKlass(Klass* k);
@@ -79,6 +80,8 @@ public:
   virtual bool can_be_inline_array_klass() {
     return element_klass()->can_be_inline_klass();
   }
+
+  virtual bool is_elem_null_free() const { return _null_free; }
 };
 
 #endif // SHARE_CI_CIOBJARRAYKLASS_HPP

--- a/src/hotspot/share/ci/ciSignature.cpp
+++ b/src/hotspot/share/ci/ciSignature.cpp
@@ -74,9 +74,17 @@ ciSignature::ciSignature(ciKlass* accessing_klass, const constantPoolHandle& cpo
 }
 
 // ------------------------------------------------------------------
-// ciSignature::returns_inline_type
+// ciSignature::returns_null_free_inline_type
 bool ciSignature::returns_null_free_inline_type() const {
   GUARDED_VM_ENTRY(return get_symbol()->is_Q_method_signature();)
+}
+
+// ------------------------------------------------------------------
+// ciSignature::is_null_free_at
+//
+// True if we know that the argument at 'index' is null-free.
+bool ciSignature::is_null_free_at(int index) const {
+  return _types.at(index)->is_null_free();
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciSignature.hpp
+++ b/src/hotspot/share/ci/ciSignature.hpp
@@ -27,6 +27,7 @@
 
 #include "ci/ciClassList.hpp"
 #include "ci/ciSymbol.hpp"
+#include "ci/ciType.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
@@ -56,8 +57,9 @@ public:
   ciKlass*  accessing_klass() const              { return _accessing_klass; }
 
   ciType*   return_type() const                  { return _return_type; }
-  ciType*   type_at(int index) const             { return _types.at(index); }
+  ciType*   type_at(int index) const             { return _types.at(index)->unwrap(); }
   bool      returns_null_free_inline_type() const;
+  bool      is_null_free_at(int index) const;
 
   int       size() const                         { return _size; }
   int       count() const                        { return _types.length(); }

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -291,6 +291,14 @@ public:
     }
   }
 
+  bool is_null_free() {
+    if (at_return_type()) {
+      return _sig->returns_null_free_inline_type();
+    } else {
+      return _sig->is_null_free_at(_pos);
+    }
+  }
+
   // next klass in the signature
   ciKlass* next_klass() {
     ciKlass* sig_k;

--- a/src/hotspot/share/ci/ciSymbol.cpp
+++ b/src/hotspot/share/ci/ciSymbol.cpp
@@ -115,8 +115,14 @@ int ciSymbol::utf8_length() {
 
 // ------------------------------------------------------------------
 // ciSymbol::is_Q_signature
-bool ciSymbol::is_Q_signature() {
+bool ciSymbol::is_Q_signature() const {
   GUARDED_VM_ENTRY(return get_symbol()->is_Q_signature();)
+}
+
+// ------------------------------------------------------------------
+// ciSymbol::is_Q_array_signature
+bool ciSymbol::is_Q_array_signature() const {
+  GUARDED_VM_ENTRY(return get_symbol()->is_Q_array_signature();)
 }
 
 // ------------------------------------------------------------------

--- a/src/hotspot/share/ci/ciSymbol.hpp
+++ b/src/hotspot/share/ci/ciSymbol.hpp
@@ -88,7 +88,8 @@ public:
   bool ends_with(const char* suffix, int len) const;
   bool ends_with(char suffix_char) const;
 
-  bool        is_Q_signature();
+  bool is_Q_signature() const;
+  bool is_Q_array_signature() const;
 
   // Determines where the symbol contains the given substring.
   int index_of_at(int i, const char* str, int len) const;

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -73,7 +73,7 @@ public:
   bool is_classless() const                 { return is_primitive_type(); }
 
   virtual ciType*     unwrap()              { return this; }
-  virtual bool is_null_free() const        { return false; }
+  virtual bool is_null_free() const         { return false; }
 
   const char* name();
   virtual void print_name_on(outputStream* st);

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -275,21 +275,25 @@ ciType* ciTypeFlow::StateVector::type_meet_internal(ciType* t1, ciType* t2, ciTy
     return t2;
   } else if (t2->equals(top_type())) {
     return t1;
-  } else if (t1->is_primitive_type() || t2->is_primitive_type()) {
+  }
+  // Unwrap after saving nullness information and handling top meets
+  bool null_free1 = t1->is_null_free();
+  bool null_free2 = t2->is_null_free();
+  if (t1->unwrap() == t2->unwrap() && null_free1 == null_free2) {
+    return t1;
+  }
+  t1 = t1->unwrap();
+  t2 = t2->unwrap();
+
+  if (t1->is_primitive_type() || t2->is_primitive_type()) {
     // Special case null_type.  null_type meet any reference type T
-    // is T (except for inline types).  null_type meet null_type is null_type.
+    // is T. null_type meet null_type is null_type.
     if (t1->equals(null_type())) {
-      if (t2->is_inlinetype()) {
-        // Inline types are null-free, return the super type
-        return t2->as_inline_klass()->super();
-      } else if (!t2->is_primitive_type() || t2->equals(null_type())) {
+      if (!t2->is_primitive_type() || t2->equals(null_type())) {
         return t2;
       }
     } else if (t2->equals(null_type())) {
-      if (t1->is_inlinetype()) {
-        // Inline types are null-free, return the super type
-        return t1->as_inline_klass()->super();
-      } else if (!t1->is_primitive_type()) {
+      if (!t1->is_primitive_type()) {
         return t1;
       }
     }
@@ -320,6 +324,8 @@ ciType* ciTypeFlow::StateVector::type_meet_internal(ciType* t1, ciType* t2, ciTy
     // But when (obj/flat)Array meets (obj/flat)Array, we look carefully at element types.
     if ((k1->is_obj_array_klass() || k1->is_flat_array_klass()) &&
         (k2->is_obj_array_klass() || k2->is_flat_array_klass())) {
+      bool null_free = k1->as_array_klass()->is_elem_null_free() &&
+                       k2->as_array_klass()->is_elem_null_free();
       ciType* elem1 = k1->as_array_klass()->element_klass();
       ciType* elem2 = k2->as_array_klass()->element_klass();
       ciType* elem = elem1;
@@ -327,14 +333,14 @@ ciType* ciTypeFlow::StateVector::type_meet_internal(ciType* t1, ciType* t2, ciTy
         elem = type_meet_internal(elem1, elem2, analyzer)->as_klass();
       }
       // Do an easy shortcut if one type is a super of the other.
-      if (elem == elem1) {
-        assert(k1 == ciArrayKlass::make(elem), "shortcut is OK");
+      if (elem == elem1 && !elem->is_inlinetype()) {
+        assert(k1 == ciArrayKlass::make(elem, null_free), "shortcut is OK");
         return k1;
-      } else if (elem == elem2) {
-        assert(k2 == ciArrayKlass::make(elem), "shortcut is OK");
+      } else if (elem == elem2 && !elem->is_inlinetype()) {
+        assert(k2 == ciArrayKlass::make(elem, null_free), "shortcut is OK");
         return k2;
       } else {
-        return ciArrayKlass::make(elem);
+        return ciArrayKlass::make(elem, null_free);
       }
     } else {
       return object_klass;
@@ -343,7 +349,11 @@ ciType* ciTypeFlow::StateVector::type_meet_internal(ciType* t1, ciType* t2, ciTy
     // Must be two plain old instance klasses.
     assert(k1->is_instance_klass(), "previous cases handle non-instances");
     assert(k2->is_instance_klass(), "previous cases handle non-instances");
-    return k1->least_common_ancestor(k2);
+    ciType* result = k1->least_common_ancestor(k2);
+    if (null_free1 && null_free2) {
+      result = analyzer->mark_as_null_free(result);
+    }
+    return result;
   }
 }
 
@@ -405,13 +415,22 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
   // "Push" the method signature into the first few locals.
   state->set_stack_size(-max_locals());
   if (!method()->is_static()) {
-    state->push(method()->holder());
+    ciType* holder = method()->holder();
+    if (holder->is_inlinetype()) {
+      // The receiver is null-free
+      holder = mark_as_null_free(holder);
+    }
+    state->push(holder);
     assert(state->tos() == state->local(0), "");
   }
   for (ciSignatureStream str(method()->signature());
        !str.at_return_type();
        str.next()) {
-    state->push_translate(str.type());
+    ciType* arg = str.type();
+    if (str.is_null_free()) {
+      arg = mark_as_null_free(arg);
+    }
+    state->push_translate(arg);
   }
   // Set the rest of the locals to bottom.
   Cell cell = state->next_cell(state->tos());
@@ -587,7 +606,11 @@ void ciTypeFlow::StateVector::do_aload(ciBytecodeStream* str) {
          (Deoptimization::Reason_unloaded,
           Deoptimization::Action_reinterpret));
   } else {
-    push_object(element_klass);
+    if (array_klass->is_elem_null_free()) {
+      push(outer()->mark_as_null_free(element_klass));
+    } else {
+      push_object(element_klass);
+    }
   }
 }
 
@@ -597,8 +620,9 @@ void ciTypeFlow::StateVector::do_aload(ciBytecodeStream* str) {
 void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
+  bool null_free = str->has_Q_signature();
   if (!will_link) {
-    if (str->has_Q_signature()) {
+    if (null_free) {
       trap(str, klass,
            Deoptimization::make_trap_request
            (Deoptimization::Reason_unloaded,
@@ -612,8 +636,12 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
       do_null_assert(klass);
     }
   } else {
-    pop_object();
-    push_object(klass);
+    ciType* type = pop_value();
+    if (klass->is_inlinetype() && (null_free || type->is_null_free())) {
+      push(outer()->mark_as_null_free(klass));
+    } else {
+      push_object(klass);
+    }
   }
 }
 
@@ -655,6 +683,9 @@ void ciTypeFlow::StateVector::do_getstatic(ciBytecodeStream* str) {
       // (See bug 4379915.)
       do_null_assert(field_type->as_klass());
     } else {
+      if (field->is_null_free()) {
+        field_type = outer()->mark_as_null_free(field_type);
+      }
       push_translate(field_type);
     }
   }
@@ -722,6 +753,9 @@ void ciTypeFlow::StateVector::do_invoke(ciBytecodeStream* str,
         // See do_getstatic() for similar explanation, as well as bug 4684993.
         do_null_assert(return_type->as_klass());
       } else {
+        if (sigstr.is_null_free()) {
+          return_type = outer()->mark_as_null_free(return_type);
+        }
         push_translate(return_type);
       }
     }
@@ -746,7 +780,11 @@ void ciTypeFlow::StateVector::do_ldc(ciBytecodeStream* str) {
         push_null();
       } else {
         assert(obj->is_instance() || obj->is_array(), "must be java_mirror of klass");
-        push_object(obj->klass());
+        ciType* type = obj->klass();
+        if (type->is_inlinetype()) {
+          type = outer()->mark_as_null_free(type);
+        }
+        push(type);
       }
     } else {
       push_translate(ciType::make(basic_type));
@@ -799,7 +837,7 @@ void ciTypeFlow::StateVector::do_defaultvalue(ciBytecodeStream* str) {
   if (!will_link || str->is_unresolved_klass() || !klass->is_inlinetype()) {
     trap(str, klass, str->get_klass_index());
   } else {
-    push_object(klass);
+    push(outer()->mark_as_null_free(klass));
   }
 }
 
@@ -820,8 +858,7 @@ void ciTypeFlow::StateVector::do_withfield(ciBytecodeStream* str) {
       assert(type == half_type(type2), "must be 2nd half");
     }
     pop_object();
-    assert(klass->is_inlinetype(), "should be inline type");
-    push_object(klass);
+    push(outer()->mark_as_null_free(klass));
   }
 }
 
@@ -958,7 +995,8 @@ bool ciTypeFlow::StateVector::apply_one_bytecode(ciBytecodeStream* str) {
       if (!will_link) {
         trap(str, element_klass, str->get_klass_index());
       } else {
-        push_object(ciArrayKlass::make(element_klass));
+        bool null_free = str->has_Q_signature();
+        push_object(ciArrayKlass::make(element_klass, null_free));
       }
       break;
     }
@@ -3034,6 +3072,11 @@ void ciTypeFlow::record_failure(const char* reason) {
     // Record the first failure reason.
     _failure_reason = reason;
   }
+}
+
+ciType* ciTypeFlow::mark_as_null_free(ciType* type) {
+  // Wrap the type to carry the information that it is null-free
+  return env()->make_null_free_wrapper(type);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -839,6 +839,8 @@ public:
                                       return _block_map[rpo]; }
   int inc_next_pre_order()          { return _next_pre_order++; }
 
+  ciType* mark_as_null_free(ciType* type);
+
 private:
   // A work list used during flow analysis.
   Block* _work_list;

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1168,12 +1168,12 @@ CallGenerator* CallGenerator::for_method_handle_call(JVMState* jvms, ciMethod* c
   }
 }
 
-static void cast_argument(int nargs, int arg_nb, ciType* t, GraphKit& kit) {
+static void cast_argument(int nargs, int arg_nb, ciType* t, GraphKit& kit, bool null_free) {
   PhaseGVN& gvn = kit.gvn();
   Node* arg = kit.argument(arg_nb);
   const Type* arg_type = arg->bottom_type();
   const Type* sig_type = TypeOopPtr::make_from_klass(t->as_klass());
-  if (t->as_klass()->is_inlinetype()) {
+  if (t->as_klass()->is_inlinetype() && null_free) {
     sig_type = sig_type->join_speculative(TypePtr::NOTNULL);
   }
   if (arg_type->isa_oopptr() && !arg_type->higher_equal(sig_type)) {
@@ -1281,13 +1281,14 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
         const int receiver_skip = target->is_static() ? 0 : 1;
         // Cast receiver to its type.
         if (!target->is_static()) {
-          cast_argument(nargs, 0, signature->accessing_klass(), kit);
+          cast_argument(nargs, 0, signature->accessing_klass(), kit, false);
         }
         // Cast reference arguments to its type.
         for (int i = 0, j = 0; i < signature->count(); i++) {
           ciType* t = signature->type_at(i);
           if (t->is_klass()) {
-            cast_argument(nargs, receiver_skip + j, t, kit);
+            bool null_free = signature->is_null_free_at(i);
+            cast_argument(nargs, receiver_skip + j, t, kit, null_free);
           }
           j += t->size();  // long and double take two slots
         }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4551,6 +4551,13 @@ int Compile::static_subtype_check(ciKlass* superk, ciKlass* subk) {
     }
   }
 
+  // Do not fold the subtype check to an array klass pointer comparison for [V? arrays.
+  // [QMyValue is a subtype of [LMyValue but the klass for [QMyValue is not equal to
+  // the klass for [LMyValue. Perform a full test.
+  if (superk->is_obj_array_klass() && !superk->as_array_klass()->is_elem_null_free() &&
+      superk->as_array_klass()->element_klass()->is_inlinetype()) {
+    return SSC_full_test;
+  }
   // If casting to an instance klass, it must have no subtypes
   if (superk->is_interface()) {
     // Cannot trust interfaces yet.

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3449,14 +3449,12 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 // If failure_control is supplied and not null, it is filled in with
 // the control edge for the cast failure.  Otherwise, an appropriate
 // uncommon trap or exception is thrown.
-Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_control) {
+Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_control, bool null_free) {
   kill_dead_locals();           // Benefit all the uncommon traps
   const TypeKlassPtr* tk = _gvn.type(superklass)->is_klassptr();
   const TypeOopPtr* toop = TypeOopPtr::make_from_klass(tk->klass());
-
-  // Check if inline types are involved
   bool from_inline = obj->is_InlineType();
-  bool to_inline = tk->klass()->is_inlinetype();
+  assert(!null_free || toop->is_inlinetypeptr(), "must be an inline type pointer");
 
   // Fast cutout:  Check the case that the cast is vacuously true.
   // This detects the common cases where the test will short-circuit
@@ -3482,20 +3480,20 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
         // to the type system as a speculative type.
         if (!from_inline) {
           obj = record_profiled_receiver_for_speculation(obj);
-          if (to_inline) {
+          if (null_free) {
             obj = null_check(obj);
-            if (toop->inline_klass()->is_scalarizable()) {
-              obj = InlineTypeNode::make_from_oop(this, obj, toop->inline_klass());
-            }
+          }
+          if (toop->is_inlinetypeptr() && toop->inline_klass()->is_scalarizable() && !gvn().type(obj)->maybe_null()) {
+            obj = InlineTypeNode::make_from_oop(this, obj, toop->inline_klass());
           }
         }
         return obj;
       case Compile::SSC_always_false:
-        if (from_inline || to_inline) {
+        if (from_inline || null_free) {
           if (!from_inline) {
             null_check(obj);
           }
-          // Inline type is never null. Always throw an exception.
+          // Inline type is null-free. Always throw an exception.
           builtin_throw(Deoptimization::Reason_class_check, makecon(TypeKlassPtr::make(klass)));
           return top();
         } else {
@@ -3544,7 +3542,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
   Node* not_null_obj = NULL;
   if (from_inline) {
     not_null_obj = obj;
-  } else if (to_inline) {
+  } else if (null_free) {
     not_null_obj = null_check(obj);
   } else {
     not_null_obj = null_check_oop(obj, &null_ctl, never_see_null, safe_for_replace, speculative_not_null);
@@ -3676,8 +3674,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
 
   if (!stopped() && !from_inline) {
     res = record_profiled_receiver_for_speculation(res);
-    if (to_inline && toop->inline_klass()->is_scalarizable()) {
-      assert(!gvn().type(res)->maybe_null(), "Inline types are null-free");
+    if (toop->is_inlinetypeptr() && toop->inline_klass()->is_scalarizable() && !gvn().type(res)->maybe_null()) {
       res = InlineTypeNode::make_from_oop(this, res, toop->inline_klass());
     }
   }
@@ -3740,9 +3737,9 @@ Node* GraphKit::inline_array_null_guard(Node* ary, Node* val, int nargs, bool sa
   region->init_req(2, control());
   set_control(_gvn.transform(region));
   record_for_igvn(region);
-  const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
-  if (val_t == TypePtr::NULL_PTR && !ary_t->is_not_null_free()) {
+  if (val_t == TypePtr::NULL_PTR) {
     // Since we were just successfully storing null, the array can't be null free.
+    const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
     ary_t = ary_t->cast_to_not_null_free();
     Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, ary_t));
     if (safe_for_replace) {
@@ -3935,11 +3932,12 @@ Node* GraphKit::get_layout_helper(Node* klass_node, jint& constant_value) {
     assert(klass != NULL, "klass should not be NULL");
     bool xklass = inst_klass->klass_is_exact();
     bool can_be_flattened = false;
-    if (UseFlatArray && klass->is_obj_array_klass()) {
+    if (UseFlatArray && klass->is_obj_array_klass() && !klass->as_obj_array_klass()->is_elem_null_free()) {
+      // The runtime type of [LMyValue might be [QMyValue due to [QMyValue <: [LMyValue.
       ciKlass* elem = klass->as_obj_array_klass()->element_klass();
       can_be_flattened = elem->can_be_inline_klass() && (!elem->is_inlinetype() || elem->flatten_array());
     }
-    if (xklass || (klass->is_array_klass() && !can_be_flattened)) {
+    if (!can_be_flattened && (xklass || klass->is_array_klass())) {
       jint lhelper = klass->layout_helper();
       if (lhelper != Klass::_lh_neutral_value) {
         constant_value = lhelper;
@@ -4323,18 +4321,17 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
   const TypeAryPtr* ary_ptr = ary_type->isa_aryptr();
 
   // Inline type array variants:
-  // - null-ok:              MyValue.ref[] (ciObjArrayKlass "[LMyValue$ref")
-  // - null-free:            MyValue.val[] (ciObjArrayKlass "[QMyValue$val")
-  // - null-free, flattened: MyValue.val[] (ciFlatArrayKlass "[QMyValue$val")
+  // - null-ok:              MyValue.ref[] (ciObjArrayKlass "[LMyValue")
+  // - null-free:            MyValue.val[] (ciObjArrayKlass "[QMyValue")
+  // - null-free, flattened: MyValue.val[] (ciFlatArrayKlass "[QMyValue")
   // Check if array is a null-free, non-flattened inline type array
   // that needs to be initialized with the default inline type.
   Node* default_value = NULL;
   Node* raw_default_value = NULL;
   if (ary_ptr != NULL && ary_ptr->klass_is_exact()) {
     // Array type is known
-    ciKlass* elem_klass = ary_ptr->klass()->as_array_klass()->element_klass();
-    if (elem_klass != NULL && elem_klass->is_inlinetype()) {
-      ciInlineKlass* vk = elem_klass->as_inline_klass();
+    if (ary_ptr->klass()->as_array_klass()->is_elem_null_free()) {
+      ciInlineKlass* vk = ary_ptr->klass()->as_array_klass()->element_klass()->as_inline_klass();
       if (!vk->flatten_array()) {
         default_value = InlineTypeNode::default_oop(gvn(), vk);
       }
@@ -4708,7 +4705,7 @@ Node* GraphKit::make_constant_from_field(ciField* field, Node* obj) {
     if (con_type->is_inlinetypeptr() && con_type->inline_klass()->is_scalarizable()) {
       assert(!con_type->is_zero_type(), "Inline types are null-free");
       con = InlineTypeNode::make_from_oop(this, con, con_type->inline_klass());
-    } else if (con_type->is_zero_type() && field->type()->is_inlinetype()) {
+    } else if (con_type->is_zero_type() && field->is_null_free()) {
       con = InlineTypeNode::default_oop(gvn(), field->type()->as_inline_klass());
     }
     return con;

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -865,7 +865,7 @@ class GraphKit : public Phase {
 
   // Generate a check-cast idiom.  Used by both the check-cast bytecode
   // and the array-store bytecode
-  Node* gen_checkcast(Node *subobj, Node* superkls, Node* *failure_control = NULL);
+  Node* gen_checkcast(Node *subobj, Node* superkls, Node* *failure_control = NULL, bool null_free = false);
 
   // Inline types
   Node* inline_type_test(Node* obj, bool is_inline = true);

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -74,6 +74,7 @@ public:
   uint          field_index(int offset) const;
   ciType*       field_type(uint index) const;
   bool          field_is_flattened(uint index) const;
+  bool          field_is_null_free(uint index) const;
 
   // Replace InlineTypeNodes in debug info at safepoints with SafePointScalarObjectNodes
   void make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop = true);

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -182,7 +182,7 @@ Node* Parse::check_interpreter_type(Node* l, const Type* type,
   if (tp != NULL && tp->klass() != C->env()->Object_klass()) {
     // TypeFlow asserted a specific object type.  Value must have that type.
     Node* bad_type_ctrl = NULL;
-    if (tp->klass()->is_inlinetype()) {
+    if (tp->is_inlinetypeptr() && !tp->maybe_null()) {
       // Check inline types for null here to prevent checkcast from adding an
       // exception state before the bytecode entry (use 'bad_type_ctrl' instead).
       l = null_check_oop(l, &bad_type_ctrl);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -386,11 +386,7 @@ void Parse::array_store(BasicType bt) {
       return;
     } else if (!ary_t->is_not_null_free()) {
       // Array is not flattened but may be null free
-      //assert(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact(), "array can't be null-free");
-      if (!(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact())) {
-        ary->dump(3);
-        assert(false, "FAIL");
-      }
+      assert(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact(), "array can't be null-free");
       ary = inline_array_null_guard(ary, cast_val, 3, true);
     }
   }

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -113,7 +113,7 @@ void Parse::array_load(BasicType bt) {
         // Element type is known, cast and load from flattened representation
         ciInlineKlass* vk = elemptr->inline_klass();
         assert(vk->flatten_array() && elemptr->maybe_null(), "never/always flat - should be optimized");
-        ciArrayKlass* array_klass = ciArrayKlass::make(vk);
+        ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
         const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
         Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, arytype));
         Node* casted_adr = array_element_address(cast, idx, T_INLINE_TYPE, ary_t->size(), control());
@@ -344,7 +344,7 @@ void Parse::array_store(BasicType bt) {
           // Element type is known, cast and store to flattened representation
           sync_kit(ideal);
           assert(vk->flatten_array() && elemtype->maybe_null(), "never/always flat - should be optimized");
-          ciArrayKlass* array_klass = ciArrayKlass::make(vk);
+          ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
           const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
           casted_ary = _gvn.transform(new CheckCastPPNode(control(), casted_ary, arytype));
           Node* casted_adr = array_element_address(casted_ary, idx, T_OBJECT, arytype->size(), control());
@@ -386,7 +386,11 @@ void Parse::array_store(BasicType bt) {
       return;
     } else if (!ary_t->is_not_null_free()) {
       // Array is not flattened but may be null free
-      assert(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact(), "array can't be null-free");
+      //assert(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact(), "array can't be null-free");
+      if (!(elemtype->is_oopptr()->can_be_inline_type() && !ary_t->klass_is_exact())) {
+        ary->dump(3);
+        assert(false, "FAIL");
+      }
       ary = inline_array_null_guard(ary, cast_val, 3, true);
     }
   }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -69,6 +69,7 @@ void GraphKit::make_dtrace_method_entry_exit(ciMethod* method, bool is_entry) {
 void Parse::do_checkcast() {
   bool will_link;
   ciKlass* klass = iter().get_klass(will_link);
+  bool null_free = iter().has_Q_signature();
   Node *obj = peek();
 
   // Throw uncommon trap if class is not loaded or the value we are casting
@@ -76,7 +77,7 @@ void Parse::do_checkcast() {
   // then the checkcast does nothing.
   const TypeOopPtr *tp = _gvn.type(obj)->isa_oopptr();
   if (!will_link || (tp && tp->klass() && !tp->klass()->is_loaded())) {
-    assert(!iter().has_Q_signature(), "Inline type should be loaded");
+    assert(!null_free, "Inline type should be loaded");
     if (C->log() != NULL) {
       if (!will_link) {
         C->log()->elem("assert_null reason='checkcast' klass='%d'",
@@ -93,7 +94,7 @@ void Parse::do_checkcast() {
     return;
   }
 
-  Node* res = gen_checkcast(obj, makecon(TypeKlassPtr::make(klass)));
+  Node* res = gen_checkcast(obj, makecon(TypeKlassPtr::make(klass)), NULL, null_free);
   if (stopped()) {
     return;
   }
@@ -257,8 +258,7 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
   Node* a_e_klass = _gvn.transform(LoadKlassNode::make(_gvn, always_see_exact_class ? control() : NULL,
                                                        immutable_memory(), p2, tak));
 
-  // Handle inline type arrays
-  if (elemtype->isa_inlinetype() != NULL || (elemtype->is_inlinetypeptr() && !elemtype->maybe_null())) {
+  if (elemtype->isa_inlinetype() != NULL || elemtype->is_inlinetypeptr()) {
     // We statically know that this is an inline type array, use precise klass ptr
     a_e_klass = makecon(TypeKlassPtr::make(elemtype->inline_klass()));
   }
@@ -346,11 +346,11 @@ void Parse::do_withfield() {
     assert(!gvn().type(holder)->maybe_null(), "Inline types are null-free");
     holder = InlineTypeNode::make_from_oop(this, holder, holder_klass);
   }
-  if (!val->is_InlineType() && field->type()->is_inlinetype()) {
+  if (!val->is_InlineType() && field->is_null_free()) {
     // Scalarize inline type field value
     assert(!gvn().type(val)->maybe_null(), "Inline types are null-free");
     val = InlineTypeNode::make_from_oop(this, val, gvn().type(val)->inline_klass());
-  } else if (val->is_InlineType() && !field->type()->is_inlinetype()) {
+  } else if (val->is_InlineType() && !field->is_null_free()) {
     // Field value needs to be allocated because it can be merged with an oop.
     // Re-execute withfield if buffering triggers deoptimization.
     PreserveReexecuteState preexecs(this);

--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -82,7 +82,7 @@ const Type* SubTypeCheckNode::sub(const Type* sub_t, const Type* super_t) const 
         // Subtype is not a flat array but supertype is. Must be unrelated.
         unrelated_classes = true;
       } else if (sub_t->isa_aryptr() && sub_t->is_aryptr()->is_not_null_free() &&
-                 superk->is_obj_array_klass() && superk->as_obj_array_klass()->element_klass()->is_inlinetype()) {
+                 superk->is_array_klass() && superk->as_array_klass()->is_elem_null_free()) {
         // Subtype is not a null-free array but supertype is. Must be unrelated.
         unrelated_classes = true;
       } else if (sub_t->is_ptr()->flatten_array() && (!superk->can_be_inline_klass() || (superk->is_inlinetype() && !superk->flatten_array()))) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -268,11 +268,12 @@ const Type* Type::get_typeflow_type(ciType* type) {
     return TypeRawPtr::make((address)(intptr_t)type->as_return_address()->bci());
 
   case T_INLINE_TYPE: {
-    ciInlineKlass* vk = type->as_inline_klass();
-    if (vk->is_scalarizable()) {
+    bool is_null_free = type->is_null_free();
+    ciInlineKlass* vk = type->unwrap()->as_inline_klass();
+    if (vk->is_scalarizable() && is_null_free) {
       return TypeInlineType::make(vk);
     } else {
-      return TypeOopPtr::make_from_klass(vk)->join_speculative(TypePtr::NOTNULL);
+      return TypeOopPtr::make_from_klass(vk)->join_speculative(is_null_free ? TypePtr::NOTNULL : TypePtr::BOTTOM);
     }
   }
 
@@ -2085,7 +2086,7 @@ const TypeTuple *TypeTuple::make_range(ciSignature* sig, bool ret_vt_fields) {
       field_array[pos++] = get_const_type(return_type);
       collect_inline_fields(return_type->as_inline_klass(), field_array, pos);
     } else {
-      field_array[TypeFunc::Parms] = get_const_type(return_type)->join_speculative(TypePtr::NOTNULL);
+      field_array[TypeFunc::Parms] = get_const_type(return_type)->join_speculative(sig->returns_null_free_inline_type() ? TypePtr::NOTNULL : TypePtr::BOTTOM);
     }
     break;
   case T_VOID:
@@ -2145,10 +2146,11 @@ const TypeTuple *TypeTuple::make_domain(ciMethod* method, bool vt_fields_as_args
       field_array[pos++] = TypeInt::INT;
       break;
     case T_INLINE_TYPE: {
-      if (vt_fields_as_args && type->as_inline_klass()->can_be_passed_as_fields()) {
+      bool is_null_free = sig->is_null_free_at(i);
+      if (vt_fields_as_args && type->as_inline_klass()->can_be_passed_as_fields() && is_null_free) {
         collect_inline_fields(type->as_inline_klass(), field_array, pos);
       } else {
-        field_array[pos++] = get_const_type(type)->join_speculative(TypePtr::NOTNULL);
+        field_array[pos++] = get_const_type(type)->join_speculative(is_null_free ? TypePtr::NOTNULL : TypePtr::BOTTOM);
       }
       break;
     }
@@ -2446,8 +2448,16 @@ bool TypeAry::ary_must_be_exact() const {
     tinst = _elem->make_ptr()->isa_instptr();
   else
     tinst = _elem->isa_instptr();
-  if (tinst)
-    return tklass->as_instance_klass()->is_final();
+  if (tinst) {
+    if (tklass->as_instance_klass()->is_final()) {
+      // Even if MyValue is exact, [LMyValue is not exact due to [QMyValue <: [LMyValue.
+      if (tinst->is_inlinetypeptr() && (tinst->ptr() == TypePtr::BotPTR || tinst->ptr() == TypePtr::TopPTR)) {
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
   const TypeAryPtr*  tap;
   if (_elem->isa_narrowoop())
     tap = _elem->make_ptr()->isa_aryptr();
@@ -3563,7 +3573,8 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
   } else if (klass->is_obj_array_klass()) {
     // Element is an object or inline type array. Recursively call ourself.
     const TypeOopPtr* etype = TypeOopPtr::make_from_klass_common(klass->as_array_klass()->element_klass(), /* klass_change= */ false, try_for_exact);
-    if (etype->is_inlinetypeptr()) {
+    bool null_free = klass->as_array_klass()->is_elem_null_free();
+    if (null_free) {
       etype = etype->join_speculative(TypePtr::NOTNULL)->is_oopptr();
     }
     // Determine null-free/flattened properties
@@ -3575,7 +3586,8 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
     bool not_null_free = !exact_etype->can_be_inline_type();
     bool not_flat = !UseFlatArray || not_null_free || (exact_etype->is_inlinetypeptr() && !exact_etype->inline_klass()->flatten_array());
 
-    bool xk = etype->klass_is_exact();
+    // Even if MyValue is exact, [LMyValue is not exact due to [QMyValue <: [LMyValue.
+    bool xk = etype->klass_is_exact() && (!etype->is_inlinetypeptr() || null_free);
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::POS, false, not_flat, not_null_free);
     // We used to pass NotNull in here, asserting that the sub-arrays
     // are all not-null.  This is not true in generally, as code can
@@ -3621,7 +3633,7 @@ const TypeOopPtr* TypeOopPtr::make_from_constant(ciObject* o, bool require_const
     // Element is an object array. Recursively call ourself.
     const TypeOopPtr* etype = TypeOopPtr::make_from_klass_raw(klass->as_array_klass()->element_klass());
     bool null_free = false;
-    if (etype->is_inlinetypeptr()) {
+    if (klass->as_array_klass()->is_elem_null_free()) {
       null_free = true;
       etype = etype->join_speculative(TypePtr::NOTNULL)->is_oopptr();
     }
@@ -5509,11 +5521,12 @@ ciKlass* TypeAryPtr::compute_klass(DEBUG_ONLY(bool verify)) const {
   // Get element klass
   if (el->isa_instptr()) {
     // Compute object array klass from element klass
-    k_ary = ciArrayKlass::make(el->is_oopptr()->klass());
+    bool null_free = el->is_inlinetypeptr() && el->isa_instptr()->ptr() != TypePtr::TopPTR && !el->isa_instptr()->maybe_null();
+    k_ary = ciArrayKlass::make(el->is_oopptr()->klass(), null_free);
   } else if (el->isa_inlinetype()) {
     // If element type is TypeInlineType::BOTTOM, inline_klass() will be null.
     if (el->inline_klass() != NULL) {
-      k_ary = ciArrayKlass::make(el->inline_klass());
+      k_ary = ciArrayKlass::make(el->inline_klass(), /* null_free */ true);
     }
   } else if ((tary = el->isa_aryptr()) != NULL) {
     // Compute array klass from element klass
@@ -5872,7 +5885,8 @@ const TypeFunc* TypeFunc::make(ciMethod* method, bool is_osr_compilation) {
   const TypeTuple* domain_sig = is_osr_compilation ? osr_domain() : TypeTuple::make_domain(method, false);
   const TypeTuple* domain_cc = has_scalar_args ? TypeTuple::make_domain(method, true) : domain_sig;
   ciSignature* sig = method->signature();
-  bool has_scalar_ret = sig->return_type()->is_inlinetype() && sig->return_type()->as_inline_klass()->can_be_returned_as_fields();
+  bool has_scalar_ret = sig->returns_null_free_inline_type() && sig->return_type()->is_inlinetype() &&
+                        sig->return_type()->as_inline_klass()->can_be_returned_as_fields();
   const TypeTuple* range_sig = TypeTuple::make_range(sig, false);
   const TypeTuple* range_cc = has_scalar_ret ? TypeTuple::make_range(sig, true) : range_sig;
   tf = TypeFunc::make(domain_sig, domain_cc, range_sig, range_cc);

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1351,7 +1351,7 @@ public:
   // Inline type array properties
   bool is_flat()          const { return _ary->_elem->isa_inlinetype() != NULL; }
   bool is_not_flat()      const { return _ary->_not_flat; }
-  bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr()); }
+  bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && !_ary->_elem->make_ptr()->maybe_null()); }
   bool is_not_null_free() const { return _ary->_not_null_free; }
 
   bool is_autobox_cache() const { return _is_autobox_cache; }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1335,7 +1335,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
         ReassignedField field;
         field._offset = fs.offset();
         field._type = Signature::basic_type(fs.signature());
-        if (field._type == T_INLINE_TYPE) {
+        if (fs.signature()->is_Q_signature()) {
           if (fs.is_inlined()) {
             // Resolve klass of flattened inline type field
             field._klass = InlineKlass::cast(klass->get_inline_type_field_klass(fs.index()));

--- a/src/hotspot/share/utilities/constantTag.cpp
+++ b/src/hotspot/share/utilities/constantTag.cpp
@@ -101,7 +101,7 @@ jbyte constantTag::error_value() const {
 }
 
 const char* constantTag::internal_name() const {
-  switch (_tag) {
+  switch (value()) {
     case JVM_CONSTANT_Invalid :
       return "Invalid index";
     case JVM_CONSTANT_Class :


### PR DESCRIPTION
After https://github.com/openjdk/valhalla/pull/409 and https://github.com/openjdk/valhalla/pull/414 have been integrated, we need to fix the JIT code as well. This mostly means re-applying the old changes from https://github.com/openjdk/valhalla/commit/22dd0da1 and https://github.com/openjdk/valhalla/commit/e895128f and adjust them to the current implementation.

All compiler tests now pass except for `TestNullableInlineTypes`, `TestNullableArrays` and `TestIntrinsics` which need reflection support. The corresponding C2 intrinsics are still broken. I'll fix them with [JDK-8267932](https://bugs.openjdk.java.net/browse/JDK-8267932) once reflection support is available.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267846](https://bugs.openjdk.java.net/browse/JDK-8267846): [lworld] JIT support for the L/Q model (step 1)


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/431/head:pull/431` \
`$ git checkout pull/431`

Update a local copy of the PR: \
`$ git checkout pull/431` \
`$ git pull https://git.openjdk.java.net/valhalla pull/431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 431`

View PR using the GUI difftool: \
`$ git pr show -t 431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/431.diff">https://git.openjdk.java.net/valhalla/pull/431.diff</a>

</details>
