### PR TITLE
8271389: [lworld] Improve typing of primitiveObject.getClass()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2691,15 +2691,10 @@ public class Attr extends JCTree.Visitor {
                     methodName == names.getClass &&
                     argtypes.isEmpty()) {
                 // as a special case, x.getClass() has type Class<? extends |X|>
-                // Temporary treatment for primitive classes: Given a primitive class V that implements
-                // I1, I2, ... In, v.getClass() is typed to be Class<? extends Object & I1 & I2 .. & In>
-                Type wcb;
-                if (qualifierType.isPrimitiveClass()) {
-                    List<Type> bounds = List.of(syms.objectType).appendList(((ClassSymbol) qualifierType.tsym).getInterfaces());
-                    wcb = bounds.size() > 1 ? types.makeIntersectionType(bounds) : syms.objectType;
-                } else {
-                    wcb = types.erasure(qualifierType);
-                }
+                // Special treatment for primitive classes: Given an expression v of type V where
+                // V is a primitive class, v.getClass() is typed to be Class<? extends |V.ref|>
+                Type wcb = types.erasure(qualifierType.isPrimitiveClass() ?
+                                                qualifierType.referenceProjection() : qualifierType);
                 return new ClassType(restype.getEnclosingType(),
                         List.of(new WildcardType(wcb,
                                 BoundKind.EXTENDS,

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
@@ -12,11 +12,11 @@ public class ClassLiteralTypingNegativeTest {
 
         public static void main(String[] args) {
             Class<? extends Foo.ref> cFooRef = Foo.class.asValueType(); // Error
-            cFooRef = new Foo().getClass(); // Error
+            cFooRef = new Foo().getClass(); // OK.
             cFooRef = Foo.ref.class; // OK.
             cFooRef = Foo.val.class; // Error.
             Foo.val xv = new Foo();
-            cFooRef = xv.getClass(); // Error
+            cFooRef = xv.getClass(); // OK.
             Foo.ref xr = new Foo();
             cFooRef = xr.getClass(); // OK.
         }
@@ -29,11 +29,11 @@ public class ClassLiteralTypingNegativeTest {
 
         public static void main(String[] args) {
             Class<? extends Bar.ref> cBarRef = Bar.class.asValueType(); // Error
-            cBarRef = new Bar().getClass(); // Error
+            cBarRef = new Bar().getClass(); // OK.
             cBarRef = Bar.ref.class; // OK.
             cBarRef = Bar.val.class; // Error.
             Bar.val xv = new Bar();
-            cBarRef = xv.getClass(); // Error
+            cBarRef = xv.getClass(); // OK
             Bar.ref xr = new Bar();
             cBarRef = xr.getClass(); // OK.
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.out
@@ -1,9 +1,5 @@
 ClassLiteralTypingNegativeTest.java:14:69: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ?>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
-ClassLiteralTypingNegativeTest.java:15:41: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
 ClassLiteralTypingNegativeTest.java:17:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
-ClassLiteralTypingNegativeTest.java:19:34: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
 ClassLiteralTypingNegativeTest.java:31:69: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ?>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
-ClassLiteralTypingNegativeTest.java:32:41: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
 ClassLiteralTypingNegativeTest.java:34:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
-ClassLiteralTypingNegativeTest.java:36:34: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
-8 errors
+4 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/GetClassTypingTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GetClassTypingTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271389
+ * @summary [lworld] Improve typing of primitiveObject.getClass()
+ * @run main GetClassTypingTest
+ */
+
+public class GetClassTypingTest {
+
+    static primitive class Primitive {}
+
+    static void foo(Class<? extends Primitive.ref> c) {}
+
+    public static void main(String [] args) {
+       foo(new Primitive().getClass());
+    }
+
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/ClassLiteralTypingNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/ClassLiteralTypingNegativeTest.java
@@ -12,11 +12,11 @@ public class ClassLiteralTypingNegativeTest {
 
         public static void main(String[] args) {
             Class<? extends Foo> cFooRef = Foo.val.class; // Error
-            cFooRef = ((Foo.val) new Foo()).getClass(); // Error
+            cFooRef = ((Foo.val) new Foo()).getClass(); // OK
             cFooRef = Foo.class; // OK.
             cFooRef = Foo.val.class; // Error.
             Foo.val xv = new Foo();
-            cFooRef = xv.getClass(); // Error
+            cFooRef = xv.getClass(); // OK
             Foo xr = new Foo();
             cFooRef = xr.getClass(); // OK.
         }
@@ -29,11 +29,11 @@ public class ClassLiteralTypingNegativeTest {
 
         public static void main(String[] args) {
             Class<? extends Bar> cBarRef = Bar.val.class; // Error
-            cBarRef = ((Bar.val) new Bar()).getClass(); // Error
+            cBarRef = ((Bar.val) new Bar()).getClass(); // OK
             cBarRef = Bar.class; // OK.
             cBarRef = Bar.val.class; // Error.
             Bar.val xv = new Bar();
-            cBarRef = xv.getClass(); // Error
+            cBarRef = xv.getClass(); // OK.
             Bar xr = new Bar();
             cBarRef = xr.getClass(); // OK.
         }

--- a/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/ClassLiteralTypingNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/ClassLiteralTypingNegativeTest.out
@@ -1,9 +1,5 @@
 ClassLiteralTypingNegativeTest.java:14:51: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo>)
-ClassLiteralTypingNegativeTest.java:15:53: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo>)
 ClassLiteralTypingNegativeTest.java:17:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo>)
-ClassLiteralTypingNegativeTest.java:19:34: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo>)
 ClassLiteralTypingNegativeTest.java:31:51: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar>)
-ClassLiteralTypingNegativeTest.java:32:53: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar>)
 ClassLiteralTypingNegativeTest.java:34:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar>)
-ClassLiteralTypingNegativeTest.java:36:34: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar>)
-8 errors
+4 errors


### PR DESCRIPTION
Static type of getClass() should align with behavior of method which always returns the primary mirror.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271389](https://bugs.openjdk.java.net/browse/JDK-8271389): [lworld] Improve typing of primitiveObject.getClass()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/505/head:pull/505` \
`$ git checkout pull/505`

Update a local copy of the PR: \
`$ git checkout pull/505` \
`$ git pull https://git.openjdk.java.net/valhalla pull/505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 505`

View PR using the GUI difftool: \
`$ git pr show -t 505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/505.diff">https://git.openjdk.java.net/valhalla/pull/505.diff</a>

</details>
