### PR TITLE
8271508: [lworld] disallow primitive classes with super_class of 0

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4155,10 +4155,8 @@ const InstanceKlass* ClassFileParser::parse_super_class(ConstantPool* const cp,
   const InstanceKlass* super_klass = NULL;
 
   if (super_class_index == 0) {
-    check_property(_class_name == vmSymbols::java_lang_Object()
-                   || (_access_flags.get_flags() & JVM_ACC_INLINE),
-                   "Invalid superclass index %u in class file %s",
-                   super_class_index,
+    check_property(_class_name == vmSymbols::java_lang_Object(),
+                   "Invalid superclass index 0 in class file %s",
                    CHECK_NULL);
   } else {
     check_property(valid_klass_reference_at(super_class_index),

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadInlineTypes.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadInlineTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary test that the right exceptions get thrown for bad inline type
  *          class files.
  * @compile cfpTests.jcod
- * @run main/othervm BadInlineTypes
+ * @run main/othervm -Xverify:remote BadInlineTypes
  */
 
 public class BadInlineTypes {
@@ -88,5 +88,7 @@ public class BadInlineTypes {
          }
 
         runTest("ValueCloneable", "Inline Types do not support Cloneable");
+
+        runTest("SuperIsZero", "Invalid superclass index 0 in class file SuperIsZero");
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2490,3 +2490,81 @@ class OldClassWithQArraySig {
     } // end SourceFile
   } // Attributes
 } // end class OldClassWithQArraySig
+
+
+// This class has a super_cpx of zero.  This should cause a ClassFormatError
+// exception when this class is loaded.
+class SuperIsZero {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [15] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "SuperIsZero"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x1A
+    NameAndType #5 #6; // #4     at 0x1F
+    Utf8 "x"; // #5     at 0x24
+    Utf8 "I"; // #6     at 0x28
+    class #8; // #7     at 0x2C
+    Utf8 "java/lang/Object"; // #8     at 0x2F
+    Utf8 "<init>"; // #9     at 0x42
+    Utf8 "()QSuperIsZero;"; // #10     at 0x4B
+    Utf8 "Code"; // #11     at 0x5C
+    Utf8 "LineNumberTable"; // #12     at 0x63
+    Utf8 "SourceFile"; // #13     at 0x75
+    Utf8 "SuperIsZero.java"; // #14     at 0x82
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #0;// super_cpx // !!! changed 7 to 0
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x9E
+      0x0010; // access
+      #5; // name_index       : x
+      #6; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0xA8
+      0x0009; // access
+      #9; // name_index       : <init>
+      #10; // descriptor_index : ()QSuperIsZero;
+      [1] { // Attributes
+        Attr(#11, 45) { // Code at 0xB0
+          2; // max_stack
+          1; // max_locals
+          Bytes[13]{
+            0xCB00014B082A5FCC;
+            0x00034B2AB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 14) { // LineNumberTable at 0xCF
+              [3] { // line_number_table
+                0  4; //  at 0xDB
+                4  5; //  at 0xDF
+                11  6; //  at 0xE3
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#13, 2) { // SourceFile at 0xE5
+      #14;
+    } // end SourceFile
+  } // Attributes
+} // end class SuperIsZero


### PR DESCRIPTION
Please review this small fix for valhalla bug JDK-8271508.  The fix was tested with a new regression test, with JCK lang and VM, mach5 tiers 1-2 on Linux, Mac OS, and WIndows, and mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271508](https://bugs.openjdk.java.net/browse/JDK-8271508): [lworld] disallow primitive classes with super_class of 0


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/513/head:pull/513` \
`$ git checkout pull/513`

Update a local copy of the PR: \
`$ git checkout pull/513` \
`$ git pull https://git.openjdk.java.net/valhalla pull/513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 513`

View PR using the GUI difftool: \
`$ git pr show -t 513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/513.diff">https://git.openjdk.java.net/valhalla/pull/513.diff</a>

</details>
