### PR TITLE
8268553: [lworld] CI must return secondary mirror when accessing CONSTANT_Class with Q-signature

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -697,7 +697,15 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
     }
     assert (klass->is_instance_klass() || klass->is_array_klass(),
             "must be an instance or array klass ");
-    return ciConstant(T_OBJECT, klass->java_mirror());
+    if (tag.is_unresolved_klass()) {
+      return ciConstant(T_OBJECT, get_unloaded_klass_mirror(klass));
+    } else {
+      if (tag.is_Qdescriptor_klass()) {
+        return ciConstant(T_OBJECT, klass->as_inline_klass()->val_mirror());
+      } else {
+        return ciConstant(T_OBJECT, klass->java_mirror());
+      }
+    }
   } else if (tag.is_method_type()) {
     // must execute Java code to link this CP entry into cache[i].f1
     ciSymbol* signature = get_symbol(cpool->method_type_signature_at(index));

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -140,3 +140,7 @@ address ciInlineKlass::unpack_handler() const {
 InlineKlass* ciInlineKlass::get_InlineKlass() const {
   GUARDED_VM_ENTRY(return to_InlineKlass();)
 }
+
+ciInstance* ciInlineKlass::val_mirror() {
+  GUARDED_VM_ENTRY(return CURRENT_ENV->get_instance(to_InlineKlass()->val_mirror());)
+}

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -90,6 +90,7 @@ public:
   address pack_handler() const;
   address unpack_handler() const;
   InlineKlass* get_InlineKlass() const;
+  ciInstance* val_mirror();
 };
 
 #endif // SHARE_VM_CI_CIINLINEKLASS_HPP


### PR DESCRIPTION
Please review this small change in CI to return the secondary mirror when accessing a CONSTANT_Class_info entry containing a Q-signature.
This change fixes all compiler tests failures in the lqagain branch but the ones depending on intrinsics (Class::getSuperclass intrinsic and Class::isAssignableFrom intrinsics need to be fixed in a separate changeset).

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268553](https://bugs.openjdk.java.net/browse/JDK-8268553): [lworld] CI must return secondary mirror when accessing CONSTANT_Class with Q-signature


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/442/head:pull/442` \
`$ git checkout pull/442`

Update a local copy of the PR: \
`$ git checkout pull/442` \
`$ git pull https://git.openjdk.java.net/valhalla pull/442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 442`

View PR using the GUI difftool: \
`$ git pr show -t 442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/442.diff">https://git.openjdk.java.net/valhalla/pull/442.diff</a>

</details>
