### PR TITLE
8271017: [lworld] Implement withfield changes from JDK-8269408 on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3823,10 +3823,15 @@ void TemplateTable::withfield() {
   transition(vtos, atos);
   resolve_cache_and_index(f2_byte, c_rarg1 /*cache*/, c_rarg2 /*index*/, sizeof(u2));
 
-  // n.b. unlike x86 cache is now rcpool plus the indexed offset
-  // so using rcpool to meet shared code expectations
+  ByteSize cp_base_offset = ConstantPoolCache::base_offset();
 
-  call_VM(r1, CAST_FROM_FN_PTR(address, InterpreterRuntime::withfield), rcpool);
+  // n.b. unlike x86 cache is now rcpool plus the indexed offset
+  __ lea(c_rarg1, Address(c_rarg1, in_bytes(cp_base_offset)));
+
+  __ lea(c_rarg2, at_tos());
+  call_VM(r1, CAST_FROM_FN_PTR(address, InterpreterRuntime::withfield), c_rarg1, c_rarg2);
+  // new value type is returned in r1
+  // stack adjustment is returned in r0
   __ verify_oop(r1);
   __ add(esp, esp, r0);
   __ mov(r0, r1);

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3188,9 +3188,9 @@ void TemplateTable::withfield() {
   __ lea(cpentry, Address(cache, index, Address::times_ptr,
                          in_bytes(cp_base_offset)));
   __ lea(rax, at_tos());
-  __ call_VM(rbx, CAST_FROM_FN_PTR(address, InterpreterRuntime::withfield2), cpentry, rax);
+  __ call_VM(rbx, CAST_FROM_FN_PTR(address, InterpreterRuntime::withfield), cpentry, rax);
   // new value type is returned in rbx
-  // stack adjustement is returned in rax
+  // stack adjustment is returned in rax
   __ verify_oop(rbx);
   __ addptr(rsp, rax);
   __ movptr(rax, rbx);

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -65,8 +65,7 @@ class InterpreterRuntime: AllStatic {
   static void    multianewarray(JavaThread* current, jint* first_size_address);
   static void    register_finalizer(JavaThread* current, oopDesc* obj);
   static void    defaultvalue  (JavaThread* current, ConstantPool* pool, int index);
-  static int     withfield     (JavaThread* current, ConstantPoolCache* cp_cache);
-  static int     withfield2     (JavaThread* current, ConstantPoolCacheEntry* cpe, uintptr_t ptr);
+  static int     withfield     (JavaThread* current, ConstantPoolCacheEntry* cpe, uintptr_t ptr);
   static void    uninitialized_static_inline_type_field(JavaThread* current, oopDesc* mirror, int offset);
   static void    write_heap_copy (JavaThread* current, oopDesc* value, int offset, oopDesc* rcv);
   static void    read_inlined_field(JavaThread* current, oopDesc* value, int index, Klass* field_holder);


### PR DESCRIPTION
This just applies the changes in JDK-8269408 to the AArch64 port.

The old `InterpreterRuntime::withfield()` is removed as it has no more users, and I've renamed withfield2 to withfield (presumably this was the original intention?).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271017](https://bugs.openjdk.java.net/browse/JDK-8271017): [lworld] Implement withfield changes from JDK-8269408 on AArch64


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/492/head:pull/492` \
`$ git checkout pull/492`

Update a local copy of the PR: \
`$ git checkout pull/492` \
`$ git pull https://git.openjdk.java.net/valhalla pull/492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 492`

View PR using the GUI difftool: \
`$ git pr show -t 492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/492.diff">https://git.openjdk.java.net/valhalla/pull/492.diff</a>

</details>
