### PR TITLE
8271309: [lworld] FieldModification event: new_value is invalid for Q objects

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2046,7 +2046,7 @@ void JvmtiExport::post_raw_field_modification(JavaThread *thread, Method* method
   bool handle_created = false;
 
   // convert oop to JNI handle.
-  if (sig_type == JVM_SIGNATURE_CLASS) {
+  if (sig_type == JVM_SIGNATURE_CLASS || sig_type == JVM_SIGNATURE_INLINE_TYPE) {
     handle_created = true;
     value->l = (jobject)JNIHandles::make_local(thread, cast_to_oop(value->l));
   }

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/FieldAccessModify.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/FieldAccessModify.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Tests that all FieldAccess and FieldModification notifications
+            are generated for primitive classes.
+ * @requires vm.jvmti
+ * @compile FieldAccessModify.java
+ * @run main/othervm/native -agentlib:FieldAccessModify FieldAccessModify
+ */
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+
+public class FieldAccessModify {
+
+    private static final String agentLib = "FieldAccessModify";
+
+    private static primitive class MyPrimitive {
+        public int MyPrimitive_fld1;
+        public int MyPrimitive_fld2;
+
+        public MyPrimitive(int v1, int v2) { MyPrimitive_fld1 = v1; MyPrimitive_fld2 = v2; }
+
+        public static MyPrimitive create(int v1, int v2) {
+            return new MyPrimitive(v1, v2);
+        }
+
+        public String toString() {
+            return "MyPrimitive { fld1=" + MyPrimitive_fld1 + ", fld2=" + MyPrimitive_fld2 + "}";
+        }
+        
+    }
+
+    private static class InstanceHolder {
+        public final MyPrimitive InstanceHolder_fld1;
+
+        public InstanceHolder(int v) {
+            InstanceHolder_fld1 = MyPrimitive.create(v, v + 100);
+        }
+
+        public String toString() {
+            return "InstanceHolder { fld1 is " + InstanceHolder_fld1 + "}";
+        }
+    }
+
+    private static primitive class PrimitiveHolder {
+        public MyPrimitive PrimitiveHolder_fld1;
+        
+        public PrimitiveHolder(int v) {
+            PrimitiveHolder_fld1 = MyPrimitive.create(v, v + 200);
+        }
+
+        public String toString() {
+            return "PrimitiveHolder { fld1 is " + PrimitiveHolder_fld1 + "}";
+        }
+    }
+
+    private static class TestHolder {
+        public MyPrimitive primitiveObj = MyPrimitive.create(1, 1);
+        public InstanceHolder instanceHolderObj = new InstanceHolder(1);
+        public PrimitiveHolder primitiveHolderObj = new PrimitiveHolder(1);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            System.loadLibrary(agentLib);
+        } catch (UnsatisfiedLinkError ex) {
+            System.err.println("Failed to load " + agentLib + " lib");
+            System.err.println("java.library.path: " + System.getProperty("java.library.path"));
+            throw ex;
+        }
+
+        // create objects for access testing before setting watchers
+        TestHolder testHolder = new TestHolder();
+
+        if (!initWatchers(MyPrimitive.class, MyPrimitive.class.getDeclaredField("MyPrimitive_fld1"))) {
+            throw new RuntimeException("Watchers initializations error (MyPrimitive_fld1)");
+        }
+        if (!initWatchers(MyPrimitive.class, MyPrimitive.class.getDeclaredField("MyPrimitive_fld2"))) {
+            throw new RuntimeException("Watchers initializations error (MyPrimitive_fld2)");
+        }
+        if (!initWatchers(InstanceHolder.class, InstanceHolder.class.getDeclaredField("InstanceHolder_fld1"))) {
+            throw new RuntimeException("Watchers initializations error (InstanceHolder_fld1)");
+        }
+        if (!initWatchers(PrimitiveHolder.class, PrimitiveHolder.class.getDeclaredField("PrimitiveHolder_fld1"))) {
+            throw new RuntimeException("Watchers initializations error (PrimitiveHolder_fld1)");
+        }
+
+        test("MyPrimitive (access)", () -> {
+                testHolder.primitiveObj.toString();     // should access both MyPrimitive_fld1 and MyPrimitive_fld2
+            }, new TestResult() {
+                public boolean MyPrimitive_fld1_access;
+                public boolean MyPrimitive_fld2_access;
+            });
+
+        test("InstanceHolder (access)", () ->  {
+                testHolder.instanceHolderObj.toString();
+            }, new TestResult() {
+                public boolean InstanceHolder_fld1_access;
+                // MyPrimitive fields should be accessed too
+                public boolean MyPrimitive_fld1_access;
+                public boolean MyPrimitive_fld2_access;
+            });
+
+        test("PrimitiveHolder (access)", () ->  {
+                testHolder.primitiveHolderObj.toString();
+            }, new TestResult() {
+                public boolean PrimitiveHolder_fld1_access;
+                // MyPrimitive fields should be accessed too
+                public boolean MyPrimitive_fld1_access;
+                public boolean MyPrimitive_fld2_access;
+            });
+
+        test("MyPrimitive (modify)", () ->  {
+                MyPrimitive obj = MyPrimitive.create(1, 1);
+            }, new TestResult() {
+                // KNOWN_ISSUE public boolean MyPrimitive_fld1_modify;
+                // KNOWN_ISSUE public boolean MyPrimitive_fld2_modify;
+            });
+
+        test("InstanceHolder (modify)", () ->  {
+                InstanceHolder obj = new InstanceHolder(10);
+            }, new TestResult() {
+                public boolean InstanceHolder_fld1_modify;
+                // MyPrimitive fields should be modified too
+                // KNOWN_ISSUE public boolean MyPrimitive_fld1_modify;
+                // KNOWN_ISSUE public boolean MyPrimitive_fld2_modify;
+            });
+
+        test("PrimitiveHolder (modify)", () ->  {
+                PrimitiveHolder obj = new PrimitiveHolder(11);
+            }, new TestResult() {
+                // KNOWN_ISSUE public boolean PrimitiveHolder_fld1_modify;
+                // MyPrimitive fields should be modified too
+                // KNOWN_ISSUE public boolean MyPrimitive_fld1_modify;
+                // KNOWN_ISSUE public boolean MyPrimitive_fld2_modify;
+            });
+
+    }
+
+    private static void log(String msg) {
+        System.out.println(msg);
+        System.out.flush();
+    }
+
+    private static void assertTrue(boolean value) {
+        if (!value) {
+            throw new RuntimeException("assert");
+        }
+    }
+
+    // For every access/modify notification native part tries to locate
+    // boolean "<field_name>_access"/"<field_name>_modify" field and sets it to true
+    private static class TestResult {
+
+        // verify that all fields are set to true
+        public void verify() {
+            Arrays.stream(this.getClass().getDeclaredFields()).forEach(f -> verify(f));
+        }
+
+        private void verify(Field f) {
+            try {
+                if (!f.getBoolean(this)) {
+                    throw new RuntimeException(f.getName() + " notification is missed");
+                }
+                log("  - " + f.getName() + ": OK");
+            } catch (IllegalAccessException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface TestAction {
+        void apply();
+    }
+
+    private static void test(String descr, TestAction action, TestResult result) throws Exception {
+        log(descr + ": starting");
+        if (!startTest(result)) {
+            throw new RuntimeException("startTest failed");
+        }
+        action.apply();
+        // wait some time to ensure all posted events are handled
+        Thread.sleep(500);
+
+        stopTest();
+
+        // check the results
+        result.verify();
+
+        log(descr + ": OK");
+        log("");
+    }
+
+    private static native boolean initWatchers(Class cls, Field field);
+    private static native boolean startTest(TestResult results);
+    private static native void stopTest();
+
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/FieldAccessModify.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/FieldAccessModify.java
@@ -51,7 +51,7 @@ public class FieldAccessModify {
         public String toString() {
             return "MyPrimitive { fld1=" + MyPrimitive_fld1 + ", fld2=" + MyPrimitive_fld2 + "}";
         }
-        
+
     }
 
     private static class InstanceHolder {
@@ -68,7 +68,7 @@ public class FieldAccessModify {
 
     private static primitive class PrimitiveHolder {
         public MyPrimitive PrimitiveHolder_fld1;
-        
+
         public PrimitiveHolder(int v) {
             PrimitiveHolder_fld1 = MyPrimitive.create(v, v + 200);
         }

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -57,8 +57,8 @@ static void printJValue(const char *prefix, JNIEnv *jni_env, char signature_type
     J long
     F float
     D double
-    L fully-qualified-class ;			fully-qualified-class
-    [ type								type[]
+    L fully-qualified-class ;   fully-qualified-class
+    [ type                      type[]
     */
     char signature[64] = {};
     if (signature_type == 'Q' || signature_type == 'L') {

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -91,7 +91,7 @@ static void handleNotification(jvmtiEnv *jvmti, JNIEnv *jni_env,
     jobject object,
     jfieldID field,
     jclass field_klass,
-    int modified,
+    bool modified,
     jlocation location)
 {
     jvmtiError err;
@@ -205,7 +205,7 @@ onFieldAccess(jvmtiEnv *jvmti_env,
     if (disableAccessEvent) {
         return;
     }
-    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, 0, location);
+    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, false, location);
 }
 
 static void JNICALL
@@ -222,7 +222,7 @@ onFieldModification(jvmtiEnv *jvmti_env,
 {
     disableAccessEvent = true;
 
-    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, 1, location);
+    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, true, location);
 
     printJValue("new value", jni_env, signature_type, new_value);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "jvmti.h"
+#include "jni.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+static jvmtiEnv *jvmti = nullptr;
+
+// valid while a test is executed
+static jobject testResultObject = nullptr;
+static jclass testResultClass = nullptr;
+// we log object values handling FieldModification event and this cause FieldAccess events are triggered.
+// The flag to disable FieldAccess handling.
+static bool disableAccessEvent = false;
+
+static void reportError(const char *msg, int err) {
+    printf("%s, error: %d\n", msg, err);
+}
+
+static void printJValue(const char *prefix, JNIEnv *jni_env, char signature_type, jvalue value) {
+    // print new_value to ensure the value is valid 
+    // use String.valueOf(...) to get string representation
+    /*
+    Z boolean
+    B byte
+    C char
+    S short
+    I int
+    J long
+    F float
+    D double
+    L fully-qualified-class ;			fully-qualified-class
+    [ type								type[]
+    */
+    char signature[64] = {};
+    if (signature_type == 'Q' || signature_type == 'L') {
+        sprintf(signature, "(Ljava/lang/Object;)Ljava/lang/String;");
+    } else {
+        sprintf(signature, "(%c)Ljava/lang/String;", signature_type);
+    }
+
+    jclass clsString = jni_env->FindClass("java/lang/String");
+    jmethodID mid = jni_env->GetStaticMethodID(clsString, "valueOf", signature);
+    jstring objJStr = (jstring)jni_env->CallStaticObjectMethodA(clsString, mid, &value);
+
+    const char* objStr = "UNKNOWN";
+    if (objJStr != nullptr) {
+        objStr = jni_env->GetStringUTFChars(objJStr, nullptr);
+    }
+
+    printf("    %s is: '%s'\n", prefix, objStr);
+    fflush(0);
+
+    if (objJStr != nullptr) {
+        jni_env->ReleaseStringUTFChars(objJStr, objStr);
+    }
+}
+
+
+// logs the notification and updates currentTestResult
+static void handleNotification(jvmtiEnv *jvmti, JNIEnv *jni_env,
+    jmethodID method,
+    jobject object,
+    jfieldID field,
+    jclass field_klass,
+    int modified,
+    jlocation location)
+{
+    jvmtiError err;
+    char *name = nullptr;
+    char *signature = nullptr;
+    char *mname = nullptr;
+    char *mgensig = nullptr;
+    jclass methodClass = nullptr;
+    char *csig = nullptr;
+
+    if (testResultObject == nullptr) {
+        // we are out of test
+        return;
+    }
+
+    err = jvmti->GetFieldName(field_klass, field, &name, &signature, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("GetFieldName failed", err);
+        return;
+    }
+
+    err = jvmti->GetMethodName(method, &mname, nullptr, &mgensig);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("GetMethodName failed", err);
+        return;
+    }
+
+    err = jvmti->GetMethodDeclaringClass(method, &methodClass);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("GetMethodDeclaringClass failed", err);
+        return;
+    }
+
+    err = jvmti->GetClassSignature(methodClass, &csig, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("GetClassSignature failed", err);
+        return;
+    }
+
+    printf("  \"class: %s method: %s%s\" %s field: \"%s\" (type '%s'), location: %d\n",
+        csig, mname, mgensig, modified ? "modified" : "accessed", name, signature, (int)location);
+
+    // For FieldModification event print current value.
+    // Note: this will cause FieldAccess event.
+    if (modified) {
+        jvalue curValue = {};
+        switch (signature[0]) {
+        case 'L':
+        case 'Q':
+            curValue.l = jni_env->GetObjectField(object, field); break;
+        case 'Z':   // boolean
+            curValue.z = jni_env->GetBooleanField(object, field); break;
+        case 'B':   // byte
+            curValue.b = jni_env->GetByteField(object, field); break;
+        case 'C':   // char
+            curValue.c = jni_env->GetCharField(object, field); break;
+        case 'S':   // short
+            curValue.s = jni_env->GetShortField(object, field); break;
+        case 'I':   // int
+            curValue.i = jni_env->GetIntField(object, field); break;
+        case 'J':   // long
+            curValue.j = jni_env->GetLongField(object, field); break;
+        case 'F':   // float
+            curValue.f = jni_env->GetFloatField(object, field); break;
+        case 'D':   // double
+            curValue.d = jni_env->GetDoubleField(object, field); break;
+        default:
+            printf("ERROR: unexpected signature: %s\n", signature);
+            return;
+        }
+        printJValue("current value: ", jni_env, signature[0], curValue);
+    }
+
+    // set TestResult
+    if (testResultObject != nullptr && testResultClass != nullptr) {
+        jfieldID fieldID;
+        // field names in TestResult are "<field_name>_access"/"<field_name>_modify"
+        char *fieldName = (char *)malloc(strlen(name) + 16);
+        strcpy(fieldName, name);
+        strcat(fieldName, modified ? "_modify" : "_access");
+
+        fieldID = jni_env->GetFieldID(testResultClass, fieldName, "Z");
+        if (fieldID != nullptr) {
+            jni_env->SetBooleanField(testResultObject, fieldID, JNI_TRUE);
+        } else {
+            // the field is not interesting for the test
+        }
+        // clear any possible exception
+        jni_env->ExceptionClear();
+
+        free(fieldName);
+    }
+
+    jvmti->Deallocate((unsigned char*)csig);
+    jvmti->Deallocate((unsigned char*)mname);
+    jvmti->Deallocate((unsigned char*)mgensig);
+    jvmti->Deallocate((unsigned char*)name);
+    jvmti->Deallocate((unsigned char*)signature);
+}
+
+static void JNICALL
+onFieldAccess(jvmtiEnv *jvmti_env,
+            JNIEnv* jni_env,
+            jthread thread,
+            jmethodID method,
+            jlocation location,
+            jclass field_klass,
+            jobject object,
+            jfieldID field)
+{
+    if (disableAccessEvent) {
+        return;
+    }
+    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, 0, location);
+}
+
+static void JNICALL
+onFieldModification(jvmtiEnv *jvmti_env,
+            JNIEnv* jni_env,
+            jthread thread,
+            jmethodID method,
+            jlocation location,
+            jclass field_klass,
+            jobject object,
+            jfieldID field,
+            char signature_type,
+            jvalue new_value)
+{
+    disableAccessEvent = true;
+
+    handleNotification(jvmti_env, jni_env, method, object, field, field_klass, 1, location);
+
+    printJValue("new value", jni_env, signature_type, new_value);
+
+    disableAccessEvent = false;
+}
+
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
+{
+    jvmtiError err;
+    jvmtiCapabilities caps = {};
+    jvmtiEventCallbacks callbacks = {};
+    jint res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
+    if (res != JNI_OK || jvmti == nullptr) {
+        reportError("GetEnv failed", res);
+        return JNI_ERR;
+    }
+
+    caps.can_generate_field_modification_events = 1;
+    caps.can_generate_field_access_events = 1;
+    caps.can_tag_objects = 1;
+    err = jvmti->AddCapabilities(&caps);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("Failed to set capabilities", err);
+        return JNI_ERR;
+    }
+
+    callbacks.FieldModification = &onFieldModification;
+    callbacks.FieldAccess = &onFieldAccess;
+
+    err = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("Failed to set event callbacks", err);
+        return JNI_ERR;
+    }
+
+    err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("Failed to set access notifications", err);
+        return JNI_ERR;
+    }
+
+    err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_MODIFICATION, nullptr);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("Failed to set modification notifications", err);
+        return JNI_ERR;
+    }
+    setbuf(stdout, nullptr);
+    return JNI_OK;
+}
+
+
+JNIEXPORT jboolean JNICALL
+Java_FieldAccessModify_initWatchers(JNIEnv *env, jclass thisClass, jclass cls, jobject field)
+{
+    jfieldID fieldId;
+    jvmtiError err;
+
+    if (jvmti == nullptr) {
+        reportError("jvmti is NULL", 0);
+        return JNI_FALSE;
+    }
+
+    fieldId = env->FromReflectedField(field);
+
+    err = jvmti->SetFieldModificationWatch(cls, fieldId);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("SetFieldModificationWatch failed", err);
+        return JNI_FALSE;
+    }
+
+    err = jvmti->SetFieldAccessWatch(cls, fieldId);
+    if (err != JVMTI_ERROR_NONE) {
+        reportError("SetFieldAccessWatch failed", err);
+        return JNI_FALSE;
+    }
+
+    return JNI_TRUE;
+}
+
+
+JNIEXPORT jboolean JNICALL
+Java_FieldAccessModify_startTest(JNIEnv *env, jclass thisClass, jobject testResults)
+{
+    testResultObject = env->NewGlobalRef(testResults);
+    testResultClass = (jclass)env->NewGlobalRef(env->GetObjectClass(testResultObject));
+
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_FieldAccessModify_stopTest(JNIEnv *env, jclass thisClass)
+{
+    if (testResultObject != nullptr) {
+        env->DeleteGlobalRef(testResultObject);
+        testResultObject = nullptr;
+    }
+    if (testResultClass != nullptr) {
+        env->DeleteGlobalRef(testResultClass);
+        testResultClass = nullptr;
+    }
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/Valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -46,7 +46,7 @@ static void reportError(const char *msg, int err) {
 }
 
 static void printJValue(const char *prefix, JNIEnv *jni_env, char signature_type, jvalue value) {
-    // print new_value to ensure the value is valid 
+    // print new_value to ensure the value is valid
     // use String.valueOf(...) to get string representation
     /*
     Z boolean


### PR DESCRIPTION
The fix adds handling of Q-type fields the same way as L-type

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271309](https://bugs.openjdk.java.net/browse/JDK-8271309): [lworld] FieldModification event: new_value is invalid for Q objects


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer) ⚠️ Review applies to 4f1bedb9e3eab1936434a22aad7c751ecffaf022


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/499/head:pull/499` \
`$ git checkout pull/499`

Update a local copy of the PR: \
`$ git checkout pull/499` \
`$ git pull https://git.openjdk.java.net/valhalla pull/499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 499`

View PR using the GUI difftool: \
`$ git pr show -t 499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/499.diff">https://git.openjdk.java.net/valhalla/pull/499.diff</a>

</details>
