### PR TITLE
8267932: [lworld] JIT support for the L/Q model (step 2)

### DIFF
--- a/src/hotspot/share/ci/ciConstant.cpp
+++ b/src/hotspot/share/ci/ciConstant.cpp
@@ -56,7 +56,6 @@ void ciConstant::print() {
   case T_DOUBLE:
     tty->print("%lf", _value._double);
     break;
-  case T_INLINE_TYPE:
   default:
     if (is_reference_type(basic_type())) {
       _value._object->print();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -693,7 +693,15 @@ ciConstant ciEnv::get_constant_by_index_impl(const constantPoolHandle& cpool,
     }
     assert (klass->is_instance_klass() || klass->is_array_klass(),
             "must be an instance or array klass ");
-    return ciConstant(T_OBJECT, klass->java_mirror());
+    if (!klass->is_loaded()) {
+      return ciConstant(T_OBJECT, get_unloaded_klass_mirror(klass));
+    } else {
+      if (tag.is_Qdescriptor_klass()) {
+        return ciConstant(T_OBJECT, klass->as_inline_klass()->val_mirror());
+      } else {
+        return ciConstant(T_OBJECT, klass->java_mirror());
+      }
+    }
   } else if (tag.is_method_type()) {
     // must execute Java code to link this CP entry into cache[i].f1
     ciSymbol* signature = get_symbol(cpool->method_type_signature_at(index));

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -121,6 +121,20 @@ ciInstance* ciInlineKlass::default_instance() const {
   )
 }
 
+ciInstance* ciInlineKlass::ref_instance() const {
+  GUARDED_VM_ENTRY(
+    oop ref_mirror = to_InlineKlass()->ref_mirror();
+    return CURRENT_ENV->get_instance(ref_mirror);
+  )
+}
+
+ciInstance* ciInlineKlass::val_instance() const {
+  GUARDED_VM_ENTRY(
+    oop val_mirror = to_InlineKlass()->val_mirror();
+    return CURRENT_ENV->get_instance(val_mirror);
+  )
+}
+
 bool ciInlineKlass::contains_oops() const {
   GUARDED_VM_ENTRY(return get_InlineKlass()->contains_oops();)
 }
@@ -139,4 +153,8 @@ address ciInlineKlass::unpack_handler() const {
 
 InlineKlass* ciInlineKlass::get_InlineKlass() const {
   GUARDED_VM_ENTRY(return to_InlineKlass();)
+}
+
+ciInstance* ciInlineKlass::val_mirror() {
+  GUARDED_VM_ENTRY(return CURRENT_ENV->get_instance(to_InlineKlass()->val_mirror());)
 }

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -85,11 +85,14 @@ public:
   int inline_arg_slots();
   int default_value_offset() const;
   ciInstance* default_instance() const;
+  ciInstance* ref_instance() const;
+  ciInstance* val_instance() const;
   bool contains_oops() const;
   int oop_count() const;
   address pack_handler() const;
   address unpack_handler() const;
   InlineKlass* get_InlineKlass() const;
+  ciInstance* val_mirror();
 };
 
 #endif // SHARE_VM_CI_CIINLINEKLASS_HPP

--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -39,7 +39,7 @@
 
 // ------------------------------------------------------------------
 // ciObject::java_mirror_type
-ciType* ciInstance::java_mirror_type() {
+ciType* ciInstance::java_mirror_type(bool* is_val_mirror) {
   VM_ENTRY_MARK;
   oop m = get_oop();
   // Return NULL if it is not java.lang.Class.
@@ -52,6 +52,9 @@ ciType* ciInstance::java_mirror_type() {
   } else {
     Klass* k = java_lang_Class::as_Klass(m);
     assert(k != NULL, "");
+    if (is_val_mirror != NULL) {
+      *is_val_mirror = java_lang_Class::is_secondary_mirror(m);
+    }
     return CURRENT_THREAD_ENV->get_klass(k);
   }
 }

--- a/src/hotspot/share/ci/ciInstance.hpp
+++ b/src/hotspot/share/ci/ciInstance.hpp
@@ -55,7 +55,7 @@ public:
   // If this object is a java mirror, return the corresponding type.
   // Otherwise, return NULL.
   // (Remember that a java mirror is an instance of java.lang.Class.)
-  ciType* java_mirror_type();
+  ciType* java_mirror_type(bool* is_val_mirror = NULL);
 
   // What kind of ciObject is this?
   bool is_instance()     { return true; }

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -630,7 +630,7 @@ ciReturnAddress* ciObjectFactory::get_return_address(int bci) {
 }
 
 ciWrapper* ciObjectFactory::make_null_free_wrapper(ciType* type) {
-  ciWrapper* wrapper = new (arena()) ciWrapper(type, /* null_free */ true);
+  ciWrapper* wrapper = new (arena()) ciWrapper(type);
   init_ident_of(wrapper);
   return wrapper;
 }

--- a/src/hotspot/share/ci/ciType.hpp
+++ b/src/hotspot/share/ci/ciType.hpp
@@ -72,7 +72,7 @@ public:
   bool is_type() const                      { return true; }
   bool is_classless() const                 { return is_primitive_type(); }
 
-  virtual ciType*     unwrap()              { return this; }
+  virtual ciType* unwrap()                  { return this; }
   virtual bool is_null_free() const         { return false; }
 
   const char* name();
@@ -112,22 +112,20 @@ public:
 
 // ciWrapper
 //
-// This class wraps another type to carry additional information like nullability.
-// Should only be instantiated and used by ciTypeFlow and ciSignature.
+// This class wraps another type to carry additional information.
+// Currently it is only used to mark inline klasses as null-free.
 class ciWrapper : public ciType {
   CI_PACKAGE_ACCESS
 
 private:
   ciType* _type;
-  bool _null_free;
 
-  ciWrapper(ciType* type, bool null_free) : ciType(type->basic_type()) {
+  ciWrapper(ciType* type) : ciType(type->basic_type()) {
     assert(type->is_inlinetype()
           // An unloaded inline type is an instance_klass (see ciEnv::get_klass_by_name_impl())
           || (type->is_instance_klass() && !type->is_loaded()),
           "should only be used for inline types");
     _type = type;
-    _null_free = null_free;
   }
 
   const char* type_string() { return "ciWrapper"; }
@@ -135,10 +133,9 @@ private:
   void print_impl(outputStream* st) { _type->print_impl(st); }
 
 public:
-  bool    is_wrapper() const { return true; }
-
-  ciType*     unwrap()       { return _type; }
-  bool is_null_free() const { return _null_free; }
+  bool is_wrapper()   const { return true; }
+  ciType* unwrap()          { return _type; }
+  bool is_null_free() const { return true; }
 };
 
 #endif // SHARE_CI_CITYPE_HPP

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -350,7 +350,7 @@ ciType* ciTypeFlow::StateVector::type_meet_internal(ciType* t1, ciType* t2, ciTy
     assert(k1->is_instance_klass(), "previous cases handle non-instances");
     assert(k2->is_instance_klass(), "previous cases handle non-instances");
     ciType* result = k1->least_common_ancestor(k2);
-    if (null_free1 && null_free2) {
+    if (null_free1 && null_free2 && result->is_inlinetype()) {
       result = analyzer->mark_as_null_free(result);
     }
     return result;
@@ -637,6 +637,10 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
     }
   } else {
     ciType* type = pop_value();
+    if (type->unwrap() != klass && type->unwrap()->is_subtype_of(klass)) {
+      // Useless cast, propagate more precise type of object
+      klass = type->unwrap()->as_klass();
+    }
     if (klass->is_inlinetype() && (null_free || type->is_null_free())) {
       push(outer()->mark_as_null_free(klass));
     } else {
@@ -1579,7 +1583,7 @@ bool ciTypeFlow::StateVector::apply_one_bytecode(ciBytecodeStream* str) {
 // ------------------------------------------------------------------
 // ciTypeFlow::StateVector::print_cell_on
 void ciTypeFlow::StateVector::print_cell_on(outputStream* st, Cell c) const {
-  ciType* type = type_at(c);
+  ciType* type = type_at(c)->unwrap();
   if (type == top_type()) {
     st->print("top");
   } else if (type == bottom_type()) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -345,6 +345,8 @@ class java_lang_Class : AllStatic {
   static int klass_offset()                { CHECK_INIT(_klass_offset); }
   static int array_klass_offset()          { CHECK_INIT(_array_klass_offset); }
   static int component_mirror_offset()     { CHECK_INIT(_component_mirror_offset); }
+  static int primary_mirror_offset()       { CHECK_INIT(_primary_mirror_offset); }
+  static int secondary_mirror_offset()     { CHECK_INIT(_secondary_mirror_offset); }
   // Support for classRedefinedCount field
   static int classRedefinedCount(oop the_class_mirror);
   static void set_classRedefinedCount(oop the_class_mirror, int value);

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -267,6 +267,9 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
       // This code will be unreachable
       assert(StressReflectiveCode, "Guard against surprises");
       bt = T_LONG;
+    } else if (ary_ptr->is_flat()) {
+      // Clone flat inline type array
+      bt = T_LONG;
     } else {
       bt = ary_ptr->elem()->array_element_basic_type();
       if (is_reference_type(bt)) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3680,6 +3680,13 @@ Node* GraphKit::inline_type_test(Node* obj, bool is_inline) {
   return _gvn.transform(new BoolNode(cmp, is_inline ? BoolTest::eq : BoolTest::ne));
 }
 
+Node* GraphKit::is_val_mirror(Node* mirror) {
+  Node* p = basic_plus_adr(mirror, java_lang_Class::secondary_mirror_offset());
+  Node* secondary_mirror = access_load_at(mirror, p, _gvn.type(p)->is_ptr(), TypeInstPtr::MIRROR->cast_to_ptr_type(TypePtr::BotPTR), T_OBJECT, IN_HEAP);
+  Node* cmp = _gvn.transform(new CmpPNode(mirror, secondary_mirror));
+  return _gvn.transform(new BoolNode(cmp, BoolTest::eq));
+}
+
 Node* GraphKit::array_lh_test(Node* klass, jint mask, jint val, bool eq) {
   Node* lh_adr = basic_plus_adr(klass, in_bytes(Klass::layout_helper_offset()));
   // Make sure to use immutable memory here to enable hoisting the check out of loops

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -869,6 +869,7 @@ class GraphKit : public Phase {
 
   // Inline types
   Node* inline_type_test(Node* obj, bool is_inline = true);
+  Node* is_val_mirror(Node* mirror);
   Node* array_lh_test(Node* kls, jint mask, jint val, bool eq = true);
   Node* flat_array_test(Node* ary, bool flat = true);
   Node* null_free_array_test(Node* klass, bool null_free = true);

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -165,7 +165,6 @@ class LibraryCallKit : public GraphKit {
                                     int modifier_mask, int modifier_bits,
                                     RegionNode* region);
   Node* generate_interface_guard(Node* kls, RegionNode* region);
-  Node* generate_value_guard(Node* kls, RegionNode* region);
 
   enum ArrayKind {
     AnyArray,

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -267,7 +267,7 @@ public:
   // Helper for match
   OptoReg::Name warp_incoming_stk_arg( VMReg reg );
 
-  RegMask* return_values_mask(const TypeTuple *range);
+  RegMask* return_values_mask(const TypeTuple* range);
 
   // Transform, then walk.  Does implicit DCE while walking.
   // Name changed from "transform" to avoid it being virtual.

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2023,11 +2023,20 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     ciObject* const_oop = tinst->const_oop();
     if (!is_mismatched_access() && off != Type::OffsetBot && const_oop != NULL && const_oop->is_instance()) {
       ciType* mirror_type = const_oop->as_instance()->java_mirror_type();
-      if (mirror_type != NULL && mirror_type->is_inlinetype()) {
-        ciInlineKlass* vk = mirror_type->as_inline_klass();
-        if (off == vk->default_value_offset()) {
-          // Loading a special hidden field that contains the oop of the default inline type
-          const Type* const_oop = TypeInstPtr::make(vk->default_instance());
+      if (mirror_type != NULL) {
+        const Type* const_oop = NULL;
+        ciInlineKlass* vk = mirror_type->is_inlinetype() ? mirror_type->as_inline_klass() : NULL;
+        // Fold default value loads
+        if (vk != NULL && off == vk->default_value_offset()) {
+          const_oop = TypeInstPtr::make(vk->default_instance());
+        }
+        // Fold class mirror loads
+        if (off == java_lang_Class::primary_mirror_offset()) {
+          const_oop = (vk == NULL) ? TypePtr::NULL_PTR : TypeInstPtr::make(vk->ref_instance());
+        } else if (off == java_lang_Class::secondary_mirror_offset()) {
+          const_oop = (vk == NULL) ? TypePtr::NULL_PTR : TypeInstPtr::make(vk->val_instance());
+        }
+        if (const_oop != NULL) {
           return (bt == T_NARROWOOP) ? const_oop->make_narrowoop() : const_oop;
         }
       }
@@ -2387,7 +2396,8 @@ const Type* LoadNode::klass_value_common(PhaseGVN* phase) const {
             offset == java_lang_Class::array_klass_offset())) {
       // We are loading a special hidden field from a Class mirror object,
       // the field which points to the VM's Klass metaobject.
-      ciType* t = tinst->java_mirror_type();
+      bool null_free = false;
+      ciType* t = tinst->java_mirror_type(&null_free);
       // java_mirror_type returns non-null for compile-time Class constants.
       if (t != NULL) {
         // constant oop => constant klass
@@ -2397,12 +2407,7 @@ const Type* LoadNode::klass_value_common(PhaseGVN* phase) const {
             // klass.  Users of this result need to do a null check on the returned klass.
             return TypePtr::NULL_PTR;
           }
-          if (t->is_inlinetype()) {
-            // TODO fix with JDK-8267932
-            return LoadNode::Value(phase);
-          } else {
-            return TypeKlassPtr::make(ciArrayKlass::make(t));
-          }
+          return TypeKlassPtr::make(ciArrayKlass::make(t, null_free));
         }
         if (!t->is_klass()) {
           // a primitive Class (e.g., int.class) has NULL for a klass field

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3323,7 +3323,7 @@ void PhaseOutput::init_scratch_buffer_blob(int const_size) {
       // when loading object fields from the buffered argument. Increase scratch buffer size accordingly.
       int barrier_size = UseZGC ? 200 : (7 DEBUG_ONLY(+ 37));
       for (ciSignatureStream str(C->method()->signature()); !str.at_return_type(); str.next()) {
-        if (str.type()->is_inlinetype() && str.type()->as_inline_klass()->can_be_passed_as_fields()) {
+        if (str.is_null_free() && str.type()->as_inline_klass()->can_be_passed_as_fields()) {
           size += str.type()->as_inline_klass()->oop_count() * barrier_size;
         }
       }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4349,13 +4349,13 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
 
 
 //------------------------java_mirror_type--------------------------------------
-ciType* TypeInstPtr::java_mirror_type() const {
+ciType* TypeInstPtr::java_mirror_type(bool* is_val_mirror) const {
   // must be a singleton type
   if( const_oop() == NULL )  return NULL;
 
   // must be of type java.lang.Class
   if( klass() != ciEnv::current()->Class_klass() )  return NULL;
-  return const_oop()->as_instance()->java_mirror_type();
+  return const_oop()->as_instance()->java_mirror_type(is_val_mirror);
 }
 
 
@@ -5886,8 +5886,7 @@ const TypeFunc* TypeFunc::make(ciMethod* method, bool is_osr_compilation) {
   const TypeTuple* domain_sig = is_osr_compilation ? osr_domain() : TypeTuple::make_domain(method, false);
   const TypeTuple* domain_cc = has_scalar_args ? TypeTuple::make_domain(method, true) : domain_sig;
   ciSignature* sig = method->signature();
-  bool has_scalar_ret = sig->returns_null_free_inline_type() && sig->return_type()->is_inlinetype() &&
-                        sig->return_type()->as_inline_klass()->can_be_returned_as_fields();
+  bool has_scalar_ret = sig->returns_null_free_inline_type() && sig->return_type()->as_inline_klass()->can_be_returned_as_fields();
   const TypeTuple* range_sig = TypeTuple::make_range(sig, false);
   const TypeTuple* range_cc = has_scalar_ret ? TypeTuple::make_range(sig, true) : range_sig;
   tf = TypeFunc::make(domain_sig, domain_cc, range_sig, range_cc);

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1265,7 +1265,7 @@ class TypeInstPtr : public TypeOopPtr {
   // If this is a java.lang.Class constant, return the type for it or NULL.
   // Pass to Type::get_const_type to turn it to a type, which will usually
   // be a TypeInstPtr, but may also be a TypeInt::INT for int.class, etc.
-  ciType* java_mirror_type() const;
+  ciType* java_mirror_type(bool* is_val_mirror = NULL) const;
 
   virtual const Type *cast_to_ptr_type(PTR ptr) const;
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2884,7 +2884,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
 
 AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& method) {
 
-  // TODO: Reimplement JDK-8266015, dropped from jdk->lworld merge
+  // TODO 8268946: Reimplement JDK-8266015, dropped from jdk->lworld merge
 
   // Use customized signature handler.  Need to lock around updates to
   // the AdapterHandlerTable (it is not safe for concurrent readers
@@ -2991,11 +2991,9 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
       }
 
 #ifdef ASSERT
-      if (VerifyAdapterSharing) {
+      // TODO fix with 8268946
+      if (false && VerifyAdapterSharing) {
         if (shared_entry != NULL) {
-          if (!shared_entry->compare_code(buf->code_begin(), buffer.insts_size())) {
-            method->print();
-          }
           assert(shared_entry->compare_code(buf->code_begin(), buffer.insts_size()), "code must match");
           // Release the one just created and return the original
           _adapters->free_entry(entry);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -1253,7 +1253,6 @@ public class TestArrays extends InlineTypeTest {
 
     @Test
     public MyValue1[] test51(MyValue1[] va) {
-        // TODO 8244562: Remove cast as workaround once javac is fixed
         Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
         return (MyValue1[]) res;
     }
@@ -1273,7 +1272,6 @@ public class TestArrays extends InlineTypeTest {
 
     @Test
     public MyValue1[] test52() {
-        // TODO 8244562: Remove cast as workaround once javac is fixed
         Object[] res = Arrays.copyOf(test52_va, 8, MyValue1[].class);
         return (MyValue1[]) res;
     }
@@ -1289,7 +1287,6 @@ public class TestArrays extends InlineTypeTest {
 
     @Test
     public MyValue1[] test53(Object[] va) {
-        // TODO 8244562: Remove cast as workaround once javac is fixed
         Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
         return (MyValue1[]) res;
     }
@@ -1339,7 +1336,6 @@ public class TestArrays extends InlineTypeTest {
 
     @Test
     public MyValue1[] test56(Object[] va) {
-        // TODO 8244562: Remove cast as workaround once javac is fixed
         Object[] res = Arrays.copyOf(va, va.length, MyValue1[].class);
         return (MyValue1[]) res;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3780,4 +3780,24 @@ public class TestLWorld extends InlineTypeTest {
         int result = test141();
         Asserts.assertEquals(result, 0);
     }
+
+    // Test that virtual calls on inline type receivers are properly inlined
+    @Test(failOn = ALLOC + LOAD + STORE)
+    public long test142() {
+        MyValue2 nonNull = MyValue2.createWithFieldsInline(rI, rD);
+        MyInterface val = null;
+
+        for (int i = 0; i < 4; i++) {
+            if ((i % 2) == 0) {
+                val = nonNull;
+            }
+        }
+        return val.hash();
+    }
+
+    @DontCompile
+    public void test142_verifier(boolean warmup) {
+        long res = test142();
+        Asserts.assertEquals(res, testValue2.hash());
+    }
 }


### PR DESCRIPTION
Pushing https://github.com/openjdk/valhalla/pull/474 into the lworld branch. Includes the dependent fix for JDK-8268553 which was not yet merged into lworld.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8267932](https://bugs.openjdk.java.net/browse/JDK-8267932): [lworld] JIT support for the L/Q model (step 2) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/475/head:pull/475` \
`$ git checkout pull/475`

Update a local copy of the PR: \
`$ git checkout pull/475` \
`$ git pull https://git.openjdk.java.net/valhalla pull/475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 475`

View PR using the GUI difftool: \
`$ git pr show -t 475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/475.diff">https://git.openjdk.java.net/valhalla/pull/475.diff</a>

</details>
