### PR TITLE
8268021: [lworld] [AArch64] fix support for InlineTypeReturnedAsFields

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1767,6 +1767,9 @@ int MachCallRuntimeNode::ret_addr_offset() {
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb) {
     return 1 * NativeInstruction::instruction_size;
+  } else if (_entry_point == NULL) {
+    // See CallLeafNoFPIndirect
+    return 1 * NativeInstruction::instruction_size;
   } else {
     return 6 * NativeInstruction::instruction_size;
   }
@@ -3694,6 +3697,17 @@ encode %{
     if (VerifyStackAtCalls) {
       // Check that stack depth is unchanged: find majik cookie on stack
       __ call_Unimplemented();
+    }
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
+      // An inline type is returned as fields in multiple registers.
+      // R0 either contains an oop if the inline type is buffered or a pointer
+      // to the corresponding InlineKlass with the lowest bit set to 1. Zero r0
+      // if the lowest bit is set to allow C2 to use the oop after null checking.
+      // r0 &= (r0 & 1) - 1
+      C2_MacroAssembler _masm(&cbuf);
+      __ andr(rscratch1, r0, 0x1);
+      __ sub(rscratch1, rscratch1, 0x1);
+      __ andr(r0, r0, rscratch1);
     }
   %}
 
@@ -16317,8 +16331,28 @@ instruct CallLeafDirect(method meth)
 
 // Call Runtime Instruction
 
+// entry point is null, target holds the address to call
+instruct CallLeafNoFPIndirect(iRegP target)
+%{
+  predicate(n->as_Call()->entry_point() == NULL);
+
+  match(CallLeafNoFP target);
+
+  ins_cost(CALL_COST);
+
+  format %{ "CALL, runtime leaf nofp indirect $target" %}
+
+  ins_encode %{
+    __ blr($target$$Register);
+  %}
+
+  ins_pipe(pipe_class_call);
+%}
+
 instruct CallLeafNoFPDirect(method meth)
 %{
+  predicate(n->as_Call()->entry_point() != NULL);
+
   match(CallLeafNoFP);
 
   effect(USE meth);

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -517,7 +517,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
       address unpack_handler = vk->unpack_handler();
       assert(unpack_handler != NULL, "must be");
       __ far_call(RuntimeAddress(unpack_handler));
-      // At this point, rax points to the value object (for interpreter or C1 caller).
+      // At this point, r0 points to the value object (for interpreter or C1 caller).
       // The fields of the object are copied into registers (for C2 caller).
     }
   }

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -65,7 +65,7 @@ define_pd_global(bool, RewriteFrequentPairs, true);
 define_pd_global(bool, PreserveFramePointer, false);
 
 define_pd_global(bool, InlineTypePassFieldsAsArgs, true);
-define_pd_global(bool, InlineTypeReturnedAsFields, false);
+define_pd_global(bool, InlineTypeReturnedAsFields, true);
 
 define_pd_global(uintx, TypeProfileLevel, 111);
 

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -793,12 +793,10 @@ void InterpreterMacroAssembler::remove_activation(
 
     blr(rscratch1);
 
-    // call above kills the value in r1. Reload it.
-    ldr(r1, Address(rfp, frame::interpreter_frame_sender_sp_offset * wordSize));
+    // call above kills sender esp in rscratch2. Reload it.
+    ldr(rscratch2, Address(rfp, frame::interpreter_frame_sender_sp_offset * wordSize));
     bind(skip);
   }
