### PR TITLE
8271025: [lworld] vmTestbase/jit/t/* tests fail after JDK-8237073

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/t/t058/t058.gold
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t058/t058.gold
@@ -8,7 +8,7 @@ jit.t.t058.k
 jit.t.t058.k
 o instanceof k: true
 Voodoo 3
-java.lang.Object
+java.util.Objects$1
 
 Here come the instance variables of ko:
 39.0

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t062/t062.gold
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t062/t062.gold
@@ -8,7 +8,7 @@ jit.t.t062.t062
 jit.t.t062.t062
 o instanceof t062: true
 Voodoo 3
-java.lang.Object
+java.util.Objects$1
 
 Here come the instance variables of ko:
 39.0


### PR DESCRIPTION
Renamed `java.lang.Object` to `java.util.Objects$1` in gold output.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271025](https://bugs.openjdk.java.net/browse/JDK-8271025): [lworld] vmTestbase/jit/t/* tests fail after JDK-8237073


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.java.net/valhalla pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/489.diff">https://git.openjdk.java.net/valhalla/pull/489.diff</a>

</details>
