### PR TITLE
8268671: [lworld] Wrong code generated for PrimitiveClass.ref.default

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2404,7 +2404,7 @@ public class Gen extends JCTree.Visitor {
     }
 
     public void visitDefaultValue(JCDefaultValue tree) {
-        if (tree.type.asElement().isPrimitiveClass()) {
+        if (tree.type.isPrimitiveClass()) {
             code.emitop2(defaultvalue, checkDimension(tree.pos(), tree.type), PoolWriter::putClass);
         } else if (tree.type.isReference()) {
             code.emitop0(aconst_null);

--- a/test/langtools/tools/javac/valhalla/lworld-values/DefaultOfPrimitiveReference.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DefaultOfPrimitiveReference.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268671
+ * @summary Wrong code generated for PrimitiveClass.ref.default
+ * @run main DefaultOfPrimitiveReference
+ */
+
+public primitive class DefaultOfPrimitiveReference {
+    public static void main(String [] args) {
+        Object o = DefaultOfPrimitiveReference.ref.default;
+        if (o != null)
+            throw new AssertionError("Expected NPE is missing");
+    }
+}


### PR DESCRIPTION
Lower X.ref.default using aconst_null

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268671](https://bugs.openjdk.java.net/browse/JDK-8268671): [lworld] Wrong code generated for PrimitiveClass.ref.default


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/445/head:pull/445` \
`$ git checkout pull/445`

Update a local copy of the PR: \
`$ git checkout pull/445` \
`$ git pull https://git.openjdk.java.net/valhalla pull/445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 445`

View PR using the GUI difftool: \
`$ git pr show -t 445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/445.diff">https://git.openjdk.java.net/valhalla/pull/445.diff</a>

</details>
