### PR TITLE
8271380: [lworld] Intrinsify j.l.Class::asPrimaryType/asValueType

### DIFF
--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -155,6 +155,10 @@ InlineKlass* ciInlineKlass::get_InlineKlass() const {
   GUARDED_VM_ENTRY(return to_InlineKlass();)
 }
 
+ciInstance* ciInlineKlass::ref_mirror() {
+  GUARDED_VM_ENTRY(return CURRENT_ENV->get_instance(to_InlineKlass()->ref_mirror());)
+}
+
 ciInstance* ciInlineKlass::val_mirror() {
   GUARDED_VM_ENTRY(return CURRENT_ENV->get_instance(to_InlineKlass()->val_mirror());)
 }

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -92,6 +92,7 @@ public:
   address pack_handler() const;
   address unpack_handler() const;
   InlineKlass* get_InlineKlass() const;
+  ciInstance* ref_mirror();
   ciInstance* val_mirror();
 };
 

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -235,6 +235,8 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   }
 
   switch (id) {
+  case vmIntrinsics::_asPrimaryType:
+  case vmIntrinsics::_asValueType:
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_isAssignableFrom:
   case vmIntrinsics::_getModifiers:

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -237,6 +237,10 @@ class methodHandle;
    do_signature(currentThread_signature,                         "()Ljava/lang/Thread;")                                \
                                                                                                                         \
   /* reflective intrinsics, for java/lang/Class, etc. */                                                                \
+  do_intrinsic(_asPrimaryType,            java_lang_Class,        asPrimaryType_name, void_class_signature,      F_R)   \
+   do_name(     asPrimaryType_name,                              "asPrimaryType")                                       \
+  do_intrinsic(_asValueType,              java_lang_Class,        asValueType_name, void_class_signature,        F_R)   \
+   do_name(     asValueType_name,                                "asValueType")                                         \
   do_intrinsic(_isAssignableFrom,         java_lang_Class,        isAssignableFrom_name, class_boolean_signature, F_RN) \
    do_name(     isAssignableFrom_name,                           "isAssignableFrom")                                    \
   do_intrinsic(_isInstance,               java_lang_Class,        isInstance_name, object_boolean_signature,     F_RN)  \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -618,6 +618,8 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_copyOf:
   case vmIntrinsics::_copyOfRange:
   case vmIntrinsics::_clone:
+  case vmIntrinsics::_asPrimaryType:
+  case vmIntrinsics::_asValueType:
   case vmIntrinsics::_isAssignableFrom:
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_getModifiers:

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -270,6 +270,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_native_getEventWriter();
 #endif
   bool inline_native_Class_query(vmIntrinsics::ID id);
+  bool inline_primitive_Class_conversion(vmIntrinsics::ID id);
   bool inline_native_subtype_check();
   bool inline_native_getLength();
   bool inline_array_copyOf(bool is_copyOfRange);

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -596,6 +596,7 @@ public final class Class<T> implements java.io.Serializable,
      *         this class or interface
      * @since Valhalla
      */
+    @IntrinsicCandidate
     public Class<?> asPrimaryType() {
         return isPrimitiveClass() ? primaryType : this;
     }
@@ -613,6 +614,7 @@ public final class Class<T> implements java.io.Serializable,
      *         is not a primitive class
      * @since Valhalla
      */
+    @IntrinsicCandidate
     public Class<?> asValueType() {
         if (isPrimitiveClass())
             return secondaryType;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -74,14 +74,14 @@ public class TestIntrinsics {
     @Run(test = "test1")
     public void test1_verifier() {
         Asserts.assertTrue(test1(java.util.AbstractList.class, java.util.ArrayList.class), "test1_1 failed");
-        Asserts.assertTrue(test1(MyValue1.ref.class, MyValue1.ref.class), "test1_2 failed");
+        Asserts.assertTrue(test1(MyValue1.class.asPrimaryType(), MyValue1.class.asPrimaryType()), "test1_2 failed");
         Asserts.assertTrue(test1(MyValue1.class.asValueType(), MyValue1.class.asValueType()), "test1_3 failed");
-        Asserts.assertTrue(test1(MyValue1.ref.class, MyValue1.class.asValueType()), "test1_4 failed");
-        Asserts.assertFalse(test1(MyValue1.class.asValueType(), MyValue1.ref.class), "test1_5 failed");
+        Asserts.assertTrue(test1(MyValue1.class.asPrimaryType(), MyValue1.class.asValueType()), "test1_4 failed");
+        Asserts.assertFalse(test1(MyValue1.class.asValueType(), MyValue1.class.asPrimaryType()), "test1_5 failed");
         Asserts.assertTrue(test1(Object.class, java.util.ArrayList.class), "test1_6 failed");
-        Asserts.assertTrue(test1(Object.class, MyValue1.ref.class), "test1_7 failed");
+        Asserts.assertTrue(test1(Object.class, MyValue1.class.asPrimaryType()), "test1_7 failed");
         Asserts.assertTrue(test1(Object.class, MyValue1.class.asValueType()), "test1_8 failed");
-        Asserts.assertTrue(!test1(MyValue1.ref.class, Object.class), "test1_9 failed");
+        Asserts.assertTrue(!test1(MyValue1.class.asPrimaryType(), Object.class), "test1_9 failed");
         Asserts.assertTrue(!test1(MyValue1.class.asValueType(), Object.class), "test1_10 failed");
     }
 
@@ -90,14 +90,14 @@ public class TestIntrinsics {
     @IR(failOn = {LOADK})
     public boolean test2() {
         boolean check1 = java.util.AbstractList.class.isAssignableFrom(java.util.ArrayList.class);
-        boolean check2 = MyValue1.ref.class.isAssignableFrom(MyValue1.ref.class);
+        boolean check2 = MyValue1.class.asPrimaryType().isAssignableFrom(MyValue1.class.asPrimaryType());
         boolean check3 = MyValue1.class.asValueType().isAssignableFrom(MyValue1.class.asValueType());
-        boolean check4 = MyValue1.ref.class.isAssignableFrom(MyValue1.class.asValueType());
-        boolean check5 = !MyValue1.class.asValueType().isAssignableFrom(MyValue1.ref.class);
+        boolean check4 = MyValue1.class.asPrimaryType().isAssignableFrom(MyValue1.class.asValueType());
+        boolean check5 = !MyValue1.class.asValueType().isAssignableFrom(MyValue1.class.asPrimaryType());
         boolean check6 = Object.class.isAssignableFrom(java.util.ArrayList.class);
-        boolean check7 = Object.class.isAssignableFrom(MyValue1.ref.class);
+        boolean check7 = Object.class.isAssignableFrom(MyValue1.class.asPrimaryType());
         boolean check8 = Object.class.isAssignableFrom(MyValue1.class.asValueType());
-        boolean check9 = !MyValue1.ref.class.isAssignableFrom(Object.class);
+        boolean check9 = !MyValue1.class.asPrimaryType().isAssignableFrom(Object.class);
         boolean check10 = !MyValue1.class.asValueType().isAssignableFrom(Object.class);
         return check1 && check2 && check3 && check4 && check5 && check6 && check7 && check8 && check9 && check10;
     }
@@ -116,8 +116,8 @@ public class TestIntrinsics {
     @Run(test = "test3")
     public void test3_verifier() {
         Asserts.assertTrue(test3(Object.class) == null, "test3_1 failed");
-        Asserts.assertTrue(test3(MyValue1.ref.class) == MyAbstract.class, "test3_2 failed");
-        Asserts.assertTrue(test3(MyValue1.val.class) == MyAbstract.class, "test3_3 failed");
+        Asserts.assertTrue(test3(MyValue1.class.asPrimaryType()) == MyAbstract.class, "test3_2 failed");
+        Asserts.assertTrue(test3(MyValue1.class.asValueType()) == MyAbstract.class, "test3_3 failed");
         Asserts.assertTrue(test3(Class.class) == Object.class, "test3_4 failed");
     }
 
@@ -126,8 +126,8 @@ public class TestIntrinsics {
     @IR(failOn = {LOADK})
     public boolean test4() {
         boolean check1 = Object.class.getSuperclass() == null;
-        boolean check2 = MyValue1.ref.class.getSuperclass() == MyAbstract.class;
-        boolean check3 = MyValue1.val.class.getSuperclass() == MyAbstract.class;
+        boolean check2 = MyValue1.class.asPrimaryType().getSuperclass() == MyAbstract.class;
+        boolean check3 = MyValue1.class.asValueType().getSuperclass() == MyAbstract.class;
         boolean check4 = Class.class.getSuperclass() == Object.class;
         return check1 && check2 && check3 && check4;
     }
@@ -190,7 +190,7 @@ public class TestIntrinsics {
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         boolean result = test8(MyValue1.class.asValueType(), vt);
         Asserts.assertTrue(result);
-        result = test8(MyValue1.ref.class, vt);
+        result = test8(MyValue1.class.asPrimaryType(), vt);
         Asserts.assertTrue(result);
     }
 
@@ -204,7 +204,7 @@ public class TestIntrinsics {
         MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
         boolean result = test9(MyValue2.class, vt);
         Asserts.assertFalse(result);
-        result = test9(MyValue2.ref.class, vt);
+        result = test9(MyValue2.class.asPrimaryType(), vt);
         Asserts.assertFalse(result);
     }
 
@@ -266,7 +266,7 @@ public class TestIntrinsics {
     // inline type array creation via reflection
     @Test()
     public void test14(int len, long hash) {
-        Object[] va = (Object[])Array.newInstance(MyValue1.val.class, len);
+        Object[] va = (Object[])Array.newInstance(MyValue1.class.asValueType(), len);
         for (int i = 0; i < len; ++i) {
             Asserts.assertEQ(((MyValue1)va[i]).hashPrimitive(), hash);
         }
@@ -465,7 +465,7 @@ public class TestIntrinsics {
         Class<?>[] ca = new Class<?>[1];
         for (int i = 0; i < 1; ++i) {
           // Folds during loop opts
-          ca[i] = MyValue1.val.class;
+          ca[i] = MyValue1.class.asValueType();
         }
         return Array.newInstance(ca[0], 1);
     }
@@ -558,7 +558,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue2 test30(MyValue1 v) {
         if (V1_FLATTENED) {
-            return U.getValue(v, V1_OFFSET, MyValue2.val.class);
+            return U.getValue(v, V1_OFFSET, MyValue2.class.asValueType());
         }
         return (MyValue2)U.getReference(v, V1_OFFSET);
     }
@@ -588,7 +588,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue1 test31() {
         if (TEST31_VT_FLATTENED) {
-            return U.getValue(this, TEST31_VT_OFFSET, MyValue1.val.class);
+            return U.getValue(this, TEST31_VT_OFFSET, MyValue1.class.asValueType());
         }
         return (MyValue1)U.getReference(this, TEST31_VT_OFFSET);
     }
@@ -605,7 +605,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public void test32(MyValue1 vt) {
         if (TEST31_VT_FLATTENED) {
-            U.putValue(this, TEST31_VT_OFFSET, MyValue1.val.class, vt);
+            U.putValue(this, TEST31_VT_OFFSET, MyValue1.class.asValueType(), vt);
         } else {
             U.putReference(this, TEST31_VT_OFFSET, vt);
         }
@@ -636,7 +636,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue1 test33(MyValue1[] arr) {
         if (TEST33_FLATTENED_ARRAY) {
-            return U.getValue(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE, MyValue1.val.class);
+            return U.getValue(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE, MyValue1.class.asValueType());
         }
         return (MyValue1)U.getReference(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE);
     }
@@ -655,7 +655,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public void test34(MyValue1[] arr, MyValue1 vt) {
         if (TEST33_FLATTENED_ARRAY) {
-            U.putValue(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE, MyValue1.val.class, vt);
+            U.putValue(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE, MyValue1.class.asValueType(), vt);
         } else {
             U.putReference(arr, TEST33_BASE_OFFSET + TEST33_INDEX_SCALE, vt);
         }
@@ -675,7 +675,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue1 test35(Object o) {
         if (TEST31_VT_FLATTENED) {
-            return U.getValue(o, TEST31_VT_OFFSET, MyValue1.val.class);
+            return U.getValue(o, TEST31_VT_OFFSET, MyValue1.class.asValueType());
         }
         return (MyValue1)U.getReference(o, TEST31_VT_OFFSET);
     }
@@ -693,7 +693,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue1 test36(long offset) {
         if (TEST31_VT_FLATTENED) {
-            return U.getValue(this, offset, MyValue1.val.class);
+            return U.getValue(this, offset, MyValue1.class.asValueType());
         }
         return (MyValue1)U.getReference(this, offset);
     }
@@ -711,7 +711,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public void test37(Object o, MyValue1 vt) {
         if (TEST31_VT_FLATTENED) {
-            U.putValue(o, TEST31_VT_OFFSET, MyValue1.val.class, vt);
+            U.putValue(o, TEST31_VT_OFFSET, MyValue1.class.asValueType(), vt);
         } else {
             U.putReference(o, TEST31_VT_OFFSET, vt);
         }
@@ -731,7 +731,7 @@ public class TestIntrinsics {
     @IR(counts = {CALL_Unsafe, "= 1"})
     public void test38(Object o) {
         if (TEST31_VT_FLATTENED) {
-            U.putValue(this, TEST31_VT_OFFSET, MyValue1.val.class, o);
+            U.putValue(this, TEST31_VT_OFFSET, MyValue1.class.asValueType(), o);
         } else {
             U.putReference(this, TEST31_VT_OFFSET, o);
         }
@@ -771,7 +771,7 @@ public class TestIntrinsics {
     @Run(test = "test40")
     public void test40_verifier() {
         int len = Math.abs(rI) % 42;
-        Object[] va = test40(MyValue1.ref.class, len);
+        Object[] va = test40(MyValue1.class.asPrimaryType(), len);
         for (int i = 0; i < len; ++i) {
             Asserts.assertEQ(va[i], null);
         }
@@ -786,7 +786,7 @@ public class TestIntrinsics {
     @Run(test = "test41")
     public void test41_verifier() {
         MyValue1.ref vt = MyValue1.createWithFieldsInline(rI, rL);
-        boolean result = test41(MyValue1.ref.class, vt);
+        boolean result = test41(MyValue1.class.asPrimaryType(), vt);
         Asserts.assertTrue(result);
         result = test41(MyValue1.class.asValueType(), vt);
         Asserts.assertTrue(result);
@@ -800,9 +800,9 @@ public class TestIntrinsics {
     @Run(test = "test42")
     public void test42_verifier() {
         MyValue1.ref vt = MyValue1.createWithFieldsInline(rI, rL);
-        boolean result = test42(MyValue2.ref.class, vt);
+        boolean result = test42(MyValue2.class.asPrimaryType(), vt);
         Asserts.assertFalse(result);
-        result = test42(MyValue2.class, vt);
+        result = test42(MyValue2.class.asValueType(), vt);
         Asserts.assertFalse(result);
     }
 
@@ -815,9 +815,9 @@ public class TestIntrinsics {
     @Run(test = "test43")
     public void test43_verifier() {
         MyValue1.ref vt = MyValue1.createWithFieldsInline(rI, rL);
-        Object result = test43(MyValue1.ref.class, vt);
+        Object result = test43(MyValue1.class.asPrimaryType(), vt);
         Asserts.assertEQ(((MyValue1)result).hash(), vt.hash());
-        result = test43(MyValue1.ref.class, null);
+        result = test43(MyValue1.class.asPrimaryType(), null);
         Asserts.assertEQ(result, null);
     }
 
@@ -830,7 +830,7 @@ public class TestIntrinsics {
     public void test44_verifier() {
         MyValue1.ref vt = MyValue1.createWithFieldsInline(rI, rL);
         try {
-            test44(MyValue2.ref.class, vt);
+            test44(MyValue2.class.asPrimaryType(), vt);
             throw new RuntimeException("should have thrown");
         } catch (ClassCastException cce) {
         }
@@ -838,7 +838,7 @@ public class TestIntrinsics {
 
     @Test()
     public Object test45(MyValue1.ref vt) {
-        return MyValue1.ref.class.cast(vt);
+        return MyValue1.class.asPrimaryType().cast(vt);
     }
 
     @Run(test = "test45")
@@ -852,7 +852,7 @@ public class TestIntrinsics {
 
     @Test()
     public Object test46(MyValue1.ref vt) {
-        return MyValue2.ref.class.cast(vt);
+        return MyValue2.class.asPrimaryType().cast(vt);
     }
 
     @Run(test = "test46")
@@ -868,7 +868,7 @@ public class TestIntrinsics {
 
     @Test()
     public Object test47(MyValue1.ref vt) {
-        return MyValue1.val.class.cast(vt);
+        return MyValue1.class.asValueType().cast(vt);
     }
 
     @Run(test = "test47")
@@ -902,7 +902,7 @@ public class TestIntrinsics {
 
     @Test()
     public Object test49(MyValue1 vt) {
-        return MyValue1.ref.class.cast(vt);
+        return MyValue1.class.asPrimaryType().cast(vt);
     }
 
     @Run(test = "test49")
@@ -924,7 +924,7 @@ public class TestIntrinsics {
         MyValue1.ref[] vba = new MyValue1.ref[42];
         Object result = test50(MyValue1.class.asValueType(), vt);
         Asserts.assertEQ(((MyValue1)result).hash(), vt.hash());
-        result = test50(MyValue1.ref.class, vt);
+        result = test50(MyValue1.class.asPrimaryType(), vt);
         Asserts.assertEQ(((MyValue1)result).hash(), vt.hash());
         result = test50(MyValue1[].class, va);
         Asserts.assertEQ(result, va);
@@ -947,7 +947,7 @@ public class TestIntrinsics {
     // inline type array creation via reflection
     @Test()
     public void test51(int len) {
-        Object[] va = (Object[])Array.newInstance(MyValue1.ref.class, len);
+        Object[] va = (Object[])Array.newInstance(MyValue1.class.asPrimaryType(), len);
         for (int i = 0; i < len; ++i) {
             Asserts.assertEQ(va[i], null);
         }
@@ -1063,7 +1063,7 @@ public class TestIntrinsics {
     @IR(failOn = {CALL_Unsafe})
     public MyValue2 test55() {
         if (V1_FLATTENED) {
-            return U.getValue(test55_vt, V1_OFFSET, MyValue2.val.class);
+            return U.getValue(test55_vt, V1_OFFSET, MyValue2.class.asValueType());
         }
         return (MyValue2)U.getReference(test55_vt, V1_OFFSET);
     }
@@ -1077,7 +1077,7 @@ public class TestIntrinsics {
     // Test OptimizePtrCompare part of Escape Analysis
     @Test()
     public void test56(int idx) {
-        Object[] va = (Object[])Array.newInstance(MyValue1.val.class, 1);
+        Object[] va = (Object[])Array.newInstance(MyValue1.class.asValueType(), 1);
         if (va[idx] == null) {
             throw new RuntimeException("Unexpected null");
         }
@@ -1091,7 +1091,7 @@ public class TestIntrinsics {
     // Same as test56 but with load from known array index
     @Test()
     public void test57() {
-        Object[] va = (Object[])Array.newInstance(MyValue1.val.class, 1);
+        Object[] va = (Object[])Array.newInstance(MyValue1.class.asValueType(), 1);
         if (va[0] == null) {
             throw new RuntimeException("Unexpected null");
         }
@@ -1155,5 +1155,42 @@ public class TestIntrinsics {
         Asserts.assertFalse(test60(MyValue1.class.asValueType(), MyValue1.class.asValueType(), false, true));
         Asserts.assertFalse(test60(MyValue1.class.asValueType(), MyValue1.class.asValueType(), true, false));
         Asserts.assertFalse(test60(MyValue1.class.asValueType(), MyValue1.class.asValueType(), true, true));
+    }
+
+    // Test asPrimaryType intrinsic with non-value mirror
+    @Test()
+    public Class<?> test61(Class<?> c) {
+        if (c.asPrimaryType() != Integer.class) {
+            throw new RuntimeException("Unexpected class");
+        }
+        return Integer.class.asPrimaryType();
+    }
+
+    @Run(test = "test61")
+    public void test61_verifier() {
+        Class<?> result = test61(Integer.class);
+        Asserts.assertEQ(result, Integer.class);
+    }
+
+    // Test asValueType intrinsic with non-value mirror
+    @Test()
+    public Class<?> test62(Class<?> c) {
+        try {
+            c.asValueType();
+            throw new RuntimeException("No exception thrown");
+        } catch (UnsupportedOperationException ex) {
+            // Expected
+        }
+        return Integer.class.asValueType();
+    }
+
+    @Run(test = "test62")
+    public void test62_verifier() {
+        try {
+            test62(Integer.class);
+            throw new RuntimeException("No exception thrown");
+        } catch (UnsupportedOperationException ex) {
+            // Expected
+        }
     }
 }


### PR DESCRIPTION
`TestIntrinsics.java` fails after [JDK-8269956](https://bugs.openjdk.java.net/browse/JDK-8269956) which replace some usages of `MyValue.class` by `MyValue.class.asValueType()`. The problem is that `asValueType()` is not always inlined by C2 and therefore IR verification fails.

This patch intrinsifies the methods similar to what we did in old L/Q world (https://github.com/openjdk/valhalla/commit/e895128f). I've also modified the test to consistently use `asPrimaryType`/`asValueType`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271380](https://bugs.openjdk.java.net/browse/JDK-8271380): [lworld] Intrinsify j.l.Class::asPrimaryType/asValueType


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/504/head:pull/504` \
`$ git checkout pull/504`

Update a local copy of the PR: \
`$ git checkout pull/504` \
`$ git pull https://git.openjdk.java.net/valhalla pull/504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 504`

View PR using the GUI difftool: \
`$ git pr show -t 504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/504.diff">https://git.openjdk.java.net/valhalla/pull/504.diff</a>

</details>
