### PR TITLE
8269231: Fix 32-bit Valhalla (Zero) builds

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -66,8 +66,12 @@ FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name) : ArrayKlass(
   assert(is_flatArray_klass(), "sanity");
   assert(is_null_free_array_klass(), "sanity");
 
+#ifdef _LP64
   set_prototype_header(markWord::flat_array_prototype());
   assert(prototype_header().is_flat_array(), "sanity");
+#else
+  set_prototype_header(markWord::inline_type_prototype());
+#endif
 
 #ifndef PRODUCT
   if (PrintFlatArrayLayout) {

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -472,6 +472,16 @@ class markWord {
   bool is_null_free_array() const {
     return (mask_bits(value(), null_free_array_mask_in_place) == null_free_array_pattern);
   }
+#else
+  bool is_flat_array() const {
+    fatal("Should not ask this for mark word, ask oopDesc");
+    return false;
+  }
+
+  bool is_null_free_array() const {
+    fatal("Should not ask this for mark word, ask oopDesc");
+    return false;
+  }
 #endif
   // Prototype mark for initialization
   static markWord prototype() {

--- a/src/hotspot/share/oops/markWord.inline.hpp
+++ b/src/hotspot/share/oops/markWord.inline.hpp
@@ -71,10 +71,13 @@ inline bool markWord::must_be_preserved_for_promotion_failure(const oopDesc* obj
 inline markWord markWord::prototype_for_klass(const Klass* klass) {
   markWord prototype_header = klass->prototype_header();
   assert(prototype_header == prototype() ||
-         (UseBiasedLocking && prototype_header.has_bias_pattern()) ||
-         prototype_header.is_inline_type() ||
-         prototype_header.is_flat_array() ||
-         prototype_header.is_null_free_array(), "corrupt prototype header");
+         (UseBiasedLocking && prototype_header.has_bias_pattern())
+         || prototype_header.is_inline_type()
+#ifdef _LP64
+         || prototype_header.is_flat_array()
+         || prototype_header.is_null_free_array()
+#endif
+         , "corrupt prototype header");
 
   return prototype_header;
 }

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -162,8 +162,12 @@ ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name, bool nul
   if (null_free) {
     assert(n == 1, "Bytecode does not support null-free multi-dim");
     lh = layout_helper_set_null_free(lh);
+#ifdef _LP64
     set_prototype_header(markWord::null_free_array_prototype());
     assert(prototype_header().is_null_free_array(), "sanity");
+#else
+    set_prototype_header(markWord::inline_type_prototype());
+#endif
   }
   set_layout_helper(lh);
   assert(is_array_klass(), "sanity");

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -207,7 +207,7 @@ bool oopDesc::is_objArray()  const { return klass()->is_objArray_klass();  }
 bool oopDesc::is_typeArray() const { return klass()->is_typeArray_klass(); }
 
 bool oopDesc::is_inline_type() const { return mark().is_inline_type(); }
-#if _LP64
+#ifdef _LP64
 bool oopDesc::is_flatArray() const {
   markWord mrk = mark();
   return (mrk.is_unlocked()) ? mrk.is_flat_array() : klass()->is_flatArray_klass();

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -33,6 +33,7 @@
 #include "compiler/disassembler.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSet.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/c2/barrierSetC2.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/allocation.hpp"

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -298,7 +298,7 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       assert(fd.is_inlined(), "field not flat");
     } else {
       if (log_is_enabled(Trace, valuetypes)) {
-        log_trace(valuetypes)("not a field in %s at offset " SIZE_FORMAT_HEX,
+        log_trace(valuetypes)("not a field in %s at offset " JLONG_FORMAT_X,
                               p->klass()->external_name(), offset);
       }
     }
@@ -316,11 +316,11 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       FlatArrayKlass* vak = FlatArrayKlass::cast(k);
       int index = (offset - vak->array_header_in_bytes()) / vak->element_byte_size();
       address dest = (address)((flatArrayOop)p)->value_at_addr(index, vak->layout_helper());
-      log_trace(valuetypes)("%s array type %s index %d element size %d offset " SIZE_FORMAT_HEX " at " INTPTR_FORMAT,
+      log_trace(valuetypes)("%s array type %s index %d element size %d offset " JLONG_FORMAT_X " at " INTPTR_FORMAT,
                             p->klass()->external_name(), vak->external_name(),
                             index, vak->element_byte_size(), offset, p2i(dest));
     } else {
-      log_trace(valuetypes)("%s field type %s at offset " SIZE_FORMAT_HEX,
+      log_trace(valuetypes)("%s field type %s at offset " JLONG_FORMAT_X,
                             p->klass()->external_name(), vk->external_name(), offset);
     }
   }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -104,6 +104,7 @@ class oopDesc;
 // Format 64-bit quantities.
 #define INT64_FORMAT           "%" PRId64
 #define UINT64_FORMAT          "%" PRIu64
+#define INT64_FORMAT_X         "%" PRIx64
 #define UINT64_FORMAT_X        "%" PRIx64
 #define INT64_FORMAT_W(width)  "%" #width PRId64
 #define UINT64_FORMAT_W(width) "%" #width PRIu64
@@ -117,6 +118,9 @@ class oopDesc;
 #endif
 #ifndef JLONG_FORMAT_W
 #define JLONG_FORMAT_W(width)  INT64_FORMAT_W(width)
+#endif
+#ifndef JLONG_FORMAT_X
+#define JLONG_FORMAT_X         INT64_FORMAT_X
 #endif
 #ifndef JULONG_FORMAT
 #define JULONG_FORMAT          UINT64_FORMAT


### PR DESCRIPTION
Building linux-x86-zero-fastdebug builds shows a few 32-bit cleanliness problems.

The first failure is:

```
/home/buildbot/worker/build-jdkX-valhalla-linux/build/src/hotspot/share/oops/oop.inline.hpp:210:5: error: "_LP64" is not defined [-Werror=undef]
 #if _LP64
     ^~~~~
```

Additional testing:
 - [x] Linux x86 Zero fastdebug completes
 - [x] Linux x86_64 Server fastdebug runs `runtime/valhalla` (no new regressions, some failures with clean `lworld`)
 - [x] Linux x86_64 Server fastdebug runs `compiler/valhalla` (no new regressions, some failures with clean `lworld`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269231](https://bugs.openjdk.java.net/browse/JDK-8269231): Fix 32-bit Valhalla (Zero) builds


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/460/head:pull/460` \
`$ git checkout pull/460`

Update a local copy of the PR: \
`$ git checkout pull/460` \
`$ git pull https://git.openjdk.java.net/valhalla pull/460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 460`

View PR using the GUI difftool: \
`$ git pr show -t 460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/460.diff">https://git.openjdk.java.net/valhalla/pull/460.diff</a>

</details>
