### PR TITLE
8271324: [lworld] java/foreign/* tests fail with "guarantee(sect->end() <= tend) failed: sanity"

### DIFF
--- a/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
+++ b/src/hotspot/cpu/x86/universalUpcallHandler_x86_64.cpp
@@ -585,7 +585,7 @@ address ProgrammableUpcallHandler::generate_optimized_upcall_stub(jobject receiv
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
   const CallRegs conv = ForeignGlobals::parse_call_regs(jconv);
   assert(conv._rets_length <= 1, "no multi reg returns");
-  CodeBuffer buffer("upcall_stub_linkToNative", /* code_size = */ 1024, /* locs_size = */ 1024);
+  CodeBuffer buffer("upcall_stub_linkToNative", /* code_size = */ 2048, /* locs_size = */ 1024);
 
   int register_size = sizeof(uintptr_t);
   int buffer_alignment = xmm_reg_size;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -1627,7 +1627,7 @@ public class TestArrays {
     }
 
     // A store with a default value can be eliminated: same as test68
-    // but store is farther away from allocation
+    // but store is further away from allocation
     @Test
     public MyValue1[] test70(MyValue1[] other) {
         other[1] = other[0];


### PR DESCRIPTION
We hit an assert because the code generated for "upcall_stub_linkToNative" does not fit into the code buffer. That's because we are currently saving all registers before the slow call in the GC barriers:
https://github.com/openjdk/valhalla/blob/8efeb68ef0594c2c7c20bc2e45c112d6ef623b2b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp#L206-L211

https://github.com/openjdk/valhalla/blob/8efeb68ef0594c2c7c20bc2e45c112d6ef623b2b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp#L332-L337

I've doubled the buffer size to be on the safe side and filed [JDK-8271370](https://bugs.openjdk.java.net/browse/JDK-8271370) to investigate if we can avoid saving all registers in all cases.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271324](https://bugs.openjdk.java.net/browse/JDK-8271324): [lworld] java/foreign/* tests fail with "guarantee(sect->end() <= tend) failed: sanity"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.java.net/valhalla pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/503.diff">https://git.openjdk.java.net/valhalla/pull/503.diff</a>

</details>
