### PR TITLE
8269084: [lworld] runtime/cds tests need to be migrated to the unified class file scheme

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/HelloInlineClassTest.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Rectangle
  * @run driver HelloInlineClassTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
@@ -42,10 +42,10 @@ public class RewriteBytecodesInlineTest {
     String wbJar = JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
     String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
 
-    String appJar = JarBuilder.build("dynamic_define", "RewriteBytecodesInline", "Util", "Point", "Point$ref", "WithInlinedField");
+    String appJar = JarBuilder.build("dynamic_define", "RewriteBytecodesInline", "Util", "Point", "WithInlinedField");
     String superClsFile = (new File(System.getProperty("test.classes", "."), "Point.class")).getPath();
 
-    TestCommon.dump(appJar, TestCommon.list("RewriteBytecodesInline", "Point", "Point$ref", "WithInlinedField"),
+    TestCommon.dump(appJar, TestCommon.list("RewriteBytecodesInline", "Point", "WithInlinedField"),
                     // command-line arguments ...
                     use_whitebox_jar);
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java
@@ -32,7 +32,7 @@
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloRelocation
  * @build sun.hotspot.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello.jar HelloRelocation HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Rectangle
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicArchiveRelocationTest
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java
@@ -29,7 +29,7 @@
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
  * @build HelloInlineClassApp
  * @build sun.hotspot.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Point$ref HelloInlineClassApp$Rectangle HelloInlineClassApp$Rectangle$ref
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar hello_inline.jar HelloInlineClassApp HelloInlineClassApp$Point HelloInlineClassApp$Rectangle
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. HelloDynamicInlineClass
  */


### PR DESCRIPTION
Tests should not attempt to bundle the non-existent .ref.class files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269084](https://bugs.openjdk.java.net/browse/JDK-8269084): [lworld] runtime/cds tests need to be migrated to the unified class file scheme


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/456/head:pull/456` \
`$ git checkout pull/456`

Update a local copy of the PR: \
`$ git checkout pull/456` \
`$ git pull https://git.openjdk.java.net/valhalla pull/456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 456`

View PR using the GUI difftool: \
`$ git pr show -t 456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/456.diff">https://git.openjdk.java.net/valhalla/pull/456.diff</a>

</details>
