### PR TITLE
8269578: [lworld] fix AArch64 build after JDK-8267824

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1555,14 +1555,14 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
   cbnz(temp_reg, is_empty_inline_type);
 }
 
-void MacroAssembler::test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline) {
+void MacroAssembler::test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free_inline_type) {
   assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
-  tbnz(flags, ConstantPoolCacheEntry::is_inline_type_shift, is_inline);
+  tbnz(flags, ConstantPoolCacheEntry::is_null_free_inline_type_shift, is_null_free_inline_type);
 }
 
-void MacroAssembler::test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline) {
+void MacroAssembler::test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free_inline_type) {
   assert(temp_reg == noreg, "not needed"); // keep signature uniform with x86
-  tbz(flags, ConstantPoolCacheEntry::is_inline_type_shift, not_inline);
+  tbz(flags, ConstantPoolCacheEntry::is_null_free_inline_type_shift, not_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_inlined(Register flags, Register temp_reg, Label& is_flattened) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -632,8 +632,8 @@ public:
   // get_default_value_oop with extra assertion for empty inline klass
   void get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj);
 
-  void test_field_is_inline_type(Register flags, Register temp_reg, Label& is_inline);
-  void test_field_is_not_inline_type(Register flags, Register temp_reg, Label& not_inline);
+  void test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free);
+  void test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free);
   void test_field_is_inlined(Register flags, Register temp_reg, Label& is_flattened);
 
   // Check oops for special arrays, i.e. flattened and/or null-free

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2618,14 +2618,14 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   } else { // Valhalla
     if (is_static) {
       __ load_heap_oop(r0, field);
-      Label is_inline_type, uninitialized;
+      Label is_null_free_inline_type, uninitialized;
       // Issue below if the static field has not been initialized yet
-      __ test_field_is_inline_type(raw_flags, noreg /*temp*/, is_inline_type);
-        // field is not an inline type
+      __ test_field_is_null_free_inline_type(raw_flags, noreg /*temp*/, is_null_free_inline_type);
+        // field is not a null free inline type
         __ push(atos);
         __ b(Done);
-      // field is an inline type, must not return null even if uninitialized
-      __ bind(is_inline_type);
+      // field is a null free inline type, must not return null even if uninitialized
+      __ bind(is_null_free_inline_type);
         __ cbz(r0, uninitialized);
           __ push(atos);
           __ b(Done);
@@ -2645,7 +2645,7 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
           __ b(Done);
     } else {
       Label is_inlined, nonnull, is_inline_type, rewrite_inline;
-      __ test_field_is_inline_type(raw_flags, noreg /*temp*/, is_inline_type);
+      __ test_field_is_null_free_inline_type(raw_flags, noreg /*temp*/, is_inline_type);
         // Non-inline field case
         __ load_heap_oop(r0, field);
         __ push(atos);
@@ -2929,14 +2929,14 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
       __ pop(atos);
       if (is_static) {
         Label is_inline_type;
-         __ test_field_is_not_inline_type(flags2, noreg /* temp */, is_inline_type);
+         __ test_field_is_not_null_free_inline_type(flags2, noreg /* temp */, is_inline_type);
          __ null_check(r0);
          __ bind(is_inline_type);
          do_oop_store(_masm, field, r0, IN_HEAP);
          __ b(Done);
       } else {
         Label is_inline_type, is_inlined, rewrite_not_inline, rewrite_inline;
-        __ test_field_is_inline_type(flags2, noreg /*temp*/, is_inline_type);
+        __ test_field_is_null_free_inline_type(flags2, noreg /*temp*/, is_inline_type);
         // Not an inline type
         pop_and_check_object(obj);
         // Store into the field


### PR DESCRIPTION
Replace ConstantPoolCacheEntry::is_inline_type_shift with
is_null_free_inline_type_shift and change inline_type to
null_free_inline_type in a few other places to match x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269578](https://bugs.openjdk.java.net/browse/JDK-8269578): [lworld] fix AArch64 build after JDK-8267824


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/467/head:pull/467` \
`$ git checkout pull/467`

Update a local copy of the PR: \
`$ git checkout pull/467` \
`$ git pull https://git.openjdk.java.net/valhalla pull/467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 467`

View PR using the GUI difftool: \
`$ git pr show -t 467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/467.diff">https://git.openjdk.java.net/valhalla/pull/467.diff</a>

</details>
