### PR TITLE
8270896: [lworld] C2 compilation fails with "Meet Not Symmetric"

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -682,18 +682,13 @@ int BarrierSetC2::arraycopy_payload_base_offset(bool is_array) {
   return base_off;
 }
 
-void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* countx, bool is_array) const {
-#ifdef ASSERT
-  intptr_t src_offset;
-  Node* src = AddPNode::Ideal_base_and_offset(src_base, &kit->gvn(), src_offset);
-  intptr_t dst_offset;
-  Node* dst = AddPNode::Ideal_base_and_offset(dst_base, &kit->gvn(), dst_offset);
-  assert(src == NULL || (src_offset % BytesPerLong == 0), "expect 8 bytes alignment");
-  assert(dst == NULL || (dst_offset % BytesPerLong == 0), "expect 8 bytes alignment");
-#endif
+void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* size, bool is_array) const {
   int base_off = arraycopy_payload_base_offset(is_array);
+  Node* payload_size = size;
   Node* offset = kit->MakeConX(base_off);
-  ArrayCopyNode* ac = ArrayCopyNode::make(kit, false, src_base, offset, dst_base, offset, countx, true, false);
+  payload_size = kit->gvn().transform(new SubXNode(payload_size, offset));
+  payload_size = kit->gvn().transform(new URShiftXNode(payload_size, kit->intcon(LogBytesPerLong)));
+  ArrayCopyNode* ac = ArrayCopyNode::make(kit, false, src_base, offset, dst_base, offset, payload_size, true, false);
   if (is_array) {
     ac->set_clone_array();
   } else {

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -242,7 +242,7 @@ public:
   virtual Node* atomic_xchg_at(C2AtomicParseAccess& access, Node* new_val, const Type* value_type) const;
   virtual Node* atomic_add_at(C2AtomicParseAccess& access, Node* new_val, const Type* value_type) const;
 
-  virtual void clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* countx, bool is_array) const;
+  virtual void clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* size, bool is_array) const;
 
   virtual Node* obj_allocate(PhaseMacroExpand* macro, Node* mem, Node* toobig_false, Node* size_in_bytes,
                              Node*& i_o, Node*& needgc_ctrl,

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.cpp
@@ -125,8 +125,8 @@ void CardTableBarrierSetC2::post_barrier(GraphKit* kit,
   kit->final_sync(ideal);
 }
 
-void CardTableBarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* countx, bool is_array) const {
-  BarrierSetC2::clone(kit, src_base, dst_base, countx, is_array);
+void CardTableBarrierSetC2::clone(GraphKit* kit, Node* src, Node* dst, Node* size, bool is_array) const {
+  BarrierSetC2::clone(kit, src, dst, size, is_array);
   const TypePtr* raw_adr_type = TypeRawPtr::BOTTOM;
 
   // If necessary, emit some card marks afterwards.  (Non-arrays only.)
@@ -141,7 +141,7 @@ void CardTableBarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base,
     int raw_adr_idx = Compile::AliasIdxRaw;
     post_barrier(kit, kit->control(),
                  kit->memory(raw_adr_type),
-                 dst_base,
+                 dst,
                  no_particular_field,
                  raw_adr_idx,
                  no_particular_value,

--- a/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/cardTableBarrierSetC2.hpp
@@ -42,7 +42,7 @@ protected:
   Node* byte_map_base_node(GraphKit* kit) const;
 
 public:
-  virtual void clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* countx, bool is_array) const;
+  virtual void clone(GraphKit* kit, Node* src, Node* dst, Node* size, bool is_array) const;
   virtual bool is_gc_barrier_node(Node* node) const;
   virtual void eliminate_gc_barrier(PhaseIterGVN* igvn, Node* node) const;
   virtual bool array_copy_requires_gc_barriers(bool tightly_coupled_alloc, BasicType type, bool is_clone, bool is_clone_instance, ArrayCopyPhase phase) const;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1763,8 +1763,8 @@ Node* GraphKit::access_atomic_add_at(Node* obj,
   }
 }
 
-void GraphKit::access_clone(Node* src_base, Node* dst_base, Node* countx, bool is_array) {
-  return _barrier_set->clone(this, src_base, dst_base, countx, is_array);
+void GraphKit::access_clone(Node* src, Node* dst, Node* size, bool is_array) {
+  return _barrier_set->clone(this, src, dst, size, is_array);
 }
 
 //-------------------------array_element_address-------------------------

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -657,7 +657,7 @@ class GraphKit : public Phase {
                              BasicType bt,
                              DecoratorSet decorators);
 
-  void access_clone(Node* src_base, Node* dst_base, Node* countx, bool is_array);
+  void access_clone(Node* src, Node* dst, Node* size, bool is_array);
 
   // Return addressing for an array element.
   Node* array_element_address(Node* ary, Node* idx, BasicType elembt,

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4429,14 +4429,7 @@ void LibraryCallKit::copy_to_clone(Node* obj, Node* alloc_obj, Node* obj_size, b
   }
 
   Node* size = _gvn.transform(obj_size);
-  // Exclude the header but include array length to copy by 8 bytes words.
-  // Can't use base_offset_in_bytes(bt) since basic type is unknown.
-  int base_off = BarrierSetC2::arraycopy_payload_base_offset(is_array);
-  Node* countx = size;
-  countx = _gvn.transform(new SubXNode(countx, MakeConX(base_off)));
-  countx = _gvn.transform(new URShiftXNode(countx, intcon(LogBytesPerLong)));
-
-  access_clone(obj, alloc_obj, countx, is_array);
+  access_clone(obj, alloc_obj, size, is_array);
 
   // Do not let reads from the cloned object float above the arraycopy.
   if (alloc != NULL) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5777,7 +5777,7 @@ const Type    *TypeKlassPtr::xmeet( const Type *t ) const {
       ptr = NotNull;
     // Now we find the LCA of Java classes
     ciKlass* k = this_klass->least_common_ancestor(tkls_klass);
-    return make(ptr, k, off, false, is_not_flat, is_not_null_free);
+    return make(ptr, k, off, this->flatten_array() && tkls->flatten_array(), is_not_flat, is_not_null_free);
   } // End of case KlassPtr
 
   } // End of switch

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4259,11 +4259,11 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
       subtype = this_klass;
       subtype_exact = below_centerline(ptr) ? (this_xk && tinst_xk) : (this_xk || tinst_xk);
       flat_array = below_centerline(ptr) ? (this_flatten_array && tinst_flatten_array) : (this_flatten_array || tinst_flatten_array);
-    } else if(!tinst_xk && this_klass->is_subtype_of(tinst_klass) && (!tinst_flatten_array || this_flatten_array)) {
+    } else if (!tinst_xk && this_klass->is_subtype_of(tinst_klass) && (!tinst_flatten_array || this_flatten_array)) {
       subtype = this_klass;     // Pick subtyping class
       subtype_exact = this_xk;
       flat_array = this_flatten_array;
-    } else if(!this_xk && tinst_klass->is_subtype_of(this_klass) && (!this_flatten_array || tinst_flatten_array)) {
+    } else if (!this_xk && tinst_klass->is_subtype_of(this_klass) && (!this_flatten_array || tinst_flatten_array)) {
       subtype = tinst_klass;    // Pick subtyping class
       subtype_exact = tinst_xk;
       flat_array = tinst_flatten_array;
@@ -4319,7 +4319,7 @@ const Type *TypeInstPtr::xmeet_helper(const Type *t) const {
 
     // Now we find the LCA of Java classes
     ciKlass* k = this_klass->least_common_ancestor(tinst_klass);
-    return make(ptr, k, false, NULL, off, false, instance_id, speculative, depth);
+    return make(ptr, k, false, NULL, off, flatten_array() && tinst->flatten_array(), instance_id, speculative, depth);
   } // End of case InstPtr
 
   case InlineType: {


### PR DESCRIPTION
`compiler/valhalla/inlinetypes/MyValue1:NotNull:exact * (flatten array)` meeting `java/lang/Object:NotNull * (flatten array)` should result in `java/lang/Object:NotNull * (flatten array)` but currently the "flatten array" property is lost.

The fix is in `type.cpp`. The other changes are unrelated refactoring that bring Valhalla code closer to mainline.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8270896](https://bugs.openjdk.java.net/browse/JDK-8270896): [lworld] C2 compilation fails with "Meet Not Symmetric"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/484/head:pull/484` \
`$ git checkout pull/484`

Update a local copy of the PR: \
`$ git checkout pull/484` \
`$ git pull https://git.openjdk.java.net/valhalla pull/484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 484`

View PR using the GUI difftool: \
`$ git pr show -t 484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/484.diff">https://git.openjdk.java.net/valhalla/pull/484.diff</a>

</details>
