### PR TITLE
8267910: [lworld] Javac fails to implicitly type abstract classes as implementing IdentityObject

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5415,8 +5415,6 @@ public class Attr extends JCTree.Visitor {
                     env.info.isSerializable = true;
                 }
 
-                attribClassBody(env, c);
-
                 if ((c.flags() & (PRIMITIVE_CLASS | ABSTRACT)) == PRIMITIVE_CLASS) { // for non-intersection, concrete values.
                     Assert.check(env.tree.hasTag(CLASSDEF));
                     JCClassDecl classDecl = (JCClassDecl) env.tree;
@@ -5424,6 +5422,8 @@ public class Attr extends JCTree.Visitor {
                         chk.checkSuperConstraintsOfPrimitiveClass(env.tree.pos(), c);
                     }
                 }
+
+                attribClassBody(env, c);
 
                 chk.checkDeprecatedAnnotation(env.tree.pos(), c);
                 chk.checkClassOverrideEqualsAndHashIfNeeded(env.tree.pos(), c);

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
@@ -1,8 +1,8 @@
-BinarySuperclassConstraints.java:14:15: compiler.err.primitive.class.must.not.implement.identity.object: BinarySuperclassConstraints.I0
+BinarySuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.primitive.class: BinarySuperclassConstraints.I0, SuperclassCollections.BadSuper
 BinarySuperclassConstraints.java:29:15: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
 BinarySuperclassConstraints.java:38:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
 BinarySuperclassConstraints.java:40:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor
 BinarySuperclassConstraints.java:42:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithInstanceInit(), BinarySuperclassConstraints.I11, SuperclassCollections.SuperWithInstanceInit
 BinarySuperclassConstraints.java:44:15: compiler.err.super.method.cannot.be.synchronized: foo(), BinarySuperclassConstraints.I12, SuperclassCollections.SuperWithSynchronizedMethod
-BinarySuperclassConstraints.java:46:15: compiler.err.encl.class.required: SuperclassCollections.InnerSuper
+BinarySuperclassConstraints.java:46:15: compiler.err.super.class.cannot.be.inner: BinarySuperclassConstraints.I13, SuperclassCollections.InnerSuper
 7 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.java
@@ -1,11 +1,11 @@
 /*
  * @test /nodynamiccopyright/
- * @summary Values may not extend an identity class
+ * @summary Check that a concrete class is not allowed to be the super class of a primitive class
  *
  * @compile/fail/ref=CheckExtends.out -XDrawDiagnostics CheckExtends.java
  */
 
 final primitive class CheckExtends extends Object {
-    static class Nested {}
-    static primitive class NestedValue extends Nested {}
+    static class NestedConcrete {}
+    static primitive class NestedPrimitive extends NestedConcrete {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:10:22: compiler.err.primitive.class.must.not.implement.identity.object: CheckExtends.NestedValue
+CheckExtends.java:10:22: compiler.err.concrete.supertype.for.primitive.class: CheckExtends.NestedPrimitive, CheckExtends.NestedConcrete
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ConflictingSuperInterfaceTest.java
@@ -8,7 +8,7 @@
 public class ConflictingSuperInterfaceTest {
 
     interface I<T> {}
-    abstract class S implements I<String> {}
+    static abstract class S implements I<String> {}
     primitive static class Foo extends S implements I<Integer> {
         String s = "";
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 8209400 8215246
- * @summary Allow anonymous classes to be value types
+ * @summary Allow anonymous classes to be primitive class types
  * @compile/fail/ref=IllegalByValueTest2.out -XDrawDiagnostics -XDdev IllegalByValueTest2.java
  */
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
@@ -1,3 +1,3 @@
 IllegalByValueTest2.java:19:30: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
-IllegalByValueTest2.java:19:59: compiler.err.primitive.class.must.not.implement.identity.object: compiler.misc.anonymous.class: IllegalByValueTest2
+IllegalByValueTest2.java:19:59: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: IllegalByValueTest2$1, IllegalByValueTest2
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ImplicitIdentityTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ImplicitIdentityTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8267910
+ * @summary Javac fails to implicitly type abstract classes as implementing IdentityObject
+ * @compile/fail/ref=ImplicitIdentityTypeTest.out -XDrawDiagnostics ImplicitIdentityTypeTest.java
+ */
+
+/* An abstract implicitly implements IdentityObject
+        - if it declares a field,
+        - an instance initializer,
+        - a non-empty constructor,
+        - a synchronized method,
+        - has a concrete super,
+        - is an inner class.
+*/
+
+public class ImplicitIdentityTypeTest {
+
+    static abstract class A {}  // Not an Identity class.
+    static abstract class B { static { System.out.println(); } }  // Not an Identity class.
+
+
+    // All abstract classes below are identity classes by implicit typing.
+
+    abstract class C {}  // inner class implicitly implements IdentityObject
+    static abstract class D { int f; }  // instance field lends it identity.
+    static abstract class E { { System.out.println(); } }  // initializer lends it identity.
+    static abstract class F { F(){ System.out.println(); }}  // non-empty ctor.
+    static abstract class G { synchronized void f() {} }  // synchronized method.
+    static abstract class H extends ImplicitIdentityTypeTest {}  // concrete super.
+
+    void check() {
+        IdentityObject i;
+        A a = null;
+        B b = null;
+        C c = null;
+        D d = null;
+        E e = null;
+        F f = null;
+        G g = null;
+        H h = null;
+
+        i = a; // Error.
+        i = b; // Error.
+
+        // The following assignments are kosher.
+        i = c; i = d; i = e; i = f; i = g; i = h;
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/ImplicitIdentityTypeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ImplicitIdentityTypeTest.out
@@ -1,0 +1,3 @@
+ImplicitIdentityTypeTest.java:43:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: ImplicitIdentityTypeTest.A, java.lang.IdentityObject)
+ImplicitIdentityTypeTest.java:44:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: ImplicitIdentityTypeTest.B, java.lang.IdentityObject)
+2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,4 +1,4 @@
-SuperclassConstraints.java:14:15: compiler.err.primitive.class.must.not.implement.identity.object: SuperclassConstraints.I0
+SuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.primitive.class: SuperclassConstraints.I0, SuperclassConstraints.BadSuper
 SuperclassConstraints.java:44:15: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
 SuperclassConstraints.java:76:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
 SuperclassConstraints.java:85:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor


### PR DESCRIPTION
Align with deraft spec on implicit typing of abstract classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267910](https://bugs.openjdk.java.net/browse/JDK-8267910): [lworld] Javac fails to implicitly type abstract classes as implementing IdentityObject


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/434/head:pull/434` \
`$ git checkout pull/434`

Update a local copy of the PR: \
`$ git checkout pull/434` \
`$ git pull https://git.openjdk.java.net/valhalla pull/434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 434`

View PR using the GUI difftool: \
`$ git pr show -t 434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/434.diff">https://git.openjdk.java.net/valhalla/pull/434.diff</a>

</details>
