### PR TITLE
8271544: [lworld] GraphBuilder::withfield should handle identity class holder

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2074,7 +2074,7 @@ void GraphBuilder::withfield(int field_index) {
   Value val = pop(type);
   Value obj = apop();
 
-  if (!holder->is_loaded()) {
+  if (!holder->is_loaded() || !holder->is_inlinetype()) {
     apush(append_split(new Deoptimize(holder, state_before)));
     return;
   }
@@ -2083,7 +2083,6 @@ void GraphBuilder::withfield(int field_index) {
   const bool needs_patching = !field_modify->will_link(method(), Bytecodes::_withfield) ||
                               (!field_modify->is_flattened() && PatchALot);
   const int offset_modify = !needs_patching ? field_modify->offset() : -1;
-  assert(holder->is_inlinetype(), "must be an inline klass");
 
   scope()->set_wrote_final();
   scope()->set_wrote_fields();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -42,7 +42,7 @@ import static compiler.valhalla.inlinetypes.InlineTypes.*;
  * @summary Test inline types in LWorld.
  * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
+ * @build test.java.lang.invoke.lib.InstructionHelper
  * @run driver/timeout=450 compiler.valhalla.inlinetypes.TestLWorld
  */
 
@@ -1079,6 +1079,7 @@ public class TestLWorld {
     }
 
     @Run(test = "test35")
+    @Warmup(10000)
     public void test35_verifier() throws Throwable {
         int index = Math.abs(rI) % 3;
         try {
@@ -1406,6 +1407,7 @@ public class TestLWorld {
     }
 
     @Run(test = "test44")
+    @Warmup(10000)
     public void test44_verifier() throws Throwable {
         int index = Math.abs(rI) % 3;
         try {
@@ -3883,5 +3885,36 @@ public class TestLWorld {
     public void test142_verifier() {
         long res = test142();
         Asserts.assertEquals(res, testValue2.hash());
+    }
+
+    public int intField;
+
+    private static final MethodHandle withfieldWithInvalidHolder = InstructionHelper.loadCode(MethodHandles.lookup(),
+        "withfieldWithInvalidHolder",
+        MethodType.methodType(void.class, TestLWorld.class, int.class),
+        CODE -> {
+            CODE.
+            aload_0().
+            iload_1().
+            withfield(TestLWorld.class, "intField", "I").
+            return_();
+        });
+
+    // Test withfield on identity class
+    @Test
+    public void test143() throws Throwable {
+        withfieldWithInvalidHolder.invoke(this, 0);
+    }
+
+    @Run(test = "test143")
+    @Warmup(10000)
+    public void test143_verifier() throws Throwable {
+        intField = 42;
+        try {
+            test143();
+            throw new RuntimeException("IncompatibleClassChangeError expected");
+        } catch (IncompatibleClassChangeError e) {
+            // Expected
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3909,7 +3909,6 @@ public class TestLWorld {
     @Run(test = "test143")
     @Warmup(10000)
     public void test143_verifier() throws Throwable {
-        intField = 42;
         try {
             test143();
             throw new RuntimeException("IncompatibleClassChangeError expected");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/RunWithfieldTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/RunWithfieldTests.java
@@ -27,7 +27,7 @@
  * @summary test scenarios where getfield, putfield, and withfield access the
  *          same constant pool field_ref and test other withfield error cases.
  * @compile withfieldTests.jcod
- * @run main/othervm -Xverify:remote -Xint RunWithfieldTests
+ * @run main/othervm -Xverify:remote RunWithfieldTests
  */
 
 public class RunWithfieldTests {


### PR DESCRIPTION
The test added by [8269756](https://bugs.openjdk.java.net/browse/JDK-8269756) asserts in `GraphBuilder::withfield` because the holder klass is not an inline klass. C1 should handle that edge case by deoptimizing.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271544](https://bugs.openjdk.java.net/browse/JDK-8271544): [lworld] GraphBuilder::withfield should handle identity class holder


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/512/head:pull/512` \
`$ git checkout pull/512`

Update a local copy of the PR: \
`$ git checkout pull/512` \
`$ git pull https://git.openjdk.java.net/valhalla pull/512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 512`

View PR using the GUI difftool: \
`$ git pr show -t 512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/512.diff">https://git.openjdk.java.net/valhalla/pull/512.diff</a>

</details>
