### PR TITLE
JDK-8218159: ValueBootstrapMethods.isSubstitutable should not filter synthetic fields

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/ValueBootstrapMethods.java
+++ b/src/java.base/share/classes/java/lang/invoke/ValueBootstrapMethods.java
@@ -107,9 +107,9 @@ public final class ValueBootstrapMethods {
 
         static MethodHandle[] getters(Class<?> type, Comparator<MethodHandle> comparator) {
             Lookup lookup = new MethodHandles.Lookup(type.asPrimaryType());
-            // filter static fields and synthetic fields
+            // filter static fields
             Stream<MethodHandle> s = Arrays.stream(type.getDeclaredFields())
-                .filter(f -> !Modifier.isStatic(f.getModifiers()) && !f.isSynthetic())
+                .filter(f -> !Modifier.isStatic(f.getModifiers()))
                 .map(f -> {
                     try {
                         return lookup.unreflectGetter(f);

--- a/test/jdk/valhalla/valuetypes/Nest.java
+++ b/test/jdk/valhalla/valuetypes/Nest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run main Nest
+ * @summary Test substitutability of inner class and anonymous class that
+ * has the enclosing instance and possibly other captured outer locals
+ */
+
+public interface Nest {
+    public static void main(String... args) {
+        assertEquals(Nest.of(1, null), Nest.of(1, null));
+        assertNotEquals(Nest.of(1, null), Nest.of(2, null));
+
+        Outer n = new Outer(1);
+        Outer.Inner inner = n.new Inner(10);
+        Outer n1 = new Outer(1);
+        Outer n2 = new Outer(2);
+        assertEquals(n1.new Inner(10), inner);
+        assertEquals(n2.new Inner(10), new Outer(2).new Inner(10));
+    }
+
+    // o1.new Inner(1) == o2.new Inner(1) iff o1 == o2
+    static primitive class Outer {
+        final int i;
+        Outer(int i) {
+            this.i = i;
+        }
+
+        primitive class Inner {
+            final int ic;
+            Inner(int ic) {
+                this.ic = ic;
+            }
+        }
+    }
+
+    String toString();
+
+    static Nest of(int value, Object next) {
+        // anonymous class capturing outer locals
+        return new primitive Nest() {
+            public String toString() {
+                return value + " -> " + next;
+            }
+        };
+    }
+
+    static void assertEquals(Object o1, Object o2) {
+        if (o1 != o2) {
+            throw new RuntimeException(o1 + " != " + o2);
+        }
+    }
+    static void assertNotEquals(Object o1, Object o2) {
+        if (o1 == o2) {
+            throw new RuntimeException(o1 + " == " + o2);
+        }
+    }
+}

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -178,9 +178,9 @@ public class ObjectMethods {
 
     private static Object[] hashCodeComponents(Object o) {
         Class<?> type = o.getClass();
-        // filter static fields and synthetic fields
+        // filter static fields
         Stream<Object> fields = Arrays.stream(type.getDeclaredFields())
-            .filter(f -> !Modifier.isStatic(f.getModifiers()) && !f.isSynthetic())
+            .filter(f -> !Modifier.isStatic(f.getModifiers()))
             .map(f -> {
                 try {
                     return f.get(o);


### PR DESCRIPTION
`acmp` on two primitive objects of the same type are considered equals if all of their fields are "equivalent" including synthetic fields, for example, which can be an enclosing instance and captured outer locals.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8218159](https://bugs.openjdk.java.net/browse/JDK-8218159): ValueBootstrapMethods.isSubstitutable should not filter synthetic fields


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/454/head:pull/454` \
`$ git checkout pull/454`

Update a local copy of the PR: \
`$ git checkout pull/454` \
`$ git pull https://git.openjdk.java.net/valhalla pull/454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 454`

View PR using the GUI difftool: \
`$ git pr show -t 454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/454.diff">https://git.openjdk.java.net/valhalla/pull/454.diff</a>

</details>