-
-
 
   // restore sender esp
   mov(esp, rscratch2);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -312,22 +312,27 @@ class StubGenerator: public StubCodeGenerator {
     // T_OBJECT, T_INLINE_TYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     // n.b. this assumes Java returns an integral result in r0
     // and a floating result in j_farg0
-    __ ldr(j_rarg2, result);
+    // All of j_rargN may be used to return inline type fields so be careful
+    // not to clobber those.
+    // SharedRuntime::generate_buffered_inline_type_adapter() knows the register
+    // assignment of Rresult below.
+    Register Rresult = r14, Rresult_type = r15;
+    __ ldr(Rresult, result);
     Label is_long, is_float, is_double, is_value, exit;
-    __ ldr(j_rarg1, result_type);
-    __ cmp(j_rarg1, (u1)T_OBJECT);
+    __ ldr(Rresult_type, result_type);
+    __ cmp(Rresult_type, (u1)T_OBJECT);
     __ br(Assembler::EQ, is_long);
-    __ cmp(j_rarg1, (u1)T_INLINE_TYPE);
+    __ cmp(Rresult_type, (u1)T_INLINE_TYPE);
     __ br(Assembler::EQ, is_value);
-    __ cmp(j_rarg1, (u1)T_LONG);
+    __ cmp(Rresult_type, (u1)T_LONG);
     __ br(Assembler::EQ, is_long);
-    __ cmp(j_rarg1, (u1)T_FLOAT);
+    __ cmp(Rresult_type, (u1)T_FLOAT);
     __ br(Assembler::EQ, is_float);
-    __ cmp(j_rarg1, (u1)T_DOUBLE);
+    __ cmp(Rresult_type, (u1)T_DOUBLE);
     __ br(Assembler::EQ, is_double);
 
     // handle T_INT case
-    __ strw(r0, Address(j_rarg2));
+    __ strw(r0, Address(Rresult));
 
     __ BIND(exit);
 
@@ -376,27 +381,25 @@ class StubGenerator: public StubCodeGenerator {
     __ BIND(is_value);
     if (InlineTypeReturnedAsFields) {
       // Check for flattened return value
-      __ cbz(r0, is_long);
-      // Initialize pre-allocated buffer
-      __ mov(r1, r0);
-      __ andr(r1, r1, -2);
-      __ ldr(r1, Address(r1, InstanceKlass::adr_inlineklass_fixed_block_offset()));
-      __ ldr(r1, Address(r1, InlineKlass::pack_handler_offset()));
-      __ ldr(r0, Address(j_rarg2, 0));
-      __ blr(r1);
+      __ tbz(r0, 0, is_long);
+      // Load pack handler address
+      __ andr(rscratch1, r0, -2);
+      __ ldr(rscratch1, Address(rscratch1, InstanceKlass::adr_inlineklass_fixed_block_offset()));
+      __ ldr(rscratch1, Address(rscratch1, InlineKlass::pack_handler_jobject_offset()));
+      __ blr(rscratch1);
       __ b(exit);
     }
 
     __ BIND(is_long);
-    __ str(r0, Address(j_rarg2, 0));
+    __ str(r0, Address(Rresult, 0));
     __ br(Assembler::AL, exit);
 
     __ BIND(is_float);
-    __ strs(j_farg0, Address(j_rarg2, 0));
+    __ strs(j_farg0, Address(Rresult, 0));
     __ br(Assembler::AL, exit);
 
     __ BIND(is_double);
-    __ strd(j_farg0, Address(j_rarg2, 0));
+    __ strd(j_farg0, Address(Rresult, 0));
     __ br(Assembler::AL, exit);
 
     return start;
@@ -7000,16 +7003,12 @@ class StubGenerator: public StubCodeGenerator {
   // returned to registers or to store returned values to a newly
   // allocated inline type instance.
   address generate_return_value_stub(address destination, const char* name, bool has_res) {
-
-    // Information about frame layout at time of blocking runtime call.
-    // Note that we only have to preserve callee-saved registers since
-    // the compilers are responsible for supplying a continuation point
-    // if they expect all registers to be preserved.
+    // We need to save all registers the calling convention may use so
+    // the runtime calls read or update those registers. This needs to
+    // be in sync with SharedRuntime::java_return_convention().
     // n.b. aarch64 asserts that frame::arg_reg_save_area_bytes == 0
     enum layout {
-      rfp_off = 0, rfp_off2,
-
-      j_rarg7_off, j_rarg7_2,
+      j_rarg7_off = 0, j_rarg7_2,    // j_rarg7 is r0
       j_rarg6_off, j_rarg6_2,
       j_rarg5_off, j_rarg5_2,
       j_rarg4_off, j_rarg4_2,
@@ -7018,50 +7017,32 @@ class StubGenerator: public StubCodeGenerator {
       j_rarg1_off, j_rarg1_2,
       j_rarg0_off, j_rarg0_2,
 
-      j_farg0_off, j_farg0_2,
-      j_farg1_off, j_farg1_2,
-      j_farg2_off, j_farg2_2,
-      j_farg3_off, j_farg3_2,
-      j_farg4_off, j_farg4_2,
-      j_farg5_off, j_farg5_2,
-      j_farg6_off, j_farg6_2,
       j_farg7_off, j_farg7_2,
+      j_farg6_off, j_farg6_2,
+      j_farg5_off, j_farg5_2,
+      j_farg4_off, j_farg4_2,
+      j_farg3_off, j_farg3_2,
+      j_farg2_off, j_farg2_2,
+      j_farg1_off, j_farg1_2,
+      j_farg0_off, j_farg0_2,
 
+      rfp_off, rfp_off2,
       return_off, return_off2,
+
       framesize // inclusive of return address
     };
 
-    int insts_size = 512;
-    int locs_size  = 64;
-
-    CodeBuffer code(name, insts_size, locs_size);
-    OopMapSet* oop_maps  = new OopMapSet();
+    CodeBuffer code(name, 512, 64);
     MacroAssembler* masm = new MacroAssembler(&code);
 
-    address start = __ pc();
+    int frame_size_in_bytes = align_up(framesize*BytesPerInt, 16);
+    assert(frame_size_in_bytes == framesize*BytesPerInt, "misaligned");
+    int frame_size_in_slots = frame_size_in_bytes / BytesPerInt;
+    int frame_size_in_words = frame_size_in_bytes / wordSize;
 
-    const Address f7_save       (rfp, j_farg7_off * wordSize);
-    const Address f6_save       (rfp, j_farg6_off * wordSize);
-    const Address f5_save       (rfp, j_farg5_off * wordSize);
-    const Address f4_save       (rfp, j_farg4_off * wordSize);
-    const Address f3_save       (rfp, j_farg3_off * wordSize);
-    const Address f2_save       (rfp, j_farg2_off * wordSize);
-    const Address f1_save       (rfp, j_farg1_off * wordSize);
-    const Address f0_save       (rfp, j_farg0_off * wordSize);
+    OopMapSet* oop_maps = new OopMapSet();
+    OopMap* map = new OopMap(frame_size_in_slots, 0);
 
-    const Address r0_save      (rfp, j_rarg0_off * wordSize);
-    const Address r1_save      (rfp, j_rarg1_off * wordSize);
-    const Address r2_save      (rfp, j_rarg2_off * wordSize);
-    const Address r3_save      (rfp, j_rarg3_off * wordSize);
-    const Address r4_save      (rfp, j_rarg4_off * wordSize);
-    const Address r5_save      (rfp, j_rarg5_off * wordSize);
-    const Address r6_save      (rfp, j_rarg6_off * wordSize);
-    const Address r7_save      (rfp, j_rarg7_off * wordSize);
-
-    // Generate oop map
-    OopMap* map = new OopMap(framesize, 0);
-
-    map->set_callee_saved(VMRegImpl::stack2reg(rfp_off), rfp->as_VMReg());
     map->set_callee_saved(VMRegImpl::stack2reg(j_rarg7_off), j_rarg7->as_VMReg());
     map->set_callee_saved(VMRegImpl::stack2reg(j_rarg6_off), j_rarg6->as_VMReg());
     map->set_callee_saved(VMRegImpl::stack2reg(j_rarg5_off), j_rarg5->as_VMReg());
@@ -7080,47 +7061,30 @@ class StubGenerator: public StubCodeGenerator {
     map->set_callee_saved(VMRegImpl::stack2reg(j_farg6_off), j_farg6->as_VMReg());
     map->set_callee_saved(VMRegImpl::stack2reg(j_farg7_off), j_farg7->as_VMReg());
 
-    // This is an inlined and slightly modified version of call_VM
-    // which has the ability to fetch the return PC out of
-    // thread-local storage and also sets up last_Java_sp slightly
-    // differently than the real call_VM
+    address start = __ pc();
 
     __ enter(); // Save FP and LR before call
 
-    assert(is_even(framesize/2), "sp not 16-byte aligned");
+    __ stpd(j_farg1, j_farg0, Address(__ pre(sp, -2 * wordSize)));
+    __ stpd(j_farg3, j_farg2, Address(__ pre(sp, -2 * wordSize)));
+    __ stpd(j_farg5, j_farg4, Address(__ pre(sp, -2 * wordSize)));
+    __ stpd(j_farg7, j_farg6, Address(__ pre(sp, -2 * wordSize)));
 
-    // lr and fp are already in place
-    __ sub(sp, rfp, ((unsigned)framesize - 4) << LogBytesPerInt); // prolog
+    __ stp(j_rarg1, j_rarg0, Address(__ pre(sp, -2 * wordSize)));
+    __ stp(j_rarg3, j_rarg2, Address(__ pre(sp, -2 * wordSize)));
+    __ stp(j_rarg5, j_rarg4, Address(__ pre(sp, -2 * wordSize)));
+    __ stp(j_rarg7, j_rarg6, Address(__ pre(sp, -2 * wordSize)));
 
-    __ strd(j_farg7, f7_save);
-    __ strd(j_farg6, f6_save);
-    __ strd(j_farg5, f5_save);
-    __ strd(j_farg4, f4_save);
-    __ strd(j_farg3, f3_save);
-    __ strd(j_farg2, f2_save);
-    __ strd(j_farg1, f1_save);
-    __ strd(j_farg0, f0_save);
-
-    __ str(j_rarg0, r0_save);
-    __ str(j_rarg1, r1_save);
-    __ str(j_rarg2, r2_save);
-    __ str(j_rarg3, r3_save);
-    __ str(j_rarg4, r4_save);
-    __ str(j_rarg5, r5_save);
-    __ str(j_rarg6, r6_save);
-    __ str(j_rarg7, r7_save);
-
-    int frame_complete = __ pc() - start;
+    int frame_complete = __ offset();
 
     // Set up last_Java_sp and last_Java_fp
     address the_pc = __ pc();
     __ set_last_Java_frame(sp, rfp, the_pc, rscratch1);
 
     // Call runtime
-    __ mov(c_rarg0, rthread);
     __ mov(c_rarg1, r0);
+    __ mov(c_rarg0, rthread);
 
-    BLOCK_COMMENT("call runtime_entry");
     __ mov(rscratch1, destination);
     __ blr(rscratch1);
 
@@ -7128,47 +7092,37 @@ class StubGenerator: public StubCodeGenerator {
 
     __ reset_last_Java_frame(false);
 
-    __ ldrd(j_farg7, f7_save);
-    __ ldrd(j_farg6, f6_save);
-    __ ldrd(j_farg5, f5_save);
-    __ ldrd(j_farg4, f4_save);
-    __ ldrd(j_farg3, f3_save);
-    __ ldrd(j_farg3, f2_save);
-    __ ldrd(j_farg1, f1_save);
-    __ ldrd(j_farg0, f0_save);
+    __ ldp(j_rarg7, j_rarg6, Address(__ post(sp, 2 * wordSize)));
+    __ ldp(j_rarg5, j_rarg4, Address(__ post(sp, 2 * wordSize)));
+    __ ldp(j_rarg3, j_rarg2, Address(__ post(sp, 2 * wordSize)));
+    __ ldp(j_rarg1, j_rarg0, Address(__ post(sp, 2 * wordSize)));
 
-    __ ldr(j_rarg0, r0_save);
-    __ ldr(j_rarg1, r1_save);
-    __ ldr(j_rarg2, r2_save);
-    __ ldr(j_rarg3, r3_save);
-    __ ldr(j_rarg4, r4_save);
-    __ ldr(j_rarg5, r5_save);
-    __ ldr(j_rarg6, r6_save);
-    __ ldr(j_rarg7, r7_save);
+    __ ldpd(j_farg7, j_farg6, Address(__ post(sp, 2 * wordSize)));
+    __ ldpd(j_farg5, j_farg4, Address(__ post(sp, 2 * wordSize)));
+    __ ldpd(j_farg3, j_farg2, Address(__ post(sp, 2 * wordSize)));
+    __ ldpd(j_farg1, j_farg0, Address(__ post(sp, 2 * wordSize)));
 
     __ leave();
 
     // check for pending exceptions
     Label pending;
     __ ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
-    __ cmp(rscratch1, (u1)NULL_WORD);
-    __ br(Assembler::NE, pending);
+    __ cbnz(rscratch1, pending);
 
     if (has_res) {
       __ get_vm_result(r0, rthread);
     }
+
     __ ret(lr);
 
     __ bind(pending);
-    __ ldr(r0, Address(rthread, in_bytes(Thread::pending_exception_offset())));
     __ far_jump(RuntimeAddress(StubRoutines::forward_exception_entry()));
 
+    // -------------
+    // make sure all code is generated
+    masm->flush();
 
-    // codeBlob framesize is in words (not VMRegImpl::slot_size)
-    int frame_size_in_words = (framesize >> (LogBytesPerWord - LogBytesPerInt));
-    RuntimeStub* stub =
-      RuntimeStub::new_runtime_stub(name, &code, frame_complete, frame_size_in_words, oop_maps, false);
-
+    RuntimeStub* stub = RuntimeStub::new_runtime_stub(name, &code, frame_complete, frame_size_in_words, oop_maps, false);
     return stub->entry_point();
   }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2015,7 +2015,7 @@ bool Arguments::check_vm_args_consistency() {
     warning("InlineTypePassFieldsAsArgs is not supported on this platform");
   }
 
-  if (AMD64_ONLY(false &&) !FLAG_IS_DEFAULT(InlineTypeReturnedAsFields)) {
+  if (AMD64_ONLY(false &&) AARCH64_ONLY(false &&) !FLAG_IS_DEFAULT(InlineTypeReturnedAsFields)) {
     FLAG_SET_CMDLINE(InlineTypeReturnedAsFields, false);
     warning("InlineTypeReturnedAsFields is not supported on this platform");
   }


### PR DESCRIPTION
The code to support this on AArch64 was already mostly written but
untested or bit-rotted. This patch also contains the allocation
optimisation to MacroAssembler::store_inline_type_fields_to_buf() from
JDK-8263067.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8268021](https://bugs.openjdk.java.net/browse/JDK-8268021): [lworld] [AArch64] fix support for InlineTypeReturnedAsFields


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/461/head:pull/461` \
`$ git checkout pull/461`

Update a local copy of the PR: \
`$ git checkout pull/461` \
`$ git pull https://git.openjdk.java.net/valhalla pull/461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 461`

View PR using the GUI difftool: \
`$ git pr show -t 461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/461.diff">https://git.openjdk.java.net/valhalla/pull/461.diff</a>

</details>
