### PR TITLE
8264340: [lworld] [AArch64] TestLWorld.java assertion failure in OopFlow::build_oop_map

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3162,7 +3162,11 @@ void Scheduling::ComputeRegisterAntidependencies(Block *b) {
       }
 
       // Do not allow a CheckCastPP node whose input is a raw pointer to
-      // float past a safepoint.
+      // float past a safepoint.  This can occur when a buffered inline
+      // type is allocated in a loop and the CheckCastPP from that
+      // allocation is reused outside the loop.  If the use inside the
+      // loop is scalarized the CheckCastPP will no longer be connected
+      // to the loop safepoint.  See JDK-8264340.
       if (m->is_Mach() && m->as_Mach()->ideal_Opcode() == Op_CheckCastPP) {
         Node *def = m->in(1);
         if (def != NULL && def->bottom_type()->base() == Type::RawPtr) {

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3160,6 +3160,15 @@ void Scheduling::ComputeRegisterAntidependencies(Block *b) {
           break;
         }
       }
+
+      // Do not allow a CheckCastPP node whose input is a raw pointer to
+      // float past a safepoint.
+      if (m->is_Mach() && m->as_Mach()->ideal_Opcode() == Op_CheckCastPP) {
+        Node *def = m->in(1);
+        if (def != NULL && def->bottom_type()->base() == Type::RawPtr) {
+          last_safept_node->add_prec(m);
+        }
+      }
     }
 
     if( n->jvms() ) {           // Precedence edge from derived to safept


### PR DESCRIPTION
This happens reliably in TestLWorld::test9() scenario 0 on AArch64:

```
  # A fatal error has been detected by the Java Runtime Environment:
  #
  # Internal Error (/mnt/nicgas01-pc/valhalla/src/hotspot/share/opto/buildOopMap.cpp:360), pid=8866, tid=8882
  # assert(false) failed: there should be a oop in OopMap instead of a live raw oop at safepoint
  #
```

The crash can also be reproduced on x86 by running with -XX:+OptoScheduling (this is the default on AArch64).

The problem seems to be caused by a CheckCastPP node whose input is a raw pointer being scheduled after a SafePoint node such that the raw pointer is live in a register over the safepoint.

Before scheduling we have a basic block like:

```
  R0      73  Phi  ===  15  74  30  [[ 72  71  70  69  68  67  84 ]]  #rawptr:BotPTR !jvms: SchedCrash$MyValue1::setX @ bci:-1 (line 27) SchedCrash::test9 @ bci:25 (line 39)
  ...
  R0      84  checkCastPP  ===  11  73  [[ 2 ]] SchedCrash$MyValue1:NotNull:exact *  Oop:SchedCrash$MyValue1:NotNull:exact * !jvms: SchedCrash$MyValue1::<init> @ bci:65 (line 24) SchedCrash$MyValue1::setX @ bci:21 (line 27) SchedCrash::test9 @ bci:25 (line 39)
  ...
          6  safePoint  ===  9  0  33  0  0  7  0  78  40  0  140  135  136  139  138  141  [[ 8  4 ]]  !jvms: SchedCrash::test9 @ bci:33 (line 37)
```

But after scheduling this is transformed into:

```
  R0      73  Phi  ===  15  74  30  [[ 72  71  70  69  68  67  84 ]]  #rawptr:BotPTR !jvms: SchedCrash$MyValue1::setX @ bci:-1 (line 27) SchedCrash::test9 @ bci:25 (line 39)
  ...
          6  safePoint  ===  9  0  33  0  0  7  0  78  40  0  140  135  136  139  138  141  | 164  [[ 8  4 ]]  !jvms: SchedCrash::test9 @ bci:33 (line 37)
  ...
  R0      84  checkCastPP  ===  11  73  | 67  68  69  70  71  72  [[ 2 ]] SchedCrash$MyValue1:NotNull:exact *  Oop:SchedCrash$MyValue1:NotNull:exact * !jvms: SchedCrash$MyValue1::<init> @ bci:65 (line 24) SchedCrash$MyValue1::setX @ bci:21 (line 27) SchedCrash::test9 @ bci:25 (line 39)
```

Where R0 is holding the live raw pointer over the safepoint, which triggers the assertion failure.

The fix here is to add a precedence edge from any CheckCastPP with a raw pointer input to the following safepoint, which prevents them being rearranged. I'm not very familiar with this code so I can't be sure this is the correct solution, but the same logic exists in GCM's PhaseCFG::schedule_late().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8264340](https://bugs.openjdk.java.net/browse/JDK-8264340): [lworld] [AArch64] TestLWorld.java assertion failure in OopFlow::build_oop_map


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/479/head:pull/479` \
`$ git checkout pull/479`

Update a local copy of the PR: \
`$ git checkout pull/479` \
`$ git pull https://git.openjdk.java.net/valhalla pull/479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 479`

View PR using the GUI difftool: \
`$ git pr show -t 479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/479.diff">https://git.openjdk.java.net/valhalla/pull/479.diff</a>

</details>
