### PR TITLE
8269095: Fix Valhalla Zero build failures

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -48,7 +48,7 @@ ifeq ($(call check-jvm-feature, zero), true)
   JVM_EXCLUDES += opto libadt
   JVM_EXCLUDE_PATTERNS += c1_ c1/ c2_ runtime_ /c2/
   JVM_EXCLUDE_FILES += templateInterpreter.cpp templateInterpreterGenerator.cpp \
-                       bcEscapeAnalyzer.cpp ciTypeFlow.cpp
+                       bcEscapeAnalyzer.cpp ciTypeFlow.cpp macroAssembler_common.cpp
   JVM_CFLAGS_FEATURES += -DZERO -DZERO_LIBARCH='"$(OPENJDK_TARGET_CPU_LEGACY_LIB)"' $(LIBFFI_CFLAGS)
   JVM_LIBS_FEATURES += $(LIBFFI_LIBS)
   ifeq ($(ENABLE_LIBFFI_BUNDLING), true)

--- a/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
+++ b/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
@@ -54,15 +54,35 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
   return 0;
 }
 
-AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(
-                        MacroAssembler *masm,
-                        int total_args_passed,
-                        int comp_args_on_stack,
-                        const BasicType *sig_bt,
-                        const VMRegPair *regs,
-                        AdapterFingerPrint *fingerprint) {
+int SharedRuntime::java_return_convention(const BasicType *sig_bt,
+                                           VMRegPair *regs,
+                                           int total_args_passed) {
+  Unimplemented();
+  return 0;
+}
+
+BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
+  Unimplemented();
+  return NULL;
+}
+
+AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm,
+                                                            int comp_args_on_stack,
+                                                            const GrowableArray <SigEntry> *sig,
+                                                            const VMRegPair *regs,
+                                                            const GrowableArray <SigEntry> *sig_cc,
+                                                            const VMRegPair *regs_cc,
+                                                            const GrowableArray <SigEntry> *sig_cc_ro,
+                                                            const VMRegPair *regs_cc_ro,
+                                                            AdapterFingerPrint *fingerprint,
+                                                            AdapterBlob *&new_adapter) {
+  new_adapter = AdapterBlob::create(masm->code(), 0, 0, NULL);
   return AdapterHandlerLibrary::new_entry(
     fingerprint,
+    CAST_FROM_FN_PTR(address,zero_null_code_stub),
+    CAST_FROM_FN_PTR(address,zero_null_code_stub),
+    CAST_FROM_FN_PTR(address,zero_null_code_stub),
+    CAST_FROM_FN_PTR(address,zero_null_code_stub),
     CAST_FROM_FN_PTR(address,zero_null_code_stub),
     CAST_FROM_FN_PTR(address,zero_null_code_stub),
     CAST_FROM_FN_PTR(address,zero_null_code_stub));

--- a/src/hotspot/cpu/zero/vtableStubs_zero.cpp
+++ b/src/hotspot/cpu/zero/vtableStubs_zero.cpp
@@ -27,12 +27,12 @@
 #include "code/vtableStubs.hpp"
 #include "utilities/debug.hpp"
 
-VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
+VtableStub* VtableStubs::create_vtable_stub(int vtable_index, bool caller_is_c1) {
   ShouldNotCallThis();
   return NULL;
 }
 
-VtableStub* VtableStubs::create_itable_stub(int vtable_index) {
+VtableStub* VtableStubs::create_itable_stub(int vtable_index, bool caller_is_c1) {
   ShouldNotCallThis();
   return NULL;
 }


### PR DESCRIPTION
This should make Zero buildable again in Valhalla workspace. Zero would not work with primitive classes just yet, failing with "unimplemented bytecode" when reaching the Valhalla code, but at least it would not fail the builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269095](https://bugs.openjdk.java.net/browse/JDK-8269095): Fix Valhalla Zero build failures


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/458/head:pull/458` \
`$ git checkout pull/458`

Update a local copy of the PR: \
`$ git checkout pull/458` \
`$ git pull https://git.openjdk.java.net/valhalla pull/458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 458`

View PR using the GUI difftool: \
`$ git pr show -t 458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/458.diff">https://git.openjdk.java.net/valhalla/pull/458.diff</a>

</details>
