### PR TITLE
JDK-8268981:  [lworld] UnifiedPrimitiveClassNestHostTest.java should test with the primary mirror

### DIFF
--- a/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
@@ -65,7 +65,7 @@ public primitive class UnifiedPrimitiveClassNestHostTest implements java.io.Seri
         if (!members[0].equals(nestHost))
             throw new AssertionError("Wrong initial member: " + members[0]);
 
-        if (!members[1].equals(Inner.class))
+        if (!members[1].equals(Inner.class.asPrimaryType()))
             throw new AssertionError("Wrong initial member: " + members[1]);
 
         if (!members[1].getNestHost().equals(nestHost))


### PR DESCRIPTION
Fix the bug in test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java test that verifies the nest host with a secondary mirror but the core reflection API returns the primary mirror.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268981](https://bugs.openjdk.java.net/browse/JDK-8268981): [lworld] UnifiedPrimitiveClassNestHostTest.java should test with the primary mirror


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/452/head:pull/452` \
`$ git checkout pull/452`

Update a local copy of the PR: \
`$ git checkout pull/452` \
`$ git pull https://git.openjdk.java.net/valhalla pull/452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 452`

View PR using the GUI difftool: \
`$ git pr show -t 452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/452.diff">https://git.openjdk.java.net/valhalla/pull/452.diff</a>

</details>
