### PR TITLE
JDK-8270350: [lworld] GeneratedMethodAccessor contains incorrect cast

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5177,7 +5177,8 @@ void ClassFileParser::verify_legal_class_name(const Symbol* name, TRAPS) const {
         p = skip_over_field_name(bytes, true, length);
         legal = (p != NULL) && ((p - bytes) == (int)length);
       }
-    } else if (_major_version >= CONSTANT_CLASS_DESCRIPTORS && bytes[length - 1] == ';' ) {
+    } else if ((_major_version >= CONSTANT_CLASS_DESCRIPTORS || _class_name->starts_with("jdk/internal/reflect/"))
+                   && bytes[length - 1] == ';' ) {
       // Support for L...; and Q...; descriptors
       legal = verify_unqualified_name(bytes + 1, length - 2, LegalClass);
     } else {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -341,7 +341,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
         for (int i = 0; i < parameterTypes.length; i++) {
             Class<?> c = parameterTypes[i];
             if (!isPrimitive(c)) {
-                asm.emitConstantPoolUTF8(getClassName(c, false));
+                asm.emitConstantPoolUTF8(getClassName(c, true));
                 asm.emitConstantPoolClass(asm.cpi());
             }
         }


### PR DESCRIPTION
This patch updates the bytecode generated for core reflection to use ReferenceType descriptor in CONSTANT_Class_info for primitive classes.   In addition, the VM classFileParser temporarily disables the class file version check for `jdk/internal/reflect` classes since it's still version 49 until JDK-8266010 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8270350](https://bugs.openjdk.java.net/browse/JDK-8270350): [lworld] GeneratedMethodAccessor contains incorrect cast


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.java.net/valhalla pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/483.diff">https://git.openjdk.java.net/valhalla/pull/483.diff</a>

</details>
