### PR TITLE
8269279: [lworld] 8269231 causes build failures

### DIFF
--- a/src/hotspot/share/oops/markWord.inline.hpp
+++ b/src/hotspot/share/oops/markWord.inline.hpp
@@ -70,15 +70,19 @@ inline bool markWord::must_be_preserved_for_promotion_failure(const oopDesc* obj
 
 inline markWord markWord::prototype_for_klass(const Klass* klass) {
   markWord prototype_header = klass->prototype_header();
+#ifdef _LP64
   assert(prototype_header == prototype() ||
          (UseBiasedLocking && prototype_header.has_bias_pattern())
          || prototype_header.is_inline_type()
-#ifdef _LP64
          || prototype_header.is_flat_array()
          || prototype_header.is_null_free_array()
-#endif
          , "corrupt prototype header");
-
+#else
+  assert(prototype_header == prototype() ||
+         (UseBiasedLocking && prototype_header.has_bias_pattern())
+         || prototype_header.is_inline_type()
+         , "corrupt prototype header");
+#endif
   return prototype_header;
 }
 

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -298,8 +298,8 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       assert(fd.is_inlined(), "field not flat");
     } else {
       if (log_is_enabled(Trace, valuetypes)) {
-        log_trace(valuetypes)("not a field in %s at offset " JLONG_FORMAT_X,
-                              p->klass()->external_name(), offset);
+        log_trace(valuetypes)("not a field in %s at offset " JULONG_FORMAT_X,
+                              p->klass()->external_name(), (uint64_t)offset);
       }
     }
   } else if (k->is_flatArray_klass()) {
@@ -316,12 +316,12 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       FlatArrayKlass* vak = FlatArrayKlass::cast(k);
       int index = (offset - vak->array_header_in_bytes()) / vak->element_byte_size();
       address dest = (address)((flatArrayOop)p)->value_at_addr(index, vak->layout_helper());
-      log_trace(valuetypes)("%s array type %s index %d element size %d offset " JLONG_FORMAT_X " at " INTPTR_FORMAT,
+      log_trace(valuetypes)("%s array type %s index %d element size %d offset " JULONG_FORMAT_X " at " INTPTR_FORMAT,
                             p->klass()->external_name(), vak->external_name(),
-                            index, vak->element_byte_size(), offset, p2i(dest));
+                            index, vak->element_byte_size(), (uint64_t)offset, p2i(dest));
     } else {
-      log_trace(valuetypes)("%s field type %s at offset " JLONG_FORMAT_X,
-                            p->klass()->external_name(), vk->external_name(), offset);
+      log_trace(valuetypes)("%s field type %s at offset " JULONG_FORMAT_X,
+                            p->klass()->external_name(), vk->external_name(), (uint64_t)offset);
     }
   }
 }

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -298,7 +298,7 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       assert(fd.is_inlined(), "field not flat");
     } else {
       if (log_is_enabled(Trace, valuetypes)) {
-        log_trace(valuetypes)("not a field in %s at offset " JULONG_FORMAT_X,
+        log_trace(valuetypes)("not a field in %s at offset " UINT64_FORMAT_X,
                               p->klass()->external_name(), (uint64_t)offset);
       }
     }
@@ -316,11 +316,11 @@ static void assert_and_log_unsafe_value_access(oop p, jlong offset, InlineKlass*
       FlatArrayKlass* vak = FlatArrayKlass::cast(k);
       int index = (offset - vak->array_header_in_bytes()) / vak->element_byte_size();
       address dest = (address)((flatArrayOop)p)->value_at_addr(index, vak->layout_helper());
-      log_trace(valuetypes)("%s array type %s index %d element size %d offset " JULONG_FORMAT_X " at " INTPTR_FORMAT,
+      log_trace(valuetypes)("%s array type %s index %d element size %d offset " UINT64_FORMAT_X " at " INTPTR_FORMAT,
                             p->klass()->external_name(), vak->external_name(),
                             index, vak->element_byte_size(), (uint64_t)offset, p2i(dest));
     } else {
-      log_trace(valuetypes)("%s field type %s at offset " JULONG_FORMAT_X,
+      log_trace(valuetypes)("%s field type %s at offset " UINT64_FORMAT_X,
                             p->klass()->external_name(), vk->external_name(), (uint64_t)offset);
     }
   }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -104,7 +104,6 @@ class oopDesc;
 // Format 64-bit quantities.
 #define INT64_FORMAT           "%" PRId64
 #define UINT64_FORMAT          "%" PRIu64
-#define INT64_FORMAT_X         "%" PRIx64
 #define UINT64_FORMAT_X        "%" PRIx64
 #define INT64_FORMAT_W(width)  "%" #width PRId64
 #define UINT64_FORMAT_W(width) "%" #width PRIu64
@@ -118,9 +117,6 @@ class oopDesc;
 #endif
 #ifndef JLONG_FORMAT_W
 #define JLONG_FORMAT_W(width)  INT64_FORMAT_W(width)
-#endif
-#ifndef JLONG_FORMAT_X
-#define JLONG_FORMAT_X         INT64_FORMAT_X
 #endif
 #ifndef JULONG_FORMAT
 #define JULONG_FORMAT          UINT64_FORMAT


### PR DESCRIPTION
Removed signed hex formats since "x" is unsigned by definition

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269279](https://bugs.openjdk.java.net/browse/JDK-8269279): [lworld] 8269231 causes build failures


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/463/head:pull/463` \
`$ git checkout pull/463`

Update a local copy of the PR: \
`$ git checkout pull/463` \
`$ git pull https://git.openjdk.java.net/valhalla pull/463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 463`

View PR using the GUI difftool: \
`$ git pr show -t 463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/463.diff">https://git.openjdk.java.net/valhalla/pull/463.diff</a>

</details>
