### PR TITLE
JDK-8270316: [lworld] enable -Xcomp run in test/jdk/valhalla/valuetypes/ObjectMethods.java

### DIFF
--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -27,9 +27,6 @@
  * @summary test Object methods on primitive classes
  * @run testng/othervm -Xint -Dvalue.bsm.salt=1 ObjectMethods
  * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
- */
-
-/* To be enabled by JDK-8267932
  * @run testng/othervm -Xcomp -Dvalue.bsm.salt=1 ObjectMethods
  */
 import java.lang.reflect.Modifier;


### PR DESCRIPTION
It's a follow-up since JDK-8267932 has been resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8270316](https://bugs.openjdk.java.net/browse/JDK-8270316): [lworld] enable -Xcomp run in test/jdk/valhalla/valuetypes/ObjectMethods.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/478/head:pull/478` \
`$ git checkout pull/478`

Update a local copy of the PR: \
`$ git checkout pull/478` \
`$ git pull https://git.openjdk.java.net/valhalla pull/478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 478`

View PR using the GUI difftool: \
`$ git pr show -t 478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/478.diff">https://git.openjdk.java.net/valhalla/pull/478.diff</a>

</details>
