### PR TITLE
8271397: [lworld] SIGSEGV in ciKlass::is_subtype_of

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -637,7 +637,7 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
     }
   } else {
     ciType* type = pop_value();
-    if (type->is_loaded() && type->unwrap() != klass && type->unwrap()->is_subtype_of(klass)) {
+    if (type->unwrap() != klass && klass->is_loaded() && type->unwrap()->is_subtype_of(klass)) {
       // Useless cast, propagate more precise type of object
       klass = type->unwrap()->as_klass();
     }

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -637,7 +637,7 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
     }
   } else {
     ciType* type = pop_value();
-    if (type->unwrap() != klass && type->unwrap()->is_subtype_of(klass)) {
+    if (type->is_loaded() && type->unwrap() != klass && type->unwrap()->is_subtype_of(klass)) {
       // Useless cast, propagate more precise type of object
       klass = type->unwrap()->as_klass();
     }


### PR DESCRIPTION
This should fix an extremely intermittent crash (only happened once) in `ciKlass::is_subtype_of`. Similar to the checks in `Parse::do_checkcast`, we need to check for `klass->is_loaded()` before calling `is_subtype_of(klass)` in type flow analysis.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271397](https://bugs.openjdk.java.net/browse/JDK-8271397): [lworld] SIGSEGV in ciKlass::is_subtype_of


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.java.net/valhalla pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/506.diff">https://git.openjdk.java.net/valhalla/pull/506.diff</a>

</details>
