### PR TITLE
JDK-8268908: Update test/jdk/valhalla/valuetypes tests to prepare for jtreg 6 and other clean up

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -791,6 +791,10 @@ public final class Class<T> implements java.io.Serializable,
      * superinterface of, the class or interface represented by the specified
      * {@code Class} parameter. It returns {@code true} if so;
      * otherwise it returns {@code false}. If this {@code Class}
+     * object represents the {@linkplain #isPrimaryType() reference type}
+     * of a {@linkplain #isPrimitiveClass() primitive class}, this method
+     * return {@code true} if the specified {@code Class} parameter represents
+     * the same primitive class. If this {@code Class}
      * object represents a primitive type, this method returns
      * {@code true} if the specified {@code Class} parameter is
      * exactly this {@code Class} object; otherwise it returns
@@ -799,9 +803,9 @@ public final class Class<T> implements java.io.Serializable,
      * <p> Specifically, this method tests whether the type represented by the
      * specified {@code Class} parameter can be converted to the type
      * represented by this {@code Class} object via an identity conversion
-     * or via a widening reference conversion. See <cite>The Java Language
-     * Specification</cite>, sections {@jls 5.1.1} and {@jls 5.1.4},
-     * for details.
+     * or via a widening reference conversion or via a primitive widening
+     * conversion. See <cite>The Java Language Specification</cite>,
+     * sections {@jls 5.1.1} and {@jls 5.1.4}, for details.
      *
      * @param     cls the {@code Class} object to be checked
      * @return    the {@code boolean} value indicating whether objects of the

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -4313,7 +4313,9 @@ return mh1;
      * <p> When the returned method handle is invoked,
      * the array reference and array index are checked.
      * A {@code NullPointerException} will be thrown if the array reference
-     * is {@code null} and an {@code ArrayIndexOutOfBoundsException} will be
+     * is {@code null} or if the array's element type is a {@link Class#isValueType()
+     * a primitive value type} and attempts to set {@code null} in the
+     * array element.  An {@code ArrayIndexOutOfBoundsException} will be
      * thrown if the index is negative or if it is greater than or equal to
      * the length of the array.
      *

--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @summary test VarHandle on inline class array
+ * @summary test VarHandle on primitive class array
  * @run testng/othervm -XX:FlatArrayElementMaxSize=-1 ArrayElementVarHandleTest
  * @run testng/othervm -XX:FlatArrayElementMaxSize=0  ArrayElementVarHandleTest
  */
@@ -36,116 +36,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class ArrayElementVarHandleTest {
-    private final Class<?> varHandleArrayType;
-    private final Class<?> componentType;
-    private final VarHandle vh;
-
-    ArrayElementVarHandleTest(Class<?> arrayType) {
-        this.varHandleArrayType = arrayType;
-        this.componentType = arrayType.getComponentType();
-        this.vh = MethodHandles.arrayElementVarHandle(arrayType);
-    }
-
-    Object[] newArray(int size) throws Throwable {
-        MethodHandle ctor = MethodHandles.arrayConstructor(varHandleArrayType);
-        return (Object[]) ctor.invoke(size);
-    }
-
-    void setElements(Object[] array, Object[] elements) {
-        Class<?> arrayType = array.getClass();
-        assertTrue(varHandleArrayType.isAssignableFrom(arrayType));
-        assertTrue(array.length >= elements.length);
-        set(array.clone(), elements);
-        setVolatile(array.clone(), elements);
-        setOpaque(array.clone(), elements);
-        setRelease(array.clone(), elements);
-        getAndSet(array.clone(), elements);
-        compareAndSet(array.clone(), elements);
-        compareAndExchange(array.clone(), elements);
-    }
-
-    // VarHandle::set
-    void set(Object[] array, Object[] elements) {
-        for (int i = 0; i < elements.length; i++) {
-            vh.set(array, i, elements[i]);
-        }
-        for (int i = 0; i < elements.length; i++) {
-            Object v = (Object) vh.get(array, i);
-            assertEquals(v, elements[i]);
-        }
-    }
-
-    // VarHandle::setVolatile
-    void setVolatile(Object[] array, Object[] elements) {
-        for (int i = 0; i < elements.length; i++) {
-            vh.setVolatile(array, i, elements[i]);
-        }
-        for (int i = 0; i < elements.length; i++) {
-            Object v = (Object) vh.getVolatile(array, i);
-            assertEquals(v, elements[i]);
-        }
-    }
-
-    // VarHandle::setOpaque
-    void setOpaque(Object[] array, Object[] elements) {
-        for (int i = 0; i < elements.length; i++) {
-            vh.setOpaque(array, i, elements[i]);
-        }
-        for (int i = 0; i < elements.length; i++) {
-            Object v = (Object) vh.getOpaque(array, i);
-            assertEquals(v, elements[i]);
-        }
-    }
-
-    // VarHandle::setRelease
-    void setRelease(Object[] array, Object[] elements) {
-        for (int i = 0; i < elements.length; i++) {
-            vh.setRelease(array, i, elements[i]);
-        }
-        for (int i = 0; i < elements.length; i++) {
-            Object v = (Object) vh.getAcquire(array, i);
-            assertEquals(v, elements[i]);
-        }
-    }
-
-    void getAndSet(Object[] array, Object[] elements) {
-        for (int i = 0; i < elements.length; i++) {
-            Object o = vh.getAndSet(array, i, elements[i]);
-        }
-        for (int i = 0; i < elements.length; i++) {
-            Object v = (Object) vh.get(array, i);
-            assertEquals(v, elements[i]);
-        }
-    }
-
-    // sanity CAS test
-    // see test/jdk/java/lang/invoke/VarHandles tests
-    void compareAndSet(Object[] array, Object[] elements) {
-        // initialize to some values
-        for (int i = 0; i < elements.length; i++) {
-            vh.set(array, i, elements[i]);
-        }
-        // shift to the right element
-        for (int i = 0; i < elements.length; i++) {
-            Object v = elements[i+1 < elements.length ? i+1 : 0];
-            boolean cas = vh.compareAndSet(array, i, elements[i], v);
-            if (!cas)
-                System.out.format("cas = %s array[%d] = %s vs old = %s new = %s%n", cas, i, array[i], elements[i], v);
-            assertTrue(cas);
-        }
-    }
-    void compareAndExchange(Object[] array, Object[] elements) {
-        // initialize to some values
-        for (int i = 0; i < elements.length; i++) {
-            vh.set(array, i, elements[i]);
-        }
-        // shift to the right element
-        for (int i = 0; i < elements.length; i++) {
-            Object v = elements[i+1 < elements.length ? i+1 : 0];
-            assertEquals(vh.compareAndExchange(array, i, elements[i], v), elements[i]);
-        }
-    }
-
     private static final Point P = Point.makePoint(10, 20);
     private static final Line L = Line.makeLine(10, 20, 30, 40);
     private static final MutablePath PATH = MutablePath.makePath(10, 20, 30, 40);
@@ -157,9 +47,9 @@ public class ArrayElementVarHandleTest {
     };
 
     private static final Point.ref[] NULL_POINTS = new Point.ref[]{
-        Point.makePoint(11, 22),
-                Point.makePoint(110, 220),
-                null
+            Point.makePoint(11, 22),
+            Point.makePoint(110, 220),
+            null
     };
 
     private static final Line[] LINES = new Line[]{
@@ -181,107 +71,202 @@ public class ArrayElementVarHandleTest {
      * VarHandle of Object[].class
      */
     @Test
-    public static void testObjectArrayVarHandle() throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Object[].class);
+    public void testObjectArrayVarHandle() throws Throwable {
         // Point[] <: Point.ref[] <: Object
-        Object[] array1 = test.newArray(POINTS.length);
-        test.setElements(array1, POINTS);
-        test.setElements(array1, NULL_POINTS);
-        test.setElements(array1, new Object[] { "abc", Point.makePoint(1, 2) });
+        Object[] array1 = newArray(Object[].class, POINTS.length);
+        setElements(array1, POINTS);
+        setElements(array1, NULL_POINTS);
+        setElements(array1, new Object[] { "abc", Point.makePoint(1, 2) });
 
-        Point.ref []array2 = new Point.ref [NULL_POINTS.length];
-        test.setElements(array2, POINTS);
-        test.setElements(array2, NULL_POINTS);
+        Point.ref[] array2 = new Point.ref[NULL_POINTS.length];
+        setElements(array2, POINTS);
+        setElements(array2, NULL_POINTS);
 
         Point[] array3 = new Point[POINTS.length];
-        test.setElements(array3, POINTS);
+        setElements(array3, POINTS);
     }
 
     /*
      * VarHandle of Point.ref[].class
      */
     @Test
-    public static void testPointRefVarHandle() throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Point.ref[].class);
-        assertTrue(test.componentType == Point.ref.class);
-
+    public void testPointRefVarHandle() throws Throwable {
         // Point[] <: Point.ref[] <: Object
-        Point.ref[] array1 = (Point.ref[])test.newArray(POINTS.length);
-        test.setElements(array1, POINTS);
-        test.setElements(array1, NULL_POINTS);
+        Point.ref[] array1 = (Point.ref[])newArray(Point.ref[].class, POINTS.length);
+        assertTrue(array1.getClass().componentType() == Point.ref.class);
+
+        setElements(array1, POINTS);
+        setElements(array1, NULL_POINTS);
 
         Point.ref[] array2 = new Point.ref[NULL_POINTS.length];
-        test.setElements(array2, POINTS);
-        test.setElements(array2, NULL_POINTS);
+        setElements(array2, POINTS);
+        setElements(array2, NULL_POINTS);
 
         Point[] array3 = new Point[POINTS.length];
-        test.setElements(array3, POINTS);
+        setElements(array3, POINTS);
     }
 
     /*
      * VarHandle of Point[].class
      */
     @Test
-    public static void testPointArrayVarHandle()  throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Point[].class);
-        assertTrue(test.componentType == Point.class);
-
+    public void testPointArrayVarHandle()  throws Throwable {
         // Point[] <: Point.ref[] <: Object
-        Point[] array1 = (Point[]) test.newArray(POINTS.length);
-        test.setElements(array1, POINTS);
+        Point[] array1 = (Point[]) newArray(Point[].class, POINTS.length);
+        assertTrue(array1.getClass().componentType() == Point.class);
+        setElements(array1, POINTS);
 
         Point[] array3 = new Point[POINTS.length];
-        test.setElements(array3, POINTS);
+        setElements(array3, POINTS);
     }
 
     /*
      * VarHandle of Line.ref[].class
      */
     @Test
-    public static void testLineRefVarHandle() throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Line.ref[].class);
-        assertTrue(test.componentType == Line.ref.class);
-
+    public void testLineRefVarHandle() throws Throwable {
         // Line[] <: Line.ref[]
-        Line.ref[] array1 = (Line.ref[])test.newArray(LINES.length);
-        test.setElements(array1, LINES);
-        test.setElements(array1, NULL_LINES);
+        Line.ref[] array1 = (Line.ref[])newArray(Line.ref[].class, LINES.length);
+        assertTrue(array1.getClass().componentType() == Line.ref.class);
+
+        setElements(array1, LINES);
+        setElements(array1, NULL_LINES);
 
         Line.ref[] array2 = new Line.ref[LINES.length];
-        test.setElements(array2, LINES);
-        test.setElements(array2, NULL_LINES);
+        setElements(array2, LINES);
+        setElements(array2, NULL_LINES);
 
         Line[] array3 = new Line[LINES.length];
-        test.setElements(array3, LINES);
+        setElements(array3, LINES);
     }
 
     /*
      * VarHandle of Line[].class
      */
     @Test
