### PR TITLE
8268418: [lworld] VM assert illegal mirror klass when calling Class::getInterfaces on a flat array

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1170,7 +1170,7 @@ JVM_ENTRY(jobjectArray, JVM_GetClassInterfaces(JNIEnv *env, jclass cls))
     InstanceKlass* ik = InstanceKlass::cast(klass);
     size = ik->local_interfaces()->length();
   } else {
-    assert(klass->is_objArray_klass() || klass->is_typeArray_klass(), "Illegal mirror klass");
+    assert(klass->is_objArray_klass() || klass->is_typeArray_klass() || klass->is_flatArray_klass(), "Illegal mirror klass");
     size = 3;
   }
 


### PR DESCRIPTION
Fix the assert in `JVM_GetClassInterfaces` to check for flat array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268418](https://bugs.openjdk.java.net/browse/JDK-8268418): [lworld] VM assert illegal mirror klass when calling Class::getInterfaces on a flat array


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/440/head:pull/440` \
`$ git checkout pull/440`

Update a local copy of the PR: \
`$ git checkout pull/440` \
`$ git pull https://git.openjdk.java.net/valhalla pull/440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 440`

View PR using the GUI difftool: \
`$ git pr show -t 440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/440.diff">https://git.openjdk.java.net/valhalla/pull/440.diff</a>

</details>
