### PR TITLE
8271154: [lworld] CDS LoaderConstraintsTest fails after injection of IdentityObject

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
@@ -95,12 +95,13 @@ public class LoaderConstraintsTest  {
         String src = " source: " + appJar;
         String classList[] =
             TestCommon.concat(loaderClasses,
+                              "java/lang/IdentityObject id: 0",
                               "java/lang/Object id: 1",
-                              mainClass + " id: 2 super: 1" + src,
+                              mainClass + " id: 2 super: 1 interfaces: 0" + src,
                               httpHandlerClass + " id: 3",
-                              "MyHttpHandler id: 5 super: 1 interfaces: 3" + src,
+                              "MyHttpHandler id: 5 super: 1 interfaces: 3 0" + src,
                               "MyHttpHandlerB id: 6 super: 1 interfaces: 3" + src,
-                              "MyHttpHandlerC id: 7 super: 1 interfaces: 3" + src);
+                              "MyHttpHandlerC id: 7 super: 1 interfaces: 3 0" + src);
         TestCommon.dump(loaderJar, classList, "-Xlog:cds");
 
         String cmdLine[] =


### PR DESCRIPTION
Please review this small change in CDS LoaderConstraints test. The fix simply adds the missing IdentityObject interface to the test classlist.

Tested on all platforms with Mach5 (tiers1-3).

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271154](https://bugs.openjdk.java.net/browse/JDK-8271154): [lworld] CDS LoaderConstraintsTest fails after injection of IdentityObject


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/494/head:pull/494` \
`$ git checkout pull/494`

Update a local copy of the PR: \
`$ git checkout pull/494` \
`$ git pull https://git.openjdk.java.net/valhalla pull/494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 494`

View PR using the GUI difftool: \
`$ git pr show -t 494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/494.diff">https://git.openjdk.java.net/valhalla/pull/494.diff</a>

</details>
