### PR TITLE
8271486: [lworld] Memory corruption due to out of bound access in MacroAssembler::move_helper

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5789,6 +5789,7 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
 
 // Move a value between registers/stack slots and update the reg_state
 bool MacroAssembler::move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[]) {
+  assert(from->is_valid() && to->is_valid(), "source and destination must be valid");
   if (reg_state[to->value()] == reg_written) {
     return true; // Already written
   }
@@ -5873,7 +5874,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
                                           VMReg from, int& from_index, VMRegPair* to, int to_count, int& to_index,
                                           RegState reg_state[]) {
   assert(sig->at(sig_index)._bt == T_VOID, "should be at end delimiter");
-  assert(from->is_valid(), "source must bevalid");
+  assert(from->is_valid(), "source must be valid");
   Register tmp1 = r10, tmp2 = r11;
   Register fromReg;
   if (from->is_reg()) {
@@ -5890,6 +5891,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
   VMReg toReg;
   BasicType bt;
   while (stream.next(toReg, bt)) {
+    assert(toReg->is_valid(), "destination must be valid");
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
     Address fromAddr = Address(fromReg, off);
@@ -5974,6 +5976,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
   VMReg fromReg;
   BasicType bt;
   while (stream.next(fromReg, bt)) {
+    assert(fromReg->is_valid(), "source must be valid");
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
     size_t size_in_bytes = is_java_primitive(bt) ? type2aelembytes(bt) : wordSize;

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5738,6 +5738,7 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
 
 // Move a value between registers/stack slots and update the reg_state
 bool MacroAssembler::move_helper(VMReg from, VMReg to, BasicType bt, RegState reg_state[]) {
+  assert(from->is_valid() && to->is_valid(), "source and destination must be valid");
   if (reg_state[to->value()] == reg_written) {
     return true; // Already written
   }
@@ -5818,7 +5819,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
                                           VMReg from, int& from_index, VMRegPair* to, int to_count, int& to_index,
                                           RegState reg_state[]) {
   assert(sig->at(sig_index)._bt == T_VOID, "should be at end delimiter");
-  assert(from->is_valid(), "source must bevalid");
+  assert(from->is_valid(), "source must be valid");
   Register fromReg;
   if (from->is_reg()) {
     fromReg = from->as_Register();
@@ -5834,6 +5835,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
   VMReg toReg;
   BasicType bt;
   while (stream.next(toReg, bt)) {
+    assert(toReg->is_valid(), "destination must be valid");
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
     Address fromAddr = Address(fromReg, off);
@@ -5917,6 +5919,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
   VMReg fromReg;
   BasicType bt;
   while (stream.next(fromReg, bt)) {
+    assert(fromReg->is_valid(), "source must be valid");
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
     size_t size_in_bytes = is_java_primitive(bt) ? type2aelembytes(bt) : wordSize;

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -173,7 +173,12 @@ void MacroAssembler::shuffle_inline_args(bool is_packing, bool receiver_only,
       BasicType bt = sig->at(sig_index)._bt;
       if (SigEntry::skip_value_delimiters(sig, sig_index)) {
         VMReg from_reg = regs[from_index].first();
-        done &= move_helper(from_reg, regs_to[to_index].first(), bt, reg_state);
+        if (from_reg->is_valid()) {
+          done &= move_helper(from_reg, regs_to[to_index].first(), bt, reg_state);
+        } else {
+          // halves of T_LONG or T_DOUBLE
+          assert(bt == T_VOID, "unexpected basic type");
+        }
         to_index += step;
         from_index += step;
       } else if (is_packing) {


### PR DESCRIPTION
While debugging weird crashes that only showed up when merging current mainline with lworld, I've noticed that we are writing outside of the `reg_state` array in `MacroAssembler::move_helper` because `from->value()` is `-1` (`OptoReg::BAD_REG`): 
https://github.com/openjdk/valhalla/blob/3c399d9f7f36903e4c2583c16b0080e01181114a/src/hotspot/cpu/x86/macroAssembler_x86.cpp#L5794-L5797

The register is invalid because it belongs to the second half of a `T_LONG` or `T_DOUBLE` argument in the calling convention and should simply be ignored. I've also added asserts to catch similar issues in the future.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271486](https://bugs.openjdk.java.net/browse/JDK-8271486): [lworld] Memory corruption due to out of bound access in MacroAssembler::move_helper


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/507/head:pull/507` \
`$ git checkout pull/507`

Update a local copy of the PR: \
`$ git checkout pull/507` \
`$ git pull https://git.openjdk.java.net/valhalla pull/507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 507`

View PR using the GUI difftool: \
`$ git pr show -t 507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/507.diff">https://git.openjdk.java.net/valhalla/pull/507.diff</a>

</details>
