### PR TITLE
8267984: [lworld] The fix for JDK-8267918 incorrectly precludes synchronization of variables of TypeVariable type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -857,10 +857,7 @@ public class Check {
      */
     Type checkIdentityType(DiagnosticPosition pos, Type t) {
 
-        if (t.hasTag(ARRAY))
-            return t;
-
-        if (!t.hasTag(CLASS) || t.isPrimitiveClass() || t.isReferenceProjection())
+        if (t.isPrimitive() || t.isPrimitiveClass() || t.isReferenceProjection())
             return typeTagError(pos,
                     diags.fragment(Fragments.TypeReqIdentity),
                     t);

--- a/test/langtools/tools/javac/valhalla/lworld-values/TypeVarSynchronize.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TypeVarSynchronize.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267984
+ * @summary The fix for JDK-8267918 incorrectly precludes synchronization of variables of Type Variable type.
+ * @run main TypeVarSynchronize
+ */
+
+public class TypeVarSynchronize <T> {
+    void foo(T t) {
+        synchronized (t) {}
+    }
+    public static void main(String [] args) {
+    }
+}


### PR DESCRIPTION
Simplify check for identity type requirement so type variables are precluded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267984](https://bugs.openjdk.java.net/browse/JDK-8267984): [lworld] The fix for JDK-8267918 incorrectly precludes synchronization of variables of TypeVariable type


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/433/head:pull/433` \
`$ git checkout pull/433`

Update a local copy of the PR: \
`$ git checkout pull/433` \
`$ git pull https://git.openjdk.java.net/valhalla pull/433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 433`

View PR using the GUI difftool: \
`$ git pr show -t 433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/433.diff">https://git.openjdk.java.net/valhalla/pull/433.diff</a>

</details>