-    public static void testLineVarHandle() throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(Line[].class);
-        assertTrue(test.componentType == Line.class);
-
-        Line[] array1 = (Line[]) test.newArray(LINES.length);
-        test.setElements(array1, LINES);
+    public void testLineVarHandle() throws Throwable {
+        Line[] array1 = (Line[])newArray(Line[].class, LINES.length);
+        assertTrue(array1.getClass().componentType() == Line.class);
+        setElements(array1, LINES);
 
         Line[] array3 = new Line[LINES.length];
-        test.setElements(array3, LINES);
+        setElements(array3, LINES);
     }
 
     /*
      * VarHandle of NonFlattenValue[].class
      */
     @Test
-    public static void testNonFlattenedValueVarHandle() throws Throwable {
-        ArrayElementVarHandleTest test = new ArrayElementVarHandleTest(NonFlattenValue[].class);
-        assertTrue(test.componentType == NonFlattenValue.class);
-
-        NonFlattenValue[] array1 = (NonFlattenValue[]) test.newArray(NFV_ARRAY.length);
-        test.setElements(array1, NFV_ARRAY);
+    public void testNonFlattenedValueVarHandle() throws Throwable {
+        NonFlattenValue[] array1 = (NonFlattenValue[])newArray(NonFlattenValue[].class, NFV_ARRAY.length);
+        assertTrue(array1.getClass().componentType() == NonFlattenValue.class);
+        setElements(array1, NFV_ARRAY);
 
         NonFlattenValue[] array3 = new NonFlattenValue[POINTS.length];
-        test.setElements(array3, NFV_ARRAY);
+        setElements(array3, NFV_ARRAY);
     }
+
+    Object[] newArray(Class<?> arrayType, int size) throws Throwable {
+        MethodHandle ctor = MethodHandles.arrayConstructor(arrayType);
+        return (Object[]) ctor.invoke(size);
+    }
+
+    void setElements(Object[] array, Object[] elements) {
+        Class<?> arrayType = array.getClass();
+        assertTrue(array.length >= elements.length);
+
+        VarHandle vh = MethodHandles.arrayElementVarHandle(arrayType);
+        set(vh, array.clone(), elements);
+        setVolatile(vh, array.clone(), elements);
+        setOpaque(vh, array.clone(), elements);
+        setRelease(vh, array.clone(), elements);
+        getAndSet(vh, array.clone(), elements);
+        compareAndSet(vh, array.clone(), elements);
+        compareAndExchange(vh, array.clone(), elements);
+    }
+
+    // VarHandle::set
+    void set(VarHandle vh, Object[] array, Object[] elements) {
+        for (int i = 0; i < elements.length; i++) {
+            vh.set(array, i, elements[i]);
+        }
+        for (int i = 0; i < elements.length; i++) {
+            Object v = (Object) vh.get(array, i);
+            assertEquals(v, elements[i]);
+        }
+    }
+
+    // VarHandle::setVolatile
+    void setVolatile(VarHandle vh, Object[] array, Object[] elements) {
+        for (int i = 0; i < elements.length; i++) {
+            vh.setVolatile(array, i, elements[i]);
+        }
+        for (int i = 0; i < elements.length; i++) {
+            Object v = (Object) vh.getVolatile(array, i);
+            assertEquals(v, elements[i]);
+        }
+    }
+
+    // VarHandle::setOpaque
+    void setOpaque(VarHandle vh, Object[] array, Object[] elements) {
+        for (int i = 0; i < elements.length; i++) {
+            vh.setOpaque(array, i, elements[i]);
+        }
+        for (int i = 0; i < elements.length; i++) {
+            Object v = (Object) vh.getOpaque(array, i);
+            assertEquals(v, elements[i]);
+        }
+    }
+
+    // VarHandle::setRelease
+    void setRelease(VarHandle vh, Object[] array, Object[] elements) {
+        for (int i = 0; i < elements.length; i++) {
+            vh.setRelease(array, i, elements[i]);
+        }
+        for (int i = 0; i < elements.length; i++) {
+            Object v = (Object) vh.getAcquire(array, i);
+            assertEquals(v, elements[i]);
+        }
+    }
+
+    void getAndSet(VarHandle vh, Object[] array, Object[] elements) {
+        for (int i = 0; i < elements.length; i++) {
+            Object o = vh.getAndSet(array, i, elements[i]);
+        }
+        for (int i = 0; i < elements.length; i++) {
+            Object v = (Object) vh.get(array, i);
+            assertEquals(v, elements[i]);
+        }
+    }
+
+    // sanity CAS test
+    // see test/jdk/java/lang/invoke/VarHandles tests
+    void compareAndSet(VarHandle vh, Object[] array, Object[] elements) {
+        // initialize to some values
+        for (int i = 0; i < elements.length; i++) {
+            vh.set(array, i, elements[i]);
+        }
+        // shift to the right element
+        for (int i = 0; i < elements.length; i++) {
+            Object v = elements[i + 1 < elements.length ? i + 1 : 0];
+            boolean cas = vh.compareAndSet(array, i, elements[i], v);
+            if (!cas)
+                System.out.format("cas = %s array[%d] = %s vs old = %s new = %s%n", cas, i, array[i], elements[i], v);
+            assertTrue(cas);
+        }
+    }
+
+    void compareAndExchange(VarHandle vh, Object[] array, Object[] elements) {
+        // initialize to some values
+        for (int i = 0; i < elements.length; i++) {
+            vh.set(array, i, elements[i]);
+        }
+        // shift to the right element
+        for (int i = 0; i < elements.length; i++) {
+            Object v = elements[i + 1 < elements.length ? i + 1 : 0];
+            assertEquals(vh.compareAndExchange(array, i, elements[i], v), elements[i]);
+        }
+    }
+
+
 }

--- a/test/jdk/valhalla/valuetypes/LambdaConversion.java
+++ b/test/jdk/valhalla/valuetypes/LambdaConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,9 @@
 /*
  * @test
  * @run testng/othervm LambdaConversion
- * @summary test lambda type conversion of inline type
+ * @summary test lambda type conversion of primitive class
  */
 
-import java.util.List;
 import java.util.function.ToIntFunction;
 import java.util.stream.Stream;
 

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @summary test MethodHandle/VarHandle on inline types
+ * @summary test MethodHandle/VarHandle o primitive classes
  * @run testng/othervm MethodHandleTest
  */
 
