### PR TITLE
8271330: [lworld] SIGSEGV in MemNode::find_previous_store

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2892,7 +2892,7 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
       result = mem;
     }
 
-    if (result == this) {
+    if (result == this && phase->type(val)->is_zero_type()) {
       // the store may also apply to zero-bits in an earlier object
       Node* prev_mem = find_previous_store(phase);
       // Steps (a), (b):  Walk past independent stores to find an exact match.
@@ -2901,15 +2901,7 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
         if (prev_val != NULL && prev_val == val) {
           // prev_val and val might differ by a cast; it would be good
           // to keep the more informative of the two.
-          if (phase->type(val)->is_zero_type()) {
-            result = mem;
-          } else if (prev_mem->is_Proj() && prev_mem->in(0)->is_Initialize()) {
-            InitializeNode* init = prev_mem->in(0)->as_Initialize();
-            AllocateNode* alloc = init->allocation();
-            if (alloc != NULL && alloc->in(AllocateNode::DefaultValue) == val) {
-              result = mem;
-            }
-          }
+          result = mem;
         }
       }
     }


### PR DESCRIPTION
Another bug that showed up now because it requires AVX-512 VLBW capable machines (and we added them to our test infra only recently). The problem is that default value store elimination to inline type arrays introduced by [JDK-8189802](https://bugs.openjdk.java.net/browse/JDK-8189802) invokes `MemNode::find_previous_store` on non-zero stores which confused `ClearArrayNode::step_through`.

This patch disables the code for now. I've filed [JDK-8271339](https://bugs.openjdk.java.net/browse/JDK-8271339) to re-enable it.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271330](https://bugs.openjdk.java.net/browse/JDK-8271330): [lworld] SIGSEGV in MemNode::find_previous_store


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/502/head:pull/502` \
`$ git checkout pull/502`

Update a local copy of the PR: \
`$ git checkout pull/502` \
`$ git pull https://git.openjdk.java.net/valhalla pull/502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 502`

View PR using the GUI difftool: \
`$ git pr show -t 502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/502.diff">https://git.openjdk.java.net/valhalla/pull/502.diff</a>

</details>
