### PR TITLE
JDK-8269172: Add java.util.Objects.newIdentity method

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -424,20 +424,6 @@ public final class Objects {
     }
 
     /**
-     * Returns a new Object implementing the {@code IdentityObject} interface.
-     * The object is a unique {@link IdentityObject} suitable for all purposes
-     * for which {@code new Object{}} was used including synchronization,
-     * mutexes and unique placeholders.
-     *
-     * @return a new Object implementing the IdentityObject interface
-     * @since Valhalla
-     */
-    public static IdentityObject newIdentity() {
-        // Return a new instance of an anonymous inner class.
-        return new IdentityObject() { };
-    }
-
-    /**
      * Checks if the {@code index} is within the bounds of the range from
      * {@code 0} (inclusive) to {@code length} (exclusive).
      *
@@ -511,5 +497,16 @@ public final class Objects {
     public static
     long checkFromIndexSize(long fromIndex, long size, long length) {
         return Preconditions.checkFromIndexSize(fromIndex, size, length, null);
+    }
+    /**
+     * {@return a new instance of an unspecified class}
+     * The object has a unique identity; no other references to it exist.
+     * It can be used for synchronization, or where a placeholder Object is needed.
+     * Use this method to avoid relying on the {@linkplain Object#Object() Object constructor}.
+     *
+     * @since 17
+     */
+    public static Object newIdentity() {
+        return new Object() {};
     }
 }

--- a/test/jdk/java/util/Objects/BasicObjectsTest.java
+++ b/test/jdk/java/util/Objects/BasicObjectsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public class BasicObjectsTest {
         errors += testIsNull();
         errors += testNonNull();
         errors += testNonNullOf();
+        errors += testNewIdentity();
         if (errors > 0 )
             throw new RuntimeException();
     }
@@ -273,6 +274,21 @@ public class BasicObjectsTest {
             // expected
             errors += npe.getMessage().equals("supplier") ? 0 : 1;
         }
+        return errors;
+    }
+
+    private static int testNewIdentity() {
+        int errors = 0;
+
+        Object o1 = Objects.newIdentity();
+        Object o2 = Objects.newIdentity();
+
+        if (o1 == null || o2 == null)
+            errors += 1;
+
+        if (o1 == o2)
+            errors += 1;
+
         return errors;
     }
 }


### PR DESCRIPTION
Replaces the existing Objects.newIdentity() method with the matching method in JDK17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269172](https://bugs.openjdk.java.net/browse/JDK-8269172): Add java.util.Objects.newIdentity method


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/459/head:pull/459` \
`$ git checkout pull/459`

Update a local copy of the PR: \
`$ git checkout pull/459` \
`$ git pull https://git.openjdk.java.net/valhalla pull/459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 459`

View PR using the GUI difftool: \
`$ git pr show -t 459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/459.diff">https://git.openjdk.java.net/valhalla/pull/459.diff</a>

</details>
