### PR TITLE
8267948: [lword] Core reflection and method handles support for L/Q model

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -245,6 +245,9 @@ class java_lang_Class : AllStatic {
   static int _class_loader_offset;
   static int _module_offset;
   static int _component_mirror_offset;
+  static int _primary_mirror_offset;
+  static int _secondary_mirror_offset;
+
   static int _name_offset;
   static int _source_file_offset;
   static int _classData_offset;
@@ -259,6 +262,9 @@ class java_lang_Class : AllStatic {
   static void set_protection_domain(oop java_class, oop protection_domain);
   static void set_class_loader(oop java_class, oop class_loader);
   static void set_component_mirror(oop java_class, oop comp_mirror);
+  static void set_primary_mirror(oop java_class, oop comp_mirror);
+  static void set_secondary_mirror(oop java_class, oop comp_mirror);
+
   static void initialize_mirror_fields(Klass* k, Handle mirror, Handle protection_domain,
                                        Handle classData, TRAPS);
   static void set_mirror_module_field(JavaThread* current, Klass* K, Handle mirror, Handle module);
@@ -271,6 +277,7 @@ class java_lang_Class : AllStatic {
                             Handle protection_domain, Handle classData, TRAPS);
   static void fixup_mirror(Klass* k, TRAPS);
   static oop  create_basic_type_mirror(const char* basic_type_name, BasicType type, TRAPS);
+  static oop  create_secondary_mirror(Klass* k, Handle mirror, TRAPS);
   static void update_archived_primitive_mirror_native_pointers(oop archived_mirror) NOT_CDS_JAVA_HEAP_RETURN;
   static void update_archived_mirror_native_pointers(oop archived_mirror) NOT_CDS_JAVA_HEAP_RETURN;
 
@@ -318,6 +325,11 @@ class java_lang_Class : AllStatic {
     set_init_lock(java_class, NULL);
   }
   static oop  component_mirror(oop java_class);
+  static oop  primary_mirror(oop java_class);
+  static oop  secondary_mirror(oop java_class);
+  static bool is_primary_mirror(oop java_class);
+  static bool is_secondary_mirror(oop java_class);
+
   static objArrayOop  signers(oop java_class);
   static void set_signers(oop java_class, objArrayOop signers);
   static oop  class_data(oop java_class);

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -234,6 +234,24 @@ inline bool java_lang_Class::is_primitive(oop java_class) {
   return is_primitive;
 }
 
+inline bool java_lang_Class::is_primary_mirror(oop java_class) {
+  Klass* k = as_Klass(java_class);
+  if (k->is_inline_klass()) {
+    return java_class == primary_mirror(java_class);
+  } else {
+    return true;
+  }
+}
+
+inline bool java_lang_Class::is_secondary_mirror(oop java_class) {
+  Klass* k = as_Klass(java_class);
+  if (k->is_inline_klass()) {
+    return java_class == secondary_mirror(java_class);
+  } else {
+    return false;
+  }
+}
+
 inline int java_lang_Class::oop_size_raw(oop java_class) {
   assert(_oop_size_offset != 0, "must be set");
   int size = java_class->int_field_raw(_oop_size_offset);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -687,6 +687,8 @@
   template(classRedefinedCount_name,                   "classRedefinedCount")                                     \
   template(classLoader_name,                           "classLoader")                                             \
   template(componentType_name,                         "componentType")                                           \
+  template(primaryType_name,                           "primaryType")                                             \
+  template(secondaryType_name,                         "secondaryType")                                           \
                                                                                                                   \
   /* forEachRemaining support */                                                                                  \
   template(java_util_stream_StreamsRangeIntSpliterator,          "java/util/stream/Streams$RangeIntSpliterator")  \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -160,7 +160,9 @@ JRT_ENTRY(void, InterpreterRuntime::ldc(JavaThread* current, bool wide))
 
   assert (tag.is_unresolved_klass() || tag.is_klass(), "wrong ldc call");
   Klass* klass = pool->klass_at(index, CHECK);
-  oop java_class = klass->java_mirror();
+  oop java_class = tag.is_Qdescriptor_klass()
+                      ? InlineKlass::cast(klass)->val_mirror()
+                      : klass->java_mirror();
   current->set_vm_result(java_class);
 JRT_END
 

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1046,7 +1046,9 @@ oop ConstantPool::resolve_constant_at_impl(const constantPoolHandle& this_cp,
       assert(cache_index == _no_index_sentinel, "should not have been set");
       Klass* resolved = klass_at_impl(this_cp, index, CHECK_NULL);
       // ldc wants the java mirror.
-      result_oop = resolved->java_mirror();
+      result_oop = tag.is_Qdescriptor_klass()
+                      ? InlineKlass::cast(resolved)->val_mirror()
+                      : resolved->java_mirror();
       break;
     }
 

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -142,6 +142,18 @@ class InlineKlass: public InstanceKlass {
   // Type testing
   bool is_inline_klass_slow() const        { return true; }
 
+  // ref and val mirror
+  oop ref_mirror() const { return java_mirror(); }
+  oop val_mirror() const { return java_lang_Class::secondary_mirror(java_mirror()); }
+
+  // naming
+  const char* ref_signature_name() const {
+    return InstanceKlass::signature_name_of_carrier(JVM_SIGNATURE_CLASS);
+  }
+  const char* val_signature_name() const {
+    return InstanceKlass::signature_name_of_carrier(JVM_SIGNATURE_INLINE_TYPE);
+  }
+
   // Iterators
   virtual void array_klasses_do(void f(Klass* k));
   virtual void array_klasses_do(void f(Klass* k, TRAPS), TRAPS);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2874,6 +2874,10 @@ void InstanceKlass::set_source_debug_extension(const char* array, int length) {
 }
 
 const char* InstanceKlass::signature_name() const {
+  return signature_name_of_carrier(JVM_SIGNATURE_CLASS);
+}
+
+const char* InstanceKlass::signature_name_of_carrier(char c) const {
   int hash_len = 0;
   char hash_buf[40];
 
@@ -2892,7 +2896,7 @@ const char* InstanceKlass::signature_name() const {
 
   // Add L or Q as type indicator
   int dest_index = 0;
-  dest[dest_index++] = JVM_SIGNATURE_CLASS;
+  dest[dest_index++] = c;
 
   // Add the actual class name
   for (int src_index = 0; src_index < src_length; ) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1261,6 +1261,7 @@ public:
 
   // Naming
   const char* signature_name() const;
+  const char* signature_name_of_carrier(char c) const;
 
   // Oop fields (and metadata) iterators
   //

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -591,8 +591,6 @@ protected:
   // For arrays, this returns the name of the element with a leading '['.
   // For classes, this returns the name with a leading 'L' and a trailing ';'
   //     and the package separators as '/'.
-  // For value classes, this returns the name with a leading 'Q' and a trailing ';'
-  //     and the package separators as '/'.
   virtual const char* signature_name() const;
 
   const char* joint_in_module_of_loader(const Klass* class2, bool include_parent_loader = false) const;

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -436,7 +436,8 @@ oop SignatureStream::as_java_mirror(Handle class_loader, Handle protection_domai
   if (klass == NULL) {
     return NULL;
   }
-  return klass->java_mirror();
+  return has_Q_descriptor() ? InlineKlass::cast(klass)->val_mirror()
+                            : klass->java_mirror();
 }
 
 void SignatureStream::skip_to_return_type() {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -235,7 +235,7 @@ public final class Class<T> implements java.io.Serializable,
     public String toString() {
         return (isPrimitiveClass() ? "primitive " : "")
                + (isInterface() ? "interface " : (isPrimitive() ? "" : "class "))
-               + getName();
+               + getName() + (isPrimitiveClass() && isPrimaryType() ? ".ref" : "");
     }
 
     /**
@@ -551,8 +551,21 @@ public final class Class<T> implements java.io.Serializable,
         }
     }
 
+    // set by VM if this class is an exotic type such as primitive class
+    // otherwise, these two fields are null
+    private transient Class<T> primaryType;
+    private transient Class<T> secondaryType;
+
     /**
      * Returns {@code true} if this class is a primitive class.
+     * <p>
+     * Each primitive class has a {@linkplain #isPrimaryType() primary type}
+     * representing the <em>primitive reference type</em> and a
+     * {@linkplain #isValueType() secondary type} representing
+     * the <em>primitive value type</em>.  The primitive reference type
+     * and primitive value type can be obtained by calling the
+     * {@link #asPrimaryType()} and {@link #asValueType} method
+     * of a primitive class respectively.
      *
      * @return {@code true} if this class is a primitive class, otherwise {@code false}
      * @since Valhalla
@@ -562,156 +575,77 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     /**
-     * Returns an {@code Optional<Class>} object representing the <em>primitive value type</em>
-     * of this class if this {@code Class} represents the <em>reference type</em>
-     * of a {@linkplain #isPrimitiveClass() primitive class}.
-     * If this {@code Class} represents the value type of a primitive class,
-     * then this method returns this class.
-     * Otherwise an empty {@link Optional} is returned.
+     * Returns a {@code Class} object representing the primary type
+     * of this class or interface.
+     * <p>
+     * If this {@code Class} object represents a reference type, then
+     * this method returns this class.
+     * <p>
+     * If this {@code Class} object represents a {@linkplain #isPrimitiveClass()
+     * primitive class}, then this method returns the <em>primitive reference type</em>
+     * type of this primitive class.
+     * <p>
+     * If this is a primitive type, then this method returns this class.
      *
-     * @return the {@code Optional<Class>} representing the primitive value type of
-     *         this class if this class is either the value type
-     *         or the reference type of a primitive class;
-     *         an empty {@link Optional} otherwise
+     * @return the {@code Class} representing the primary type of
+     *         this class or interface
      * @since Valhalla
      */
-    public Optional<Class<?>> valueType() {
-        if (isPrimitive() || isInterface() || isArray())
-            return Optional.empty();
-
-        Class<?>[] valRefTypes = getPrimitiveTypes();
-        return valRefTypes.length > 0 ? Optional.of(valRefTypes[0]) : Optional.empty();
+    public Class<?> asPrimaryType() {
+        return isPrimitiveClass() ? primaryType : this;
     }
 
     /**
-     * Returns a {@code Class} object representing the reference type
-     * of this class.
-     * <p>
-     * If this {@code Class} represents a {@linkplain #isPrimitiveClass()
-     * primitive reference type}, then this method
-     * returns the <em>primitive reference type</em> type of this primitive class.
-     * <p>
-     * If this {@code Class} represents the reference type
-     * of a primitive class, then this method returns this class.
-     * <p>
-     * If this class is an identity class, then this method returns this class.
-     * <p>
-     * Otherwise this method returns an empty {@code Optional}.
+     * Returns a {@code Class} object representing the <em>primitive value type</em>
+     * of this class if this class is a {@linkplain #isPrimitiveClass() primitive class}.
      *
-     * @return the {@code Optional<Class>} object representing the reference type for
-     *         this class, if present; an empty {@link Optional} otherwise.
+     * @return the {@code Class} representing the primitive value type of
+     *         this class if this class is a primitive class
+     * @throws UnsupportedOperationException if this class or interface
+     *         is not a primitive class
      * @since Valhalla
      */
-    public Optional<Class<?>> referenceType() {
-        if (isPrimitive()) return Optional.empty();
-        if (isInterface() || isArray()) return Optional.of(this);
-        if (!isPrimitiveClass()) return Optional.of(this);
-
-        Class<?>[] valRefTypes = getPrimitiveTypes();
-        return valRefTypes.length == 2 ? Optional.of(valRefTypes[1]) : Optional.empty();
-    }
-
-    /*
-     * Returns true if this Class object represents a primitive reference
-     * type for a primitive class.
-     *
-     * A primitive reference type must be a sealed abstract class that
-     * permits the primitive value type to extend.  The primitive value type
-     * and primitive reference type for a primitive type must be of the same package.
-     */
-    private boolean isPrimitiveReferenceType() {
-        if (isPrimitive() || isArray() || isInterface() || isPrimitiveClass())
-            return false;
-
-        int mods = getModifiers();
-        if (!Modifier.isAbstract(mods)) {
-            return false;
-        }
-
-        Class<?>[] valRefTypes = getPrimitiveTypes();
-        return valRefTypes.length == 2 && valRefTypes[1] == this;
-    }
-
-    private transient Class<?>[] primitiveTypes;
-    private Class<?>[] getPrimitiveTypes() {
-        if (isPrimitive() || isArray() || isInterface())
-            return null;
-
-        Class<?>[] valRefTypes = primitiveTypes;
-        if (valRefTypes == null) {
-            // So newPrimitiveTypeArray is called without holding any lock to
-            // avoid potential deadlock when multiple threads attempt to
-            // initialize the primitive types for C and E where D is
-            // the superclass of both C and E (which is an error case)
-            valRefTypes = newTypeArrayForPrimitiveClass();
-        }
-        synchronized (this) {
-            // set the value and reference types if not set
-            if (primitiveTypes == null) {
-                primitiveTypes = valRefTypes;
-            }
-        }
-        return primitiveTypes;
-    }
-
-    /*
-     * Returns an array of Class objects whose element at index 0 represents the
-     * primitive value type and element at index 1 represents the
-     * primitive reference type, if present.
-     *
-     * If this Class object is neither a primitive value type nor
-     * a primitive reference type for a primitive class, then an empty array
-     * is returned.
-     */
-    private Class<?>[] newTypeArrayForPrimitiveClass() {
-        if (isPrimitive() || isArray() || isInterface())
-            return null;
-
-        if (isPrimitiveClass()) {
-            Class<?> superClass = getSuperclass();
-            if (superClass != Object.class && superClass.isPrimitiveReferenceType()) {
-                return new Class<?>[] { this, superClass };
-            } else {
-                return new Class<?>[] { this };
-            }
-        } else {
-            Class<?> valType = primitiveValueType();
-            if (valType != null) {
-                return new Class<?>[] { valType, this};
-            } else {
-                return EMPTY_CLASS_ARRAY;
-            }
-        }
-    }
-
-    /*
-     * Returns the primitive value type if this Class represents
-     * a primitive reference type.  If this class is a primitive class
-     * then this method returns this class.  Otherwise, returns null.
-     */
-    private Class<?> primitiveValueType() {
-        if (isPrimitive() || isArray() || isInterface())
-            return null;
-
+    public Class<?> asValueType() {
         if (isPrimitiveClass())
-            return this;
+            return secondaryType;
 
-        int mods = getModifiers();
-        if (!Modifier.isAbstract(mods)) {
-            return null;
-        }
+        throw new UnsupportedOperationException(this.getName() + " is not a primitive class");
+    }
 
-        // A primitive reference type must be a sealed abstract class
-        // that permits the primitive class type to extend.
-        // The primitive class project type and primitive reference type for
-        // a primitive class type must be of the same package.
-        Class<?>[] subclasses = getPermittedSubclasses0();
-        if ((subclasses.length == 1) &&
-                (subclasses[0].isPrimitiveClass()) &&
-                (getPackageName().equals(subclasses[0].getPackageName()))) {
-            return subclasses[0];
+    /**
+     * Returns {@code true} if this {@code Class} object represents the primary type
+     * of this class or interface.
+     * <p>
+     * If this is a primitive type, then this method returns {@code true}.
+     * <p>
+     * If this {@code Class} object represents a reference type, then
+     * this method returns {@code true}.
+     * <p>
+     * If this {@code Class} object represents a {@linkplain #isPrimitiveClass()
+     * primitive} reference type, then this method returns {@code true};
+     * otherwise, this method returns {@code false}.
+     *
+     * @return {@code true} if this {@code Class} object represents
+     * the primary type of this class or interface
+     * @since Valhalla
+     */
+    public boolean isPrimaryType() {
+        if (isPrimitiveClass()) {
+            return this == primaryType;
         }
-        return null;
+        return true;
+    }
+
+    /**
+     * Returns {@code true} if this {@code Class} object represents
+     * a {@linkplain #isPrimitiveClass() primitive} value type.
+     *
+     * @return {@code true} if this {@code Class} object represents the
+     * value type of a primitive class
+     * @since Valhalla
+     */
+    public boolean isValueType() {
+        return isPrimitiveClass() && this == secondaryType;
     }
 
     /**
@@ -1022,7 +956,7 @@ public final class Class<T> implements java.io.Serializable,
      * (new Point[3]).getClass().getName()
      *     returns "[QPoint;"
      * (new Point.ref[3][4]).getClass().getName()
-     *     returns "[[LPoint$ref;"
+     *     returns "[[LPoint;"
      * (new int[3][4][5][6][7][8][9]).getClass().getName()
      *     returns "[[[[[[[I"
      * </pre></blockquote>
@@ -1851,7 +1785,12 @@ public final class Class<T> implements java.io.Serializable,
                 return cl.getTypeName() + "[]".repeat(dimensions);
             } catch (Throwable e) { /*FALLTHRU*/ }
         }
-        return getName();
+        if (isPrimitiveClass()) {
+            // TODO: null-default
+            return isPrimaryType() ? getName() + ".ref" : getName();
+        } else {
+            return getName();
+        }
     }
 
     /**
@@ -4022,16 +3961,16 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @throws ClassCastException if the object is not
      * {@code null} and is not assignable to the type T.
-     * @throws NullPointerException if this is an {@linkplain #isPrimitiveClass()
-     * primitive class} and the object is {@code null}
+     * @throws NullPointerException if this is an {@linkplain #isValueType()
+     * primitive value type} and the object is {@code null}
      *
      * @since 1.5
      */
     @SuppressWarnings("unchecked")
     @IntrinsicCandidate
     public T cast(Object obj) {
-        if (isPrimitiveClass() && obj == null)
-            throw new NullPointerException(getName() + " is a primitive class");
+        if (isValueType() && obj == null)
+            throw new NullPointerException(getName() + " is a primitive value type");
 
         if (obj != null && !isInstance(obj))
             throw new ClassCastException(cannotCastMsg(obj));
@@ -4542,7 +4481,7 @@ public final class Class<T> implements java.io.Serializable,
         if (isArray()) {
             return "[" + componentType.descriptorString();
         }
-        String typeDesc = isPrimitiveClass() ? "Q" : "L";
+        String typeDesc = isValueType()  ? "Q" : "L";
         if (isHidden()) {
             String name = getName();
             int index = name.indexOf('/');

--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -382,12 +382,8 @@ import static sun.invoke.util.Wrapper.isWrapperType;
      * returns {@code true} if {@code toType} is the same as,
      * or is a superclass or superinterface of, {@code fromType}.
      * <p>
-     * If {@code fromType} is a primitive class, this method returns {@code true}
-     * if {@code toType} is the {@linkplain Class#referenceType() primitive reference type}
-     * of {@code fromType}.
-     * If {@code toType} is a primitive class, this method returns {@code true}
-     * if {@code toType} is the {@linkplain Class#valueType() primitive value type}
-     * of {@code fromType}.
+     * If {@code fromType} and {@code toType} is of the same primitive class,
+     * this method returns {@code true}.
      * <p>
      * Otherwise, this method returns {@code false}.
      *
@@ -400,11 +396,12 @@ import static sun.invoke.util.Wrapper.isWrapperType;
             return true;
         }
 
-        if (!fromType.isPrimitiveClass() && !toType.isPrimitiveClass()) {
-            return false;
+        if (fromType.isPrimitiveClass() && toType.isPrimitiveClass()) {
+            // val projection can be converted to ref projection; or vice verse
+            return fromType.asPrimaryType() == toType.asPrimaryType();
         }
 
-        return fromType.valueType().equals(toType.valueType());
+        return false;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -81,7 +81,8 @@ class DirectMethodHandle extends MethodHandle {
         if (!member.isStatic()) {
             if (!member.getDeclaringClass().isAssignableFrom(refc) || member.isObjectConstructor())
                 throw new InternalError(member.toString());
-            mtype = mtype.insertParameterTypes(0, refc);
+            Class<?> receiverType = refc.isPrimitiveClass() ? refc.asValueType() : refc;
+            mtype = mtype.insertParameterTypes(0, receiverType);
         }
         if (!member.isField()) {
             // refKind reflects the original type of lookup via findSpecial or

--- a/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -115,9 +115,10 @@ final class InfoFromMemberName implements MethodHandleInfo {
                 // object constructor
                 throw new IllegalArgumentException("object constructor must be of void return type");
             } else if (MethodHandleNatives.refKindIsMethod(refKind) &&
-                       methodType.returnType() != defc) {
+                       methodType.returnType() != defc.asValueType()) {
+                // TODO: allow to return Object or perhaps one of the supertypes of that class
                 // static init factory
-                throw new IllegalArgumentException("static constructor must be of " + getDeclaringClass().getName());
+                throw new IllegalArgumentException("static constructor must be of " + defc.getName());
             }
 
             return isPublic ? defc.getConstructor(methodType.parameterArray())

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -191,10 +191,11 @@ final class MemberName implements Member, Cloneable {
      */
     public MethodType getInvocationType() {
         MethodType itype = getMethodOrFieldType();
+        Class<?> c = clazz.isPrimitiveClass() ? clazz.asValueType() : clazz;
         if (isObjectConstructor() && getReferenceKind() == REF_newInvokeSpecial)
-            return itype.changeReturnType(clazz);
+            return itype.changeReturnType(c);
         if (!isStatic())
-            return itype.insertParameterTypes(0, clazz);
+            return itype.insertParameterTypes(0, c);
         return itype;
     }
 
@@ -477,7 +478,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isInlineableField()  {
         if (isField()) {
             Class<?> type = getFieldType();
-            return type.isPrimitiveClass();
+            return type.isValueType();
         }
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1622,6 +1622,7 @@ public class MethodHandles {
         }
 
         private Lookup(Class<?> lookupClass, Class<?> prevLookupClass, int allowedModes) {
+            assert lookupClass.isPrimaryType();
             assert prevLookupClass == null || ((allowedModes & MODULE) == 0
                     && prevLookupClass.getModule() != lookupClass.getModule());
             assert !lookupClass.isArray() && !lookupClass.isPrimitive();
@@ -3445,14 +3446,15 @@ return mh1;
             assert(ctor.isObjectConstructorOrStaticInitMethod());
             @SuppressWarnings("deprecation")
             Lookup lookup = c.isAccessible() ? IMPL_LOOKUP : this;
+            Class<?> defc = c.getDeclaringClass();
             if (ctor.isObjectConstructor()) {
                 assert(ctor.getReturnType() == void.class);
-                return lookup.getDirectConstructorNoSecurityManager(ctor.getDeclaringClass(), ctor);
+                return lookup.getDirectConstructorNoSecurityManager(defc, ctor);
             } else {
                 // static init factory is a static method
-                assert(ctor.isMethod() && ctor.getReturnType() == ctor.getDeclaringClass() && ctor.getReferenceKind() == REF_invokeStatic);
+                assert(ctor.isMethod() && ctor.getReturnType() == defc && ctor.getReferenceKind() == REF_invokeStatic) : ctor.toString();
                 assert(!MethodHandleNatives.isCallerSensitive(ctor));  // must not be caller-sensitive
-                return lookup.getDirectMethodNoSecurityManager(ctor.getReferenceKind(), ctor.getDeclaringClass(), ctor, lookup);
+                return lookup.getDirectMethodNoSecurityManager(ctor.getReferenceKind(), defc, ctor, lookup);
             }
         }
 
@@ -3824,7 +3826,7 @@ return mh1;
 
             // Step 3:
             Class<?> defc = m.getDeclaringClass();
-            if (!fullPrivilegeLookup && defc != refc) {
+            if (!fullPrivilegeLookup && defc.asPrimaryType() != refc.asPrimaryType()) {
                 ReflectUtil.checkPackageAccess(defc);
             }
         }
@@ -3907,12 +3909,12 @@ return mh1;
             int mods = m.getModifiers();
             // check the class first:
             boolean classOK = (Modifier.isPublic(defc.getModifiers()) &&
-                               (defc == refc ||
+                               (defc.asPrimaryType() == refc.asPrimaryType() ||
                                 Modifier.isPublic(refc.getModifiers())));
             if (!classOK && (allowedModes & PACKAGE) != 0) {
                 // ignore previous lookup class to check if default package access
                 classOK = (VerifyAccess.isClassAccessible(defc, lookupClass(), null, FULL_POWER_MODES) &&
-                           (defc == refc ||
+                           (defc.asPrimaryType() == refc.asPrimaryType() ||
                             VerifyAccess.isClassAccessible(refc, lookupClass(), null, FULL_POWER_MODES)));
             }
             if (!classOK)
@@ -3989,7 +3991,6 @@ return mh1;
             if (checkSecurity)
                 checkSecurityManager(refc, method);
             assert(!method.isMethodHandleInvoke());
-
             if (refKind == REF_invokeSpecial &&
                 refc != lookupClass() &&
                 !refc.isInterface() &&
@@ -4323,9 +4324,6 @@ return mh1;
      * @jvms 6.5 {@code aastore} Instruction
      */
     public static MethodHandle arrayElementSetter(Class<?> arrayClass) throws IllegalArgumentException {
-        if (arrayClass.isPrimitiveClass()) {
-            throw new UnsupportedOperationException();
-        }
         return MethodHandleImpl.makeArrayElementAccessor(arrayClass, MethodHandleImpl.ArrayAccess.SET);
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.internal.vm.annotation.Stable;
@@ -889,13 +890,20 @@ class MethodType
     @Override
     public String toString() {
         StringJoiner sj = new StringJoiner(",", "(",
-                ")" + rtype.getSimpleName());
+                ")" + toSimpleName(rtype));
         for (int i = 0; i < ptypes.length; i++) {
-            sj.add(ptypes[i].getSimpleName());
+            sj.add(toSimpleName(ptypes[i]));
         }
         return sj.toString();
     }
 
+    static String toSimpleName(Class<?> c) {
+        if (c.isPrimitiveClass() && c.isPrimaryType()) {
+            return c.getSimpleName() + ".ref";
+        } else {
+            return c.getSimpleName();
+        }
+    }
     /** True if my parameter list is effectively identical to the given full list,
      *  after skipping the given number of my own initial parameters.
      *  In other words, after disregarding {@code skipPos} parameters,

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1648,6 +1648,12 @@ public abstract class VarHandle implements Constable {
                                   Class<?>... intermediate) {
             Class<?>[] ps;
             int i;
+            // the field type (value) is mapped to the return type of MethodType
+            // the receiver type is mapped to a parameter type of MethodType
+            // So use the value type if it's a primitive class
+            if (receiver != null && receiver.isPrimitiveClass()) {
+                receiver = receiver.asValueType();
+            }
             switch (this) {
                 case GET:
                     ps = allocateParameters(0, receiver, intermediate);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -227,7 +227,7 @@ final class VarHandles {
             // minimize the performance impact to non-value array.
             // It should be removed when Unsafe::isFlattenedArray is intrinsified.
 
-            return maybeAdapt(componentType.isPrimitiveClass() && UNSAFE.isFlattenedArray(arrayClass)
+            return maybeAdapt(componentType.isValueType() && UNSAFE.isFlattenedArray(arrayClass)
                 ? new VarHandleValues.Array(aoffset, ashift, arrayClass)
                 : new VarHandleReferences.Array(aoffset, ashift, arrayClass));
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -148,7 +148,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object checkCast(FieldInstanceReadWrite handle, $type$ value) {
-            if (handle.fieldType.isPrimitiveClass())
+            if (handle.fieldType.isValueType())
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -501,7 +501,7 @@ final class VarHandle$Type$s {
 
 #if[Object]
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
-            if (handle.fieldType.isPrimitiveClass())
+            if (handle.fieldType.isValueType())
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -744,7 +744,7 @@ final class VarHandle$Type$s {
 #if[Reference]
     static VarHandle makeVarHandleValuesArray(Class<?> arrayClass) {
         Class<?> componentType = arrayClass.getComponentType();
-        assert componentType.isPrimitiveClass() && UNSAFE.isFlattenedArray(arrayClass);
+        assert componentType.isValueType() && UNSAFE.isFlattenedArray(arrayClass);
         // should cache these VarHandle for performance
         return VarHandles.makeArrayElementHandle(arrayClass);
     }
@@ -803,7 +803,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
-            if (handle.componentType.isPrimitiveClass())
+            if (handle.componentType.isValueType())
                  Objects.requireNonNull(value);
 
             if (handle.arrayType == oarray.getClass()) {

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -121,6 +121,7 @@ public final class Constructor<T> extends Executable {
                 String signature,
                 byte[] annotations,
                 byte[] parameterAnnotations) {
+        assert declaringClass.isPrimaryType();
         this.clazz = declaringClass;
         this.parameterTypes = parameterTypes;
         this.exceptionTypes = checkedExceptions;
@@ -359,13 +360,13 @@ public final class Constructor<T> extends Executable {
 
     @Override
     void specificToStringHeader(StringBuilder sb) {
-        sb.append(getDeclaringClass().getTypeName());
+        sb.append(getDeclaringClassTypeName());
     }
 
     @Override
     String toShortString() {
         StringBuilder sb = new StringBuilder("constructor ");
-        sb.append(getDeclaringClass().getTypeName());
+        sb.append(getDeclaringClassTypeName());
         sb.append('(');
         StringJoiner sj = new StringJoiner(",");
         for (Class<?> parameterType : getParameterTypes()) {

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -777,4 +777,12 @@ public abstract class Executable extends AccessibleObject
                 getGenericExceptionTypes(),
                 TypeAnnotation.TypeAnnotationTarget.THROWS);
     }
+
+    String getDeclaringClassTypeName() {
+        Class<?> c = getDeclaringClass();
+        if (c.isPrimitiveClass()) {
+            c = c.asValueType();
+        }
+        return c.getTypeName();
+    }
 }

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -125,6 +125,7 @@ class Field extends AccessibleObject implements Member {
           String signature,
           byte[] annotations)
     {
+        assert declaringClass.isPrimaryType();
         this.clazz = declaringClass;
         this.name = name;
         this.type = type;
@@ -327,13 +328,21 @@ class Field extends AccessibleObject implements Member {
         int mod = getModifiers();
         return (((mod == 0) ? "" : (Modifier.toString(mod) + " "))
             + getType().getTypeName() + " "
-            + getDeclaringClass().getTypeName() + "."
+            + getDeclaringClassTypeName() + "."
             + getName());
     }
 
     @Override
     String toShortString() {
-        return "field " + getDeclaringClass().getTypeName() + "." + getName();
+        return "field " + getDeclaringClassTypeName() + "." + getName();
+    }
+
+    String getDeclaringClassTypeName() {
+        Class<?> c = getDeclaringClass();
+        if (c.isPrimitiveClass()) {
+            c = c.asValueType();
+        }
+        return c.getTypeName();
     }
 
     /**
@@ -361,7 +370,7 @@ class Field extends AccessibleObject implements Member {
         Type fieldType = getGenericType();
         return (((mod == 0) ? "" : (Modifier.toString(mod) + " "))
             + fieldType.getTypeName() + " "
-            + getDeclaringClass().getTypeName() + "."
+            + getDeclaringClassTypeName() + "."
             + getName());
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -129,6 +129,7 @@ public final class Method extends Executable {
            byte[] annotations,
            byte[] parameterAnnotations,
            byte[] annotationDefault) {
+        assert declaringClass.isPrimaryType();
         this.clazz = declaringClass;
         this.name = name;
         this.parameterTypes = parameterTypes;
@@ -418,13 +419,13 @@ public final class Method extends Executable {
     @Override
     void specificToStringHeader(StringBuilder sb) {
         sb.append(getReturnType().getTypeName()).append(' ');
-        sb.append(getDeclaringClass().getTypeName()).append('.');
+        sb.append(getDeclaringClassTypeName()).append('.');
         sb.append(getName());
     }
 
     @Override
     String toShortString() {
-        return "method " + getDeclaringClass().getTypeName() +
+        return "method " + getDeclaringClassTypeName() +
                 '.' + toShortSignature();
     }
 
@@ -487,7 +488,7 @@ public final class Method extends Executable {
     void specificToGenericStringHeader(StringBuilder sb) {
         Type genRetType = getGenericReturnType();
         sb.append(genRetType.getTypeName()).append(' ');
-        sb.append(getDeclaringClass().getTypeName()).append('.');
+        sb.append(getDeclaringClassTypeName()).append('.');
         sb.append(getName());
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -872,7 +872,7 @@ public class Proxy implements java.io.Serializable {
                 type = Class.forName(c.getName(), false, ld);
             } catch (ClassNotFoundException e) {
             }
-            if (type != c) {
+            if (type.asPrimaryType() != c.asPrimaryType()) {
                 throw new IllegalArgumentException(c.getName() +
                         " referenced from a method is not visible from class loader");
             }

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -864,7 +864,7 @@ final class ProxyGenerator extends ClassWriter {
                 }
             } else {
                 String internalName = dotToSlash(type.getName());
-                if (type.isPrimitiveClass()) {
+                if (type.isValueType()) {
                     internalName = 'Q' + internalName + ";";
                 }
                 mv.visitTypeInsn(CHECKCAST, internalName);
@@ -919,7 +919,7 @@ final class ProxyGenerator extends ClassWriter {
         /**
          * Generate code to invoke the Class.forName with the name of the given
          * class to get its Class object at runtime.  And also generate code
-         * to invoke Class.asPrimaryType if the class is regular value type.
+         * to invoke Class::asValueType if the class is a primitive value type.
          *
          * The code is written to the supplied stream.  Note that the code generated
          * by this method may caused the checked ClassNotFoundException to be thrown.
@@ -929,6 +929,11 @@ final class ProxyGenerator extends ClassWriter {
             mv.visitMethodInsn(INVOKESTATIC,
                     JL_CLASS,
                     "forName", "(Ljava/lang/String;)Ljava/lang/Class;", false);
+            if (cl.isValueType()) {
+              mv.visitMethodInsn(INVOKEVIRTUAL,
+                                 JL_CLASS,
+                                 "asValueType", "()Ljava/lang/Class;", false);
+            }
         }
 
         /**

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -265,7 +265,7 @@ public final class Unsafe {
      */
     public Object getReference(Object o, long offset, Class<?> pc) {
         Object ref = getReference(o, offset);
-        if (ref == null && pc.isPrimitiveClass()) {
+        if (ref == null && pc.isValueType()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);
@@ -275,7 +275,7 @@ public final class Unsafe {
 
     public Object getReferenceVolatile(Object o, long offset, Class<?> pc) {
         Object ref = getReferenceVolatile(o, offset);
-        if (ref == null && pc.isPrimitiveClass()) {
+        if (ref == null && pc.isValueType()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeFieldAccessorImpl.java
@@ -64,7 +64,7 @@ abstract class UnsafeFieldAccessorImpl extends FieldAccessorImpl {
     }
 
     protected boolean canBeNull() {
-        return !field.getType().isPrimitiveClass();
+        return !field.getType().isPrimitiveClass() || field.getType().isPrimaryType();
     }
 
     protected Object checkValue(Object value) {
@@ -72,7 +72,11 @@ abstract class UnsafeFieldAccessorImpl extends FieldAccessorImpl {
             throw new NullPointerException(field + " cannot be set to null");
 
         if (value != null) {
-            if (!field.getType().isAssignableFrom(value.getClass())) {
+            Class<?> type = value.getClass();
+            if (type.isPrimitiveClass()) {
+                type = type.asValueType();
+            }
+            if (!field.getType().isAssignableFrom(type)) {
                 throwSetIllegalArgumentException(value);
             }
         }

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -90,7 +90,8 @@ public class BytecodeDescriptor {
             i[0] = endc+1;
             String name = str.substring(begc, endc).replace('/', '.');
             try {
-                return Class.forName(name, false, loader);
+                Class<?> clz = Class.forName(name, false, loader);
+                return c == 'Q' ? clz.asValueType() : clz.asPrimaryType();
             } catch (ClassNotFoundException ex) {
                 throw new TypeNotPresentException(name, ex);
             }

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -106,7 +106,7 @@ public class VerifyAccess {
             return false;
         }
         // Usually refc and defc are the same, but verify defc also in case they differ.
-        if (defc == lookupClass  &&
+        if (defc.asPrimaryType() == lookupClass  &&
             (allowedModes & PRIVATE) != 0)
             return true;        // easy check; all self-access is OK with a private lookup
 
@@ -141,7 +141,7 @@ public class VerifyAccess {
                                  Reflection.areNestMates(defc, lookupClass));
             // for private methods the selected method equals the
             // resolved method - so refc == defc
-            assert (canAccess && refc == defc) || !canAccess;
+            assert (canAccess && refc.asPrimaryType() == defc.asPrimaryType()) || !canAccess;
             return canAccess;
         default:
             throw new IllegalArgumentException("bad modifiers: "+Modifier.toString(mods));
@@ -149,7 +149,7 @@ public class VerifyAccess {
     }
 
     static boolean isRelatedClass(Class<?> refc, Class<?> lookupClass) {
-        return (refc == lookupClass ||
+        return (refc.asPrimaryType() == lookupClass.asPrimaryType() ||
                 isSubClass(refc, lookupClass) ||
                 isSubClass(lookupClass, refc));
     }
@@ -274,7 +274,7 @@ public class VerifyAccess {
      * @param refc the class attempting to make the reference
      */
     public static boolean isTypeVisible(Class<?> type, Class<?> refc) {
-        if (type == refc) {
+        if (type.asPrimaryType() == refc.asPrimaryType()) {
             return true;  // easy check
         }
         while (type.isArray())  type = type.getComponentType();
@@ -334,7 +334,7 @@ public class VerifyAccess {
                         }
                     }
             });
-        return (type == res);
+        return (type.asPrimaryType() == res);
     }
 
     /**

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/EmptyInlineTest.java
@@ -70,22 +70,22 @@ public class EmptyInlineTest {
 
         // Create an inline with an empty inline field
         EmptyField emptyField = new EmptyField();
-        Asserts.assertEquals(emptyField.empty.getClass(), EmptyInline.class);
+        Asserts.assertEquals(emptyField.empty.getClass(), EmptyInline.ref.class);
         Asserts.assertTrue(emptyField.empty.isEmpty());
         System.out.println(emptyField.empty.isEmpty());
 
         // Regular instance with an empty field inside
         WithEmptyField w = new WithEmptyField();
-        Asserts.assertEquals(w.empty.getClass(), EmptyInline.class);
+        Asserts.assertEquals(w.empty.getClass(), EmptyInline.ref.class);
         Asserts.assertTrue(w.empty.isEmpty());
         w.empty = new EmptyInline();
-        Asserts.assertEquals(w.empty.getClass(), EmptyInline.class);
+        Asserts.assertEquals(w.empty.getClass(), EmptyInline.ref.class);
         Asserts.assertTrue(w.empty.isEmpty());
 
         // Create an array of empty inlines
         EmptyInline[] emptyArray = new EmptyInline[100];
         for(EmptyInline element : emptyArray) {
-            Asserts.assertEquals(element.getClass(), EmptyInline.class);
+            Asserts.assertEquals(element.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(element.isEmpty());
         }
 
@@ -94,19 +94,19 @@ public class EmptyInlineTest {
         // with two arrays
         System.arraycopy(emptyArray, 10, array2, 20, 50);
         for(EmptyInline element : array2) {
-            Asserts.assertEquals(element.getClass(), EmptyInline.class);
+            Asserts.assertEquals(element.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(element.isEmpty());
         }
         // single array, no overlap
         System.arraycopy(emptyArray, 10, emptyArray, 50, 20);
         for(EmptyInline element : emptyArray) {
-            Asserts.assertEquals(element.getClass(), EmptyInline.class);
+            Asserts.assertEquals(element.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(element.isEmpty());
         }
         // single array with overlap
         System.arraycopy(emptyArray, 10, emptyArray, 20, 50);
         for(EmptyInline element : emptyArray) {
-            Asserts.assertEquals(element.getClass(), EmptyInline.class);
+            Asserts.assertEquals(element.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(element.isEmpty());
         }
 
@@ -130,11 +130,11 @@ public class EmptyInlineTest {
         try {
             Field emptyfield = c2.getDeclaredField("empty");
             EmptyInline e = (EmptyInline)emptyfield.get(w0);
-            Asserts.assertEquals(e.getClass(), EmptyInline.class);
+            Asserts.assertEquals(e.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(e.isEmpty());
             emptyfield.set(w0, new EmptyInline());
             e = (EmptyInline)emptyfield.get(w0);
-            Asserts.assertEquals(e.getClass(), EmptyInline.class);
+            Asserts.assertEquals(e.getClass(), EmptyInline.ref.class);
             Asserts.assertTrue(e.isEmpty());
         } catch(Throwable t) {
             t.printStackTrace();

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -286,10 +286,10 @@ public class InlineTypeArray {
         MyInt[] myInts = new MyInt[1];
         assertTrue(myInts instanceof Object[]);
         assertTrue(myInts instanceof Comparable[]);
-        assertTrue(myInts instanceof MyInt.ref[]);
+        assertTrue(myInts instanceof MyInt[]);
 
         Class<?> cls = MyInt.class;
-        assertTrue(cls.isPrimitiveClass());
+        assertTrue(cls.isValueType());
         Object arrObj = Array.newInstance(cls, 1);
         assertTrue(arrObj instanceof Object[], "Not Object array");
         assertTrue(arrObj instanceof Comparable[], "Not Comparable array");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
@@ -58,7 +58,7 @@ public class ObjectMethods {
         }
 
         // getClass()
-        checkGetClass(val, MyInt.class);
+        checkGetClass(val, MyInt.ref.class);
 
         //hashCode()/identityHashCode()
         checkHashCodes(val, sameVal.hashCode());

--- a/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
+++ b/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
@@ -263,14 +263,14 @@ public class InstructionHelper {
                 if (aClass.isArray()) {
                     return classToInternalName(aClass);
                 } else {
-                    return (aClass.isPrimitiveClass() ? "Q" : "L") + classToInternalName(aClass) + ";";
+                    return (aClass.isValueType() ? "Q" : "L") + classToInternalName(aClass) + ";";
                 }
             }
 
             @Override
             public boolean isInlineClass(String desc) {
                 Class<?> aClass = symbol(desc);
-                return aClass != null && aClass.isPrimitiveClass();
+                return aClass != null && aClass.isValueType();
             }
 
             @Override
@@ -279,7 +279,8 @@ public class InstructionHelper {
                     if (desc.startsWith("[")) {
                         return Class.forName(desc.replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
                     } else {
-                        return Class.forName(basicTypeHelper.symbol(desc).replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
+                        Class<?> c = Class.forName(basicTypeHelper.symbol(desc).replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
+                        return basicTypeHelper.isInlineClass(desc) ? c.asValueType() : c.asPrimaryType();
                     }
                 } catch (ReflectiveOperationException ex) {
                     throw new AssertionError(ex);

--- a/test/jdk/valhalla/valuetypes/BasicTest.java
+++ b/test/jdk/valhalla/valuetypes/BasicTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary test reflection on inline types
+ * @compile --enable-preview --source ${jdk.version} BasicTest.java
+ * @run testng/othervm --enable-preview BasicTest
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.testng.Assert.*;
+
+public class BasicTest {
+    static primitive class Point {
+        int x;
+        int y;
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        int x() {
+            return x;
+        }
+
+        int y() {
+            return y;
+        }
+        static Point.val newVal(int x, int y) {
+            return new Point(x, y);
+        }
+        static Point.ref toRef(Object o) {
+            return (Point.ref) o;
+        }
+        static Point.val toVal(Point.ref o) {
+            return (Point.val) o;
+        }
+    }
+
+    @DataProvider(name="constants")
+    static Object[][] constants() {
+        return new Object[][]{
+            new Object[] { Point.class, Point.class.asValueType()},
+            new Object[] { Point.val.class, Point.class.asValueType()},
+            new Object[] { Point.ref.class, Point.class.asPrimaryType()},
+        };
+    }
+
+    @Test(dataProvider="constants")
+    public void ldc(Class<?> type, Class<?> expected) {
+        assertTrue(type == expected);
+    }
+
+    @DataProvider(name="refTypes")
+    static Object[][] refTypes() {
+        return new Object[][]{
+                new Object[] { int.class, true},
+                new Object[] { Integer.class, true},
+                new Object[] { Object.class, true},
+                new Object[] { Point.ref.class, true},
+                new Object[] { Point.val.class, false},
+                new Object[] { Point.class.asPrimaryType(), true},
+                new Object[] { Point.class.asValueType(), false},
+        };
+    }
+    @Test(dataProvider="refTypes")
+    public void isPrimaryType(Class<?> type, boolean isRefType) {
+        assertTrue(type.isPrimaryType() == isRefType);
+    }
+
+    @Test
+    public void testMirrors() {
+        Class<?> refType = Point.class.asPrimaryType();
+        Class<?> valType = Point.class.asValueType();
+
+        assertTrue(refType == Point.ref.class);
+        // ## ldc not implemented
+        assertTrue(valType == Point.val.class);
+        assertTrue(refType != valType);
+        assertTrue(refType.isPrimitiveClass());
+        assertTrue(valType.isPrimitiveClass());
+        assertTrue(refType.isPrimaryType());
+        assertFalse(valType.isPrimaryType());
+
+        assertEquals(refType.getName(), "BasicTest$Point");
+        assertEquals(valType.getName(), "BasicTest$Point");
+    }
+
+    @DataProvider(name="names")
+    static Object[][] names() {
+        return new Object[][]{
+                new Object[] { "BasicTest$Point", Point.class.asPrimaryType()},
+                new Object[] { "[QBasicTest$Point;", Point[].class},
+                new Object[] { "[LBasicTest$Point;", Point.ref[].class},
+        };
+    }
+    @Test(dataProvider="names")
+    public void classForName(String name, Class<?> expected) throws ClassNotFoundException {
+        Class<?> type = Class.forName(name);
+        assertTrue(type == expected);
+    }
+
+    @Test
+    public void testNull() {
+        Point.ref ref = Point.toRef(null);
+        assertTrue(ref == null);
+        try {
+            Point.toVal(null);
+            throw new RuntimeException("expected NPE thrown");
+        } catch (NullPointerException e) {}
+    }
+
+    @Test
+    public void testConversion() {
+        Point p = new Point(10,20);
+        Point.ref ref = Point.toRef(p);
+        Point.val val = Point.toVal(ref);
+        assertEquals(ref, p);
+        assertEquals(val, p);
+    }
+
+    @Test
+    public void testMembers() {
+        Method[] refMethods = Point.ref.class.getDeclaredMethods();
+        Method[] valMethods = Point.val.class.getDeclaredMethods();
+        assertEquals(refMethods, valMethods);
+        assertTrue(valMethods.length == 5);
+
+        Field[] refFields = Point.ref.class.getDeclaredFields();
+        Field[] valFields = Point.val.class.getDeclaredFields();
+        assertEquals(refFields, valFields);
+        assertTrue(valFields.length == 2);
+
+        Constructor[] refCtors = Point.ref.class.getDeclaredConstructors();
+        Constructor[] valCtors = Point.val.class.getDeclaredConstructors();
+        assertEquals(refCtors, valCtors);
+        assertTrue(valCtors.length == 1);
+        assertTrue(Modifier.isStatic(valCtors[0].getModifiers()));
+    }
+
+    @DataProvider(name="methods")
+    static Object[][] methods() {
+        return new Object[][]{
+                new Object[] { "toVal", Point.val.class, new Class<?>[] { Point.ref.class }},
+                new Object[] { "toRef", Point.ref.class, new Class<?>[] { Object.class }},
+        };
+    }
+    @Test(dataProvider = "methods")
+    public void testMethod(String name, Class<?> returnType, Class<?>[] paramTypes) throws ReflectiveOperationException {
+        Method m = Point.class.getDeclaredMethod(name, paramTypes);
+        System.out.print(m.toString() + "  ");
+        System.out.println(m.getReturnType().descriptorString());
+        assertTrue(m.getDeclaringClass() == Point.class.asPrimaryType());
+        assertTrue(m.getReturnType() == returnType);
+        assertEquals(m.getParameterTypes(), paramTypes);
+    }
+
+    @Test
+    public void testConstructor() throws ReflectiveOperationException {
+        Constructor<?> ctor = Point.class.getDeclaredConstructor(int.class, int.class);
+        assertTrue(ctor.getDeclaringClass() == Point.class.asPrimaryType());
+    }
+
+}

--- a/test/jdk/valhalla/valuetypes/InlineConstructorTest.java
+++ b/test/jdk/valhalla/valuetypes/InlineConstructorTest.java
@@ -59,17 +59,17 @@ public class InlineConstructorTest {
     @Test
     public static void testInlineClassConstructor() throws Exception {
         String cn = INLINE_TYPE.getName();
-        Class<?> c = Class.forName(cn);
+        Class<?> c = Class.forName(cn).asValueType();
 
         assertTrue(c.isPrimitiveClass());
-        assertEquals(c, INLINE_TYPE);
+        assertTrue(c == INLINE_TYPE);
     }
 
     @Test
     public static void constructor() throws Exception {
         Constructor<?> ctor = INLINE_TYPE.getDeclaredConstructor();
         Object o = ctor.newInstance();
-        assertEquals(o.getClass(), INLINE_TYPE);
+        assertTrue(o.getClass() == INLINE_TYPE.asPrimaryType());
     }
 
     // Check that the class has the expected Constructors

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -29,11 +29,9 @@
  * @run testng/othervm -Xcomp -Dvalue.bsm.salt=1 ObjectMethods
  * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
  */
-
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.testng.annotations.BeforeTest;
@@ -166,7 +164,7 @@ public class ObjectMethods {
             { P1,                   hash(Point.class, 1, 2) },
             { LINE1,                hash(Line.class, Point.makePoint(1, 2), Point.makePoint(3, 4)) },
             { VALUE,                hash(hashCodeComponents(VALUE))},
-            { VALUE1,                hash(hashCodeComponents(VALUE1))},
+            { VALUE1,               hash(hashCodeComponents(VALUE1))},
             { Point.makePoint(0,0), hash(Point.class, 0, 0) },
             { Point.default,        hash(Point.class, 0, 0) },
             { MyValue1.default,     hash(MyValue1.class, Point.default, null) },
@@ -191,6 +189,9 @@ public class ObjectMethods {
                     throw new RuntimeException(e);
                 }
             });
+        if (type.isPrimitiveClass()) {
+            type = type.asValueType();
+        }
         return Stream.concat(Stream.of(type), fields).toArray(Object[]::new);
     }
 

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -139,9 +139,7 @@ public class QTypeDescriptorTest {
     @Test(dataProvider = "descriptors")
     public static void testDescriptors(Class<?> defc, String name, Class<?>[] params, boolean found) throws Exception {
         try {
-            // TODO: methods are in the reference projection
-            Class<?> declaringClass = defc /* defc.referenceType().get() */;
-            declaringClass.getDeclaredMethod(name, params);
+            defc.getDeclaredMethod(name, params);
             if (!found) throw new AssertionError("Expected NoSuchMethodException");
         } catch (NoSuchMethodException e) {
             if (found) throw e;
@@ -152,18 +150,18 @@ public class QTypeDescriptorTest {
     static Object[][] methodTypes() {
         ClassLoader loader = QTypeDescriptorTest.class.getClassLoader();
         return new Object[][]{
-            { "point",      MethodType.methodType(Point.ref.class),                                     true },
-            { "pointValue", MethodType.methodType(Point.class),                                         true },
-            { "has",        MethodType.methodType(boolean.class, Point.class, Point.ref.class),         true },
-            { "point",      MethodType.methodType(Point.class),                                         false },
-            { "pointValue", MethodType.methodType(Point.ref.class),                                     false },
-            { "has",        MethodType.methodType(boolean.class, Point.ref.class, Point.class),         false },
-            { "point",      MethodType.fromMethodDescriptorString("()LPoint$ref;", loader),             true },
-            { "point",      MethodType.fromMethodDescriptorString("()QPoint;", loader),                 false },
-            { "pointValue", MethodType.fromMethodDescriptorString("()QPoint;", loader),                 true },
-            { "pointValue", MethodType.fromMethodDescriptorString("()LPoint$ref;", loader),             false },
-            { "has",        MethodType.fromMethodDescriptorString("(QPoint;LPoint$ref;)Z", loader),     true },
-            { "has",        MethodType.fromMethodDescriptorString("(LPoint$ref;LPoint$ref;)Z", loader), false },
+            { "point",      MethodType.methodType(Point.ref.class),                                      true },
+            { "pointValue", MethodType.methodType(Point.class),                                          true },
+            { "has",        MethodType.methodType(boolean.class, Point.class, Point.ref.class),          true },
+            { "point",      MethodType.methodType(Point.class),                                          false },
+            { "pointValue", MethodType.methodType(Point.ref.class),                                      false },
+            { "has",        MethodType.methodType(boolean.class, Point.ref.class, Point.class),          false },
+            { "point",      MethodType.fromMethodDescriptorString("()LPoint;", loader),        true },
+            { "point",      MethodType.fromMethodDescriptorString("()QPoint;", loader),        false },
+            { "pointValue", MethodType.fromMethodDescriptorString("()QPoint;", loader),        true },
+            { "pointValue", MethodType.fromMethodDescriptorString("()LPoint;", loader),        false },
+            { "has",        MethodType.fromMethodDescriptorString("(QPoint;LPoint;)Z", loader),true },
+            { "has",        MethodType.fromMethodDescriptorString("(LPoint;LPoint;)Z", loader),false },
         };
     }
 

--- a/test/jdk/valhalla/valuetypes/StaticInitFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticInitFactoryTest.java
@@ -115,7 +115,7 @@ public class StaticInitFactoryTest {
 
         // crack method handle
         MethodHandleInfo minfo = lookup.revealDirect(mh);
-        assertEquals(minfo.getDeclaringClass(), c);
+        assertEquals(minfo.getDeclaringClass(), c.asPrimaryType());
         assertEquals(minfo.getName(), "<init>");
         assertEquals(minfo.getReferenceKind(), MethodHandleInfo.REF_invokeStatic);
         assertEquals(minfo.getMethodType(), mtype);

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -56,9 +56,9 @@ public class ValueArray {
         testClassName();
         testArrayElements();
 
-        if (componentType.isPrimitiveClass()) {
+        if (componentType.isValueType()) {
             Object[] qArray = (Object[]) Array.newInstance(componentType, 0);
-            Object[] lArray = (Object[]) Array.newInstance(componentType.referenceType().get(), 0);
+            Object[] lArray = (Object[]) Array.newInstance(componentType.asPrimaryType(), 0);
             testInlineArrayCovariance(componentType, qArray, lArray);
         }
     }
@@ -72,7 +72,7 @@ public class ValueArray {
             sb.append("[");
             c = c.getComponentType();
         }
-        sb.append(c.isPrimitiveClass() ? "Q" : "L").append(c.getName()).append(";");
+        sb.append(c.isValueType() ? "Q" : "L").append(c.getName()).append(";");
         assertEquals(sb.toString(), arrayClassName);
     }
 
@@ -92,7 +92,7 @@ public class ValueArray {
         Arrays.setAll(array, i -> this.array[i]);
 
         // test nullable
-        if (!componentType.isPrimitiveClass()) {
+        if (!componentType.isValueType()) {
             for (int i=0; i < array.length; i++) {
                 Array.set(array, i, null);
             }
@@ -107,7 +107,7 @@ public class ValueArray {
     }
 
     void testInlineArrayCovariance(Class<?> componentType, Object[] qArray, Object[] lArray) {
-        assertTrue(componentType.isPrimitiveClass());
+        assertTrue(componentType.isValueType());
 
         // Class.instanceOf (self)
         assertTrue(qArray.getClass().isInstance(qArray));

--- a/test/langtools/tools/javac/valhalla/lworld-values/SplitPrimitiveClassNestHostTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SplitPrimitiveClassNestHostTest.java
@@ -42,7 +42,7 @@ public primitive class SplitPrimitiveClassNestHostTest implements java.io.Serial
         // check wiring of super types.
         Class<?> superClass = SplitPrimitiveClassNestHostTest.class.getSuperclass();
         if (!superClass.equals(
-                    SplitPrimitiveClassNestHostTest.class.referenceType().get()))
+                    SplitPrimitiveClassNestHostTest.class.asPrimaryType()))
             throw new AssertionError("Wrong superclass for SplitPrimitiveClassNestHostTest");
 
         Class<?> [] superInterfaces = SplitPrimitiveClassNestHostTest.class.getInterfaces();
@@ -64,7 +64,7 @@ public primitive class SplitPrimitiveClassNestHostTest implements java.io.Serial
 
 
         Class<?> nestHost = SplitPrimitiveClassNestHostTest.class.getNestHost();
-        if (!nestHost.equals(SplitPrimitiveClassNestHostTest.class.referenceType().get()))
+        if (!nestHost.equals(SplitPrimitiveClassNestHostTest.class.asPrimaryType()))
             throw new AssertionError("Wrong nest host: " + nestHost);
 
         Class<?> [] members = nestHost.getNestMembers();
@@ -92,7 +92,7 @@ public primitive class SplitPrimitiveClassNestHostTest implements java.io.Serial
         if (!Arrays.equals(members[2].getNestMembers(), members))
             throw new AssertionError("Wrong nest members for member[2]: " + members[2]);
 
-        if (!members[3].equals(Inner.class.referenceType().get()))
+        if (!members[3].equals(Inner.class.asPrimaryType()))
             throw new AssertionError("Wrong member[3]: " + members[3]);
 
         if (!members[3].getNestHost().equals(nestHost))


### PR DESCRIPTION
This PR implements the primary (`ref`) mirror and secondary (`val`) mirror for primitive classes [1].   The following APIs returning `Class` return the primary mirror: 

`Object::getClass`
`Class::getClass`
`Class::forName`
`java.lang.reflect.Member::getDeclaringClass` (i.e. `Field`, `Method` and `Constructor`)

`Class::getName` and `Class::getSimpleName` return the same name for the `ref` and `val` mirror of a primitive class.  Therefore, Class.forName(type.getName()) will work if the type is either `ref` or `val` mirror.

`Class::getTypeName` returns `Foo.ref` if this `Class` is a primitive reference type.  (we will revisit this for reference-favoring primitive class.)

New proposed APIs: 
`Class::isPrimitiveClass` returns true for the `ref` and `val` mirror of a primitive class. 

`Class::isPrimaryType` returns true if this `Class` object represents the primary mirror
`Class::asPrimaryType` returns the primary type of this class or interface.
- An alternative I considered is `Class::isReferenceType` and `Class::asReferenceType` but they will have to specify the special case for primitive types which are not (yet) primitive classes.   I want to go with this initial patch to make progress for the prototype.  We will follow up the API discussion next.

`Class::isValueType` returns true if this `Class` object represents the primary mirror
`Class::asValueType` returns the primary type of this class or interface.

Several tests fail when running with -Xcomp which may depend on the second phase JIT support work (JDK-8267932) which depends on this work to make progress.

[1] https://github.com/openjdk/valhalla-docs/blob/main/site/design-notes/state-of-valhalla/03-vm-model.md

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267948](https://bugs.openjdk.java.net/browse/JDK-8267948): [lword] Core reflection and method handles support for L/Q model


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.java.net/valhalla pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/436.diff">https://git.openjdk.java.net/valhalla/pull/436.diff</a>

</details>
