### PR TITLE
8269792: [lworld] Duplicate/redundant CONSTANT_Class_info entry in constant pool 

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -116,6 +116,12 @@ public class PoolWriter {
      * or an array type.
      */
     int putClass(Type t) {
+        /* Their is nothing to be gained by having the pair of class types Foo.ref and Foo.val
+           result in two different CONSTANT_Class_info strucures in the pool. These are
+           indistinguishable at the class file level. Hence we coalesce them here.
+        */
+        if (t.isReferenceProjection())
+            t = t.valueProjection();
         return pool.writeIfNeeded(types.erasure(t));
     }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ArrayCreationWithQuestion.java
@@ -53,10 +53,10 @@ public class ArrayCreationWithQuestion {
                                             Paths.get(System.getProperty("test.classes"),
                                                 "ArrayCreationWithQuestion$VT.class").toString() };
         runCheck(params, new String [] {
-        "         6: anewarray     #3                  // class ArrayCreationWithQuestion$VT",
-        "        17: anewarray     #3                  // class ArrayCreationWithQuestion$VT",
-        "        28: anewarray     #11                 // class \"QArrayCreationWithQuestion$VT;\"",
-        "        39: anewarray     #11                 // class \"QArrayCreationWithQuestion$VT;\"",
+        "         6: anewarray     #1                  // class ArrayCreationWithQuestion$VT",
+        "        17: anewarray     #1                  // class ArrayCreationWithQuestion$VT",
+        "        28: anewarray     #10                 // class \"QArrayCreationWithQuestion$VT;\"",
+        "        39: anewarray     #10                 // class \"QArrayCreationWithQuestion$VT;\"",
          });
 
      }

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassBytecodeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassBytecodeTest.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -72,14 +73,14 @@ public class UnifiedPrimitiveClassBytecodeTest {
         " 2: anewarray     #11                 // class \"QUnifiedPrimitiveClassBytecodeTest$X;\"",
         " 5: astore_2",
         " 6: bipush        10",
-        " 8: anewarray     #13                 // class UnifiedPrimitiveClassBytecodeTest$X",
+        " 8: anewarray     #1                  // class UnifiedPrimitiveClassBytecodeTest$X",
         "11: astore_1",
         "12: aload_1",
         "13: iconst_0",
         "14: aload_2",
         "15: iconst_0",
         "16: aaload",
-        "17: checkcast     #13                 // class UnifiedPrimitiveClassBytecodeTest$X",
+        "17: checkcast     #1                  // class UnifiedPrimitiveClassBytecodeTest$X",
         "20: aastore",
         "21: aload_2",
         "22: iconst_1",
@@ -90,7 +91,7 @@ public class UnifiedPrimitiveClassBytecodeTest {
         "29: aastore",
         "30: ldc           #11                 // class \"QUnifiedPrimitiveClassBytecodeTest$X;\"",
         "32: astore_3",
-        "33: ldc           #13                 // class UnifiedPrimitiveClassBytecodeTest$X",
+        "33: ldc           #1                  // class UnifiedPrimitiveClassBytecodeTest$X",
         "35: astore_3",
         "36: return",
          });


### PR DESCRIPTION
Do not emit distinct Constant_class_info entries for Foo.ref and Foo.val

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269792](https://bugs.openjdk.java.net/browse/JDK-8269792): [lworld] Duplicate/redundant CONSTANT_Class_info entry in constant pool


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/471/head:pull/471` \
`$ git checkout pull/471`

Update a local copy of the PR: \
`$ git checkout pull/471` \
`$ git pull https://git.openjdk.java.net/valhalla pull/471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 471`

View PR using the GUI difftool: \
`$ git pr show -t 471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/471.diff">https://git.openjdk.java.net/valhalla/pull/471.diff</a>

</details>
