### PR TITLE
8271531: [lworld] Implicit null check optimization does not hoist constant load input

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -407,23 +407,23 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
         }
       }
     }
-  } else {
-    // Hoist constant load inputs as well.
-    for (uint i = 1; i < best->req(); ++i) {
-      Node* n = best->in(i);
-      if (n->is_Con() && get_block_for_node(n) == get_block_for_node(best)) {
-        get_block_for_node(n)->find_remove(n);
-        block->add_inst(n);
-        map_node_to_block(n, block);
-        // Constant loads may kill flags (for example, when XORing a register).
-        // Check for flag-killing projections that also need to be hoisted.
-        for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++) {
-          Node* proj = n->fast_out(j);
-          if (proj->is_MachProj()) {
-            get_block_for_node(proj)->find_remove(proj);
-            block->add_inst(proj);
-            map_node_to_block(proj, block);
-          }
+  }
+
+  // Hoist constant load inputs as well.
+  for (uint i = 1; i < best->req(); ++i) {
+    Node* n = best->in(i);
+    if (n->is_Con() && get_block_for_node(n) == get_block_for_node(best)) {
+      get_block_for_node(n)->find_remove(n);
+      block->add_inst(n);
+      map_node_to_block(n, block);
+      // Constant loads may kill flags (for example, when XORing a register).
+      // Check for flag-killing projections that also need to be hoisted.
+      for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++) {
+        Node* proj = n->fast_out(j);
+        if (proj->is_MachProj()) {
+          get_block_for_node(proj)->find_remove(proj);
+          block->add_inst(proj);
+          map_node_to_block(proj, block);
         }
       }
     }


### PR DESCRIPTION
[JDK-8231561](https://bugs.openjdk.java.net/browse/JDK-8231561) added support for hoisting constant load inputs during C2's implicit null check optimization, assuming that it's only required if `!is_decoden`. However,  the following `andL` has both a `decodeHeapOop_not_null` val input and a `loadConUL32`  that needs to be hoisted:

```
 239  loadConUL32  ===  1  [[ 238 ]] #5/0x0000000000000005
 245  decodeHeapOop_not_null  === _  208  [[ 246  238  228  250 ]] java/lang/Object:NotNull *  ...
 238  andL_rReg_mem_0  ===  1041  133  245  239  [[ 240  237 ]]
```

The fix is to simply always check for constant loads inputs that require hoisting.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271531](https://bugs.openjdk.java.net/browse/JDK-8271531): [lworld] Implicit null check optimization does not hoist constant load input


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/508/head:pull/508` \
`$ git checkout pull/508`

Update a local copy of the PR: \
`$ git checkout pull/508` \
`$ git pull https://git.openjdk.java.net/valhalla pull/508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 508`

View PR using the GUI difftool: \
`$ git pr show -t 508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/508.diff">https://git.openjdk.java.net/valhalla/pull/508.diff</a>

</details>
