### PR TITLE
JDK-8271113: [lworld] java/lang/constant/MethodHandleDescTest.java fails after JDK-8247376

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -311,8 +311,7 @@ public sealed interface ClassDesc
             return Wrapper.forBasicType(descriptorString().charAt(0)).primitiveSimpleName();
         else if (isClassOrInterface()) {
             return descriptorString().substring(Math.max(1, descriptorString().lastIndexOf('/') + 1),
-                                                descriptorString().length() - 1) +
-                   (isValueType() ? "" : ".ref");
+                                                descriptorString().length() - 1);
         }
         else if (isArray()) {
             int depth = ConstantUtils.arrayDepth(descriptorString());

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -44,9 +44,9 @@ public class ValueConstantDesc {
     static Object[][] descs() {
         return new Object[][]{
             new Object[] { Point.class,     ClassDesc.ofDescriptor("Q" + NAME + ";"), NAME},
-            new Object[] { Point.ref.class, ClassDesc.ofDescriptor("L" + NAME + ";"), NAME + ".ref"},
+            new Object[] { Point.ref.class, ClassDesc.ofDescriptor("L" + NAME + ";"), NAME},
             new Object[] { Point[].class,   ClassDesc.ofDescriptor("[Q" + NAME + ";"), NAME + "[]"},
-            new Object[] { Point.ref[][].class, ClassDesc.ofDescriptor("[[L" + NAME + ";"), NAME + ".ref[][]"},
+            new Object[] { Point.ref[][].class, ClassDesc.ofDescriptor("[[L" + NAME + ";"), NAME + "[][]"},
         };
     }
 


### PR DESCRIPTION
It's a bug in the fix of JDK-8247376 that appends ".ref" in the display name if the descriptor is not Q-descriptor.  It can't determine if the class represented by the given L-descriptor string is a primitive class or not.   This patch will revert the change in ClassClass::displayName.   We will follow up if ClassDesc::displayName should return a different string for primitive reference type vs primitive value type in a separate issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271113](https://bugs.openjdk.java.net/browse/JDK-8271113): [lworld] java/lang/constant/MethodHandleDescTest.java fails after JDK-8247376


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/491/head:pull/491` \
`$ git checkout pull/491`

Update a local copy of the PR: \
`$ git checkout pull/491` \
`$ git pull https://git.openjdk.java.net/valhalla pull/491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 491`

View PR using the GUI difftool: \
`$ git pr show -t 491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/491.diff">https://git.openjdk.java.net/valhalla/pull/491.diff</a>

</details>
