### PR TITLE
8271229: [lworld] Test serviceability/sa/ClhsdbDumpclass.java fails with unexpected end of file

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2310,6 +2310,8 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_constant(InstanceKlass::_misc_is_shared_app_class)              \
   declare_constant(InstanceKlass::_misc_invalid_inline_super)             \
   declare_constant(InstanceKlass::_misc_invalid_identity_super)           \
+  declare_constant(InstanceKlass::_misc_has_injected_primitiveObject)     \
+  declare_constant(InstanceKlass::_misc_has_injected_identityObject)      \
                                                                           \
   /*********************************/                                     \
   /* Symbol* - symbol max length */                                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/InstanceKlass.java
@@ -78,6 +78,8 @@ public class InstanceKlass extends Klass {
   private static int MISC_IS_SHARED_BOOT_CLASS;
   private static int MISC_IS_SHARED_PLATFORM_CLASS;
   private static int MISC_IS_SHARED_APP_CLASS;
+  private static int MISC_HAS_INJECTED_PRIMITIVEOBJECT;
+  private static int MISC_HAS_INJECTED_IDENTITYOBJECT;
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type            = db.lookupType("InstanceKlass");
@@ -135,6 +137,8 @@ public class InstanceKlass extends Klass {
     MISC_IS_SHARED_BOOT_CLASS         = db.lookupIntConstant("InstanceKlass::_misc_is_shared_boot_class").intValue();
     MISC_IS_SHARED_PLATFORM_CLASS     = db.lookupIntConstant("InstanceKlass::_misc_is_shared_platform_class").intValue();
     MISC_IS_SHARED_APP_CLASS          = db.lookupIntConstant("InstanceKlass::_misc_is_shared_app_class").intValue();
+    MISC_HAS_INJECTED_PRIMITIVEOBJECT = db.lookupIntConstant("InstanceKlass::_misc_has_injected_primitiveObject").intValue();
+    MISC_HAS_INJECTED_IDENTITYOBJECT  = db.lookupIntConstant("InstanceKlass::_misc_has_injected_identityObject").intValue();
   }
 
   public InstanceKlass(Address addr) {
@@ -567,6 +571,14 @@ public class InstanceKlass extends Klass {
     } else {
        return false;
     }
+  }
+
+  public boolean hasInjectedIdentityObject() {
+    return (getMiscFlags() & MISC_HAS_INJECTED_IDENTITYOBJECT) != 0;
+  }
+
+  public boolean hasInjectedPrimitiveObject() {
+    return (getMiscFlags() & MISC_HAS_INJECTED_PRIMITIVEOBJECT) != 0;
   }
 
   public boolean implementsInterface(Klass k) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ClassWriter.java
@@ -352,11 +352,15 @@ public class ClassWriter implements /* imports */ ClassConstants
     protected void writeInterfaces() throws IOException {
         KlassArray interfaces = klass.getLocalInterfaces();
         final int len = interfaces.length();
+        int nb_interfaces = len;
+        if (klass.hasInjectedIdentityObject() || klass.hasInjectedPrimitiveObject()) {
+            nb_interfaces--;
+        }
 
-        if (DEBUG) debugMessage("number of interfaces = " + len);
+        if (DEBUG) debugMessage("number of interfaces = " + nb_interfaces);
 
         // write interfaces count
-        dos.writeShort((short) len);
+        dos.writeShort((short) nb_interfaces);
         for (int i = 0; i < len; i++) {
            Klass k = interfaces.getAt(i);
            Short index = (Short) classToIndex.get(k.getName().asString());


### PR DESCRIPTION
Please review those changes fixing the HotSpot agent to correctly dump classes even in presence of injected interfaces.
Fix failures of serviceability/sa/ClhsdbDumpclass.java on all platforms (tested with Mach5, tiers 1 to 3).

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271229](https://bugs.openjdk.java.net/browse/JDK-8271229): [lworld] Test serviceability/sa/ClhsdbDumpclass.java fails with unexpected end of file


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/498/head:pull/498` \
`$ git checkout pull/498`

Update a local copy of the PR: \
`$ git checkout pull/498` \
`$ git pull https://git.openjdk.java.net/valhalla pull/498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 498`

View PR using the GUI difftool: \
`$ git pr show -t 498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/498.diff">https://git.openjdk.java.net/valhalla/pull/498.diff</a>

</details>