@@ -33,78 +33,106 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class MethodHandleTest {
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     private static final Point P = Point.makePoint(10, 20);
     private static final Line L = Line.makeLine(10, 20, 30, 40);
     private static final MutablePath PATH = MutablePath.makePath(10, 20, 30, 40);
 
-    @Test
-    public static void testPointClass() throws Throwable  {
-        MethodHandleTest test = new MethodHandleTest("Point", P, "x", "y");
-        test.run();
+    @DataProvider(name="fields")
+    static Object[][] fields() {
+        MutablePath path = MutablePath.makePath(1, 2, 3, 4);
+        MixedValues mv = new MixedValues(P, L, PATH, "mixed", "types");
+        return new Object[][]{
+                // primitive class with int fields
+                new Object[] { "Point", P, new String[] { "x", "y"} },
+                // primitive class whose fields are of primitive value type
+                new Object[] { "Line", L, new String[] { "p1", "p2"} },
+                // non-primitive class whose non-final fields are of primitive value type
+                new Object[] { "MutablePath", PATH, new String[] {"p1", "p2"} },
+                new Object[] { "Point", path.p1, new String[] {"x", "y"} },
+                new Object[] { "Point", path.p2, new String[] {"x", "y"} },
+                new Object[] { "MixedValues", mv, new String[] {"p", "l", "mutablePath", "list", "nfp"} },
+        };
+    }
+
+    /**
+     * Test MethodHandle invocation on the fields of a given class.
+     * MethodHandle produced by Lookup::unreflectGetter, Lookup::findGetter,
+     * Lookup::findVarHandle.
+     */
+    @Test(dataProvider = "fields")
+    public void testFieldGetterAndSetter(String cn, Object o, String[] fieldNames) throws Throwable  {
+        Class<?> c = Class.forName(cn);
+        for (String name : fieldNames) {
+            Field f = c.getDeclaredField(name);
+
+            MethodHandle mh = LOOKUP.findGetter(c, f.getName(), f.getType());
+            Object v1 = mh.invoke(o);
+
+            VarHandle vh = LOOKUP.findVarHandle(c, f.getName(), f.getType());
+            Object v2 = vh.get(o);
+
+            MethodHandle mh3 = LOOKUP.unreflectGetter(f);
+            Object v3 = mh.invoke(o);
+
+            if (c.isPrimitiveClass())
+                ensureImmutable(f, o);
+            else
+                ensureNullable(f, o);
+        }
     }
 
     @Test
-    public static void testLineClass() throws Throwable {
-        MethodHandleTest test = new MethodHandleTest("Line", L, "p1", "p2");
-        test.run();
-    }
-
-    @Test
-    public static void testMutablePath() throws Throwable {
-        MethodHandleTest test = new MethodHandleTest("MutablePath", PATH, "p1", "p2");
-        test.run();
-
-        // set the mutable fields
+    public void testValueFields() throws Throwable {
+        // set the mutable value fields
         MutablePath path = MutablePath.makePath(1, 2, 3, 44);
         Point p = Point.makePoint(100, 200);
-        test.setValueField("p1", path, p);
-        test.setValueField("p2", path, p);
+        setValueField(MutablePath.class, "p1", path, p);
+        setValueField(MutablePath.class, "p2", path, p);
     }
 
+    // Test writing to a field of primitive value type and of primitive
+    // reference type
     @Test
-    public static void testValueFields() throws Throwable {
-        MutablePath path = MutablePath.makePath(1, 2, 3, 4);
-        // p1 and p2 are a non-final field of inline type in a reference
-        MethodHandleTest test1 = new MethodHandleTest("Point", path.p1, "x", "y");
-        test1.run();
-
-        MethodHandleTest test2 = new MethodHandleTest("Point", path.p2, "x", "y");
-        test2.run();
-    }
-
-    @Test
-    public static void testMixedValues() throws Throwable {
+    public void testMixedValues() throws Throwable {
+        // set the mutable fields
+        MutablePath path = MutablePath.makePath(1, 2, 3, 44);
         MixedValues mv = new MixedValues(P, L, PATH, "mixed", "types");
-        MethodHandleTest test =
-            new MethodHandleTest("MixedValues", mv, "p", "l", "mutablePath", "list", "nfp");
-        test.run();
-
         Point p = Point.makePoint(100, 200);
         Line l = Line.makeLine(100, 200, 300, 400);
-        test.setValueField("p", mv, p);
-        test.setValueField("l", mv, l);
-        test.setValueField("staticPoint", null, p);
+
+        setValueField(MutablePath.class, "p1", path, p);
+        setValueField(MutablePath.class, "p2", path, p);
+        setValueField(MixedValues.class, "p", mv, p);
+        setValueField(MixedValues.class, "l", mv, l);
+        setValueField(MixedValues.class, "staticPoint", null, p);
         // the following are nullable fields
-        test.setField("nfp", mv, p, false);
-        test.setField("staticLine", null, l, false);
-        test.setField("staticLine", null, null, false);
+        setField(MixedValues.class, "nfp", mv, p, false);
+        setField(MixedValues.class, "staticLine", null, l, false);
+        setField(MixedValues.class, "staticLine", null, null, false);
     }
 
-    @Test
-    public static void testArrayElementSetterAndGetter() throws Throwable {
-        testArray(Point[].class, P);
-        testArray(Line[].class, L);
-        testArray(MutablePath[].class, PATH);
+    @DataProvider(name="arrays")
+    static Object[][] arrays() {
+        return new Object[][]{
+                new Object[] { Point[].class, P },
+                new Object[] { Point.ref[].class, P },
+                new Object[] { Line[].class, L },
+                new Object[] { MutablePath[].class, PATH },
+        };
     }
 
-    static void testArray(Class<?> c, Object o) throws Throwable {
-        MethodHandle setter = MethodHandles.arrayElementSetter(c);
-        MethodHandle getter = MethodHandles.arrayElementGetter(c);
-        MethodHandle ctor = MethodHandles.arrayConstructor(c);
+    @Test(dataProvider = "arrays")
+    public void testArrayElementSetterAndGetter(Class<?> arrayClass, Object o) throws Throwable {
+        Class<?> elementType = arrayClass.getComponentType();
+        MethodHandle setter = MethodHandles.arrayElementSetter(arrayClass);
+        MethodHandle getter = MethodHandles.arrayElementGetter(arrayClass);
+        MethodHandle ctor = MethodHandles.arrayConstructor(arrayClass);
         int size = 5;
         Object[] array = (Object[])ctor.invoke(size);
         for (int i=0; i < size; i++) {
@@ -114,86 +142,91 @@ public class MethodHandleTest {
             Object v = (Object)getter.invoke(array, i);
             assertEquals(v, o);
         }
-
-        Class<?> elementType = c.getComponentType();
-        if (elementType.isPrimitiveClass()) {
-            assertTrue(elementType == elementType.asValueType());
-        }
         // set an array element to null
         try {
-            Object v = (Object)setter.invoke(array, 0, null);
-            assertFalse(elementType.isPrimitiveClass(), "should fail to set an inline class array element to null");
+            Object v = (Object)setter.invoke(array, 1, null);
+            assertFalse(elementType.isValueType(), "should fail to set a primitive class array element to null");
+            assertNull((Object)getter.invoke(array, 1));
         } catch (NullPointerException e) {
-            assertTrue(elementType.isPrimitiveClass(), "should only fail to set an inline class array element to null");
+            assertTrue(elementType.isValueType(), "should only fail to set a primitive class array element to null");
         }
-    }
-
-    @Test
-    public static void testNullableArray() throws Throwable {
-        Class<?> arrayClass = (new Point.ref[0]).getClass();
-        Class<?> elementType = arrayClass.getComponentType();
-        assertTrue(elementType == Point.ref.class, arrayClass.getComponentType().toString());
-
-        MethodHandle setter = MethodHandles.arrayElementSetter(arrayClass);
-        MethodHandle getter = MethodHandles.arrayElementGetter(arrayClass);
-        MethodHandle ctor = MethodHandles.arrayConstructor(arrayClass);
-        Object[] array = (Object[]) ctor.invoke(2);
-        setter.invoke(array, 0, P);
-        setter.invoke(array, 1, null);
-        assertEquals((Point)getter.invoke(array, 0), P);
-        assertNull((Object)getter.invoke(array, 1));
-    }
-
-    private final Class<?> c;
-    private final Object o;
-    private final List<String> names;
-    public MethodHandleTest(String cn, Object o, String... fields) throws Exception {
-        this.c = Class.forName(cn);
-        this.o = o;
-        this.names = List.of(fields);
-    }
-
-    public void run() throws Throwable {
-        for (String name : names) {
-            Field f = c.getDeclaredField(name);
-            unreflectField(f);
-            findGetter(f);
-            varHandle(f);
-            if (c.isPrimitiveClass())
-                ensureImmutable(f);
-            else
-                ensureNullable(f);
-        }
-    }
-
-    public List<String> names() {
-        return names;
-    }
-
-    void findGetter(Field f) throws Throwable {
-        MethodHandle mh = MethodHandles.lookup().findGetter(c, f.getName(), f.getType());
-        Object value = mh.invoke(o);
-    }
-
-    void varHandle(Field f) throws Throwable {
-        VarHandle vh = MethodHandles.lookup().findVarHandle(c, f.getName(), f.getType());
-        Object value = vh.get(o);
-    }
-
-    void unreflectField(Field f) throws Throwable {
-        MethodHandle mh = MethodHandles.lookup().unreflectGetter(f);
-        Object value = mh.invoke(o);
     }
 
     /*
-     * Test setting a field of an inline type to a new value.
-     * The field must be flattenable but may or may not be flattened.
+     * Test setting the given field to null via reflection, method handle
+     * and var handle.
      */
-    void setValueField(String name, Object obj, Object value) throws Throwable {
-        setField(name, obj, value, true);
+    static void ensureNullable(Field f, Object o) throws Throwable {
+        Class<?> c = f.getDeclaringClass();
+        assertFalse(Modifier.isFinal(f.getModifiers()));
+        assertFalse(Modifier.isStatic(f.getModifiers()));
+        boolean canBeNull = f.getType().isPrimaryType();
+        // test reflection
+        try {
+            f.set(o, null);
+            assertTrue(canBeNull, f + " cannot be set to null");
+        } catch (NullPointerException e) {
+            assertFalse(canBeNull, f + " should allow be set to null");
+        }
+        // test method handle, i.e. putfield bytecode behavior
+        try {
+            MethodHandle mh = LOOKUP.findSetter(c, f.getName(), f.getType());
+            mh.invoke(o, null);
+            assertTrue(canBeNull, f + " cannot be set to null");
+        } catch (NullPointerException e) {
+            assertFalse(canBeNull, f + " should allow be set to null");
+        }
+        // test var handle
+        try {
+            VarHandle vh = LOOKUP.findVarHandle(c, f.getName(), f.getType());
+            vh.set(o, null);
+            assertTrue(canBeNull, f + " cannot be set to null");
+        } catch (NullPointerException e) {
+            assertFalse(canBeNull, f + " should allow be set to null");
+        }
     }
 
-    void setField(String name, Object obj, Object value, boolean isValue) throws Throwable {
+    static void ensureImmutable(Field f, Object o) throws Throwable {
+        Class<?> c = f.getDeclaringClass();
+        assertTrue(Modifier.isFinal(f.getModifiers()));
+        assertFalse(Modifier.isStatic(f.getModifiers()));
+        Object v = f.get(o);
+        // test Field::set
+        try {
+            f.set(o, v);
+            throw new RuntimeException(f + " should be immutable");
+        } catch (IllegalAccessException e) {
+        }
+
+        // test method handle, i.e. putfield bytecode behavior
+        try {
+            MethodHandle mh = LOOKUP.findSetter(c, f.getName(), f.getType());
+            mh.invoke(o, v);
+            throw new RuntimeException(f + " should be immutable");
+        } catch (IllegalAccessException e) {
+        }
+        // test var handle
+        try {
+            VarHandle vh = LOOKUP.findVarHandle(c, f.getName(), f.getType());
+            vh.set(o, v);
+            throw new RuntimeException(f + " should be immutable");
+        } catch (UnsupportedOperationException e) {
+        }
+    }
+
+    /*
+     * Test setting a field of a primitive class to a new value.
+     * The field must be flattenable but may or may not be flattened.
+     */
+    static void setValueField(Class<?> c, String name, Object obj, Object value) throws Throwable {
+        setField(c, name, obj, value, true);
+    }
+
+    /*
+     * Test Field::set, MethodHandle::set on a method handle of a field
+     * and VarHandle::compareAndSet and compareAndExchange.
+     */
+    static void setField(Class<?> c, String name, Object obj, Object value, boolean isValue) throws Throwable {
         Field f = c.getDeclaredField(name);
         boolean isStatic = Modifier.isStatic(f.getModifiers());
         assertTrue(f.getType().isPrimitiveClass());
@@ -209,7 +242,6 @@ public class MethodHandleTest {
             f.set(obj, v);
         }
 
-
         if (isStatic) {
             setStaticField(f, value);
         } else {
@@ -217,11 +249,11 @@ public class MethodHandleTest {
         }
     }
 
-    private void setInstanceField(Field f, Object obj, Object value) throws Throwable {
+    static void setInstanceField(Field f, Object obj, Object value) throws Throwable {
         Object v = f.get(obj);
         // MethodHandle::invoke
         try {
-            MethodHandle mh = MethodHandles.lookup().findSetter(c, f.getName(), f.getType());
+            MethodHandle mh = LOOKUP.findSetter(f.getDeclaringClass(), f.getName(), f.getType());
             mh.invoke(obj, value);
             assertEquals(f.get(obj), value);
         } finally {
@@ -229,7 +261,7 @@ public class MethodHandleTest {
         }
 
         // VarHandle tests
-        VarHandle vh = MethodHandles.lookup().findVarHandle(c, f.getName(), f.getType());
+        VarHandle vh = LOOKUP.findVarHandle(f.getDeclaringClass(), f.getName(), f.getType());
         try {
             vh.set(obj, value);
             assertEquals(f.get(obj), value);
@@ -252,18 +284,18 @@ public class MethodHandleTest {
         }
     }
 
-    private void setStaticField(Field f, Object value) throws Throwable {
+    static void setStaticField(Field f, Object value) throws Throwable {
         Object v = f.get(null);
         // MethodHandle::invoke
         try {
-            MethodHandle mh = MethodHandles.lookup().findStaticSetter(c, f.getName(), f.getType());
+            MethodHandle mh = LOOKUP.findStaticSetter(f.getDeclaringClass(), f.getName(), f.getType());
             mh.invoke(f.getType().cast(value));
             assertEquals(f.get(null), value);
         } finally {
             f.set(null, v);
         }
         // VarHandle tests
-        VarHandle vh = MethodHandles.lookup().findStaticVarHandle(c, f.getName(), f.getType());
+        VarHandle vh = LOOKUP.findStaticVarHandle(f.getDeclaringClass(), f.getName(), f.getType());
         try {
             vh.set(f.getType().cast(value));
             assertEquals(f.get(null), value);
@@ -284,64 +316,5 @@ public class MethodHandleTest {
         } finally {
             f.set(null, v);
         }
-    }
-
-    /*
-     * Test setting the given field to null via reflection, method handle
-     * and var handle.
-     */
-    void ensureNullable(Field f) throws Throwable {
-        assertFalse(Modifier.isStatic(f.getModifiers()));
-        boolean canBeNull = f.getType().isPrimaryType();
-        // test reflection
-        try {
-            f.set(o, null);
-            assertTrue(canBeNull, f + " cannot be set to null");
-        } catch (NullPointerException e) {
-            assertFalse(canBeNull, f + " should allow be set to null");
-        }
-        // test method handle, i.e. putfield bytecode behavior
-        try {
-            MethodHandle mh = MethodHandles.lookup().findSetter(c, f.getName(), f.getType());
-            mh.invoke(o, null);
-            assertTrue(canBeNull, f + " cannot be set to null");
-        } catch (NullPointerException e) {
-            assertFalse(canBeNull, f + " should allow be set to null");
-        }
-        // test var handle
-        try {
-            VarHandle vh = MethodHandles.lookup().findVarHandle(c, f.getName(), f.getType());
-            vh.set(o, null);
-            assertTrue(canBeNull, f + " cannot be set to null");
-        } catch (NullPointerException e) {
-            assertFalse(canBeNull, f + " should allow be set to null");
-        }
-    }
-
-    void ensureImmutable(Field f) throws Throwable {
-        assertFalse(Modifier.isStatic(f.getModifiers()));
-        Object v = f.get(o);
-        // test reflection
-        try {
-            f.set(o, v);
-            throw new RuntimeException(f + " should be immutable");
-        } catch (IllegalAccessException e) {}
-
-        // test method handle, i.e. putfield bytecode behavior
-        try {
-            MethodHandle mh = MethodHandles.lookup().findSetter(c, f.getName(), f.getType());
-            mh.invoke(o, v);
-            throw new RuntimeException(f + " should be immutable");
-        } catch (IllegalAccessException e) { }
-        // test var handle
-        try {
-            VarHandle vh = MethodHandles.lookup().findVarHandle(c, f.getName(), f.getType());
-            vh.set(o, v);
-            throw new RuntimeException(f + " should be immutable");
-        } catch (UnsupportedOperationException e) {}
-    }
-
-    boolean isFlattened(Field f) {
-        return (f.getModifiers() & 0x00008000) == 0x00008000;
     }
 }

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @summary test Object methods on inline types
+ * @summary test Object methods on primitive classes
  * @run testng/othervm -Xint -Dvalue.bsm.salt=1 ObjectMethods
  * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
  */
@@ -88,7 +88,7 @@ public class ObjectMethods {
                               .setNumber(Value.Number.intValue(10)).build(), true},
             { new Value.Builder().setNumber(new Value.IntNumber(10)).build(),
               new Value.Builder().setNumber(new Value.IntNumber(10)).build(), false},
-            // reference classes containing fields of inline type
+            // reference classes containing fields of primitive class
             { MUTABLE_PATH, MutablePath.makePath(10, 20, 30, 40), false},
             { MIXED_VALUES, MIXED_VALUES, true},
             { MIXED_VALUES, new MixedValues(P1, LINE1, MUTABLE_PATH, "value"), false},
@@ -96,13 +96,13 @@ public class ObjectMethods {
             { MyValue1.default, MyValue1.default, true},
             { MyValue1.default, new MyValue1(0,0, null), true},
             { new MyValue1(10, 20, P1), new MyValue1(10, 20, Point.makePoint(1,2)), true},
-            { new IndirectType0(10), new IndirectType0(10), true},
-            { new InlineType1(10),   new InlineType1(10), true},
-            { new InlineType2(10),   new InlineType2(10), true},
-            { new InlineType1(20),   new InlineType2(20), false},
-            { new InlineType2(20),   new InlineType1(20), true},
-            { new IndirectType0(30), new InlineType1(30), true},
-            { new IndirectType0(30), new InlineType2(30), true},
+            { new ReferenceType0(10), new ReferenceType0(10), true},
+            { new ValueType1(10),   new ValueType1(10), true},
+            { new ValueType2(10),   new ValueType2(10), true},
+            { new ValueType1(20),   new ValueType2(20), false},
+            { new ValueType2(20),   new ValueType1(20), true},
+            { new ReferenceType0(30), new ValueType1(30), true},
+            { new ReferenceType0(30), new ValueType2(30), true},
         };
     }
 
@@ -114,13 +114,13 @@ public class ObjectMethods {
     @DataProvider(name="interfaceEqualsTests")
     Object[][] interfaceEqualsTests() {
         return new Object[][]{
-                { new IndirectType0(10), new IndirectType0(10), false, true},
-                { new InlineType1(10),   new InlineType1(10),   true,  true},
-                { new InlineType2(10),   new InlineType2(10),   true,  true},
-                { new InlineType1(20),   new InlineType2(20),   false, false},
-                { new InlineType2(20),   new InlineType1(20),   false, true},
-                { new IndirectType0(30), new InlineType1(30),   false, true},
-                { new IndirectType0(30), new InlineType2(30),   false, true},
+                { new ReferenceType0(10), new ReferenceType0(10), false, true},
+                { new ValueType1(10),   new ValueType1(10),   true,  true},
+                { new ValueType2(10),   new ValueType2(10),   true,  true},
+                { new ValueType1(20),   new ValueType2(20),   false, false},
+                { new ValueType2(20),   new ValueType1(20),   false, true},
+                { new ReferenceType0(30), new ValueType1(30),   false, true},
+                { new ReferenceType0(30), new ValueType2(30),   false, true},
         };
     }
 
@@ -217,9 +217,9 @@ public class ObjectMethods {
         int value();
     }
 
-    static class IndirectType0 implements Number {
+    static class ReferenceType0 implements Number {
         int i;
-        public IndirectType0(int i) {
+        public ReferenceType0(int i) {
             this.i = i;
         }
         public int value() {
@@ -234,9 +234,9 @@ public class ObjectMethods {
         }
     }
 
-    static primitive class InlineType1 implements Number {
+    static primitive class ValueType1 implements Number {
         int i;
-        public InlineType1(int i) {
+        public ValueType1(int i) {
             this.i = i;
         }
         public int value() {
@@ -244,9 +244,9 @@ public class ObjectMethods {
         }
     }
 
-    static primitive class InlineType2 implements Number {
+    static primitive class ValueType2 implements Number {
         int i;
-        public InlineType2(int i) {
+        public ValueType2(int i) {
             this.i = i;
         }
         public int value() {

--- a/test/jdk/valhalla/valuetypes/PrimitiveTypeConversionTest.java
+++ b/test/jdk/valhalla/valuetypes/PrimitiveTypeConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
 
 /*
  * @test
- * @summary test method handles with inline type conversion
- * @run testng/othervm InlineTypeConversionTest
+ * @summary test method handles with primitive narrowing/widening conversion
+ * @run testng/othervm PrimitiveTypeConversionTest
  */
 
 import java.lang.invoke.*;
@@ -35,7 +35,7 @@ import static java.lang.invoke.MethodType.*;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-public class InlineTypeConversionTest {
+public class PrimitiveTypeConversionTest {
     static primitive class Value {
         Point val;
         Point.ref ref;
@@ -59,9 +59,9 @@ public class InlineTypeConversionTest {
     static final Value VALUE = new Value(new Point(10,10), new Point(20, 20));
 
     @Test
-    public static void inlineWidening() throws Throwable {
+    public static void primitiveWidening() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh1 = lookup.findStatic(InlineTypeConversionTest.class, "narrow", methodType(Value.class, Value.ref.class));
+        MethodHandle mh1 = lookup.findStatic(PrimitiveTypeConversionTest.class, "narrow", methodType(Value.class, Value.ref.class));
         MethodHandle mh2 = mh1.asType(methodType(Value.class, Value.class));
         Object v = mh1.invoke(VALUE);
         assertEquals(v, VALUE);
@@ -77,9 +77,9 @@ public class InlineTypeConversionTest {
     }
 
     @Test
-    public static void inlineNarrowing() throws Throwable {
+    public static void primitiveNarrowing() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh = lookup.findStatic(InlineTypeConversionTest.class, "widen", methodType(Value.ref.class, Value.class));
+        MethodHandle mh = lookup.findStatic(PrimitiveTypeConversionTest.class, "widen", methodType(Value.ref.class, Value.class));
         Object v = mh.invoke(VALUE);
         assertTrue(v == null);
         try {

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class QTypeDescriptorTest {
     static final NonFlattenValue NFV = NonFlattenValue.make(30, 40);
 
     @Test
-    public static void testLambda() {
+    public void testLambda() {
         newArray(Point[]::new, 2);
         newArray(Point[][]::new, 1);
 
@@ -58,7 +58,7 @@ public class QTypeDescriptorTest {
     }
 
     @Test
-    public static void testMethodInvoke() throws Exception {
+    public void testMethodInvoke() throws Exception {
         Class<?> pointQType = Point.class;
         Class<?> nonFlattenValueQType = NonFlattenValue.class;
         Method m = QTypeDescriptorTest.class
@@ -77,8 +77,8 @@ public class QTypeDescriptorTest {
     }
 
     @Test
-    public static void testStaticMethod() throws Throwable {
-        // static method in an inline type with no parameter and void return type
+    public void testStaticMethod() throws Throwable {
+        // static method in a primitive class with no parameter and void return type
         Runnable r = () -> ValueTest.run();
         r.run();
 
@@ -96,7 +96,7 @@ public class QTypeDescriptorTest {
     }
 
     @Test
-    public static void testConstructor() throws Exception {
+    public void testConstructor() throws Exception {
         Constructor<T> ctor = T.class.getDeclaredConstructor(Point[].class);
         Point[] points = new Point[] { P0, P1 };
         T test = (T) ctor.newInstance((Object)points);
@@ -105,7 +105,7 @@ public class QTypeDescriptorTest {
     }
 
     @Test
-    public static void testProxy() throws Exception {
+    public void testProxy() throws Exception {
         InvocationHandler handler = new InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
@@ -137,7 +137,7 @@ public class QTypeDescriptorTest {
     }
 
     @Test(dataProvider = "descriptors")
-    public static void testDescriptors(Class<?> defc, String name, Class<?>[] params, boolean found) throws Exception {
+    public void testDescriptors(Class<?> defc, String name, Class<?>[] params, boolean found) throws Exception {
         try {
             defc.getDeclaredMethod(name, params);
             if (!found) throw new AssertionError("Expected NoSuchMethodException");
@@ -166,7 +166,7 @@ public class QTypeDescriptorTest {
     }
 
     @Test(dataProvider = "methodTypes")
-    public static void methodHandleLookup(String name, MethodType mtype, boolean found) throws Throwable {
+    public void methodHandleLookup(String name, MethodType mtype, boolean found) throws Throwable {
         try {
             MethodHandles.lookup().findVirtual(NonFlattenValue.class, name, mtype);
             if (!found) throw new AssertionError("Expected NoSuchMethodException");

--- a/test/jdk/valhalla/valuetypes/Serialization.java
+++ b/test/jdk/valhalla/valuetypes/Serialization.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary No Serialization support of inline value classes, without a proxy
+ * @summary No Serialization support of primitive classes, without a proxy
  * @build Point Line NonFlattenValue Serialization
  * @run testng/othervm Serialization
  */
@@ -71,7 +71,7 @@ public class Serialization {
         };
     }
 
-    // inline class that DOES NOT implement Serializable should throw NSE
+    // primitive class that DOES NOT implement Serializable should throw NSE
     @Test(dataProvider = "doesNotImplementSerializable")
     public void doesNotImplementSerializable(Object obj) {
         assertThrows(NSE, () -> serialize(obj));
@@ -123,7 +123,7 @@ public class Serialization {
         };
     }
 
-    // inline class that DOES implement Serializable should throw NSE
+    // primitive class that DOES implement Serializable should throw NSE
     @Test(dataProvider = "doesImplementSerializable")
     public void doesImplementSerializable(Object obj) {
         assertThrows(NSE, () -> serialize(obj));
@@ -175,7 +175,7 @@ public class Serialization {
         @Override public void writeExternal(ObjectOutput out) {  }
     }
 
-    // inline classes that DO implement Serializable, but have a serial proxy
+    // primitive classes that DO implement Serializable, but have a serial proxy
     @Test
     public void serializableFooWithProxy() throws Exception {
         SerializableFoo foo = SerializableFoo.make(45);
@@ -234,8 +234,8 @@ public class Serialization {
         return byteStreamFor(className, uid, SC_EXTERNALIZABLE);
     }
 
-    @DataProvider(name = "inlineClasses")
-    public Object[][] inlineClasses() {
+    @DataProvider(name = "classes")
+    public Object[][] classes() {
         return new Object[][] {
             new Object[] { Point.class             },
             new Object[] { SerializablePoint.class }
@@ -244,8 +244,8 @@ public class Serialization {
 
     static final Class<InvalidClassException> ICE = InvalidClassException.class;
 
-    // inline class read directly from a byte stream
-    @Test(dataProvider = "inlineClasses")
+    // primitive class read directly from a byte stream
+    @Test(dataProvider = "classes")
     public void deserialize(Class<?> cls) throws Exception {
         var clsDesc = ObjectStreamClass.lookup(cls);
         long uid = clsDesc == null ? 0L : clsDesc.getSerialVersionUID();

--- a/test/jdk/valhalla/valuetypes/StaticFactoryMethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryMethodHandleTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary test MethodHandle of static init factories
- * @run main/othervm StaticInitFactoryTest
+ * @run main/othervm StaticFactoryMethodHandleTest
  */
 
 import java.lang.invoke.MethodHandle;
@@ -37,7 +37,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
-public class StaticInitFactoryTest {
+public class StaticFactoryMethodHandleTest {
     static interface Cons {};
 
     static primitive class DefaultConstructor implements Cons {

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
 
 /*
  * @test
- * @summary Test reflection of constructors for inline classes
- * @run testng/othervm InlineConstructorTest
+ * @summary Test reflection of constructors for primitive classes
+ * @run testng/othervm StaticFactoryTest
  */
 
 import java.lang.reflect.Constructor;
@@ -39,45 +39,44 @@ import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-public class InlineConstructorTest {
-
+public class StaticFactoryTest {
     // Target test class
-    static primitive class SimpleInline {
+    static primitive class SimplePrimitive {
         public final int x;
 
-        SimpleInline() {
+        SimplePrimitive() {
             x = -1;
         }
 
-        public SimpleInline(int x) {
+        public SimplePrimitive(int x) {
             this.x = x;
         }
     }
 
-    static final Class<?> INLINE_TYPE = SimpleInline.class;
+    static final Class<?> PRIMITIVE_TYPE = SimplePrimitive.class;
 
     @Test
-    public static void testInlineClassConstructor() throws Exception {
-        String cn = INLINE_TYPE.getName();
+    public static void testPrimitiveClassConstructor() throws Exception {
+        String cn = PRIMITIVE_TYPE.getName();
         Class<?> c = Class.forName(cn).asValueType();
 
         assertTrue(c.isPrimitiveClass());
-        assertTrue(c == INLINE_TYPE);
+        assertTrue(c == PRIMITIVE_TYPE);
     }
 
     @Test
     public static void constructor() throws Exception {
-        Constructor<?> ctor = INLINE_TYPE.getDeclaredConstructor();
+        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
         Object o = ctor.newInstance();
-        assertTrue(o.getClass() == INLINE_TYPE.asPrimaryType());
+        assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
     }
 
     // Check that the class has the expected Constructors
     @Test
     public static void constructors() throws Exception {
-        Set<String> expectedSig = Set.of("public InlineConstructorTest$SimpleInline(int)",
-                                         "InlineConstructorTest$SimpleInline()");
-        Constructor<? extends Object>[] cons = INLINE_TYPE.getDeclaredConstructors();
+        Set<String> expectedSig = Set.of("public StaticFactoryTest$SimplePrimitive(int)",
+                                         "StaticFactoryTest$SimplePrimitive()");
+        Constructor<? extends Object>[] cons = PRIMITIVE_TYPE.getDeclaredConstructors();
         Set<String> actualSig = Arrays.stream(cons).map(Constructor::toString)
                                       .collect(Collectors.toSet());
         boolean ok = expectedSig.equals(actualSig);
@@ -91,36 +90,36 @@ public class InlineConstructorTest {
     // Check that the constructor and field can be set accessible
     @Test
     public static void setAccessible() throws Exception {
-        Constructor<?> ctor = INLINE_TYPE.getDeclaredConstructor();
+        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
         ctor.setAccessible(true);
 
-        Field field = INLINE_TYPE.getField("x");
+        Field field = PRIMITIVE_TYPE.getField("x");
         field.setAccessible(true);
     }
 
     // Check that the constructor and field can be set accessible
     @Test
     public static void trySetAccessible() throws Exception {
-        Constructor<?> ctor = INLINE_TYPE.getDeclaredConstructor();
+        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
         assertTrue(ctor.trySetAccessible());
 
-        Field field = INLINE_TYPE.getField("x");
+        Field field = PRIMITIVE_TYPE.getField("x");
         assertTrue(field.trySetAccessible());
     }
 
     // Check that the final field cannot be modified
     @Test(expectedExceptions = IllegalAccessException.class)
     public static void setFinalField() throws Exception {
-        Field field = INLINE_TYPE.getField("x");
+        Field field = PRIMITIVE_TYPE.getField("x");
         field.setAccessible(true);
-        field.setInt(new SimpleInline(100), 200);
+        field.setInt(new SimplePrimitive(100), 200);
     }
 
 
     // Check that the class does not have a static method with the name <init>
     @Test
     public static void initFactoryNotMethods() {
-        Method[] methods = INLINE_TYPE.getDeclaredMethods();
+        Method[] methods = PRIMITIVE_TYPE.getDeclaredMethods();
         for (Method m : methods) {
             if (Modifier.isStatic(m.getModifiers())) {
                 assertFalse(m.getName().equals("<init>"));

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
+ * @summary Basic test for Array::get, Array::set, Arrays::setAll on primitive class array
  * @compile StreamTest.java
  * @run testng StreamTest
  */
@@ -53,7 +53,7 @@ public class StreamTest {
     }
 
     @Test
-    public void testInlineType() {
+    public void testValueType() {
         Arrays.stream(values)
                 .map(Value.ref::point)
                 .filter(p -> p.x >= 5)

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary test MethodHandle/VarHandle on inline types
+ * @summary test MethodHandle/VarHandle on primitive classes
  * @modules java.base/java.lang.invoke:open
  * @run testng/othervm -Xint SubstitutabilityTest
  * @run testng/othervm -Xcomp SubstitutabilityTest
@@ -179,7 +179,7 @@ public class SubstitutabilityTest {
 
     /*
      * isSubstitutable method handle invoker requires both parameters are
-     * non-null and of the same inline class.
+     * non-null and of the same primitive class.
      *
      * This verifies ValueBootstrapMethods::isSubstitutable0 that does not
      * throw an exception if any one of parameter is null or if

--- a/test/jdk/valhalla/valuetypes/UninitializedValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedValueTest.java
@@ -24,10 +24,10 @@
 
 /*
  * @test
- * @compile --enable-preview --source ${jdk.version} UninitializedInlineValueTest.java
- * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=128 UninitializedInlineValueTest
- * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=0 UninitializedInlineValueTest
- * @summary Test reflection and method handle on accessing a field of inline type
+ * @compile --enable-preview --source ${jdk.version} UninitializedValueTest.java
+ * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=128 UninitializedValueTest
+ * @run testng/othervm --enable-preview -XX:InlineFieldMaxFlatSize=0 UninitializedValueTest
+ * @summary Test reflection and method handle on accessing a field of a primitive class
  *          that may be flattened or non-flattened
  */
 
@@ -38,46 +38,46 @@ import java.lang.reflect.Field;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-public class UninitializedInlineValueTest {
-    static primitive class EmptyInline {
+public class UninitializedValueTest {
+    static primitive class EmptyValue {
         public boolean isEmpty() {
             return true;
         }
     }
 
-    static primitive class InlineValue {
+    static primitive class Value {
         Object o;
-        EmptyInline empty;
-        InlineValue() {
+        EmptyValue empty;
+        Value() {
             this.o = null;
-            this.empty = new EmptyInline();
+            this.empty = new EmptyValue();
         }
     }
 
     static class MutableValue {
         Object o;
-        EmptyInline empty;
-        volatile EmptyInline vempty;
+        EmptyValue empty;
+        volatile EmptyValue vempty;
     }
 
     @Test
-    public void emptyInlineClass() throws ReflectiveOperationException {
-        EmptyInline e = new EmptyInline();
+    public void emptyValueClass() throws ReflectiveOperationException {
+        EmptyValue e = new EmptyValue();
         Field[] fields = e.getClass().getDeclaredFields();
         assertTrue(fields.length == 0);
     }
 
     @Test
-    public void testInlineValue() throws ReflectiveOperationException {
-        InlineValue v = new InlineValue();
+    public void testValue() throws ReflectiveOperationException {
+        Value v = new Value();
         Field f0 = v.getClass().getDeclaredField("o");
         Object o = f0.get(v);
         assertTrue(o == null);
 
-        // field of inline type must be non-null
+        // field of primitive value type must be non-null
         Field f1 = v.getClass().getDeclaredField("empty");
-        assertTrue(f1.getType() == EmptyInline.class);
-        EmptyInline empty = (EmptyInline)f1.get(v);
+        assertTrue(f1.getType() == EmptyValue.class);
+        EmptyValue empty = (EmptyValue)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
     }
 
@@ -88,56 +88,56 @@ public class UninitializedInlineValueTest {
         f0.set(v, null);
         assertTrue( f0.get(v) == null);
 
-        // field of inline type must be non-null
+        // field of primitive value type type must be non-null
         Field f1 = v.getClass().getDeclaredField("empty");
-        assertTrue(f1.getType() == EmptyInline.class);
-        EmptyInline empty = (EmptyInline)f1.get(v);
+        assertTrue(f1.getType() == EmptyValue.class);
+        EmptyValue empty = (EmptyValue)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
         Field f2 = v.getClass().getDeclaredField("vempty");
-        assertTrue(f2.getType() == EmptyInline.class);
-        EmptyInline vempty = (EmptyInline)f2.get(v);
+        assertTrue(f2.getType() == EmptyValue.class);
+        EmptyValue vempty = (EmptyValue)f2.get(v);
         assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
 
-        f1.set(v, new EmptyInline());
-        assertTrue((EmptyInline)f1.get(v) == new EmptyInline());
-        f2.set(v, new EmptyInline());
-        assertTrue((EmptyInline)f2.get(v) == new EmptyInline());
+        f1.set(v, new EmptyValue());
+        assertTrue((EmptyValue)f1.get(v) == new EmptyValue());
+        f2.set(v, new EmptyValue());
+        assertTrue((EmptyValue)f2.get(v) == new EmptyValue());
     }
 
     @Test
-    public void testMethodHandleInlineValue() throws Throwable {
-        InlineValue v = new InlineValue();
-        MethodHandle mh = MethodHandles.lookup().findGetter(InlineValue.class, "empty", EmptyInline.class);
-        EmptyInline empty = (EmptyInline) mh.invokeExact(v);
+    public void testMethodHandleValue() throws Throwable {
+        Value v = new Value();
+        MethodHandle mh = MethodHandles.lookup().findGetter(Value.class, "empty", EmptyValue.class);
+        EmptyValue empty = (EmptyValue) mh.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
     }
 
     @Test
     public void testMethodHandleMutableValue() throws Throwable {
         MutableValue v = new MutableValue();
-        MethodHandle getter = MethodHandles.lookup().findGetter(MutableValue.class, "empty", EmptyInline.class);
-        EmptyInline empty = (EmptyInline) getter.invokeExact(v);
+        MethodHandle getter = MethodHandles.lookup().findGetter(MutableValue.class, "empty", EmptyValue.class);
+        EmptyValue empty = (EmptyValue) getter.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
-        MethodHandle getter1 = MethodHandles.lookup().findGetter(MutableValue.class, "vempty", EmptyInline.class);
-        EmptyInline vempty = (EmptyInline) getter1.invokeExact(v);
+        MethodHandle getter1 = MethodHandles.lookup().findGetter(MutableValue.class, "vempty", EmptyValue.class);
+        EmptyValue vempty = (EmptyValue) getter1.invokeExact(v);
         assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
 
-        MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyInline.class);
-        setter.invokeExact(v, new EmptyInline());
-        empty = (EmptyInline) getter.invokeExact(v);
-        assertTrue(empty == new EmptyInline());
+        MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyValue.class);
+        setter.invokeExact(v, new EmptyValue());
+        empty = (EmptyValue) getter.invokeExact(v);
+        assertTrue(empty == new EmptyValue());
 
-        MethodHandle setter1 = MethodHandles.lookup().findSetter(MutableValue.class, "vempty", EmptyInline.class);
-        setter1.invokeExact(v, new EmptyInline());
-        vempty = (EmptyInline) getter1.invokeExact(v);
-        assertTrue(vempty == new EmptyInline());
+        MethodHandle setter1 = MethodHandles.lookup().findSetter(MutableValue.class, "vempty", EmptyValue.class);
+        setter1.invokeExact(v, new EmptyValue());
+        vempty = (EmptyValue) getter1.invokeExact(v);
+        assertTrue(vempty == new EmptyValue());
     }
 
     @Test(expectedExceptions = { IllegalAccessException.class})
     public void noWriteAccess() throws ReflectiveOperationException {
-        InlineValue v = new InlineValue();
+        Value v = new Value();
         Field f = v.getClass().getDeclaredField("empty");
         f.set(v, null);
     }
@@ -152,8 +152,8 @@ public class UninitializedInlineValueTest {
     @Test(expectedExceptions = { NullPointerException.class})
     public void nonNullableField_MethodHandle() throws Throwable {
         MutableValue v = new MutableValue();
-        MethodHandle mh = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyInline.class);
-        EmptyInline.ref e = null;
-        EmptyInline empty = (EmptyInline) mh.invokeExact(v, (EmptyInline)e);
+        MethodHandle mh = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyValue.class);
+        EmptyValue.ref e = null;
+        EmptyValue empty = (EmptyValue) mh.invokeExact(v, (EmptyValue)e);
     }
 }

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary Basic test for Array::get, Array::set, Arrays::setAll on inline class array
+ * @summary Basic test for Array::get, Array::set, Arrays::setAll on primitive class array
  * @run testng/othervm -XX:FlatArrayElementMaxSize=-1 ValueArray
  * @run testng/othervm -XX:FlatArrayElementMaxSize=0  ValueArray
  */
@@ -36,107 +36,35 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class ValueArray {
-    private final Class<?> arrayClass;
-    private final Class<?> componentType;
-    private final Object[] array;
-    ValueArray(Class<?> arrayClass, Object[] array) {
-        this.arrayClass = arrayClass;
-        this.array = array;
-        this.componentType = arrayClass.getComponentType();
-        assertTrue(arrayClass.isArray());
-        assertTrue(array.getClass() == arrayClass);
+    @DataProvider(name="elementTypes")
+    static Object[][] elementTypes() {
+        return new Object[][]{
+            new Object[] { Point.class, new Point(0,0) },
+            new Object[] { Point.ref.class, null },
+        };
     }
+    @Test(dataProvider="elementTypes")
+    public void testPrimitiveElementType(Class<?> elementType, Object defaultValue) {
+        assertTrue(elementType.isPrimitiveClass());
+        assertTrue(elementType.isPrimaryType() || defaultValue != null);
 
-    private static Class<?> nullablePointArrayClass() {
-        Object a = new Point.ref[0];
-        return a.getClass();
-    }
+        Object[] array = (Object[])Array.newInstance(elementType, 1);
+        Class<?> arrayType = array.getClass();
+        assertTrue(arrayType.componentType() == elementType);
+        // Array is a reference type
+        assertTrue(arrayType.isArray());
+        assertTrue(arrayType.isPrimaryType());
+        assertEquals(arrayType.asPrimaryType(), arrayType);
+        assertTrue(array[0] == defaultValue);
 
-    void run() {
-        testClassName();
-        testArrayElements();
-
-        if (componentType.isValueType()) {
-            Object[] qArray = (Object[]) Array.newInstance(componentType, 0);
-            Object[] lArray = (Object[]) Array.newInstance(componentType.asPrimaryType(), 0);
-            testInlineArrayCovariance(componentType, qArray, lArray);
-        }
-    }
-
-    void testClassName() {
-        // test class names
-        String arrayClassName = arrayClass.getName();
-        StringBuilder sb = new StringBuilder();
-        Class<?> c = arrayClass;
-        while (c.isArray()) {
-            sb.append("[");
+        // check the element type of multi-dimensional array
+        Object[][] multiArray = (Object[][])Array.newInstance(elementType, 1, 2, 3);
+        Class<?> c = multiArray.getClass();
+        while (c.getComponentType() != null) {
             c = c.getComponentType();
         }
-        sb.append(c.isValueType() ? "Q" : "L").append(c.getName()).append(";");
-        assertEquals(sb.toString(), arrayClassName);
+        assertTrue(c == elementType);
     }
-
-    void testArrayElements() {
-        Object[] array = (Object[]) Array.newInstance(componentType, this.array.length);
-        assertTrue(array.getClass() == arrayClass);
-        assertTrue(array.getClass().getComponentType() == componentType);
-
-        // set elements
-        for (int i=0; i < this.array.length; i++) {
-            Array.set(array, i, this.array[i]);
-        }
-        for (int i=0; i < this.array.length; i++) {
-            Object o = Array.get(array, i);
-            assertEquals(o, this.array[i]);
-        }
-        Arrays.setAll(array, i -> this.array[i]);
-
-        // test nullable
-        if (!componentType.isValueType()) {
-            for (int i=0; i < array.length; i++) {
-                Array.set(array, i, null);
-            }
-        } else {
-            for (int i=0; i < array.length; i++) {
-                try {
-                    Array.set(array, i, null);
-                    assertFalse(true, "expect NPE but not thrown");
-                } catch (NullPointerException e) { }
-            }
-        }
-    }
-
-    void testInlineArrayCovariance(Class<?> componentType, Object[] qArray, Object[] lArray) {
-        assertTrue(componentType.isValueType());
-
-        // Class.instanceOf (self)
-        assertTrue(qArray.getClass().isInstance(qArray));
-        assertTrue(lArray.getClass().isInstance(lArray));
-
-        // Class.instanceof inline vs indirect
-        assertFalse(qArray.getClass().isInstance(lArray));
-        assertTrue(lArray.getClass().isInstance(qArray));
-
-        // Class.isAssignableFrom (self)
-        assertTrue(qArray.getClass().isAssignableFrom(qArray.getClass()));
-        assertTrue(lArray.getClass().isAssignableFrom(lArray.getClass()));
-
-        // Class.isAssignableFrom inline vs indirect
-        assertTrue(lArray.getClass().isAssignableFrom(qArray.getClass()));
-        assertFalse(qArray.getClass().isAssignableFrom(lArray.getClass()));
-
-        // Class.cast (self)
-        qArray.getClass().cast(qArray);
-        lArray.getClass().cast(lArray);
-
-        // Class.cast inline vs indirect
-        lArray.getClass().cast(qArray);
-        try {
-            qArray.getClass().cast(lArray);
-            assertFalse(true, "cast of Point? to Point should not succeed");
-        } catch (ClassCastException cce) { }
-    }
-
 
     @DataProvider(name="arrayTypes")
     static Object[][] arrayTypes() {
@@ -150,21 +78,118 @@ public class ValueArray {
             new Object[] { Point[][].class,
                            new Point[][] { new Point[] { Point.makePoint(1, 2),
                                                          Point.makePoint(10, 20)}}},
-            new Object[] { nullablePointArrayClass(),
+            new Object[] { Point.ref[].class,
                            new Point.ref[] { Point.makePoint(11, 22),
-                                          Point.makePoint(110, 220),
-                                          null }},
+                                             Point.makePoint(110, 220),
+                                             null }},
             new Object[] { NonFlattenValue[].class,
                            new NonFlattenValue[] { NonFlattenValue.make(1, 2),
                                                    NonFlattenValue.make(10, 20),
                                                    NonFlattenValue.make(100, 200)}},
+            new Object[] { Point[].class,  new Point[0] },
+            new Object[] { Point.ref[].class,  new Point.ref[0] },
         };
     }
 
     @Test(dataProvider="arrayTypes")
-    public static void test(Class<?> arrayClass, Object[] array) {
-        ValueArray test = new ValueArray(arrayClass, array);
-        test.run();
+    public void testArrays(Class<?> arrayClass, Object[] array) {
+        testClassName(arrayClass);
+        testArrayElements(arrayClass, array);
+        Class<?> componentType = arrayClass.componentType();
+        if (componentType.isPrimitiveClass()) {
+            Object[] qArray = (Object[]) Array.newInstance(componentType.asValueType(), 0);
+            Object[] lArray = (Object[]) Array.newInstance(componentType.asPrimaryType(), 0);
+            testArrayCovariance(componentType, qArray, lArray);
+        }
+    }
+
+    /**
+     * Verify the array class's name of the form "[QPoint;" or "[LPoint;"
+     */
+    static void testClassName(Class<?> arrayClass) {
+        // test class names
+        String arrayClassName = arrayClass.getName();
+        StringBuilder sb = new StringBuilder();
+        Class<?> c = arrayClass;
+        while (c.isArray()) {
+            sb.append("[");
+            c = c.getComponentType();
+        }
+        sb.append(c.isValueType() ? "Q" : "L").append(c.getName()).append(";");
+        assertEquals(sb.toString(), arrayClassName);
+    }
+
+    /**
+     * Setting the elements of an array.
+     * NPE will be thrown if null is set on an element in an array of value type
+     */
+    static void testArrayElements(Class<?> arrayClass, Object[] array) {
+        Class<?> componentType = arrayClass.getComponentType();
+        assertTrue(arrayClass.isArray());
+        assertTrue(array.getClass() == arrayClass);
+        Object[] newArray = (Object[]) Array.newInstance(componentType, array.length);
+        assertTrue(newArray.getClass() == arrayClass);
+        assertTrue(newArray.getClass().getComponentType() == componentType);
+
+        // set elements
+        for (int i = 0; i < array.length; i++) {
+            Array.set(newArray, i, array[i]);
+        }
+        for (int i = 0; i < array.length; i++) {
+            Object o = Array.get(newArray, i);
+            assertEquals(o, array[i]);
+        }
+        Arrays.setAll(newArray, i -> array[i]);
+
+        // test nullable
+        if (!componentType.isValueType()) {
+            for (int i = 0; i < newArray.length; i++) {
+                Array.set(newArray, i, null);
+            }
+        } else {
+            for (int i = 0; i < newArray.length; i++) {
+                try {
+                    Array.set(newArray, i, null);
+                    fail("expect NPE but not thrown");
+                } catch (NullPointerException e) {
+                }
+            }
+        }
+    }
+
+    /**
+     * Point[] is a subtype of Point.ref[], which is a subtype of Object[].
+     */
+    static void testArrayCovariance(Class<?> componentType, Object[] qArray, Object[] lArray) {
+        assertTrue(componentType.isPrimitiveClass());
+
+        // Class.instanceOf (self)
+        assertTrue(qArray.getClass().isInstance(qArray));
+        assertTrue(lArray.getClass().isInstance(lArray));
+
+        // Class.isAssignableFrom (self)
+        assertTrue(qArray.getClass().isAssignableFrom(qArray.getClass()));
+        assertTrue(lArray.getClass().isAssignableFrom(lArray.getClass()));
+
+        // V.val[] is a subtype of V.ref[]
+        assertFalse(qArray.getClass().isInstance(lArray));
+        assertTrue(lArray.getClass().isInstance(qArray));
+
+        // V.val[] is a subtype of V.ref[]
+        assertTrue(lArray.getClass().isAssignableFrom(qArray.getClass()));
+        assertFalse(qArray.getClass().isAssignableFrom(lArray.getClass()));
+
+        // Class.cast (self)
+        qArray.getClass().cast(qArray);
+        lArray.getClass().cast(lArray);
+
+        // Class.cast
+        lArray.getClass().cast(qArray);
+        try {
+            qArray.getClass().cast(lArray);
+            fail("cast of Point.ref[] to Point[] should not succeed");
+        } catch (ClassCastException cce) {
+        }
     }
 
     @Test
@@ -186,12 +211,12 @@ public class ValueArray {
         Object o = new Object();
         try {
             Array.get(o, 0);
-            throw new AssertionError("IAE not thrown");
+            fail("IAE not thrown");
         } catch (IllegalArgumentException e) {}
 
         try {
             Array.set(o, 0, o);
-            throw new AssertionError("IAE not thrown");
+            fail("IAE not thrown");
         } catch (IllegalArgumentException e) {}
 
     }
@@ -200,12 +225,6 @@ public class ValueArray {
     static void testPointArray() {
         Point[] qArray = new Point[0];
         Point.ref[] lArray = new Point.ref[0];
-
-        ValueArray test = new ValueArray(Point[].class, qArray);
-        test.run();
-
-        ValueArray test1 = new ValueArray(Point.ref[].class, lArray);
-        test.run();
 
         // language instanceof
         assertTrue(qArray instanceof Point[]);

--- a/test/jdk/valhalla/valuetypes/ValueBootstrapMethods.java
+++ b/test/jdk/valhalla/valuetypes/ValueBootstrapMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
+++ b/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
@@ -31,11 +31,11 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @summary Test inline classes with Reference types
- * @run testng/othervm InlineReferenceTest
+ * @summary Test primitive classes with Reference types
+ * @run testng/othervm WeakReferenceTest
  */
 @Test
-public class InlineReferenceTest {
+public class WeakReferenceTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     static void test1() {


### PR DESCRIPTION
Update test/jdk/valhalla/valuetypes tests to prepare for jtreg 6. Also rename references to the term "inline" to "primitive". some test case reorganization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268908](https://bugs.openjdk.java.net/browse/JDK-8268908): Update test/jdk/valhalla/valuetypes tests to prepare for jtreg 6 and other clean up


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/447/head:pull/447` \
`$ git checkout pull/447`

Update a local copy of the PR: \
`$ git checkout pull/447` \
`$ git pull https://git.openjdk.java.net/valhalla pull/447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 447`

View PR using the GUI difftool: \
`$ git pr show -t 447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/447.diff">https://git.openjdk.java.net/valhalla/pull/447.diff</a>

</details>
