### PR TITLE
[lworld] Re-enable testing

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -141,20 +141,6 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
 compiler/intrinsics/VectorizedMismatchTest.java 8268482 windows-x64
 
-compiler/debug/VerifyAdapterSharing.java 8268946 generic-all
-
-# JDK-8267932 [lworld] JIT support for the L/Q model (step 2)...
-
-compiler/valhalla/inlinetypes/TestIntrinsics.java 8267932 generic-all
-compiler/valhalla/inlinetypes/TestNewAcmp.java 8267932 generic-all
-runtime/valhalla/inlinetypes/InlineOops.java#id4 8267932 generic-all
-runtime/valhalla/inlinetypes/InlineOops.java#id5 8267932 generic-all
-runtime/valhalla/inlinetypes/InlineOops.java#id6 8267932 generic-all
-runtime/valhalla/inlinetypes/InlineOops.java#id7 8267932 generic-all
-runtime/valhalla/inlinetypes/InlineTypeArray.java 8267932 generic-all
-runtime/valhalla/inlinetypes/VarArgsArray.java 8267932 generic-all
-
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,4 +29,3 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java 8256368 generic-all
-valhalla/valuetypes/ObjectMethods.java 8267932 generic-all


### PR DESCRIPTION
Re-enable testing disabled by https://github.com/openjdk/valhalla/pull/462 after JDK-8267932 has been fixed.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/476/head:pull/476` \
`$ git checkout pull/476`

Update a local copy of the PR: \
`$ git checkout pull/476` \
`$ git pull https://git.openjdk.java.net/valhalla pull/476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 476`

View PR using the GUI difftool: \
`$ git pr show -t 476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/476.diff">https://git.openjdk.java.net/valhalla/pull/476.diff</a>

</details>
