### PR TITLE
JDK-8247376: [lworld] Constant API support for primitive classes

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -570,6 +570,8 @@ public final class Class<T> implements java.io.Serializable,
      * of a primitive class respectively.
      *
      * @return {@code true} if this class is a primitive class, otherwise {@code false}
+     * @see #asPrimaryType()
+     * @see #asValueType()
      * @since Valhalla
      */
     public boolean isPrimitiveClass() {
@@ -580,14 +582,15 @@ public final class Class<T> implements java.io.Serializable,
      * Returns a {@code Class} object representing the primary type
      * of this class or interface.
      * <p>
-     * If this {@code Class} object represents a reference type, then
-     * this method returns this class.
+     * If this {@code Class} object represents a primitive type or an array type,
+     * then this method returns this class.
      * <p>
      * If this {@code Class} object represents a {@linkplain #isPrimitiveClass()
      * primitive class}, then this method returns the <em>primitive reference type</em>
      * type of this primitive class.
      * <p>
-     * If this is a primitive type, then this method returns this class.
+     * Otherwise, this {@code Class} object represents a non-primitive class or interface
+     * and this method returns this class.
      *
      * @return the {@code Class} representing the primary type of
      *         this class or interface
@@ -601,8 +604,11 @@ public final class Class<T> implements java.io.Serializable,
      * Returns a {@code Class} object representing the <em>primitive value type</em>
      * of this class if this class is a {@linkplain #isPrimitiveClass() primitive class}.
      *
-     * @return the {@code Class} representing the primitive value type of
-     *         this class if this class is a primitive class
+     * @apiNote Alternatively, this method returns null if this class is not
+     *          a primitive class rather than throwing UOE.
+     *
+     * @return the {@code Class} representing the {@linkplain #isValueType()
+     * primitive value type} of this class if this class is a primitive class
      * @throws UnsupportedOperationException if this class or interface
      *         is not a primitive class
      * @since Valhalla
@@ -618,14 +624,16 @@ public final class Class<T> implements java.io.Serializable,
      * Returns {@code true} if this {@code Class} object represents the primary type
      * of this class or interface.
      * <p>
-     * If this is a primitive type, then this method returns {@code true}.
-     * <p>
-     * If this {@code Class} object represents a reference type, then
-     * this method returns {@code true}.
+     * If this {@code Class} object represents a primitive type or an array type,
+     * then this method returns {@code true}.
      * <p>
      * If this {@code Class} object represents a {@linkplain #isPrimitiveClass()
-     * primitive} reference type, then this method returns {@code true};
-     * otherwise, this method returns {@code false}.
+     * primitive}, then this method returns {@code true} if this {@code Class}
+     * object represents a primitive reference type, or returns {@code false}
+     * if this {@code Class} object represents a primitive value type.
+     * <p>
+     * If this {@code Class} object represents a non-primitive class or interface,
+     * then this method returns {@code true}.
      *
      * @return {@code true} if this {@code Class} object represents
      * the primary type of this class or interface
@@ -3996,7 +4004,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @throws ClassCastException if the object is not
      * {@code null} and is not assignable to the type T.
-     * @throws NullPointerException if this is an {@linkplain #isValueType()
+     * @throws NullPointerException if this class is an {@linkplain #isValueType()
      * primitive value type} and the object is {@code null}
      *
      * @since 1.5

--- a/test/jdk/valhalla/valuetypes/Point.java
+++ b/test/jdk/valhalla/valuetypes/Point.java
@@ -21,8 +21,10 @@
  * questions.
  */
 
+import java.util.Objects;
+
 public primitive class Point {
-    static final Object STATIC_FIELD = new Object();
+    static final Object STATIC_FIELD = Objects.newIdentity();
     public int x;
     public int y;
     public static Point makePoint(int x, int y) {

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test ConstantDesc for primitive classes
+ * @compile --enable-preview --source ${jdk.version} Point.java ValueConstantDesc.java
+ * @run testng/othervm --enable-preview ValueConstantDesc
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.constant.ClassDesc;
+import java.lang.invoke.MethodHandles;
+
+import static org.testng.Assert.*;
+
+public class ValueConstantDesc {
+    private static final String NAME = "Point";
+
+    @DataProvider(name="descs")
+    static Object[][] descs() {
+        return new Object[][]{
+            new Object[] { Point.class,     ClassDesc.ofDescriptor("Q" + NAME + ";"), NAME},
+            new Object[] { Point.ref.class, ClassDesc.ofDescriptor("L" + NAME + ";"), NAME + ".ref"},
+            new Object[] { Point[].class,   ClassDesc.ofDescriptor("[Q" + NAME + ";"), NAME + "[]"},
+            new Object[] { Point.ref[][].class, ClassDesc.ofDescriptor("[[L" + NAME + ";"), NAME + ".ref[][]"},
+        };
+    }
+
+    @Test(dataProvider="descs")
+    public void classDesc(Class<?> type, ClassDesc expected, String displayName) {
+        ClassDesc cd = type.describeConstable().orElseThrow();
+        if (type.isArray()) {
+            assertTrue(cd.isArray());
+            assertFalse(cd.isClassOrInterface());
+        } else {
+            assertFalse(cd.isArray());
+            assertTrue(cd.isClassOrInterface());
+        }
+        assertEquals(cd, expected);
+        assertEquals(cd.displayName(), displayName);
+        assertEquals(cd.descriptorString(), type.descriptorString());
+    }
+
+    @DataProvider(name="componentTypes")
+    static Object[][] componentTypes() {
+        return new Object[][]{
+            new Object[] { Point.class },
+            new Object[] { Point.ref.class }
+        };
+    }
+
+    @Test(dataProvider="componentTypes")
+    public void arrayType(Class<?> componentType) {
+        ClassDesc cd = componentType.describeConstable().orElseThrow();
+        ClassDesc arrayDesc = cd.arrayType();
+        ClassDesc arrayDesc2 = cd.arrayType(2);
+
+        assertTrue(arrayDesc.isArray());
+        assertEquals(arrayDesc.componentType(), cd);
+        assertTrue(arrayDesc2.isArray());
+        assertEquals(arrayDesc2.componentType(), arrayDesc);
+    }
+
+    @DataProvider(name="valueDesc")
+    static Object[][] valueDesc() {
+        return new Object[][]{
+                new Object[] { Point.class,         "Q" + NAME + ";"},
+                new Object[] { Point.ref.class,     "L" + NAME + ";"},
+                new Object[] { Point[].class,       "[Q" + NAME + ";"},
+                new Object[] { Point.ref[][].class, "[[L" + NAME + ";"},
+        };
+    }
+    @Test(dataProvider="valueDesc")
+    public void asValueType(Class<?> type, String descriptor) throws ReflectiveOperationException {
+        ClassDesc cd = type.describeConstable().orElseThrow();
+        ClassDesc valueDesc = ClassDesc.ofDescriptor(descriptor);
+        assertEquals(cd, valueDesc);
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Class<?> c = (Class<?>) cd.resolveConstantDesc(lookup);
+        assertTrue(c == type);
+        assertTrue(cd.isValueType() == type.isValueType());
+    }
+
+    @Test(expectedExceptions = {LinkageError.class})
+    public void illegalDescriptor() throws ReflectiveOperationException {
+        // ValueConstantDesc is not a primitive class
+        ClassDesc cd = ClassDesc.ofDescriptor("QValueConstantDesc;");
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        Class<?> c = (Class<?>) cd.resolveConstantDesc(lookup);
+    }
+}


### PR DESCRIPTION
This updates `ClassDesc` implementation to support primitive classes.    `ClassDesc::of` creates a `L-descriptor`, i.e. a reference type.   `ClassDesc::ofDescriptor` can be used to create a `L` or `Q`-descriptor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247376](https://bugs.openjdk.java.net/browse/JDK-8247376): [lworld] Constant API support for primitive classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/488/head:pull/488` \
`$ git checkout pull/488`

Update a local copy of the PR: \
`$ git checkout pull/488` \
`$ git pull https://git.openjdk.java.net/valhalla pull/488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 488`

View PR using the GUI difftool: \
`$ git pr show -t 488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/488.diff">https://git.openjdk.java.net/valhalla/pull/488.diff</a>

</details>
