### PR TITLE
8271528: [lworld] [TESTBUG] Several C2 IR tests fail on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7521,7 +7521,7 @@ instruct loadConP(iRegPNoSp dst, immP con)
 
   ins_cost(INSN_COST * 4);
   format %{
-    "mov  $dst, $con\t# ptr\n\t"
+    "mov  $dst, $con\t# ptr"
   %}
 
   ins_encode(aarch64_enc_mov_p(dst, con));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -111,11 +111,12 @@ public class InlineTypes {
         protected static final String MID = ".*)+ ===.*";
         protected static final String END = ")";
         // Generic allocation
-        protected static final String ALLOC_G  = "(.*call,static  wrapper for: _new_instance_Java" + END;
-        protected static final String ALLOCA_G = "(.*call,static  wrapper for: _new_array_Java" + END;
+        protected static final String ALLOC_G  = "(.*call,static.*wrapper for: _new_instance_Java" + END;
+        protected static final String ALLOCA_G = "(.*call,static.*wrapper for: _new_array_Java" + END;
         // Inline type allocation
-        protected static final String ALLOC  = "(.*precise klass compiler/valhalla/inlinetypes/MyValue.*\\R(.*(movl|xorl|nop|spill).*\\R)*.*_new_instance_Java" + END;
-        protected static final String ALLOCA = "(.*precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue.*\\R(.*(movl|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
+        protected static final String MYVALUE_KLASS = "precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue";
+        protected static final String ALLOC  = "(.*precise klass compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_instance_Java" + END;
+        protected static final String ALLOCA = "(.*" + MYVALUE_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
         protected static final String LOAD   = START + "Load(B|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/MyValue.*" + END;
         protected static final String LOADK  = START + "LoadK" + MID + END;
         protected static final String STORE  = START + "Store(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/MyValue.*" + END;
@@ -126,12 +127,14 @@ public class InlineTypes {
         protected static final String LINKTOSTATIC = START + "CallStaticJava" + MID + "linkToStatic" + END;
         protected static final String NPE = START + "CallStaticJava" + MID + "null_check" + END;
         protected static final String CALL = START + "CallStaticJava" + MID + END;
+        protected static final String CALL_LEAF = "(CALL, runtime leaf|call_leaf,runtime)";
+        protected static final String CALL_LEAF_NOFP = "(CALL, runtime leaf nofp|call_leaf_nofp,runtime)";
         protected static final String STORE_INLINE_FIELDS = START + "CallStaticJava" + MID + "store_inline_type_fields" + END;
         protected static final String SCOBJ = "(.*# ScObj.*" + END;
-        protected static final String LOAD_UNKNOWN_INLINE = "(.*call_leaf,runtime  load_unknown_inline.*" + END;
-        protected static final String STORE_UNKNOWN_INLINE = "(.*call_leaf,runtime  store_unknown_inline.*" + END;
-        protected static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static  wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
-        protected static final String INTRINSIC_SLOW_PATH = "(.*call,static  wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;
+        protected static final String LOAD_UNKNOWN_INLINE = "(.*" + CALL_LEAF + ".*load_unknown_inline.*" + END;
+        protected static final String STORE_UNKNOWN_INLINE = "(.*" + CALL_LEAF + ".*store_unknown_inline.*" + END;
+        protected static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static.*wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
+        protected static final String INTRINSIC_SLOW_PATH = "(.*call,static.*wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;
         protected static final String CLONE_INTRINSIC_SLOW_PATH = "(.*call,static.*java.lang.Object::clone.*" + END;
         protected static final String CLASS_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*class_check" + END;
         protected static final String NULL_CHECK_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*null_check" + END;
@@ -140,9 +143,9 @@ public class InlineTypes {
         protected static final String UNHANDLED_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unhandled" + END;
         protected static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
         protected static final String MEMBAR = START + "MemBar" + MID + END;
-        protected static final String CHECKCAST_ARRAY = "(cmp.*precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue.*" + END;
-        protected static final String CHECKCAST_ARRAYCOPY = "(.*call_leaf_nofp,runtime  checkcast_arraycopy.*" + END;
-        protected static final String JLONG_ARRAYCOPY = "(.*call_leaf_nofp,runtime  jlong_disjoint_arraycopy.*" + END;
+        protected static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_KLASS + ".*;:|.*(?i:mov|or).*" + MYVALUE_KLASS + ".*;:.*\\R.*(cmp|CMP|CLR))" + END;
+        protected static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
+        protected static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
         protected static final String FIELD_ACCESS = "(.*Field: *" + END;
         protected static final String SUBSTITUTABILITY_TEST = START + "CallStaticJava" + MID + "java.lang.invoke.ValueBootstrapMethods::isSubstitutable" + END;
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -114,9 +114,9 @@ public class InlineTypes {
         protected static final String ALLOC_G  = "(.*call,static.*wrapper for: _new_instance_Java" + END;
         protected static final String ALLOCA_G = "(.*call,static.*wrapper for: _new_array_Java" + END;
         // Inline type allocation
-        protected static final String MYVALUE_KLASS = "precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue";
+        protected static final String MYVALUE_ARRAY_KLASS = "precise klass \\[(L|Q)compiler/valhalla/inlinetypes/MyValue";
         protected static final String ALLOC  = "(.*precise klass compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_instance_Java" + END;
-        protected static final String ALLOCA = "(.*" + MYVALUE_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
+        protected static final String ALLOCA = "(.*" + MYVALUE_ARRAY_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
         protected static final String LOAD   = START + "Load(B|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/MyValue.*" + END;
         protected static final String LOADK  = START + "LoadK" + MID + END;
         protected static final String STORE  = START + "Store(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/MyValue.*" + END;
@@ -143,7 +143,7 @@ public class InlineTypes {
         protected static final String UNHANDLED_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unhandled" + END;
         protected static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
         protected static final String MEMBAR = START + "MemBar" + MID + END;
-        protected static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_KLASS + ".*;:|.*(?i:mov|or).*" + MYVALUE_KLASS + ".*;:.*\\R.*(cmp|CMP|CLR))" + END;
+        protected static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*;:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*;:.*\\R.*(cmp|CMP|CLR))" + END;
         protected static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
         protected static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
         protected static final String FIELD_ACCESS = "(.*Field: *" + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -36,7 +36,7 @@ import static compiler.valhalla.inlinetypes.InlineTypes.rI;
  * @key randomness
  * @summary Test the handling of fields of unloaded inline classes.
  * @library /test/lib /
- * @requires os.simpleArch == "x64"
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
  * @compile hack/GetUnresolvedInlineFieldWrongSignature.java
  * @compile TestUnloadedInlineTypeField.java
  * @run driver/timeout=300 compiler.valhalla.inlinetypes.TestUnloadedInlineTypeField


### PR DESCRIPTION
The regexes just need to be adjusted slightly for the different opto assembly output.  Also removed an unnecessary extra black line after some loadConP instructions which caused match failures.

Test hotspot_valhalla on x86 and AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271528](https://bugs.openjdk.java.net/browse/JDK-8271528): [lworld] [TESTBUG] Several C2 IR tests fail on AArch64


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - no project role)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/515/head:pull/515` \
`$ git checkout pull/515`

Update a local copy of the PR: \
`$ git checkout pull/515` \
`$ git pull https://git.openjdk.java.net/valhalla pull/515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 515`

View PR using the GUI difftool: \
`$ git pr show -t 515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/515.diff">https://git.openjdk.java.net/valhalla/pull/515.diff</a>

</details>
