### PR TITLE
8267824: [lworld] Lots of lingering references to inline/value types in Javac code base

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -479,9 +479,9 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return name == name.table.names.init && (flags() & STATIC) == 0;
     }
 
-    /** Is this symbol a value factory?
+    /** Is this symbol a primitive object factory?
      */
-    public boolean isValueFactory() {
+    public boolean isPrimitiveObjectFactory() {
         return ((name == name.table.names.init && this.type.getReturnType().tsym == this.owner));
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -269,7 +269,7 @@ public class Symtab {
             new UniqueType(type, types), k -> {
                 Type arg = null;
                 if (type.getTag() == ARRAY || type.getTag() == CLASS) {
-                    /* Temporary treatment for inline class: Given an inline class V that implements
+                    /* Temporary treatment for primitive class: Given a primitive class V that implements
                        I1, I2, ... In, V.class is typed to be Class<? extends Object & I1 & I2 .. & In>
                     */
                     if (type.isPrimitiveClass()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -250,7 +250,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     }
 
     /**
-     * @return true IFF the receiver is a reference projection of an inline type and false
+     * @return true IFF the receiver is a reference projection of a primitive class type and false
      * for primitives or plain references
      */
     public boolean isReferenceProjection() {
@@ -258,7 +258,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     }
 
     /**
-     * @return the value projection type IFF the receiver is a reference projection of an inline type
+     * @return the value projection type IFF the receiver is a reference projection of a primitive class type
      * and null otherwise
      */
     public Type valueProjection() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1645,7 +1645,7 @@ public class Types {
 
                     // -----------------------------------  Unspecified behavior ----------------
 
-                    /* If a value class V implements an interface I, then does "? extends I" contain V?
+                    /* If a primitive class V implements an interface I, then does "? extends I" contain V?
                        It seems widening must be applied here to answer yes to compile some common code
                        patterns.
                     */
@@ -2374,7 +2374,7 @@ public class Types {
                     return true;
                 }
 
-                // No instance fields and no arged constructors both mean inner classes cannot be inline supers.
+                // No instance fields and no arged constructors both mean inner classes cannot be primitive class supers.
                 Type encl = t.getEnclosingType();
                 if (encl != null && encl.hasTag(CLASS)) {
                     return true;
@@ -2476,7 +2476,7 @@ public class Types {
         if ((sym.flags() & STATIC) != 0)
             return sym.type;
 
-        /* If any inline types are involved, switch over to the reference universe,
+        /* If any primitive class types are involved, switch over to the reference universe,
            where the hierarchy is navigable. V and V.ref have identical membership
            with no bridging needs.
         */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1677,8 +1677,8 @@ public class Flow {
         all instance fields are DA.
      */
     enum ThisExposability {
-        ALLOWED,     // Normal Object classes - NOP
-        BANNED,      // Value types           - Error
+        ALLOWED,     // identity Object classes - NOP
+        BANNED,      // primitive classes - Error
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2273,8 +2273,8 @@ public class LambdaToMethod extends TreeTranslator {
                 return tree.ownerAccessible;
             }
 
-            /* Per our interim inline class translation scheme, the reference projection classes
-               are completely empty, so we want the methods in the value class to be invoked instead.
+            /* Per our interim primitive class translation scheme, the reference projection classes
+               are completely empty, so we want the methods in the primitive class to be invoked instead.
                As the lambda meta factory isn't clued into this, it will try to invoke the method in
                C$ref.class and fail with a NoSuchMethodError. we need to workaround it ourselves.
             */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -287,7 +287,7 @@ public class MemberEnter extends JCTree.Visitor {
         VarSymbol v = new VarSymbol(0, tree.name, vartype, enclScope.owner);
         v.flags_field = chk.checkFlags(tree.pos(), tree.mods.flags, v, tree);
         tree.sym = v;
-        /* Don't want constant propagation/folding for instance fields of value classes,
+        /* Don't want constant propagation/folding for instance fields of primitive classes,
            as these can undergo updates via copy on write.
         */
         if (tree.init != null) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -420,7 +420,7 @@ public class Resolve {
 
         ClassSymbol enclosingCsym = env.enclClass.sym;
         if (sym.kind == MTH || sym.kind == VAR) {
-            /* If any inline types are involved, ask the same question in the reference universe,
+            /* If any primitive class types are involved, ask the same question in the reference universe,
                where the hierarchy is navigable
             */
             if (site.isPrimitiveClass())
@@ -485,7 +485,7 @@ public class Resolve {
         if (sym.kind != MTH || sym.isConstructor() || sym.isStatic())
             return true;
 
-        /* If any inline types are involved, ask the same question in the reference universe,
+        /* If any primitive class types are involved, ask the same question in the reference universe,
            where the hierarchy is navigable
         */
         if (site.isPrimitiveClass())

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ByteCodes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ByteCodes.java
@@ -243,7 +243,7 @@ public interface ByteCodes {
         jsr_w           = 201,
         breakpoint      = 202,
 
-        // value-type bytecodes
+        // primitive classes related bytecodes
         defaultvalue    = 203,
         withfield       = 204,
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2736,7 +2736,7 @@ public class ClassReader {
             /* http://cr.openjdk.java.net/~briangoetz/valhalla/sov/04-translation.html
                The relationship of value and reference projections differs between the language model
                and the VM model. In the language, the value projection is not a subtype of the
-               reference projection; instead, the two are related by inline narrowing and widening
+               reference projection; instead, the two are related by primitive reference and value
                conversions, whereas in the VM, the two are related by actual subtyping.
                Sever the subtyping relationship by rewiring the supertypes here and now.
              */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -79,7 +79,7 @@ public class Gen extends JCTree.Visitor {
     private final Lower lower;
     private final Annotate annotate;
     private final StringConcat concat;
-    private final TransValues transValues;
+    private final TransPrimitiveClass transPrimitiveClass;
 
     /** Format of stackmap tables to be generated. */
     private final Code.StackMapFormat stackMap;
@@ -116,7 +116,7 @@ public class Gen extends JCTree.Visitor {
         accessDollar = names.
             fromString("access" + target.syntheticNameChar());
         lower = Lower.instance(context);
-        transValues = TransValues.instance(context);
+        transPrimitiveClass = TransPrimitiveClass.instance(context);
 
         Options options = Options.instance(context);
         lineDebugInfo =
@@ -1001,7 +1001,7 @@ public class Gen extends JCTree.Visitor {
                     if (env.enclMethod == null ||
                         env.enclMethod.sym.type.getReturnType().hasTag(VOID)) {
                         code.emitop0(return_);
-                    } else if (env.enclMethod.sym.isValueFactory()) {
+                    } else if (env.enclMethod.sym.isPrimitiveObjectFactory()) {
                         items.makeLocalItem(env.enclMethod.factoryProduct).load();
                         code.emitop0(areturn);
                     } else {
@@ -2279,7 +2279,7 @@ public class Gen extends JCTree.Visitor {
         // which is not statically a supertype of the expression's type.
         // For basic types, the coerce(...) in genExpr(...) will do
         // the conversion.
-        // inline widening conversion is a nop when we bifurcate the primitive class, as the VM sees a subtyping relationship.
+        // primitive reference conversion is a nop when we bifurcate the primitive class, as the VM sees a subtyping relationship.
         if (!tree.clazz.type.isPrimitive() &&
            !types.isSameType(tree.expr.type, tree.clazz.type) &&
             (!tree.clazz.type.isReferenceProjection() || !types.splitPrimitiveClass || !types.isSameType(tree.clazz.type.valueProjection(), tree.expr.type)) &&
@@ -2479,7 +2479,7 @@ public class Gen extends JCTree.Visitor {
             /* method normalizeDefs() can add references to external classes into the constant pool
              */
             cdef.defs = normalizeDefs(cdef.defs, c);
-            cdef = transValues.translateTopLevelClass(cdef, make);
+            cdef = transPrimitiveClass.translateTopLevelClass(cdef, make);
             generateReferencesToPrunedTree(c);
             Env<GenContext> localEnv = new Env<>(cdef, new GenContext());
             localEnv.toplevel = env.toplevel;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3354,7 +3354,7 @@ public class JavacParser implements Parser {
         if ((flags & (Flags.ModifierFlags | Flags.ANNOTATION)) == 0 && annotations.isEmpty())
             pos = Position.NOPOS;
 
-        // Force value classes to be automatically final.
+        // Force primitive classes to be automatically final.
         if ((flags & (Flags.PRIMITIVE_CLASS | Flags.ABSTRACT | Flags.INTERFACE | Flags.ENUM)) == Flags.PRIMITIVE_CLASS) {
             flags |= Flags.FINAL;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -390,7 +390,7 @@ public class Names {
         makeConcat = fromString("makeConcat");
         makeConcatWithConstants = fromString("makeConcatWithConstants");
 
-        // value types
+        // primitive classes
         dollarValue = fromString("$value");
         ref = fromString("ref");
         val = fromString("val");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2492,7 +2492,7 @@ public class Utils {
     }
 
     public boolean isValue(DocTree doctree) {
-        return isKind(doctree, Kind.VALUE);
+        return isKind(doctree, VALUE);
     }
 
     public boolean isVersion(DocTree doctree) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -1147,8 +1147,6 @@ public class Checker extends DocTreePathScanner<Void, Void> {
             case CONSTRUCTOR:
                 // A synthetic default constructor has the same pos as the
                 // enclosing class
-            case METHOD:
-                // Ditto for a synthetic method injected by the compiler (for value types)
                 TreePath p = env.currPath;
                 return env.getPos(p) == env.getPos(p.getParentPath());
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -530,7 +530,7 @@ public class ClassWriter extends BasicWriter {
         switch (name) {
             case "<init>":
                 String returnType = getJavaReturnType(d);
-                if (!returnType.equals("void")) { // value static factories
+                if (!returnType.equals("void")) { // static factories for primitive classes
                     print(returnType);
                     print(" ");
                 }

--- a/src/jdk.jshell/share/classes/jdk/jshell/TypePrinter.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TypePrinter.java
@@ -165,9 +165,7 @@ class TypePrinter extends Printer {
                             : "<anonymous class implementing " + s + ">";
             }
             return s;
-        }
-        String s;
-        if (longform) {
+        } else if (longform) {
             String pkg = "";
             for (Symbol psym = sym; psym != null; psym = psym.owner) {
                 if (psym.kind == PCK) {
@@ -175,14 +173,13 @@ class TypePrinter extends Printer {
                     break;
                 }
             }
-            s = fullClassNameAndPackageToClass.apply(
+            return fullClassNameAndPackageToClass.apply(
                     sym.getQualifiedName().toString(),
                     pkg
             );
         } else {
-            s = sym.name.toString();
+            return sym.name.toString();
         }
-        return s;
     }
 
     @Override

--- a/test/langtools/tools/javac/valhalla/lworld-values/DocLintSyntheticsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/DocLintSyntheticsTest.java
@@ -24,12 +24,13 @@
 /**
  * @test
  * @bug 8210122
- * @summary [lworld] javac issues bogus "no comment" doclint warning while compiling value class
+ * @summary [lworld] javac issues bogus "no comment" doclint warning while compiling primitive class
  * @compile -Xdoclint:all -Werror DocLintSyntheticsTest.java
  */
 
 /**
- * Test javadoc
+ * NOTE: This test is not relevant as we don't inject synthetic methods into primitive
+ *       classes anymore, but is still left in just the same.
  */
 public primitive class DocLintSyntheticsTest {
   /** field */


### PR DESCRIPTION
Purge stale terminilogy references in identifiers, comments, files ...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267824](https://bugs.openjdk.java.net/browse/JDK-8267824): [lworld] Lots of lingering references to inline/value types in Javac code base


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/455/head:pull/455` \
`$ git checkout pull/455`

Update a local copy of the PR: \
`$ git checkout pull/455` \
`$ git pull https://git.openjdk.java.net/valhalla pull/455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 455`

View PR using the GUI difftool: \
`$ git pr show -t 455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/455.diff">https://git.openjdk.java.net/valhalla/pull/455.diff</a>

</details>
