### PR TITLE
[lworld] Problemlist TestNativeClone until 8270098 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -144,6 +144,7 @@ serviceability/sa/TestJmapCore.java 8190936 generic-all
 serviceability/sa/TestJmapCoreMetaspace.java 8190936 generic-all
 serviceability/sa/TestPrintMdo.java 8190936 generic-all
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java 8190936 generic-all
+compiler/valhalla/inlinetypes/TestNativeClone.java 8270098 generic-all
 
 
 #############################################################################


### PR DESCRIPTION
Problem listing the test until mainline bug [JDK-8270098](https://bugs.openjdk.java.net/browse/JDK-8270098) is fixed.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.java.net/valhalla pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/500.diff">https://git.openjdk.java.net/valhalla/pull/500.diff</a>

</details>
