### PR TITLE
8268584: [lqagain] Javac tests should not needlessly hardcode toString() output 

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ChainedAssignmentTest.java
@@ -47,11 +47,11 @@ public class ChainedAssignmentTest {
     }
     public static void main(String[] args) {
         Point p = new Point();
-        if (!p.toString().equals("[ChainedAssignmentTest$Point x=1234 y=1234]"))
+        if (p.x != 1234 || p.y != 1234)
             throw new AssertionError("Broken");
 
         LongPoint lp = new LongPoint();
-        if (!lp.toString().equals("[ChainedAssignmentTest$LongPoint x=1234 y=1234]"))
+        if (lp.x != 1234 || lp.y != 1234)
             throw new AssertionError("Broken");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile.java
@@ -30,8 +30,8 @@
  */
 
 public class CheckSeparateCompile {
-	public static void main(String[] args) {
-		if (new CheckSeparateCompile0().new O().new M().new I().foo().i != 890)
+    public static void main(String[] args) {
+        if (new CheckSeparateCompile0().new O().new M().new I().foo().i != 890)
             throw new AssertionError("Broken");
-	}
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile.java
@@ -31,8 +31,7 @@
 
 public class CheckSeparateCompile {
 	public static void main(String[] args) {
-		String s = new CheckSeparateCompile0().new O().new M().new I().foo();
-        if (!s.equals("[CheckSeparateCompile0$O$M$I i=0]"))
-            throw new AssertionError(s);
+		if (new CheckSeparateCompile0().new O().new M().new I().foo().i != 890)
+            throw new AssertionError("Broken");
 	}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSeparateCompile0.java
@@ -32,12 +32,12 @@ public class CheckSeparateCompile0 {
         public class M {
             int m = 789;
             public primitive class I {
-                int i = 0;
+                int i = 890;
                 I() {
 
                 }
-                String foo() {
-                    return this.toString();
+                I foo() {
+                    return this;
                 }
             }
             public String toString() {

--- a/test/langtools/tools/javac/valhalla/lworld-values/CtorChain.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CtorChain.java
@@ -55,8 +55,8 @@ public primitive class CtorChain {
     }
 
     public static void main(String [] args) {
-        String o = new CtorChain().toString();
-        if (!o.equals("[CtorChain x1=10 x2=20 x3=30 x4=40 x5=50]"))
+        CtorChain cc = new CtorChain();
+        if (cc.x1 != 10 || cc.x2 != 20 || cc.x3 != 30 || cc.x4 != 40 || cc.x5 != 50)
             throw new AssertionError("Broken");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InlineClassTest.java
@@ -33,7 +33,7 @@
 public primitive class InlineClassTest {
     int x = 42;
     public static void main(String [] args) {
-        if (!new InlineClassTest().toString().equals("[InlineClassTest x=42]"))
+        if (new InlineClassTest().x != 42)
             throw new AssertionError("Unexpected state");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/QualifiedSuperCtor.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QualifiedSuperCtor.java
@@ -31,12 +31,12 @@
 primitive class A {
     int x = 1000000;
     class Inner { 
-        String aDotThis;
+        A aDotThis;
         Inner() {
-            aDotThis = A.this.toString();
+            aDotThis = A.this;
         }
 
-        String getADotThis() {
+        A getADotThis() {
             return aDotThis;
         }
     }
@@ -48,7 +48,7 @@ public class QualifiedSuperCtor extends A.Inner {
     }
 
     public static void main(String [] args) {
-        if (!new QualifiedSuperCtor(new A()).getADotThis().equals("[A x=1000000]"))
+        if (new QualifiedSuperCtor(new A()).getADotThis().x !=1000000)
             throw new AssertionError("Broken");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SideEffectTest.java
@@ -55,12 +55,12 @@ public class SideEffectTest {
         V v = new V();
         if (!v.output.equals("1234"))
             throw new AssertionError("Broken");
-        if (!v.toString().equals("[SideEffectTest$V x=1234]"))
+        if (v.x != 1234)
             throw new AssertionError("Broken");
         v = new V(8765);
         if (!v.output.equals("12349999"))
             throw new AssertionError("Broken");
-        if (!v.toString().equals("[SideEffectTest$V x=8765]"))
+        if (v.x != 8765)
             throw new AssertionError("Broken");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/TestQualifierOnInit.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TestQualifierOnInit.java
@@ -42,7 +42,7 @@ primitive final class TestValue1 {
 public class TestQualifierOnInit {
     static public void main(String[] args) {
         TestValue1 testValue1 = new TestValue1(42);
-        if (!testValue1.toString().equals("[TestValue1 x=42]"))
+        if (testValue1.x != 42)
             throw new AssertionError("unexpected " + testValue1);
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueConstructorRef.java
@@ -44,7 +44,7 @@ public primitive class ValueConstructorRef {
     public static void main(String [] args) {   
        Supplier<ValueConstructorRef.ref> sx = ValueConstructorRef::new;
     	ValueConstructorRef x = (ValueConstructorRef) sx.get();
-        if (!x.toString().equals("[ValueConstructorRef x=1234 y=5678]"))
+        if (x.x != 1234 || x.y != 5678)
             throw new AssertionError(x);
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldAccessorTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldAccessorTest.java
@@ -46,7 +46,7 @@ public class WithFieldAccessorTest {
 
     public static void main(String... args) throws Throwable {
         V v = __WithField(V.make(10).i, 20);
-        if (!v.toString().equals("[WithFieldAccessorTest$V i=20]"))
-            throw new AssertionError("Withfield didn't work!" + v.toString());
+        if (v.i != 20)
+            throw new AssertionError("Withfield didn't work!");
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfGenericType.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/WithFieldOfGenericType.java
@@ -45,7 +45,7 @@ public final primitive class WithFieldOfGenericType<E> {
 
   public static void main(String[] args) {
      WithFieldOfGenericType<String> w = create();
-     if (!w.toString().equals("[WithFieldOfGenericType value=true]"))
+     if (w.value != true)
         throw new AssertionError("Withfield didn't work!");
   }
 }


### PR DESCRIPTION
Modify javac tests to not use textual comparisons of primitive object state as a means of verifying behavior

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268584](https://bugs.openjdk.java.net/browse/JDK-8268584): [lqagain] Javac tests should not needlessly hardcode toString() output


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/443/head:pull/443` \
`$ git checkout pull/443`

Update a local copy of the PR: \
`$ git checkout pull/443` \
`$ git pull https://git.openjdk.java.net/valhalla pull/443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 443`

View PR using the GUI difftool: \
`$ git pr show -t 443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/443.diff">https://git.openjdk.java.net/valhalla/pull/443.diff</a>

</details>
