### PR TITLE
8271141: [lworld] Remove unused jvaluetype q member in jvalue

### DIFF
--- a/src/java.base/share/native/include/jni.h
+++ b/src/java.base/share/native/include/jni.h
@@ -64,7 +64,6 @@ typedef jint            jsize;
 
 #ifdef __cplusplus
 
-class _jvaluetype {};
 class _jobject {};
 class _jclass : public _jobject {};
 class _jthrowable : public _jobject {};
@@ -80,7 +79,6 @@ class _jfloatArray : public _jarray {};
 class _jdoubleArray : public _jarray {};
 class _jobjectArray : public _jarray {};
 
-typedef _jvaluetype *jvaluetype;
 typedef _jobject *jobject;
 typedef _jclass *jclass;
 typedef _jthrowable *jthrowable;
@@ -98,10 +96,8 @@ typedef _jobjectArray *jobjectArray;
 
 #else
 
-struct _jvaluetype;
 struct _jobject;
 
-typedef struct _jvaluetype *jvaluetype;
 typedef struct _jobject *jobject;
 typedef jobject jclass;
 typedef jobject jthrowable;
@@ -131,7 +127,6 @@ typedef union jvalue {
     jfloat   f;
     jdouble  d;
     jobject  l;
-    jvaluetype q;
 } jvalue;
 
 struct _jfieldID;


### PR DESCRIPTION
Simple cleanup in jvalue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271141](https://bugs.openjdk.java.net/browse/JDK-8271141): [lworld] Remove unused jvaluetype q member in jvalue


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.java.net/valhalla pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/493.diff">https://git.openjdk.java.net/valhalla/pull/493.diff</a>

</details>
