### PR TITLE
8269756: [lworld] Add tests for invalid withfield operands

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/RunWithfieldTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/RunWithfieldTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @bug 8269756
+ * @summary test scenarios where getfield, putfield, and withfield access the
+ *          same constant pool field_ref and test other withfield error cases.
+ * @compile withfieldTests.jcod
+ * @run main/othervm -Xverify:remote -Xint RunWithfieldTests
+ */
+
+public class RunWithfieldTests {
+
+    public static void main(String argv[]) throws Throwable {
+
+        // Check that a withfield on a CONSTANT_Field_info entry that references
+        // an identity object will fail and that subsequent putfield and getfield
+        // operations on the same CONSTANT_FIELD_info entry will succeed.
+        Class wfoClass = Class.forName("withfieldObject");
+        withfieldObject wfo = (withfieldObject)wfoClass.getDeclaredConstructor().newInstance();
+        String y = wfo.getfield();
+        if (!y.equals("cde")) {
+            throw new RuntimeException("Unexpected value of wfo.getfield(): " + y);
+        }
+
+
+        // Check that a putfield and getfield on a CONSTANT_Field_info entry that
+        // references an identity object will succeed and that a subsequent withfield
+        // operation on the same CONSTANT_FIELD_info entry will fail.
+        Class pfoClass = Class.forName("putfieldObject");
+        putfieldObject pfo = (putfieldObject)pfoClass.getDeclaredConstructor().newInstance();
+        String x = pfo.getfield();
+        if (!x.equals("abc")) {
+            throw new RuntimeException("Unexpected value of pfo.getfield(): " + x);
+        }
+        try {
+            pfo.withfieldFunc();
+            throw new RuntimeException("ICCE not thrown");
+        } catch (IncompatibleClassChangeError e) {
+            if (!e.getMessage().contains("withfield cannot be used on identity class")) {
+                throw new RuntimeException("Wrong ICCE thrown: " + e.getMessage());
+            }
+        }
+
+
+        // Check that a putfield on a CONSTANT_Field_info entry that references
+        // a primitive object will fail and that subsequent withfield and getfield
+        // operations on the same CONSTANT_FIELD_info entry will succeed.
+        try {
+            putfieldPrimitive pfp = new putfieldPrimitive(false);  // putfield on a primitive class
+            throw new RuntimeException("ICCE not thrown");
+        } catch (IncompatibleClassChangeError e) {
+            if (!e.getMessage().contains("putfield cannot be used on primitive class")) {
+                throw new RuntimeException("Wrong ICCE thrown: " + e.getMessage());
+            }
+        }
+        putfieldPrimitive pfp = new putfieldPrimitive(true);  // withfield on a primitive class
+        if (pfp.getX() != 5) {
+            throw new RuntimeException("Unexpected value of d.getfield(): " + pfp.getX());
+        }
+
+
+        // Check that a withfield and getfield on a CONSTANT_Field_info entry that
+        // references a primitive object will succeed and that a subsequent putfield
+        // operation on the same CONSTANT_FIELD_info entry will fail.
+        withfieldPrimitive wfp = new withfieldPrimitive(true);  // withfield on a primitive class
+        if (wfp.getX() != 5) {
+            throw new RuntimeException("Unexpected value of d.getfield(): " + wfp.getX());
+        }
+        try {
+            withfieldPrimitive wfp2 = new withfieldPrimitive(false);  // putfield on a primitive class
+            throw new RuntimeException("ICCE not thrown");
+        } catch (IncompatibleClassChangeError e) {
+            if (!e.getMessage().contains("putfield cannot be used on primitive class")) {
+                throw new RuntimeException("Wrong ICCE thrown: " + e.getMessage());
+            }
+        }
+
+
+        // Test withfield with a null stack operand.
+        try {
+            withfieldNull wfn = new withfieldNull();
+            throw new RuntimeException("NPE not thrown");
+        } catch (NullPointerException e) {
+            if (!e.getMessage().contains("Cannot assign field \"x\"")) {
+                throw new RuntimeException("Wrong NPE thrown: " + e.getMessage());
+            }
+        }
+
+
+        // Test that a VerifyError exception is thrown for a withfield bytecode if the
+        // stack operand is a different primitive type than the primitive type in the
+        // constant pool field_ref.
+        try {
+            WrongPrimWF wPrim = new WrongPrimWF();
+            throw new RuntimeException("No exception thrown");
+        } catch (VerifyError e) {
+            if (!e.getMessage().contains("Bad type on operand stack")) {
+                throw new RuntimeException("Wrong VerifyError thrown: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/withfieldTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/withfieldTests.jcod
@@ -1,0 +1,1120 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/* This jcod class is based on this Java code. To see what changed from the
+   original jcod file search for !!!!.
+ public class withfieldObject {
+
+     String y;
+
+     public withfieldObject() {
+         try {
+             y = "abc";  // Change this putfield to a withfield
+         } catch (IncompatibleClassChangeError e) {
+             y = "cde";
+         }
+     }
+
+     public String getfield() {
+         return y;
+     }
+ }
+*/
+
+class withfieldObject {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [26] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    String #8; // #7     at 0x39
+    Utf8 "abc"; // #8     at 0x3C
+    Field #10 #11; // #9     at 0x42
+    class #12; // #10     at 0x47
+    NameAndType #13 #14; // #11     at 0x4A
+    Utf8 "withfieldObject"; // #12     at 0x4F
+    Utf8 "y"; // #13     at 0x60
+    Utf8 "Ljava/lang/String;"; // #14     at 0x64
+    class #16; // #15     at 0x79
+    Utf8 "java/lang/IncompatibleClassChangeError"; // #16     at 0x7C
+    String #18; // #17     at 0xA5
+    Utf8 "cde"; // #18     at 0xA8
+    Utf8 "Code"; // #19     at 0xAE
+    Utf8 "LineNumberTable"; // #20     at 0xB5
+    Utf8 "StackMapTable"; // #21     at 0xC7
+    Utf8 "getfield"; // #22     at 0xD7
+    Utf8 "()Ljava/lang/String;"; // #23     at 0xE2
+    Utf8 "SourceFile"; // #24     at 0xF9
+    Utf8 "withfieldObject.java"; // #25     at 0x0106
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #10;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x0126
+      0x0000; // access
+      #13; // name_index       : y
+      #14; // descriptor_index : Ljava/lang/String;
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x0130
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#19, 96) { // Code at 0x0138  // !!!! Changed 95 -> 96
+          2; // max_stack
+          2; // max_locals
+          Bytes[22]{                // !!!! Changed from 21 -> 22
+            0x2AB700012A1207CC;     // !!!! Changed last byte from B5 (putfield) to CC (withfield)
+            0x000957A7000A4C2A;     // !!!! Inserted 0x57 (pop) to clear the stack.
+            0x1211B50009B1;
+          }
+          [1] { // Traps
+            4 11 14 15; //  at 0x0165  // !!!! Changed 10 -> 11 and 13 -> 14
+          } // end Traps
+          [2] { // Attributes
+            Attr(#20, 26) { // LineNumberTable at 0x0167
+              [6] { // line_number_table
+                0  6; //  at 0x0173
+                4  8; //  at 0x0177
+                10  11; //  at 0x017B
+                13  9; //  at 0x017F
+                14  10; //  at 0x0183
+                20  12; //  at 0x0187
+              }
+            } // end LineNumberTable
+            ;
+            Attr(#21, 16) { // StackMapTable at 0x0187
+              [2] { //
+                255b, 14, [1]{7b,10}, [1]{7b,15}; // full_frame  // !!!! Changed 13 to 14
+                6b; // same_frame
+              }
+            } // end StackMapTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x019D
+      0x0001; // access
+      #22; // name_index       : getfield
+      #23; // descriptor_index : ()Ljava/lang/String;
+      [1] { // Attributes
+        Attr(#19, 29) { // Code at 0x01A5
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB40009B0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#20, 6) { // LineNumberTable at 0x01BC
+              [1] { // line_number_table
+                0  15; //  at 0x01C8
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#24, 2) { // SourceFile at 0x01CA
+      #25;
+    } // end SourceFile
+  } // Attributes
+} // end class withfieldObject
+
+
+
+/* This jcod class is based on this Java code.  To see what changed from the
+   orignal jcod file, search for !!!!.
+ public class putfieldObject {
+     String y;
+     public putfieldObject() {
+         y = "abc";
+     }
+     public void withfieldFunc() {
+         y = "cde";  // Change this putfield to a withfield
+     }
+     public String getfield() {
+         return y;
+     }
+ }
+*/
+class putfieldObject {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [24] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    String #8; // #7     at 0x39
+    Utf8 "abc"; // #8     at 0x3C
+    Field #10 #11; // #9     at 0x42
+    class #12; // #10     at 0x47
+    NameAndType #13 #14; // #11     at 0x4A
+    Utf8 "putfieldObject"; // #12     at 0x4F
+    Utf8 "y"; // #13     at 0x60
+    Utf8 "Ljava/lang/String;"; // #14     at 0x64
+    String #16; // #15     at 0x79
+    Utf8 "cde"; // #16     at 0x7C
+    Utf8 "Code"; // #17     at 0x82
+    Utf8 "LineNumberTable"; // #18     at 0x89
+    Utf8 "withfieldFunc"; // #19     at 0x9B
+    Utf8 "getfield"; // #20     at 0xAB
+    Utf8 "()Ljava/lang/String;"; // #21     at 0xB6
+    Utf8 "SourceFile"; // #22     at 0xCD
+    Utf8 "putfieldObject.java"; // #23     at 0xDA
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #10;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xFA
+      0x0000; // access
+      #13; // name_index       : y
+      #14; // descriptor_index : Ljava/lang/String;
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0104
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#17, 43) { // Code at 0x010C
+          2; // max_stack
+          1; // max_locals
+          Bytes[11]{
+            0x2AB700012A1207B5;
+            0x0009B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#18, 14) { // LineNumberTable at 0x0129
+              [3] { // line_number_table
+                0  6; //  at 0x0135
+                4  7; //  at 0x0139
+                10  8; //  at 0x013D
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x013D
+      0x0001; // access
+      #19; // name_index       : withfieldFunc
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#17, 35) { // Code at 0x0145
+          2; // max_stack
+          1; // max_locals
+          Bytes[7]{
+            0x2A120FCC0009B1;  // !!!! Change 0xB5 (putfield) to 0xCC (withfield)
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#18, 10) { // LineNumberTable at 0x015E
+              [2] { // line_number_table
+                0  11; //  at 0x016A
+                6  12; //  at 0x016E
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016E
+      0x0001; // access
+      #20; // name_index       : getfield
+      #21; // descriptor_index : ()Ljava/lang/String;
+      [1] { // Attributes
+        Attr(#17, 29) { // Code at 0x0176
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB40009B0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#18, 6) { // LineNumberTable at 0x018D
+              [1] { // line_number_table
+                0  15; //  at 0x0199
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#22, 2) { // SourceFile at 0x019B
+      #23;
+    } // end SourceFile
+  } // Attributes
+} // end class putfieldObject
+
+
+
+/* This jcod class is based on this Java code.  To see what changed from the
+   original jcod file, search for !!!!.
+public primitive final class putfieldPrimitive {
+    int x;
+
+    public putfieldPrimitive(boolean odd) {
+        if (odd) {
+            x = 5;
+        } else {
+            x = 6;
+        }
+    }
+
+    public int getX() {
+        return x;
+    }
+}
+*/
+
+// If putfieldPrimitive.<init>(bool) is passed TRUE then it uses a withfield bytecode.
+// Otherwise, it uses a putfield bytecode.
+
+class putfieldPrimitive {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [20] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "putfieldPrimitive"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x13
+    NameAndType #5 #6; // #4     at 0x18
+    Utf8 "x"; // #5     at 0x1D
+    Utf8 "I"; // #6     at 0x21
+    class #8; // #7     at 0x25
+    Utf8 "java/lang/Object"; // #8     at 0x28
+    Utf8 "getX"; // #9     at 0x3B
+    Utf8 "()I"; // #10     at 0x42
+    Utf8 "Code"; // #11     at 0x48
+    Utf8 "LineNumberTable"; // #12     at 0x4F
+    Utf8 "<init>"; // #13     at 0x61
+    Utf8 "(Z)QputfieldPrimitive;"; // #14     at 0x6A
+    Utf8 "StackMapTable"; // #15     at 0x75
+    class #17; // #16     at 0x85
+    Utf8 "QputfieldPrimitive;"; // #17     at 0x88
+    Utf8 "SourceFile"; // #18     at 0x90
+    Utf8 "putfieldPrimitive.java"; // #19     at 0x9D
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xB2
+      0x0010; // access
+      #5; // name_index       : x
+      #6; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xBC
+      0x0001; // access
+      #9; // name_index       : getX
+      #10; // descriptor_index : ()I
+      [1] { // Attributes
+        Attr(#11, 29) { // Code at 0xC4
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB40003AC;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 6) { // LineNumberTable at 0xDB
+              [1] { // line_number_table
+                0  13; //  at 0xE7
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xE7
+      0x0009; // access
+      #13; // name_index       : <init>
+      #14; // descriptor_index : (Z)QputfieldPrimitive;
+      [1] { // Attributes
+        Attr(#11, 84) { // Code at 0xEF  // !!! Change 83 -> 84
+          2; // max_stack
+          2; // max_locals
+          Bytes[29]{             // !!!! Change 28 -> 29
+            0xCB00014C1A99000D;
+            0x082B5FCC00034CA7;
+            0x000C10062B5FB500;  // !!!! Change goto target B -> C and 0xCC (withfield) to 0xB5 (putfield)
+            0x032B4C2BB0;        // !!!! Inserted 0x2B (aload_1)
+          }
+          [0] { // Traps
+          } // end Traps
+          [2] { // Attributes
+            Attr(#12, 22) { // LineNumberTable at 0x011D
+              [5] { // line_number_table
+                0  4; //  at 0x0129
+                4  5; //  at 0x012D
+                8  6; //  at 0x0131
+                18  8; //  at 0x0135
+                26  10; //  at 0x0139
+              }
+            } // end LineNumberTable
+            ;
+            Attr(#15, 9) { // StackMapTable at 0x0139
+              [2] { //
+                252b, 18, [1]z{7b,16}; // append_frame 1
+                8b; // same_frame    // !!!! change 7 -> 8
+              }
+            } // end StackMapTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#18, 2) { // SourceFile at 0x014A
+      #19;
+    } // end SourceFile
+  } // Attributes
+} // end class putfieldPrimitive
+
+
+
+/* This jcod class is based on this Java code.  To see what changed from the
+   original jcod file, search for !!!!.
+public primitive final class withfieldPrimitive {
+    int x;
+
+    public withfieldPrimitive(boolean odd) {
+        if (odd) {
+            x = 5;
+        } else {
+            x = 6;
+        }
+    }
+
+    public int getX() {
+        return x;
+    }
+}
+*/
+
+// This class is identical to putfieldPrimitive except for its name.  A new class
+// was needed for a fresh constant pool resolution.
+// If withfieldPrimitive.<init>(bool) is passed TRUE then it uses a withfield bytecode.
+// Otherwise, it uses a putfield bytecode.
+
+class withfieldPrimitive {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [20] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "withfieldPrimitive"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x13
+    NameAndType #5 #6; // #4     at 0x18
+    Utf8 "x"; // #5     at 0x1D
+    Utf8 "I"; // #6     at 0x21
+    class #8; // #7     at 0x25
+    Utf8 "java/lang/Object"; // #8     at 0x28
+    Utf8 "getX"; // #9     at 0x3B
+    Utf8 "()I"; // #10     at 0x42
+    Utf8 "Code"; // #11     at 0x48
+    Utf8 "LineNumberTable"; // #12     at 0x4F
+    Utf8 "<init>"; // #13     at 0x61
+    Utf8 "(Z)QwithfieldPrimitive;"; // #14     at 0x6A
+    Utf8 "StackMapTable"; // #15     at 0x75
+    class #17; // #16     at 0x85
+    Utf8 "QwithfieldPrimitive;"; // #17     at 0x88
+    Utf8 "SourceFile"; // #18     at 0x90
+    Utf8 "withfieldPrimitive.java"; // #19     at 0x9D
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xB2
+      0x0010; // access
+      #5; // name_index       : x
+      #6; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xBC
+      0x0001; // access
+      #9; // name_index       : getX
+      #10; // descriptor_index : ()I
+      [1] { // Attributes
+        Attr(#11, 29) { // Code at 0xC4
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB40003AC;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 6) { // LineNumberTable at 0xDB
+              [1] { // line_number_table
+                0  13; //  at 0xE7
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xE7
+      0x0009; // access
+      #13; // name_index       : <init>
+      #14; // descriptor_index : (Z)QwithfieldPrimitive;
+      [1] { // Attributes
+        Attr(#11, 84) { // Code at 0xEF  // !!! Change 83 -> 84
+          2; // max_stack
+          2; // max_locals
+          Bytes[29]{             // !!!! Change 28 -> 29
+            0xCB00014C1A99000D;
+            0x082B5FCC00034CA7;
+            0x000C10062B5FB500;  // !!!! Change goto target B -> C and 0xCC (withfield) to 0xB5 (putfield)
+            0x032B4C2BB0;        // !!!! Inserted 0x2B (aload_1)
+          }
+          [0] { // Traps
+          } // end Traps
+          [2] { // Attributes
+            Attr(#12, 22) { // LineNumberTable at 0x011D
+              [5] { // line_number_table
+                0  4; //  at 0x0129
+                4  5; //  at 0x012D
+                8  6; //  at 0x0131
+                18  8; //  at 0x0135
+                26  10; //  at 0x0139
+              }
+            } // end LineNumberTable
+            ;
+            Attr(#15, 9) { // StackMapTable at 0x0139
+              [2] { //
+                252b, 18, [1]z{7b,16}; // append_frame 1
+                8b; // same_frame    // !!!! change 7 -> 8
+              }
+            } // end StackMapTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#18, 2) { // SourceFile at 0x014A
+      #19;
+    } // end SourceFile
+  } // Attributes
+} // end class withfieldPrimitive
+
+
+
+/* This jcod class is based on this Java code. To see what changed from the
+   original jcod file search for !!!!.
+public primitive final class withfieldNull {
+    int x;
+    public withfieldNull() {
+        String s = null;
+        x = 5;
+    }
+}
+*/
+// This class tests a withfield bytecode with a stack operand that is null.
+class withfieldNull {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [15] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "withfieldNull"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x19
+    NameAndType #5 #6; // #4     at 0x1E
+    Utf8 "x"; // #5     at 0x23
+    Utf8 "I"; // #6     at 0x27
+    class #8; // #7     at 0x2B
+    Utf8 "java/lang/Object"; // #8     at 0x2E
+    Utf8 "<init>"; // #9     at 0x41
+    Utf8 "()QwithfieldNull;"; // #10     at 0x4A
+    Utf8 "Code"; // #11     at 0x5A
+    Utf8 "LineNumberTable"; // #12     at 0x61
+    Utf8 "SourceFile"; // #13     at 0x73
+    Utf8 "withfieldNull.java"; // #14     at 0x80
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x9B
+      0x0010; // access
+      #5; // name_index       : x
+      #6; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0xA5
+      0x0009; // access
+      #9; // name_index       : <init>
+      #10; // descriptor_index : ()QwithfieldNull;
+      [1] { // Attributes
+        Attr(#11, 51) { // Code at 0xAD
+          2; // max_stack
+          2; // max_locals
+          Bytes[15]{
+            0xCB00014B014C0801; // !!!! Change 0x2A (aload_0) to 0x01 (aconst_null)
+            0x5FCC00034B2AB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 18) { // LineNumberTable at 0xCE
+              [4] { // line_number_table
+                0  4; //  at 0xDA
+                4  5; //  at 0xDE
+                6  6; //  at 0xE2
+                13  7; //  at 0xE6
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#13, 2) { // SourceFile at 0xE8
+      #14;
+    } // end SourceFile
+  } // Attributes
+} // end class withfieldNull
+
+
+
+/* Thexe jcod classes are based on this Java code. To see what changed from the
+   original jcod file search for !!!!.
+
+public class WrongPrimWF {
+
+    public primitive final class Dot { }
+
+    public primitive final class Loc { }
+
+    public primitive final class Both {
+        Dot dot;
+        Loc loc;
+        Both(Dot d, Loc l) {
+            dot = d;   // this d is changed to l to cause the VerifyError
+            loc = l;
+        }
+    }
+
+    public WrongPrimWF() {
+        Both b = new Both(new Dot(), new Loc());
+    }
+}
+
+*/
+
+// Test that a withfield opcode, whose stack operand 'Loc' is a different primitive type
+// than the primitive class in its constant pool field_res,f causes a VerifyError exception.
+class WrongPrimWF$Dot {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [20] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "WrongPrimWF$Dot"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x1F
+    NameAndType #5 #6; // #4     at 0x24
+    Utf8 "this$0"; // #5     at 0x29
+    Utf8 "LWrongPrimWF;"; // #6     at 0x32
+    class #8; // #7     at 0x42
+    Utf8 "java/lang/Object"; // #8     at 0x45
+    Utf8 "<init>"; // #9     at 0x58
+    Utf8 "(LWrongPrimWF;)QWrongPrimWF$Dot;"; // #10     at 0x61
+    Utf8 "Code"; // #11     at 0x84
+    Utf8 "LineNumberTable"; // #12     at 0x8B
+    Utf8 "SourceFile"; // #13     at 0x9D
+    Utf8 "WrongPrimWF.java"; // #14     at 0xAA
+    Utf8 "NestHost"; // #15     at 0xBD
+    class #17; // #16     at 0xC8
+    Utf8 "WrongPrimWF"; // #17     at 0xCB
+    Utf8 "InnerClasses"; // #18     at 0xD9
+    Utf8 "Dot"; // #19     at 0xE8
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xF8
+      0x1010; // access
+      #5; // name_index       : this$0
+      #6; // descriptor_index : LWrongPrimWF;
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x0102
+      0x0009; // access
+      #9; // name_index       : <init>
+      #10; // descriptor_index : (LWrongPrimWF;)QWrongPrimWF$Dot;
+      [1] { // Attributes
+        Attr(#11, 37) { // Code at 0x010A
+          2; // max_stack
+          2; // max_locals
+          Bytes[13]{
+            0xCB00014C2A2B5FCC;
+            0x00034C2BB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 6) { // LineNumberTable at 0x0129
+              [1] { // line_number_table
+                0  3; //  at 0x0135
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [3] { // Attributes
+    Attr(#13, 2) { // SourceFile at 0x0137
+      #14;
+    } // end SourceFile
+    ;
+    Attr(#15, 2) { // NestHost at 0x013F
+      #16; // WrongPrimWF at 0x0147
+    } // end NestHost
+    ;
+    Attr(#18, 10) { // InnerClasses at 0x0147
+      [1] { // classes
+        #1 #16 #19 273; //  at 0x0157
+      }
+    } // end InnerClasses
+  } // Attributes
+} // end class WrongPrimWF$Dot
+
+
+class WrongPrimWF$Loc {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [20] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "WrongPrimWF$Loc"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x1F
+    NameAndType #5 #6; // #4     at 0x24
+    Utf8 "this$0"; // #5     at 0x29
+    Utf8 "LWrongPrimWF;"; // #6     at 0x32
+    class #8; // #7     at 0x42
+    Utf8 "java/lang/Object"; // #8     at 0x45
+    Utf8 "<init>"; // #9     at 0x58
+    Utf8 "(LWrongPrimWF;)QWrongPrimWF$Loc;"; // #10     at 0x61
+    Utf8 "Code"; // #11     at 0x84
+    Utf8 "LineNumberTable"; // #12     at 0x8B
+    Utf8 "SourceFile"; // #13     at 0x9D
+    Utf8 "WrongPrimWF.java"; // #14     at 0xAA
+    Utf8 "NestHost"; // #15     at 0xBD
+    class #17; // #16     at 0xC8
+    Utf8 "WrongPrimWF"; // #17     at 0xCB
+    Utf8 "InnerClasses"; // #18     at 0xD9
+    Utf8 "Loc"; // #19     at 0xE8
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xF8
+      0x1010; // access
+      #5; // name_index       : this$0
+      #6; // descriptor_index : LWrongPrimWF;
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x0102
+      0x0009; // access
+      #9; // name_index       : <init>
+      #10; // descriptor_index : (LWrongPrimWF;)QWrongPrimWF$Loc;
+      [1] { // Attributes
+        Attr(#11, 37) { // Code at 0x010A
+          2; // max_stack
+          2; // max_locals
+          Bytes[13]{
+            0xCB00014C2A2B5FCC;
+            0x00034C2BB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 6) { // LineNumberTable at 0x0129
+              [1] { // line_number_table
+                0  5; //  at 0x0135
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [3] { // Attributes
+    Attr(#13, 2) { // SourceFile at 0x0137
+      #14;
+    } // end SourceFile
+    ;
+    Attr(#15, 2) { // NestHost at 0x013F
+      #16; // WrongPrimWF at 0x0147
+    } // end NestHost
+    ;
+    Attr(#18, 10) { // InnerClasses at 0x0147
+      [1] { // classes
+        #1 #16 #19 273; //  at 0x0157
+      }
+    } // end InnerClasses
+  } // Attributes
+} // end class WrongPrimWF$Loc
+
+
+class WrongPrimWF$Both {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [34] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "WrongPrimWF$Both"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x20
+    NameAndType #5 #6; // #4     at 0x25
+    Utf8 "this$0"; // #5     at 0x2A
+    Utf8 "LWrongPrimWF;"; // #6     at 0x33
+    Field #1 #8; // #7     at 0x43
+    NameAndType #9 #10; // #8     at 0x48
+    Utf8 "dot"; // #9     at 0x4D
+    Utf8 "QWrongPrimWF$Dot;"; // #10     at 0x53
+    Field #1 #12; // #11     at 0x67
+    NameAndType #13 #14; // #12     at 0x6C
+    Utf8 "loc"; // #13     at 0x71
+    Utf8 "QWrongPrimWF$Loc;"; // #14     at 0x77
+    class #16; // #15     at 0x8B
+    Utf8 "java/lang/Object"; // #16     at 0x8E
+    Utf8 "<init>"; // #17     at 0xA1
+    Utf8 "(LWrongPrimWF;QWrongPrimWF$Dot;QWrongPrimWF$Loc;)QWrongPrimWF$Both;"; // #18     at 0xAA
+    Utf8 "Code"; // #19     at 0xF0
+    Utf8 "LineNumberTable"; // #20     at 0xF7
+    Utf8 "SourceFile"; // #21     at 0x0109
+    Utf8 "WrongPrimWF.java"; // #22     at 0x0116
+    Utf8 "NestHost"; // #23     at 0x0129
+    class #25; // #24     at 0x0134
+    Utf8 "WrongPrimWF"; // #25     at 0x0137
+    Utf8 "InnerClasses"; // #26     at 0x0145
+    Utf8 "Both"; // #27     at 0x0154
+    class #29; // #28     at 0x015B
+    Utf8 "WrongPrimWF$Dot"; // #29     at 0x015E
+    Utf8 "Dot"; // #30     at 0x0170
+    class #32; // #31     at 0x0176
+    Utf8 "WrongPrimWF$Loc"; // #32     at 0x0179
+    Utf8 "Loc"; // #33     at 0x018B
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #15;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [3] { // Fields
+    {  // field at 0x019B
+      0x0010; // access
+      #9; // name_index       : dot
+      #10; // descriptor_index : QWrongPrimWF$Dot;
+      [0] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field at 0x01A3
+      0x0010; // access
+      #13; // name_index       : loc
+      #14; // descriptor_index : QWrongPrimWF$Loc;
+      [0] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field at 0x01AB
+      0x1010; // access
+      #5; // name_index       : this$0
+      #6; // descriptor_index : LWrongPrimWF;
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x01B5
+      0x0008; // access
+      #17; // name_index       : <init>
+      #18; // descriptor_index : (LWrongPrimWF;QWrongPrimWF$Dot;QWrongPrimWF$Loc;)QWrongPrimWF$Both;
+      [1] { // Attributes
+        Attr(#19, 63) { // Code at 0x01BD
+          2; // max_stack
+          4; // max_locals
+          Bytes[27]{
+            0xCB00014E2A2D5FCC;
+            0x00034E2C2D5FCC00; // !!!! change 2B (aload_1) to 2C (aload_2) to put Loc on the stack.
+            0x074E2C2D5FCC000B; //      this should cause a VerifyError because withfield is assigning
+            0x4E2DB0;           //      to a field of type Dot.
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#20, 18) { // LineNumberTable at 0x01EA
+              [4] { // line_number_table
+                0  10; //  at 0x01F6
+                11  11; //  at 0x01FA
+                18  12; //  at 0x01FE
+                25  13; //  at 0x0202
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [3] { // Attributes
+    Attr(#21, 2) { // SourceFile at 0x0204
+      #22;
+    } // end SourceFile
+    ;
+    Attr(#23, 2) { // NestHost at 0x020C
+      #24; // WrongPrimWF at 0x0214
+    } // end NestHost
+    ;
+    Attr(#26, 26) { // InnerClasses at 0x0214
+      [3] { // classes
+        #1 #24 #27 273; //  at 0x0224
+        #28 #24 #30 273; //  at 0x022C
+        #31 #24 #33 273; //  at 0x0234
+      }
+    } // end InnerClasses
+  } // Attributes
+} // end class WrongPrimWF$Both
+
+
+class WrongPrimWF {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Method #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #5 #11; // #9     at 0x41
+    Utf8 "WrongPrimWF$Dot"; // #10     at 0x46
+    Utf8 "(LWrongPrimWF;)QWrongPrimWF$Dot;"; // #11     at 0x58
+    Method #13 #14; // #12     at 0x7B
+    class #15; // #13     at 0x80
+    NameAndType #5 #16; // #14     at 0x83
+    Utf8 "WrongPrimWF$Loc"; // #15     at 0x88
+    Utf8 "(LWrongPrimWF;)QWrongPrimWF$Loc;"; // #16     at 0x9A
+    Method #18 #19; // #17     at 0xBD
+    class #20; // #18     at 0xC2
+    NameAndType #5 #21; // #19     at 0xC5
+    Utf8 "WrongPrimWF$Both"; // #20     at 0xCA
+    Utf8 "(LWrongPrimWF;QWrongPrimWF$Dot;QWrongPrimWF$Loc;)QWrongPrimWF$Both;"; // #21     at 0xDD
+    class #23; // #22     at 0x0123
+    Utf8 "WrongPrimWF"; // #23     at 0x0126
+    Utf8 "Code"; // #24     at 0x0134
+    Utf8 "LineNumberTable"; // #25     at 0x013B
+    Utf8 "SourceFile"; // #26     at 0x014D
+    Utf8 "WrongPrimWF.java"; // #27     at 0x015A
+    Utf8 "NestMembers"; // #28     at 0x016D
+    Utf8 "InnerClasses"; // #29     at 0x017B
+    Utf8 "Dot"; // #30     at 0x018A
+    Utf8 "Loc"; // #31     at 0x0190
+    Utf8 "Both"; // #32     at 0x0196
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x01A9
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#24, 50) { // Code at 0x01B1
+          3; // max_stack
+          2; // max_locals
+          Bytes[18]{
+            0x2AB700012A2AB800;
+            0x072AB8000CB80011;
+            0x4CB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#25, 14) { // LineNumberTable at 0x01D5
+              [3] { // line_number_table
+                0  16; //  at 0x01E1
+                4  17; //  at 0x01E5
+                17  18; //  at 0x01E9
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [3] { // Attributes
+    Attr(#26, 2) { // SourceFile at 0x01EB
+      #27;
+    } // end SourceFile
+    ;
+    Attr(#28, 8) { // NestMembers at 0x01F3
+      [3] { // classes
+        #18; // WrongPrimWF$Both at 0x01FD
+        #13; // WrongPrimWF$Loc at 0x01FF
+        #8; // WrongPrimWF$Dot at 0x0201
+      }
+    } // end NestMembers
+    ;
+    Attr(#29, 26) { // InnerClasses at 0x0201
+      [3] { // classes
+        #8 #22 #30 273; //  at 0x0211
+        #13 #22 #31 273; //  at 0x0219
+        #18 #22 #32 273; //  at 0x0221
+      }
+    } // end InnerClasses
+  } // Attributes
+} // end class WrongPrimWF


### PR DESCRIPTION
Please review this change to add a test for various scenarios involving withfield.  The test was run locally on Linux x64 and using Mach5 tiers 1-2.

Note that the test temporarily is run with -Xint because it fails when run with -Xcomp.  -Xint will be removed once it passes with -Xcomp.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8269756](https://bugs.openjdk.java.net/browse/JDK-8269756): [lworld] Add tests for invalid withfield operands


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/490/head:pull/490` \
`$ git checkout pull/490`

Update a local copy of the PR: \
`$ git checkout pull/490` \
`$ git pull https://git.openjdk.java.net/valhalla pull/490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 490`

View PR using the GUI difftool: \
`$ git pr show -t 490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/490.diff">https://git.openjdk.java.net/valhalla/pull/490.diff</a>

</details>
