### PR TITLE
JDK-8271405: [lworld] Redo test/jdk/java/lang/invoke/VarHandles changes for JDK-8269956

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
+    static final Class<?> type = boolean.class;
+
     static final boolean static_final_v = true;
 
     static boolean static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessBoolean.class, "final_v" + postfix, boolean.class);
+                    VarHandleTestAccessBoolean.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessBoolean.class, "v" + postfix, boolean.class);
+                    VarHandleTestAccessBoolean.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessBoolean.class, "static_final_v" + postfix, boolean.class);
+                VarHandleTestAccessBoolean.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessBoolean.class, "static_v" + postfix, boolean.class);
+                VarHandleTestAccessBoolean.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessBoolean.class, "final_v", boolean.class);
+                VarHandleTestAccessBoolean.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessBoolean.class, "v", boolean.class);
+                VarHandleTestAccessBoolean.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessBoolean.class, "static_final_v", boolean.class);
+            VarHandleTestAccessBoolean.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessBoolean.class, "static_v", boolean.class);
+            VarHandleTestAccessBoolean.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(boolean[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "boolean_v", boolean.class);
+                    Value.class, "boolean_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), boolean.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessBoolean.class, "final_v", boolean.class);
+                    VarHandleTestAccessBoolean.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessBoolean.class, "v", boolean.class);
+                    VarHandleTestAccessBoolean.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessBoolean.class, "static_final_v", boolean.class);
+                VarHandleTestAccessBoolean.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessBoolean.class, "static_v", boolean.class);
+                VarHandleTestAccessBoolean.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessByte extends VarHandleBaseTest {
+    static final Class<?> type = byte.class;
+
     static final byte static_final_v = (byte)0x01;
 
     static byte static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessByte.class, "final_v" + postfix, byte.class);
+                    VarHandleTestAccessByte.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessByte.class, "v" + postfix, byte.class);
+                    VarHandleTestAccessByte.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessByte.class, "static_final_v" + postfix, byte.class);
+                VarHandleTestAccessByte.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessByte.class, "static_v" + postfix, byte.class);
+                VarHandleTestAccessByte.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessByte.class, "final_v", byte.class);
+                VarHandleTestAccessByte.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessByte.class, "v", byte.class);
+                VarHandleTestAccessByte.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessByte.class, "static_final_v", byte.class);
+            VarHandleTestAccessByte.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessByte.class, "static_v", byte.class);
+            VarHandleTestAccessByte.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(byte[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "byte_v", byte.class);
+                    Value.class, "byte_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), byte.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessByte.class, "final_v", byte.class);
+                    VarHandleTestAccessByte.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessByte.class, "v", byte.class);
+                    VarHandleTestAccessByte.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessByte.class, "static_final_v", byte.class);
+                VarHandleTestAccessByte.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessByte.class, "static_v", byte.class);
+                VarHandleTestAccessByte.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessChar extends VarHandleBaseTest {
+    static final Class<?> type = char.class;
+
     static final char static_final_v = '\u0123';
 
     static char static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessChar.class, "final_v" + postfix, char.class);
+                    VarHandleTestAccessChar.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessChar.class, "v" + postfix, char.class);
+                    VarHandleTestAccessChar.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessChar.class, "static_final_v" + postfix, char.class);
+                VarHandleTestAccessChar.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessChar.class, "static_v" + postfix, char.class);
+                VarHandleTestAccessChar.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessChar.class, "final_v", char.class);
+                VarHandleTestAccessChar.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessChar.class, "v", char.class);
+                VarHandleTestAccessChar.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessChar.class, "static_final_v", char.class);
+            VarHandleTestAccessChar.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessChar.class, "static_v", char.class);
+            VarHandleTestAccessChar.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(char[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "char_v", char.class);
+                    Value.class, "char_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), char.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessChar.class, "final_v", char.class);
+                    VarHandleTestAccessChar.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessChar.class, "v", char.class);
+                    VarHandleTestAccessChar.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessChar.class, "static_final_v", char.class);
+                VarHandleTestAccessChar.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessChar.class, "static_v", char.class);
+                VarHandleTestAccessChar.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessDouble extends VarHandleBaseTest {
+    static final Class<?> type = double.class;
+
     static final double static_final_v = 1.0d;
 
     static double static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessDouble.class, "final_v" + postfix, double.class);
+                    VarHandleTestAccessDouble.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessDouble.class, "v" + postfix, double.class);
+                    VarHandleTestAccessDouble.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessDouble.class, "static_final_v" + postfix, double.class);
+                VarHandleTestAccessDouble.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessDouble.class, "static_v" + postfix, double.class);
+                VarHandleTestAccessDouble.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessDouble.class, "final_v", double.class);
+                VarHandleTestAccessDouble.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessDouble.class, "v", double.class);
+                VarHandleTestAccessDouble.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessDouble.class, "static_final_v", double.class);
+            VarHandleTestAccessDouble.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessDouble.class, "static_v", double.class);
+            VarHandleTestAccessDouble.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(double[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "double_v", double.class);
+                    Value.class, "double_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), double.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessDouble.class, "final_v", double.class);
+                    VarHandleTestAccessDouble.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessDouble.class, "v", double.class);
+                    VarHandleTestAccessDouble.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessDouble.class, "static_final_v", double.class);
+                VarHandleTestAccessDouble.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessDouble.class, "static_v", double.class);
+                VarHandleTestAccessDouble.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessFloat extends VarHandleBaseTest {
+    static final Class<?> type = float.class;
+
     static final float static_final_v = 1.0f;
 
     static float static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessFloat.class, "final_v" + postfix, float.class);
+                    VarHandleTestAccessFloat.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessFloat.class, "v" + postfix, float.class);
+                    VarHandleTestAccessFloat.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessFloat.class, "static_final_v" + postfix, float.class);
+                VarHandleTestAccessFloat.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessFloat.class, "static_v" + postfix, float.class);
+                VarHandleTestAccessFloat.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessFloat.class, "final_v", float.class);
+                VarHandleTestAccessFloat.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessFloat.class, "v", float.class);
+                VarHandleTestAccessFloat.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessFloat.class, "static_final_v", float.class);
+            VarHandleTestAccessFloat.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessFloat.class, "static_v", float.class);
+            VarHandleTestAccessFloat.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(float[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "float_v", float.class);
+                    Value.class, "float_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), float.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessFloat.class, "final_v", float.class);
+                    VarHandleTestAccessFloat.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessFloat.class, "v", float.class);
+                    VarHandleTestAccessFloat.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessFloat.class, "static_final_v", float.class);
+                VarHandleTestAccessFloat.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessFloat.class, "static_v", float.class);
+                VarHandleTestAccessFloat.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessInt extends VarHandleBaseTest {
+    static final Class<?> type = int.class;
+
     static final int static_final_v = 0x01234567;
 
     static int static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessInt.class, "final_v" + postfix, int.class);
+                    VarHandleTestAccessInt.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessInt.class, "v" + postfix, int.class);
+                    VarHandleTestAccessInt.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessInt.class, "static_final_v" + postfix, int.class);
+                VarHandleTestAccessInt.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessInt.class, "static_v" + postfix, int.class);
+                VarHandleTestAccessInt.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessInt.class, "final_v", int.class);
+                VarHandleTestAccessInt.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessInt.class, "v", int.class);
+                VarHandleTestAccessInt.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessInt.class, "static_final_v", int.class);
+            VarHandleTestAccessInt.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessInt.class, "static_v", int.class);
+            VarHandleTestAccessInt.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(int[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "int_v", int.class);
+                    Value.class, "int_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), int.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessInt.class, "final_v", int.class);
+                    VarHandleTestAccessInt.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessInt.class, "v", int.class);
+                    VarHandleTestAccessInt.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessInt.class, "static_final_v", int.class);
+                VarHandleTestAccessInt.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessInt.class, "static_v", int.class);
+                VarHandleTestAccessInt.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessLong extends VarHandleBaseTest {
+    static final Class<?> type = long.class;
+
     static final long static_final_v = 0x0123456789ABCDEFL;
 
     static long static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessLong.class, "final_v" + postfix, long.class);
+                    VarHandleTestAccessLong.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessLong.class, "v" + postfix, long.class);
+                    VarHandleTestAccessLong.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessLong.class, "static_final_v" + postfix, long.class);
+                VarHandleTestAccessLong.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessLong.class, "static_v" + postfix, long.class);
+                VarHandleTestAccessLong.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessLong.class, "final_v", long.class);
+                VarHandleTestAccessLong.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessLong.class, "v", long.class);
+                VarHandleTestAccessLong.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessLong.class, "static_final_v", long.class);
+            VarHandleTestAccessLong.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessLong.class, "static_v", long.class);
+            VarHandleTestAccessLong.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(long[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "long_v", long.class);
+                    Value.class, "long_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), long.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessLong.class, "final_v", long.class);
+                    VarHandleTestAccessLong.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessLong.class, "v", long.class);
+                    VarHandleTestAccessLong.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessLong.class, "static_final_v", long.class);
+                VarHandleTestAccessLong.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessLong.class, "static_v", long.class);
+                VarHandleTestAccessLong.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessPoint extends VarHandleBaseTest {
+    static final Class<?> type = Point.class.asValueType();
+
     static final Point static_final_v = Point.getInstance(1,1);
 
     static Point static_v;
@@ -80,19 +82,19 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessPoint.class, "final_v" + postfix, Point.class.asValueType());
+                    VarHandleTestAccessPoint.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessPoint.class, "v" + postfix, Point.class.asValueType());
+                    VarHandleTestAccessPoint.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessPoint.class, "static_final_v" + postfix, Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessPoint.class, "static_v" + postfix, Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -111,22 +113,22 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessPoint.class, "final_v", Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessPoint.class, "v", Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessPoint.class, "static_final_v", Point.class.asValueType());
+            VarHandleTestAccessPoint.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessPoint.class, "static_v", Point.class.asValueType());
+            VarHandleTestAccessPoint.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(Point[].class);
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "point_v", Point.class.asValueType());
+                    Value.class, "point_v", type);
     }
 
 
@@ -211,7 +213,7 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), Point.class.asValueType());
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -223,12 +225,12 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessPoint.class, "final_v", Point.class.asValueType());
+                    VarHandleTestAccessPoint.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessPoint.class, "v", Point.class.asValueType());
+                    VarHandleTestAccessPoint.class, "v", type);
         });
     }
 
@@ -236,12 +238,12 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessPoint.class, "static_final_v", Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessPoint.class, "static_v", Point.class.asValueType());
+                VarHandleTestAccessPoint.class, "static_v", type);
         });
     }
 
@@ -1161,79 +1163,79 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
         for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
             final int ci = i;
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point x = (Point) vh.get(array, ci);
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 vh.set(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point x = (Point) vh.getVolatile(array, ci);
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 vh.setVolatile(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point x = (Point) vh.getAcquire(array, ci);
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 vh.setRelease(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point x = (Point) vh.getOpaque(array, ci);
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 vh.setOpaque(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 boolean r = vh.compareAndSet(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point r = (Point) vh.compareAndExchange(array, ci, Point.getInstance(2,2), Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point r = (Point) vh.compareAndExchangeAcquire(array, ci, Point.getInstance(2,2), Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point r = (Point) vh.compareAndExchangeRelease(array, ci, Point.getInstance(2,2), Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 boolean r = vh.weakCompareAndSetPlain(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 boolean r = vh.weakCompareAndSet(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 boolean r = vh.weakCompareAndSetAcquire(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 boolean r = vh.weakCompareAndSetRelease(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point o = (Point) vh.getAndSet(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point o = (Point) vh.getAndSetAcquire(array, ci, Point.getInstance(1,1));
             });
 
-            checkIOOBE(() -> {
+            checkAIOOBE(() -> {
                 Point o = (Point) vh.getAndSetRelease(array, ci, Point.getInstance(1,1));
             });
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessShort extends VarHandleBaseTest {
+    static final Class<?> type = short.class;
+
     static final short static_final_v = (short)0x0123;
 
     static short static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessShort.class, "final_v" + postfix, short.class);
+                    VarHandleTestAccessShort.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessShort.class, "v" + postfix, short.class);
+                    VarHandleTestAccessShort.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessShort.class, "static_final_v" + postfix, short.class);
+                VarHandleTestAccessShort.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessShort.class, "static_v" + postfix, short.class);
+                VarHandleTestAccessShort.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,21 +112,21 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessShort.class, "final_v", short.class);
+                VarHandleTestAccessShort.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessShort.class, "v", short.class);
+                VarHandleTestAccessShort.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessShort.class, "static_final_v", short.class);
+            VarHandleTestAccessShort.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessShort.class, "static_v", short.class);
+            VarHandleTestAccessShort.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(short[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "short_v", short.class);
+                    Value.class, "short_v", type);
     }
 
 
@@ -209,7 +211,7 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), short.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -221,12 +223,12 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessShort.class, "final_v", short.class);
+                    VarHandleTestAccessShort.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessShort.class, "v", short.class);
+                    VarHandleTestAccessShort.class, "v", type);
         });
     }
 
@@ -234,12 +236,12 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessShort.class, "static_final_v", short.class);
+                VarHandleTestAccessShort.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessShort.class, "static_v", short.class);
+                VarHandleTestAccessShort.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -44,6 +44,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessString extends VarHandleBaseTest {
+    static final Class<?> type = String.class;
+
     static final String static_final_v = "foo";
 
     static String static_v;
@@ -79,19 +81,19 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessString.class, "final_v" + postfix, String.class);
+                    VarHandleTestAccessString.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccessString.class, "v" + postfix, String.class);
+                    VarHandleTestAccessString.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessString.class, "static_final_v" + postfix, String.class);
+                VarHandleTestAccessString.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccessString.class, "static_v" + postfix, String.class);
+                VarHandleTestAccessString.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -110,16 +112,16 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessString.class, "final_v", String.class);
+                VarHandleTestAccessString.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessString.class, "v", String.class);
+                VarHandleTestAccessString.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessString.class, "static_final_v", String.class);
+            VarHandleTestAccessString.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccessString.class, "static_v", String.class);
+            VarHandleTestAccessString.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(String[].class);
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
@@ -208,7 +210,7 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), String.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -220,12 +222,12 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessString.class, "final_v", String.class);
+                    VarHandleTestAccessString.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccessString.class, "v", String.class);
+                    VarHandleTestAccessString.class, "v", type);
         });
     }
 
@@ -233,12 +235,12 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessString.class, "static_final_v", String.class);
+                VarHandleTestAccessString.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccessString.class, "static_v", String.class);
+                VarHandleTestAccessString.class, "static_v", type);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessBoolean
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessBoolean
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
+    static final Class<?> type = boolean.class;
+
     static final boolean static_final_v = true;
 
     static boolean static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessBoolean.class, "final_v", boolean.class);
+                VarHandleTestMethodHandleAccessBoolean.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessBoolean.class, "v", boolean.class);
+                VarHandleTestMethodHandleAccessBoolean.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessBoolean.class, "static_final_v", boolean.class);
+            VarHandleTestMethodHandleAccessBoolean.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessBoolean.class, "static_v", boolean.class);
+            VarHandleTestMethodHandleAccessBoolean.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(boolean[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "boolean_v", boolean.class);
+                    Value.class, "boolean_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
+    static final Class<?> type = byte.class;
+
     static final byte static_final_v = (byte)0x01;
 
     static byte static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessByte.class, "final_v", byte.class);
+                VarHandleTestMethodHandleAccessByte.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessByte.class, "v", byte.class);
+                VarHandleTestMethodHandleAccessByte.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessByte.class, "static_final_v", byte.class);
+            VarHandleTestMethodHandleAccessByte.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessByte.class, "static_v", byte.class);
+            VarHandleTestMethodHandleAccessByte.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(byte[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "byte_v", byte.class);
+                    Value.class, "byte_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessByte
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessByte
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
+    static final Class<?> type = char.class;
+
     static final char static_final_v = '\u0123';
 
     static char static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessChar.class, "final_v", char.class);
+                VarHandleTestMethodHandleAccessChar.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessChar.class, "v", char.class);
+                VarHandleTestMethodHandleAccessChar.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessChar.class, "static_final_v", char.class);
+            VarHandleTestMethodHandleAccessChar.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessChar.class, "static_v", char.class);
+            VarHandleTestMethodHandleAccessChar.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(char[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "char_v", char.class);
+                    Value.class, "char_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessChar
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessChar
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessDouble
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessDouble
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessDouble.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
+    static final Class<?> type = double.class;
+
     static final double static_final_v = 1.0d;
 
     static double static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessDouble extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessDouble.class, "final_v", double.class);
+                VarHandleTestMethodHandleAccessDouble.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessDouble.class, "v", double.class);
+                VarHandleTestMethodHandleAccessDouble.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessDouble.class, "static_final_v", double.class);
+            VarHandleTestMethodHandleAccessDouble.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessDouble.class, "static_v", double.class);
+            VarHandleTestMethodHandleAccessDouble.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(double[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "double_v", double.class);
+                    Value.class, "double_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessFloat
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessFloat
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
+    static final Class<?> type = float.class;
+
     static final float static_final_v = 1.0f;
 
     static float static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessFloat.class, "final_v", float.class);
+                VarHandleTestMethodHandleAccessFloat.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessFloat.class, "v", float.class);
+                VarHandleTestMethodHandleAccessFloat.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessFloat.class, "static_final_v", float.class);
+            VarHandleTestMethodHandleAccessFloat.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessFloat.class, "static_v", float.class);
+            VarHandleTestMethodHandleAccessFloat.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(float[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "float_v", float.class);
+                    Value.class, "float_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
+    static final Class<?> type = int.class;
+
     static final int static_final_v = 0x01234567;
 
     static int static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessInt.class, "final_v", int.class);
+                VarHandleTestMethodHandleAccessInt.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessInt.class, "v", int.class);
+                VarHandleTestMethodHandleAccessInt.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessInt.class, "static_final_v", int.class);
+            VarHandleTestMethodHandleAccessInt.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessInt.class, "static_v", int.class);
+            VarHandleTestMethodHandleAccessInt.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(int[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "int_v", int.class);
+                    Value.class, "int_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessInt
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessInt
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessLong
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessLong
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
+    static final Class<?> type = long.class;
+
     static final long static_final_v = 0x0123456789ABCDEFL;
 
     static long static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessLong.class, "final_v", long.class);
+                VarHandleTestMethodHandleAccessLong.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessLong.class, "v", long.class);
+                VarHandleTestMethodHandleAccessLong.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessLong.class, "static_final_v", long.class);
+            VarHandleTestMethodHandleAccessLong.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessLong.class, "static_v", long.class);
+            VarHandleTestMethodHandleAccessLong.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(long[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "long_v", long.class);
+                    Value.class, "long_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
+    static final Class<?> type = Point.class.asValueType();
+
     static final Point static_final_v = Point.getInstance(1,1);
 
     static Point static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessPoint.class, "final_v", Point.class.asValueType());
+                VarHandleTestMethodHandleAccessPoint.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessPoint.class, "v", Point.class.asValueType());
+                VarHandleTestMethodHandleAccessPoint.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessPoint.class, "static_final_v", Point.class.asValueType());
+            VarHandleTestMethodHandleAccessPoint.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessPoint.class, "static_v", Point.class.asValueType());
+            VarHandleTestMethodHandleAccessPoint.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(Point[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "point_v", Point.class.asValueType());
+                    Value.class, "point_v", type);
     }
 
 
@@ -681,31 +683,31 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
             final int ci = i;
 
             for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
-                checkIOOBE(am, () -> {
+                checkAIOOBE(am, () -> {
                     Point x = (Point) hs.get(am).invokeExact(array, ci);
                 });
             }
 
             for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-                checkIOOBE(am, () -> {
+                checkAIOOBE(am, () -> {
                     hs.get(am).invokeExact(array, ci, Point.getInstance(1,1));
                 });
             }
 
             for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
-                checkIOOBE(am, () -> {
+                checkAIOOBE(am, () -> {
                     boolean r = (boolean) hs.get(am).invokeExact(array, ci, Point.getInstance(1,1), Point.getInstance(2,2));
                 });
             }
 
             for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
-                checkIOOBE(am, () -> {
+                checkAIOOBE(am, () -> {
                     Point r = (Point) hs.get(am).invokeExact(array, ci, Point.getInstance(2,2), Point.getInstance(1,1));
                 });
             }
 
             for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
-                checkIOOBE(am, () -> {
+                checkAIOOBE(am, () -> {
                     Point o = (Point) hs.get(am).invokeExact(array, ci, Point.getInstance(1,1));
                 });
             }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccessShort
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessShort
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
+    static final Class<?> type = short.class;
+
     static final short static_final_v = (short)0x0123;
 
     static short static_v;
@@ -64,21 +66,21 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessShort.class, "final_v", short.class);
+                VarHandleTestMethodHandleAccessShort.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessShort.class, "v", short.class);
+                VarHandleTestMethodHandleAccessShort.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessShort.class, "static_final_v", short.class);
+            VarHandleTestMethodHandleAccessShort.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessShort.class, "static_v", short.class);
+            VarHandleTestMethodHandleAccessShort.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(short[].class);
 
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "short_v", short.class);
+                    Value.class, "short_v", type);
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -41,6 +41,8 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
+    static final Class<?> type = String.class;
+
     static final String static_final_v = "foo";
 
     static String static_v;
@@ -63,16 +65,16 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessString.class, "final_v", String.class);
+                VarHandleTestMethodHandleAccessString.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccessString.class, "v", String.class);
+                VarHandleTestMethodHandleAccessString.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessString.class, "static_final_v", String.class);
+            VarHandleTestMethodHandleAccessString.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccessString.class, "static_v", String.class);
+            VarHandleTestMethodHandleAccessString.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(String[].class);
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeBoolean
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeBoolean
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeBoolean
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
+    static final Class<?> type = boolean.class;
+
     static final boolean static_final_v = true;
 
     static boolean static_v = true;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeBoolean.class, "final_v", boolean.class);
+                VarHandleTestMethodTypeBoolean.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeBoolean.class, "v", boolean.class);
+                VarHandleTestMethodTypeBoolean.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeBoolean.class, "static_final_v", boolean.class);
+            VarHandleTestMethodTypeBoolean.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeBoolean.class, "static_v", boolean.class);
+            VarHandleTestMethodTypeBoolean.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(boolean[].class);
     }
@@ -919,15 +919,15 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -941,11 +941,11 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -953,11 +953,11 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, boolean.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, true);
             });
             checkWMTE(() -> { // value reference class
@@ -965,7 +965,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, boolean.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, true);
             });
             // Incorrect arity
@@ -974,7 +974,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeBoolean.class, boolean.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeBoolean.class, type, Class.class)).
                     invokeExact(recv, true, Void.class);
             });
         }
@@ -982,23 +982,23 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null, true, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, true, true);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class, type)).
                     invokeExact(recv, Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, type, Class.class)).
                     invokeExact(recv, true, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, true, true);
             });
             // Incorrect arity
@@ -1007,85 +1007,85 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, type, type, Class.class)).
                     invokeExact(recv, true, true, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null, true, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, true, true);
             });
             checkWMTE(() -> { // expected reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, Class.class, type)).
                     invokeExact(recv, Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type, Class.class)).
                     invokeExact(recv, true, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class , boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, true, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class , boolean.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class , type, type)).
                     invokeExact(recv, true, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class , boolean.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class , type, type)).
                     invokeExact(recv, true, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type, type, Class.class)).
                     invokeExact(recv, true, true, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, true);
             });
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true, Void.class);
             });
         }
@@ -1093,37 +1093,37 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact((VarHandleTestMethodTypeBoolean) null, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, true);
             });
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeBoolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, VarHandleTestMethodTypeBoolean.class, type)).
                     invokeExact(recv, true, Void.class);
             });
         }
@@ -1680,18 +1680,18 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, boolean.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(true, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(true, Void.class);
             });
             // Incorrect arity
@@ -1700,7 +1700,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(true, true, Void.class);
             });
         }
@@ -1708,29 +1708,29 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(true, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(true, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, type, type)).
                     invokeExact(true, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(true, true, Void.class);
             });
         }
@@ -1738,25 +1738,25 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, type)).
                     invokeExact(true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(true, Void.class);
             });
         }
@@ -1765,25 +1765,25 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, type)).
                     invokeExact(true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(true, Void.class);
             });
         }
@@ -2674,19 +2674,19 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class)).
                     invokeExact((boolean[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -2700,11 +2700,11 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -2712,11 +2712,11 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, boolean[].class, int.class, boolean.class)).
+                hs.get(am, methodType(void.class, boolean[].class, int.class, type)).
                     invokeExact((boolean[]) null, 0, true);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, boolean.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, true);
             });
             checkWMTE(() -> { // value reference class
@@ -2724,11 +2724,11 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, boolean.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, true);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, boolean[].class, Class.class, boolean.class)).
+                hs.get(am, methodType(void.class, boolean[].class, Class.class, type)).
                     invokeExact(array, Void.class, true);
             });
             // Incorrect arity
@@ -2744,27 +2744,27 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, type, type)).
                     invokeExact((boolean[]) null, 0, true, true);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, true, true);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, true, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, true, true);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class, boolean.class, boolean.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, true, true);
             });
             // Incorrect arity
@@ -2773,7 +2773,7 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, boolean.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, true, true, Void.class);
             });
         }
@@ -2781,45 +2781,45 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type, type)).
                     invokeExact((boolean[]) null, 0, true, true);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, true, true);
             });
             checkWMTE(() -> { // expected reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, true);
             });
             checkWMTE(() -> { // actual reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, true, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, true, true);
             });
             checkWMTE(() -> { // index reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class, boolean.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, true, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, boolean.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, type, type)).
                     invokeExact(array, 0, true, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, boolean.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, type, type)).
                     invokeExact(array, 0, true, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, true, true, Void.class);
             });
         }
@@ -2827,41 +2827,41 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type)).
                     invokeExact((boolean[]) null, 0, true);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, true);
             });
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, true);
             });
             checkWMTE(() -> { // index reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, Class.class, type)).
                     invokeExact(array, Void.class, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, type)).
                     invokeExact(array, 0, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, type)).
                     invokeExact(array, 0, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, true, Void.class);
             });
         }
@@ -2870,41 +2870,41 @@ public class VarHandleTestMethodTypeBoolean extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type)).
                     invokeExact((boolean[]) null, 0, true);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, true);
             });
             checkWMTE(() -> { // value reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, true);
             });
             checkWMTE(() -> { // index reference class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, Class.class, boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, Class.class, type)).
                     invokeExact(array, Void.class, true);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, boolean.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, boolean[].class, int.class, type)).
                     invokeExact(array, 0, true);
             });
             checkWMTE(() -> { // primitive class
-                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, boolean.class)).
+                int x = (int) hs.get(am, methodType(int.class, boolean[].class, int.class, type)).
                     invokeExact(array, 0, true);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                boolean x = (boolean) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, boolean[].class, int.class, boolean.class, Class.class)).
+                boolean x = (boolean) hs.get(am, methodType(type, boolean[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, true, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeBoolean.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeBoolean
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeBoolean
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeBoolean
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeByte
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeByte
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeByte
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
+    static final Class<?> type = byte.class;
+
     static final byte static_final_v = (byte)0x01;
 
     static byte static_v = (byte)0x01;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeByte.class, "final_v", byte.class);
+                VarHandleTestMethodTypeByte.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeByte.class, "v", byte.class);
+                VarHandleTestMethodTypeByte.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeByte.class, "static_final_v", byte.class);
+            VarHandleTestMethodTypeByte.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeByte.class, "static_v", byte.class);
+            VarHandleTestMethodTypeByte.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(byte[].class);
     }
@@ -1005,15 +1005,15 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class)).
                     invokeExact((VarHandleTestMethodTypeByte) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1027,11 +1027,11 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1039,11 +1039,11 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, byte.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
@@ -1051,7 +1051,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, byte.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, (byte)0x01);
             });
             // Incorrect arity
@@ -1060,7 +1060,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeByte.class, byte.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeByte.class, type, Class.class)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
         }
@@ -1068,23 +1068,23 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, Class.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, Class.class, type)).
                     invokeExact(recv, Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type, Class.class)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, (byte)0x01, (byte)0x01);
             });
             // Incorrect arity
@@ -1093,159 +1093,159 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type, type, Class.class)).
                     invokeExact(recv, (byte)0x01, (byte)0x01, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // expected reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, Class.class, type)).
                     invokeExact(recv, Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type, Class.class)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class , byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, (byte)0x01, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class , byte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class , type, type)).
                     invokeExact(recv, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class , byte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class , type, type)).
                     invokeExact(recv, (byte)0x01, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type, type, Class.class)).
                     invokeExact(recv, (byte)0x01, (byte)0x01, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact((VarHandleTestMethodTypeByte) null, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, VarHandleTestMethodTypeByte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, VarHandleTestMethodTypeByte.class, type)).
                     invokeExact(recv, (byte)0x01, Void.class);
             });
         }
@@ -1863,18 +1863,18 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, byte.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
             // Incorrect arity
@@ -1883,7 +1883,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact((byte)0x01, (byte)0x01, Void.class);
             });
         }
@@ -1891,29 +1891,29 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact((byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact((byte)0x01, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact((byte)0x01, (byte)0x01, Void.class);
             });
         }
@@ -1921,25 +1921,25 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
         }
@@ -1947,25 +1947,25 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
         }
@@ -1973,25 +1973,25 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((byte)0x01, Void.class);
             });
         }
@@ -2979,19 +2979,19 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class)).
                     invokeExact((byte[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, int.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, int.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3005,11 +3005,11 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3017,11 +3017,11 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, byte[].class, int.class, byte.class)).
+                hs.get(am, methodType(void.class, byte[].class, int.class, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, byte.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
@@ -3029,11 +3029,11 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, byte.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, byte[].class, Class.class, byte.class)).
+                hs.get(am, methodType(void.class, byte[].class, Class.class, type)).
                     invokeExact(array, Void.class, (byte)0x01);
             });
             // Incorrect arity
@@ -3049,27 +3049,27 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, Class.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, Class.class, byte.class, byte.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, (byte)0x01, (byte)0x01);
             });
             // Incorrect arity
@@ -3078,7 +3078,7 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class, byte.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, (byte)0x01, Void.class);
             });
         }
@@ -3086,45 +3086,45 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, int.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // expected reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, (byte)0x01);
             });
             checkWMTE(() -> { // actual reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, int.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, Class.class, byte.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, (byte)0x01, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, byte.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, type, type)).
                     invokeExact(array, 0, (byte)0x01, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type, type)).
                     invokeExact(array, 0, (byte)0x01, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, (byte)0x01, Void.class);
             });
         }
@@ -3132,41 +3132,41 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, Class.class, type)).
                     invokeExact(array, Void.class, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, Void.class);
             });
         }
@@ -3174,41 +3174,41 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, Class.class, type)).
                     invokeExact(array, Void.class, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, Void.class);
             });
         }
@@ -3216,41 +3216,41 @@ public class VarHandleTestMethodTypeByte extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type)).
                     invokeExact((byte[]) null, 0, (byte)0x01);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, Class.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (byte)0x01);
             });
             checkWMTE(() -> { // value reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                byte x = (byte) hs.get(am, methodType(byte.class, int.class, int.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (byte)0x01);
             });
             checkWMTE(() -> { // index reference class
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, Class.class, byte.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, Class.class, type)).
                     invokeExact(array, Void.class, (byte)0x01);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, byte.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, byte.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, byte[].class, int.class, type)).
                     invokeExact(array, 0, (byte)0x01);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                byte x = (byte) hs.get(am, methodType(byte.class)).
+                byte x = (byte) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                byte x = (byte) hs.get(am, methodType(byte.class, byte[].class, int.class, byte.class, Class.class)).
+                byte x = (byte) hs.get(am, methodType(type, byte[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (byte)0x01, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeByte.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeByte
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeByte
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeByte
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeChar
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeChar.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeChar
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeChar
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeChar
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeChar
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
+    static final Class<?> type = char.class;
+
     static final char static_final_v = '\u0123';
 
     static char static_v = '\u0123';
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeChar.class, "final_v", char.class);
+                VarHandleTestMethodTypeChar.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeChar.class, "v", char.class);
+                VarHandleTestMethodTypeChar.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeChar.class, "static_final_v", char.class);
+            VarHandleTestMethodTypeChar.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeChar.class, "static_v", char.class);
+            VarHandleTestMethodTypeChar.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(char[].class);
     }
@@ -1005,15 +1005,15 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class)).
                     invokeExact((VarHandleTestMethodTypeChar) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class)).
+                char x = (char) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1027,11 +1027,11 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1039,11 +1039,11 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeChar.class, char.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, char.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // value reference class
@@ -1051,7 +1051,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, char.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, '\u0123');
             });
             // Incorrect arity
@@ -1060,7 +1060,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeChar.class, char.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeChar.class, type, Class.class)).
                     invokeExact(recv, '\u0123', Void.class);
             });
         }
@@ -1068,23 +1068,23 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123', '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, Class.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, Class.class, type)).
                     invokeExact(recv, Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type, Class.class)).
                     invokeExact(recv, '\u0123', Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, '\u0123', '\u0123');
             });
             // Incorrect arity
@@ -1093,159 +1093,159 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type, type, Class.class)).
                     invokeExact(recv, '\u0123', '\u0123', Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123', '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // expected reference class
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, Class.class, type)).
                     invokeExact(recv, Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type, Class.class)).
                     invokeExact(recv, '\u0123', Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class , char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, '\u0123', '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class , char.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class , type, type)).
                     invokeExact(recv, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class , char.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class , type, type)).
                     invokeExact(recv, '\u0123', '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type, type, Class.class)).
                     invokeExact(recv, '\u0123', '\u0123', Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123', Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123', Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact((VarHandleTestMethodTypeChar) null, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, VarHandleTestMethodTypeChar.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, VarHandleTestMethodTypeChar.class, type)).
                     invokeExact(recv, '\u0123', Void.class);
             });
         }
@@ -1863,18 +1863,18 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, char.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
             // Incorrect arity
@@ -1883,7 +1883,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact('\u0123', '\u0123', Void.class);
             });
         }
@@ -1891,29 +1891,29 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                char x = (char) hs.get(am, methodType(char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact('\u0123', '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact('\u0123', '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact('\u0123', '\u0123', Void.class);
             });
         }
@@ -1921,25 +1921,25 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact('\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact('\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
         }
@@ -1947,25 +1947,25 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact('\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact('\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
         }
@@ -1973,25 +1973,25 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact('\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact('\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact('\u0123', Void.class);
             });
         }
@@ -2979,19 +2979,19 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class)).
                     invokeExact((char[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, int.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, int.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3005,11 +3005,11 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3017,11 +3017,11 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, char[].class, int.class, char.class)).
+                hs.get(am, methodType(void.class, char[].class, int.class, type)).
                     invokeExact((char[]) null, 0, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, char.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, '\u0123');
             });
             checkWMTE(() -> { // value reference class
@@ -3029,11 +3029,11 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, char.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, char[].class, Class.class, char.class)).
+                hs.get(am, methodType(void.class, char[].class, Class.class, type)).
                     invokeExact(array, Void.class, '\u0123');
             });
             // Incorrect arity
@@ -3049,27 +3049,27 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type, type)).
                     invokeExact((char[]) null, 0, '\u0123', '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, Class.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, '\u0123', Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, Class.class, char.class, char.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, '\u0123', '\u0123');
             });
             // Incorrect arity
@@ -3078,7 +3078,7 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class, char.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, '\u0123', '\u0123', Void.class);
             });
         }
@@ -3086,45 +3086,45 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, type)).
                     invokeExact((char[]) null, 0, '\u0123', '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, int.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // expected reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, '\u0123');
             });
             checkWMTE(() -> { // actual reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, '\u0123', Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, int.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, Class.class, char.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, '\u0123', '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, char.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, type, type)).
                     invokeExact(array, 0, '\u0123', '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type, type)).
                     invokeExact(array, 0, '\u0123', '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, '\u0123', '\u0123', Void.class);
             });
         }
@@ -3132,41 +3132,41 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type)).
                     invokeExact((char[]) null, 0, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, Class.class, type)).
                     invokeExact(array, Void.class, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, '\u0123', Void.class);
             });
         }
@@ -3174,41 +3174,41 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type)).
                     invokeExact((char[]) null, 0, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, Class.class, type)).
                     invokeExact(array, Void.class, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, '\u0123', Void.class);
             });
         }
@@ -3216,41 +3216,41 @@ public class VarHandleTestMethodTypeChar extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type)).
                     invokeExact((char[]) null, 0, '\u0123');
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                char x = (char) hs.get(am, methodType(char.class, Class.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, '\u0123');
             });
             checkWMTE(() -> { // value reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                char x = (char) hs.get(am, methodType(char.class, int.class, int.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, '\u0123');
             });
             checkWMTE(() -> { // index reference class
-                char x = (char) hs.get(am, methodType(char.class, char[].class, Class.class, char.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, Class.class, type)).
                     invokeExact(array, Void.class, '\u0123');
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, char.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, char.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, char[].class, int.class, type)).
                     invokeExact(array, 0, '\u0123');
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                char x = (char) hs.get(am, methodType(char.class)).
+                char x = (char) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                char x = (char) hs.get(am, methodType(char.class, char[].class, int.class, char.class, Class.class)).
+                char x = (char) hs.get(am, methodType(type, char[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, '\u0123', Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeDouble
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeDouble.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeDouble
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeDouble
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeDouble
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeDouble
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
+    static final Class<?> type = double.class;
+
     static final double static_final_v = 1.0d;
 
     static double static_v = 1.0d;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeDouble.class, "final_v", double.class);
+                VarHandleTestMethodTypeDouble.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeDouble.class, "v", double.class);
+                VarHandleTestMethodTypeDouble.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeDouble.class, "static_final_v", double.class);
+            VarHandleTestMethodTypeDouble.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeDouble.class, "static_v", double.class);
+            VarHandleTestMethodTypeDouble.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(double[].class);
     }
@@ -737,15 +737,15 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class)).
                     invokeExact((VarHandleTestMethodTypeDouble) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class)).
+                double x = (double) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -759,11 +759,11 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -771,11 +771,11 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact((VarHandleTestMethodTypeDouble) null, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, double.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, 1.0d);
             });
             checkWMTE(() -> { // value reference class
@@ -783,7 +783,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, double.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, 1.0d);
             });
             // Incorrect arity
@@ -792,7 +792,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeDouble.class, double.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeDouble.class, type, Class.class)).
                     invokeExact(recv, 1.0d, Void.class);
             });
         }
@@ -800,23 +800,23 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeDouble) null, 1.0d, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, Class.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, Class.class, type)).
                     invokeExact(recv, Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, type, Class.class)).
                     invokeExact(recv, 1.0d, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, 1.0d, 1.0d);
             });
             // Incorrect arity
@@ -825,122 +825,122 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, double.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, type, type, Class.class)).
                     invokeExact(recv, 1.0d, 1.0d, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeDouble) null, 1.0d, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // expected reference class
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, Class.class, type)).
                     invokeExact(recv, Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type, Class.class)).
                     invokeExact(recv, 1.0d, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class , double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, 1.0d, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class , double.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class , type, type)).
                     invokeExact(recv, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class , double.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class , type, type)).
                     invokeExact(recv, 1.0d, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type, type, Class.class)).
                     invokeExact(recv, 1.0d, 1.0d, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact((VarHandleTestMethodTypeDouble) null, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0d);
             });
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact((VarHandleTestMethodTypeDouble) null, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0d);
             });
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, VarHandleTestMethodTypeDouble.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, VarHandleTestMethodTypeDouble.class, type)).
                     invokeExact(recv, 1.0d, Void.class);
             });
         }
@@ -1372,18 +1372,18 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, double.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(1.0d, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(1.0d, Void.class);
             });
             // Incorrect arity
@@ -1392,7 +1392,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(1.0d, 1.0d, Void.class);
             });
         }
@@ -1400,29 +1400,29 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                double x = (double) hs.get(am, methodType(double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0d, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(1.0d, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact(1.0d, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(1.0d, 1.0d, Void.class);
             });
         }
@@ -1430,25 +1430,25 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0d, Void.class);
             });
         }
@@ -1456,25 +1456,25 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0d, Void.class);
             });
         }
@@ -2168,19 +2168,19 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class)).
                     invokeExact((double[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, int.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, int.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -2194,11 +2194,11 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -2206,11 +2206,11 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, double[].class, int.class, double.class)).
+                hs.get(am, methodType(void.class, double[].class, int.class, type)).
                     invokeExact((double[]) null, 0, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, double.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0d);
             });
             checkWMTE(() -> { // value reference class
@@ -2218,11 +2218,11 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, double.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0d);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, double[].class, Class.class, double.class)).
+                hs.get(am, methodType(void.class, double[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0d);
             });
             // Incorrect arity
@@ -2238,27 +2238,27 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type, type)).
                     invokeExact((double[]) null, 0, 1.0d, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, Class.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0d, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, Class.class, double.class, double.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 1.0d, 1.0d);
             });
             // Incorrect arity
@@ -2267,7 +2267,7 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class, double.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 1.0d, 1.0d, Void.class);
             });
         }
@@ -2275,45 +2275,45 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type, type)).
                     invokeExact((double[]) null, 0, 1.0d, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, int.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // expected reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 1.0d);
             });
             checkWMTE(() -> { // actual reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0d, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, int.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // index reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, Class.class, double.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 1.0d, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, double.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, type, type)).
                     invokeExact(array, 0, 1.0d, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type, type)).
                     invokeExact(array, 0, 1.0d, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 1.0d, 1.0d, Void.class);
             });
         }
@@ -2321,41 +2321,41 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type)).
                     invokeExact((double[]) null, 0, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0d);
             });
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0d);
             });
             checkWMTE(() -> { // index reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, type)).
                     invokeExact(array, 0, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type)).
                     invokeExact(array, 0, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0d, Void.class);
             });
         }
@@ -2363,41 +2363,41 @@ public class VarHandleTestMethodTypeDouble extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type)).
                     invokeExact((double[]) null, 0, 1.0d);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                double x = (double) hs.get(am, methodType(double.class, Class.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0d);
             });
             checkWMTE(() -> { // value reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                double x = (double) hs.get(am, methodType(double.class, int.class, int.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0d);
             });
             checkWMTE(() -> { // index reference class
-                double x = (double) hs.get(am, methodType(double.class, double[].class, Class.class, double.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0d);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, double.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, double[].class, int.class, type)).
                     invokeExact(array, 0, 1.0d);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, double.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, double[].class, int.class, type)).
                     invokeExact(array, 0, 1.0d);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                double x = (double) hs.get(am, methodType(double.class)).
+                double x = (double) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                double x = (double) hs.get(am, methodType(double.class, double[].class, int.class, double.class, Class.class)).
+                double x = (double) hs.get(am, methodType(type, double[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0d, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeFloat
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeFloat
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeFloat
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
+    static final Class<?> type = float.class;
+
     static final float static_final_v = 1.0f;
 
     static float static_v = 1.0f;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeFloat.class, "final_v", float.class);
+                VarHandleTestMethodTypeFloat.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeFloat.class, "v", float.class);
+                VarHandleTestMethodTypeFloat.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeFloat.class, "static_final_v", float.class);
+            VarHandleTestMethodTypeFloat.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeFloat.class, "static_v", float.class);
+            VarHandleTestMethodTypeFloat.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(float[].class);
     }
@@ -737,15 +737,15 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class)).
                     invokeExact((VarHandleTestMethodTypeFloat) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class)).
+                float x = (float) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -759,11 +759,11 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -771,11 +771,11 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact((VarHandleTestMethodTypeFloat) null, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, float.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, 1.0f);
             });
             checkWMTE(() -> { // value reference class
@@ -783,7 +783,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, float.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, 1.0f);
             });
             // Incorrect arity
@@ -792,7 +792,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeFloat.class, float.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeFloat.class, type, Class.class)).
                     invokeExact(recv, 1.0f, Void.class);
             });
         }
@@ -800,23 +800,23 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeFloat) null, 1.0f, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, Class.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, Class.class, type)).
                     invokeExact(recv, Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, type, Class.class)).
                     invokeExact(recv, 1.0f, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, 1.0f, 1.0f);
             });
             // Incorrect arity
@@ -825,122 +825,122 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, float.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, type, type, Class.class)).
                     invokeExact(recv, 1.0f, 1.0f, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeFloat) null, 1.0f, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // expected reference class
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, Class.class, type)).
                     invokeExact(recv, Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type, Class.class)).
                     invokeExact(recv, 1.0f, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class , float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, 1.0f, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class , float.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class , type, type)).
                     invokeExact(recv, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class , float.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class , type, type)).
                     invokeExact(recv, 1.0f, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type, type, Class.class)).
                     invokeExact(recv, 1.0f, 1.0f, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact((VarHandleTestMethodTypeFloat) null, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0f);
             });
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact((VarHandleTestMethodTypeFloat) null, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0f);
             });
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, VarHandleTestMethodTypeFloat.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, VarHandleTestMethodTypeFloat.class, type)).
                     invokeExact(recv, 1.0f, Void.class);
             });
         }
@@ -1372,18 +1372,18 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, float.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(1.0f, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(1.0f, Void.class);
             });
             // Incorrect arity
@@ -1392,7 +1392,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(1.0f, 1.0f, Void.class);
             });
         }
@@ -1400,29 +1400,29 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                float x = (float) hs.get(am, methodType(float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0f, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(1.0f, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact(1.0f, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(1.0f, 1.0f, Void.class);
             });
         }
@@ -1430,25 +1430,25 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0f, Void.class);
             });
         }
@@ -1456,25 +1456,25 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(1.0f, Void.class);
             });
         }
@@ -2168,19 +2168,19 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class)).
                     invokeExact((float[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, int.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, int.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -2194,11 +2194,11 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -2206,11 +2206,11 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, float[].class, int.class, float.class)).
+                hs.get(am, methodType(void.class, float[].class, int.class, type)).
                     invokeExact((float[]) null, 0, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, float.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0f);
             });
             checkWMTE(() -> { // value reference class
@@ -2218,11 +2218,11 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, float.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0f);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, float[].class, Class.class, float.class)).
+                hs.get(am, methodType(void.class, float[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0f);
             });
             // Incorrect arity
@@ -2238,27 +2238,27 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type, type)).
                     invokeExact((float[]) null, 0, 1.0f, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, Class.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0f, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, Class.class, float.class, float.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 1.0f, 1.0f);
             });
             // Incorrect arity
@@ -2267,7 +2267,7 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class, float.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 1.0f, 1.0f, Void.class);
             });
         }
@@ -2275,45 +2275,45 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type, type)).
                     invokeExact((float[]) null, 0, 1.0f, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, int.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // expected reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 1.0f);
             });
             checkWMTE(() -> { // actual reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0f, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, int.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // index reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, Class.class, float.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 1.0f, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, float.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, type, type)).
                     invokeExact(array, 0, 1.0f, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type, type)).
                     invokeExact(array, 0, 1.0f, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 1.0f, 1.0f, Void.class);
             });
         }
@@ -2321,41 +2321,41 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type)).
                     invokeExact((float[]) null, 0, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0f);
             });
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0f);
             });
             checkWMTE(() -> { // index reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, type)).
                     invokeExact(array, 0, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type)).
                     invokeExact(array, 0, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0f, Void.class);
             });
         }
@@ -2363,41 +2363,41 @@ public class VarHandleTestMethodTypeFloat extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type)).
                     invokeExact((float[]) null, 0, 1.0f);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                float x = (float) hs.get(am, methodType(float.class, Class.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 1.0f);
             });
             checkWMTE(() -> { // value reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                float x = (float) hs.get(am, methodType(float.class, int.class, int.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 1.0f);
             });
             checkWMTE(() -> { // index reference class
-                float x = (float) hs.get(am, methodType(float.class, float[].class, Class.class, float.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, Class.class, type)).
                     invokeExact(array, Void.class, 1.0f);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, float.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, float[].class, int.class, type)).
                     invokeExact(array, 0, 1.0f);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, float.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, float[].class, int.class, type)).
                     invokeExact(array, 0, 1.0f);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                float x = (float) hs.get(am, methodType(float.class)).
+                float x = (float) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                float x = (float) hs.get(am, methodType(float.class, float[].class, int.class, float.class, Class.class)).
+                float x = (float) hs.get(am, methodType(type, float[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 1.0f, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeFloat.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeFloat
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeFloat
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeFloat
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeInt
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeInt.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeInt
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeInt
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeInt
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeInt
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
+    static final Class<?> type = int.class;
+
     static final int static_final_v = 0x01234567;
 
     static int static_v = 0x01234567;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeInt.class, "final_v", int.class);
+                VarHandleTestMethodTypeInt.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeInt.class, "v", int.class);
+                VarHandleTestMethodTypeInt.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeInt.class, "static_final_v", int.class);
+            VarHandleTestMethodTypeInt.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeInt.class, "static_v", int.class);
+            VarHandleTestMethodTypeInt.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(int[].class);
     }
@@ -1005,15 +1005,15 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class)).
                     invokeExact((VarHandleTestMethodTypeInt) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1027,11 +1027,11 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1039,11 +1039,11 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeInt.class, int.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, int.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
@@ -1051,7 +1051,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, 0x01234567);
             });
             // Incorrect arity
@@ -1060,7 +1060,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeInt.class, int.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeInt.class, type, Class.class)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
         }
@@ -1068,23 +1068,23 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, Class.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, Class.class, type)).
                     invokeExact(recv, Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type, Class.class)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, 0x01234567, 0x01234567);
             });
             // Incorrect arity
@@ -1093,159 +1093,159 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type, type, Class.class)).
                     invokeExact(recv, 0x01234567, 0x01234567, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // expected reference class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, Class.class, type)).
                     invokeExact(recv, Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type, Class.class)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class , int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, 0x01234567, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class , int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class , type, type)).
                     invokeExact(recv, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class , int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class , type, type)).
                     invokeExact(recv, 0x01234567, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type, type, Class.class)).
                     invokeExact(recv, 0x01234567, 0x01234567, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact((VarHandleTestMethodTypeInt) null, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, VarHandleTestMethodTypeInt.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, VarHandleTestMethodTypeInt.class, type)).
                     invokeExact(recv, 0x01234567, Void.class);
             });
         }
@@ -1863,18 +1863,18 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, int.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
             // Incorrect arity
@@ -1883,7 +1883,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(0x01234567, 0x01234567, Void.class);
             });
         }
@@ -1891,29 +1891,29 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                int x = (int) hs.get(am, methodType(int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact(0x01234567, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(0x01234567, 0x01234567, Void.class);
             });
         }
@@ -1921,25 +1921,25 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
         }
@@ -1947,25 +1947,25 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
         }
@@ -1973,25 +1973,25 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x01234567, Void.class);
             });
         }
@@ -2979,19 +2979,19 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class)).
                     invokeExact((int[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3005,11 +3005,11 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3017,11 +3017,11 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, int[].class, int.class, int.class)).
+                hs.get(am, methodType(void.class, int[].class, int.class, type)).
                     invokeExact((int[]) null, 0, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, int.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
@@ -3029,11 +3029,11 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, int.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, int[].class, Class.class, int.class)).
+                hs.get(am, methodType(void.class, int[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x01234567);
             });
             // Incorrect arity
@@ -3049,27 +3049,27 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type, type)).
                     invokeExact((int[]) null, 0, 0x01234567, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, Class.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, Class.class, int.class, int.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 0x01234567, 0x01234567);
             });
             // Incorrect arity
@@ -3078,7 +3078,7 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class, int.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, 0x01234567, Void.class);
             });
         }
@@ -3086,45 +3086,45 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, type)).
                     invokeExact((int[]) null, 0, 0x01234567, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // expected reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 0x01234567);
             });
             checkWMTE(() -> { // actual reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, Class.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 0x01234567, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, type, type)).
                     invokeExact(array, 0, 0x01234567, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type, type)).
                     invokeExact(array, 0, 0x01234567, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, 0x01234567, Void.class);
             });
         }
@@ -3132,41 +3132,41 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type)).
                     invokeExact((int[]) null, 0, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, Void.class);
             });
         }
@@ -3174,41 +3174,41 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type)).
                     invokeExact((int[]) null, 0, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, Void.class);
             });
         }
@@ -3216,41 +3216,41 @@ public class VarHandleTestMethodTypeInt extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type)).
                     invokeExact((int[]) null, 0, 0x01234567);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                int x = (int) hs.get(am, methodType(int.class, Class.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x01234567);
             });
             checkWMTE(() -> { // value reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                int x = (int) hs.get(am, methodType(int.class, int.class, int.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x01234567);
             });
             checkWMTE(() -> { // index reference class
-                int x = (int) hs.get(am, methodType(int.class, int[].class, Class.class, int.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x01234567);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, int.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, int.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, int[].class, int.class, type)).
                     invokeExact(array, 0, 0x01234567);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                int x = (int) hs.get(am, methodType(int.class)).
+                int x = (int) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                int x = (int) hs.get(am, methodType(int.class, int[].class, int.class, int.class, Class.class)).
+                int x = (int) hs.get(am, methodType(type, int[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x01234567, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeLong
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeLong.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeLong
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeLong
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeLong
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeLong
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
+    static final Class<?> type = long.class;
+
     static final long static_final_v = 0x0123456789ABCDEFL;
 
     static long static_v = 0x0123456789ABCDEFL;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeLong.class, "final_v", long.class);
+                VarHandleTestMethodTypeLong.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeLong.class, "v", long.class);
+                VarHandleTestMethodTypeLong.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeLong.class, "static_final_v", long.class);
+            VarHandleTestMethodTypeLong.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeLong.class, "static_v", long.class);
+            VarHandleTestMethodTypeLong.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(long[].class);
     }
@@ -1005,15 +1005,15 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class)).
                     invokeExact((VarHandleTestMethodTypeLong) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class)).
+                long x = (long) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1027,11 +1027,11 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1039,11 +1039,11 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeLong.class, long.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, long.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
@@ -1051,7 +1051,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, long.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
@@ -1060,7 +1060,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeLong.class, long.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeLong.class, type, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1068,23 +1068,23 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, Class.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, Class.class, type)).
                     invokeExact(recv, Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
@@ -1093,159 +1093,159 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type, type, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // expected reference class
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, Class.class, type)).
                     invokeExact(recv, Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class , long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class , long.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class , type, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class , long.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class , type, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type, type, Class.class)).
                     invokeExact(recv, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact((VarHandleTestMethodTypeLong) null, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, VarHandleTestMethodTypeLong.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, VarHandleTestMethodTypeLong.class, type)).
                     invokeExact(recv, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1863,18 +1863,18 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, long.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
             // Incorrect arity
@@ -1883,7 +1883,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1891,29 +1891,29 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                long x = (long) hs.get(am, methodType(long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact(0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1921,25 +1921,25 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1947,25 +1947,25 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -1973,25 +1973,25 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -2979,19 +2979,19 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class)).
                     invokeExact((long[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, int.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, int.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3005,11 +3005,11 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3017,11 +3017,11 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, long[].class, int.class, long.class)).
+                hs.get(am, methodType(void.class, long[].class, int.class, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, long.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
@@ -3029,11 +3029,11 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, long.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, long[].class, Class.class, long.class)).
+                hs.get(am, methodType(void.class, long[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
@@ -3049,27 +3049,27 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, Class.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, Class.class, long.class, long.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
@@ -3078,7 +3078,7 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class, long.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -3086,45 +3086,45 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, int.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // expected reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // actual reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, int.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, Class.class, long.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, long.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, type, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -3132,41 +3132,41 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -3174,41 +3174,41 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, Void.class);
             });
         }
@@ -3216,41 +3216,41 @@ public class VarHandleTestMethodTypeLong extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type)).
                     invokeExact((long[]) null, 0, 0x0123456789ABCDEFL);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                long x = (long) hs.get(am, methodType(long.class, Class.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // value reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                long x = (long) hs.get(am, methodType(long.class, int.class, int.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // index reference class
-                long x = (long) hs.get(am, methodType(long.class, long[].class, Class.class, long.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, Class.class, type)).
                     invokeExact(array, Void.class, 0x0123456789ABCDEFL);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, long.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, long.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, long[].class, int.class, type)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                long x = (long) hs.get(am, methodType(long.class)).
+                long x = (long) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                long x = (long) hs.get(am, methodType(long.class, long[].class, int.class, long.class, Class.class)).
+                long x = (long) hs.get(am, methodType(type, long[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, 0x0123456789ABCDEFL, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
+    static final Class<?> type = Point.class.asValueType();
+
     static final Point static_final_v = Point.getInstance(1,1);
 
     static Point static_v = Point.getInstance(1,1);
@@ -66,16 +68,16 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypePoint.class, "final_v", Point.class.asValueType());
+                VarHandleTestMethodTypePoint.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypePoint.class, "v", Point.class.asValueType());
+                VarHandleTestMethodTypePoint.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypePoint.class, "static_final_v", Point.class.asValueType());
+            VarHandleTestMethodTypePoint.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypePoint.class, "static_v", Point.class.asValueType());
+            VarHandleTestMethodTypePoint.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(Point[].class);
     }
@@ -649,15 +651,15 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class)).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class)).
                     invokeExact((VarHandleTestMethodTypePoint) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class)).
+                Point x = (Point) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -671,11 +673,11 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -683,11 +685,11 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypePoint.class, type)).
                     invokeExact((VarHandleTestMethodTypePoint) null, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
@@ -695,7 +697,7 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, Point.getInstance(1,1));
             });
             // Incorrect arity
@@ -704,7 +706,7 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypePoint.class, type, Class.class)).
                     invokeExact(recv, Point.getInstance(1,1), Void.class);
             });
         }
@@ -712,23 +714,23 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, type, type)).
                     invokeExact((VarHandleTestMethodTypePoint) null, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Class.class, Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Class.class, type)).
                     invokeExact(recv, Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, type, Class.class)).
                     invokeExact(recv, Point.getInstance(1,1), Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect arity
@@ -737,85 +739,85 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, type, type, Class.class)).
                     invokeExact(recv, Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, type, type)).
                     invokeExact((VarHandleTestMethodTypePoint) null, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Class.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, Class.class, type)).
                     invokeExact(recv, Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, type, Class.class)).
                     invokeExact(recv, Point.getInstance(1,1), Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class , Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypePoint.class , Point.class.asValueType(), Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypePoint.class , type, type)).
                     invokeExact(recv, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class , Point.class.asValueType(), Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class , type, type)).
                     invokeExact(recv, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, type, type, Class.class)).
                     invokeExact(recv, Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, type)).
                     invokeExact((VarHandleTestMethodTypePoint) null, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, Point.getInstance(1,1));
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypePoint.class, type)).
                     invokeExact(recv, Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypePoint.class, type)).
                     invokeExact(recv, Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), VarHandleTestMethodTypePoint.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, VarHandleTestMethodTypePoint.class, type)).
                     invokeExact(recv, Point.getInstance(1,1), Void.class);
             });
         }
@@ -1187,18 +1189,18 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, Point.class.asValueType(), Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Void.class);
             });
             // Incorrect arity
@@ -1207,7 +1209,7 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
@@ -1215,29 +1217,29 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Void.class);
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, Point.class.asValueType(), Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact(Point.getInstance(1,1), Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact(Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
@@ -1245,25 +1247,25 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // value reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact(Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact(Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact(Point.getInstance(1,1), Void.class);
             });
         }
@@ -1861,19 +1863,19 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class)).
                     invokeExact((Point[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, int.class)).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class, int.class)).
+                Point x = (Point) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -1887,11 +1889,11 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -1899,11 +1901,11 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, Point[].class, int.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, Point[].class, int.class, type)).
                     invokeExact((Point[]) null, 0, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
@@ -1911,11 +1913,11 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, Point.getInstance(1,1));
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, Point[].class, Class.class, Point.class.asValueType())).
+                hs.get(am, methodType(void.class, Point[].class, Class.class, type)).
                     invokeExact(array, Void.class, Point.getInstance(1,1));
             });
             // Incorrect arity
@@ -1931,27 +1933,27 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, type, type)).
                     invokeExact((Point[]) null, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Class.class, Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, Point.getInstance(1,1), Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, Class.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect arity
@@ -1960,7 +1962,7 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
@@ -1968,45 +1970,45 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, type, type)).
                     invokeExact((Point[]) null, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Class.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, Point.getInstance(1,1), Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             checkWMTE(() -> { // index reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, Class.class, Point.class.asValueType(), Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, Point[].class, int.class, type, type)).
                     invokeExact(array, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, type, type)).
                     invokeExact(array, 0, Point.getInstance(1,1), Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Point.class.asValueType(), Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, Point.getInstance(1,1), Point.getInstance(1,1), Void.class);
             });
         }
@@ -2014,41 +2016,41 @@ public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, type)).
                     invokeExact((Point[]) null, 0, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Class.class, int.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, Point.getInstance(1,1));
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), int.class, int.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, Point.getInstance(1,1));
             });
             checkWMTE(() -> { // index reference class
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, Class.class, Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, Class.class, type)).
                     invokeExact(array, Void.class, Point.getInstance(1,1));
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, Point[].class, int.class, Point.class.asValueType())).
+                Void r = (Void) hs.get(am, methodType(Void.class, Point[].class, int.class, type)).
                     invokeExact(array, 0, Point.getInstance(1,1));
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, Point.class.asValueType())).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, Point[].class, int.class, type)).
                     invokeExact(array, 0, Point.getInstance(1,1));
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType())).
+                Point x = (Point) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                Point x = (Point) hs.get(am, methodType(Point.class.asValueType(), Point[].class, int.class, Point.class.asValueType(), Class.class)).
+                Point x = (Point) hs.get(am, methodType(type, Point[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, Point.getInstance(1,1), Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypePoint
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypePoint
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypePoint
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypePoint
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypePoint
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
@@ -27,7 +27,9 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeShort
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeShort.java
@@ -27,9 +27,7 @@
  * @test
  * @bug 8156486
  * @run testng/othervm VarHandleTestMethodTypeShort
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeShort
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeShort
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodTypeShort
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,6 +45,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
+    static final Class<?> type = short.class;
+
     static final short static_final_v = (short)0x0123;
 
     static short static_v = (short)0x0123;
@@ -68,16 +68,16 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeShort.class, "final_v", short.class);
+                VarHandleTestMethodTypeShort.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeShort.class, "v", short.class);
+                VarHandleTestMethodTypeShort.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeShort.class, "static_final_v", short.class);
+            VarHandleTestMethodTypeShort.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeShort.class, "static_v", short.class);
+            VarHandleTestMethodTypeShort.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(short[].class);
     }
@@ -1005,15 +1005,15 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class)).
                     invokeExact((VarHandleTestMethodTypeShort) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class)).
+                short x = (short) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1027,11 +1027,11 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1039,11 +1039,11 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeShort.class, short.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, short.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
@@ -1051,7 +1051,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, short.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, (short)0x0123);
             });
             // Incorrect arity
@@ -1060,7 +1060,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeShort.class, short.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeShort.class, type, Class.class)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
         }
@@ -1068,23 +1068,23 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, Class.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, Class.class, type)).
                     invokeExact(recv, Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type, Class.class)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, (short)0x0123, (short)0x0123);
             });
             // Incorrect arity
@@ -1093,159 +1093,159 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type, type, Class.class)).
                     invokeExact(recv, (short)0x0123, (short)0x0123, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // expected reference class
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, Class.class, type)).
                     invokeExact(recv, Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type, Class.class)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class , short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, (short)0x0123, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class , short.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class , type, type)).
                     invokeExact(recv, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class , short.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class , type, type)).
                     invokeExact(recv, (short)0x0123, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type, type, Class.class)).
                     invokeExact(recv, (short)0x0123, (short)0x0123, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact((VarHandleTestMethodTypeShort) null, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, VarHandleTestMethodTypeShort.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, VarHandleTestMethodTypeShort.class, type)).
                     invokeExact(recv, (short)0x0123, Void.class);
             });
         }
@@ -1863,18 +1863,18 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, short.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
             // Incorrect arity
@@ -1883,7 +1883,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact((short)0x0123, (short)0x0123, Void.class);
             });
         }
@@ -1891,29 +1891,29 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkWMTE(() -> { // expected reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                short x = (short) hs.get(am, methodType(short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact((short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact((short)0x0123, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact((short)0x0123, (short)0x0123, Void.class);
             });
         }
@@ -1921,25 +1921,25 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
         }
@@ -1947,25 +1947,25 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
         }
@@ -1973,25 +1973,25 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact((short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact((short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact((short)0x0123, Void.class);
             });
         }
@@ -2979,19 +2979,19 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class)).
                     invokeExact((short[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, int.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, int.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3005,11 +3005,11 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3017,11 +3017,11 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, short[].class, int.class, short.class)).
+                hs.get(am, methodType(void.class, short[].class, int.class, type)).
                     invokeExact((short[]) null, 0, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, short.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
@@ -3029,11 +3029,11 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, short.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, short[].class, Class.class, short.class)).
+                hs.get(am, methodType(void.class, short[].class, Class.class, type)).
                     invokeExact(array, Void.class, (short)0x0123);
             });
             // Incorrect arity
@@ -3049,27 +3049,27 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type, type)).
                     invokeExact((short[]) null, 0, (short)0x0123, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, Class.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, Class.class, short.class, short.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, (short)0x0123, (short)0x0123);
             });
             // Incorrect arity
@@ -3078,7 +3078,7 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class, short.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, (short)0x0123, Void.class);
             });
         }
@@ -3086,45 +3086,45 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, type)).
                     invokeExact((short[]) null, 0, (short)0x0123, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, int.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // expected reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, (short)0x0123);
             });
             checkWMTE(() -> { // actual reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, int.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, Class.class, short.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, (short)0x0123, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, short.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, type, type)).
                     invokeExact(array, 0, (short)0x0123, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type, type)).
                     invokeExact(array, 0, (short)0x0123, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, (short)0x0123, Void.class);
             });
         }
@@ -3132,41 +3132,41 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type)).
                     invokeExact((short[]) null, 0, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, Class.class, type)).
                     invokeExact(array, Void.class, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, Void.class);
             });
         }
@@ -3174,41 +3174,41 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type)).
                     invokeExact((short[]) null, 0, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, Class.class, type)).
                     invokeExact(array, Void.class, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, Void.class);
             });
         }
@@ -3216,41 +3216,41 @@ public class VarHandleTestMethodTypeShort extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type)).
                     invokeExact((short[]) null, 0, (short)0x0123);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                short x = (short) hs.get(am, methodType(short.class, Class.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, (short)0x0123);
             });
             checkWMTE(() -> { // value reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                short x = (short) hs.get(am, methodType(short.class, int.class, int.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, (short)0x0123);
             });
             checkWMTE(() -> { // index reference class
-                short x = (short) hs.get(am, methodType(short.class, short[].class, Class.class, short.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, Class.class, type)).
                     invokeExact(array, Void.class, (short)0x0123);
             });
             // Incorrect return type
             checkWMTE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, short.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, short.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, short[].class, int.class, type)).
                     invokeExact(array, 0, (short)0x0123);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                short x = (short) hs.get(am, methodType(short.class)).
+                short x = (short) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                short x = (short) hs.get(am, methodType(short.class, short[].class, int.class, short.class, Class.class)).
+                short x = (short) hs.get(am, methodType(type, short[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, (short)0x0123, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
@@ -47,6 +47,8 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
+    static final Class<?> type = String.class;
+
     static final String static_final_v = "foo";
 
     static String static_v = "foo";
@@ -68,16 +70,16 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeString.class, "final_v", String.class);
+                VarHandleTestMethodTypeString.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodTypeString.class, "v", String.class);
+                VarHandleTestMethodTypeString.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeString.class, "static_final_v", String.class);
+            VarHandleTestMethodTypeString.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodTypeString.class, "static_v", String.class);
+            VarHandleTestMethodTypeString.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(String[].class);
     }
@@ -651,15 +653,15 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class)).
                     invokeExact((VarHandleTestMethodTypeString) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class)).
+                String x = (String) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -673,11 +675,11 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -685,11 +687,11 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeString.class, String.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeString.class, type)).
                     invokeExact((VarHandleTestMethodTypeString) null, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, String.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
@@ -697,7 +699,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, String.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, "foo");
             });
             // Incorrect arity
@@ -706,7 +708,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodTypeString.class, String.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeString.class, type, Class.class)).
                     invokeExact(recv, "foo", Void.class);
             });
         }
@@ -714,23 +716,23 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeString) null, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, Class.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, Class.class, type)).
                     invokeExact(recv, Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, type, Class.class)).
                     invokeExact(recv, "foo", Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, "foo", "foo");
             });
             // Incorrect arity
@@ -739,85 +741,85 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, String.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, type, type, Class.class)).
                     invokeExact(recv, "foo", "foo", Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, type, type)).
                     invokeExact((VarHandleTestMethodTypeString) null, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, Class.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, Class.class, type)).
                     invokeExact(recv, Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, type, Class.class)).
                     invokeExact(recv, "foo", Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class , String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, "foo", "foo");
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeString.class , String.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeString.class , type, type)).
                     invokeExact(recv, "foo", "foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class , String.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class , type, type)).
                     invokeExact(recv, "foo", "foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, type, type, Class.class)).
                     invokeExact(recv, "foo", "foo", Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, type)).
                     invokeExact((VarHandleTestMethodTypeString) null, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, "foo");
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeString.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeString.class, type)).
                     invokeExact(recv, "foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeString.class, type)).
                     invokeExact(recv, "foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, VarHandleTestMethodTypeString.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, VarHandleTestMethodTypeString.class, type)).
                     invokeExact(recv, "foo", Void.class);
             });
         }
@@ -1189,18 +1191,18 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, String.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact("foo", Void.class);
             });
         }
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact("foo", Void.class);
             });
             // Incorrect arity
@@ -1209,7 +1211,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact("foo", "foo", Void.class);
             });
         }
@@ -1217,29 +1219,29 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                String x = (String) hs.get(am, methodType(String.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact("foo", Void.class);
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, String.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact("foo", "foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, String.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
                     invokeExact("foo", "foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, String.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact("foo", "foo", Void.class);
             });
         }
@@ -1247,25 +1249,25 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             hs.checkWMTEOrCCE(() -> { // value reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact("foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
                     invokeExact("foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact("foo", Void.class);
             });
         }
@@ -1863,19 +1865,19 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class)).
                     invokeExact((String[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, int.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class, int.class)).
+                String x = (String) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -1889,11 +1891,11 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -1901,11 +1903,11 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, String[].class, int.class, String.class)).
+                hs.get(am, methodType(void.class, String[].class, int.class, type)).
                     invokeExact((String[]) null, 0, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, String.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
@@ -1913,11 +1915,11 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, String.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, "foo");
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, String[].class, Class.class, String.class)).
+                hs.get(am, methodType(void.class, String[].class, Class.class, type)).
                     invokeExact(array, Void.class, "foo");
             });
             // Incorrect arity
@@ -1933,27 +1935,27 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, type, type)).
                     invokeExact((String[]) null, 0, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, Class.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, "foo", Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, "foo", "foo");
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, Class.class, String.class, String.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, "foo", "foo");
             });
             // Incorrect arity
@@ -1962,7 +1964,7 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, String.class, String.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, "foo", "foo", Void.class);
             });
         }
@@ -1970,45 +1972,45 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, type, type)).
                     invokeExact((String[]) null, 0, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, int.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, "foo", "foo");
             });
             hs.checkWMTEOrCCE(() -> { // expected reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, Class.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // actual reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, "foo", Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class, int.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, "foo", "foo");
             });
             checkWMTE(() -> { // index reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, Class.class, String.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, "foo", "foo");
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, String[].class, int.class, String.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, String[].class, int.class, type, type)).
                     invokeExact(array, 0, "foo", "foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, String.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, type, type)).
                     invokeExact(array, 0, "foo", "foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, String.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, "foo", "foo", Void.class);
             });
         }
@@ -2016,41 +2018,41 @@ public class VarHandleTestMethodTypeString extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, type)).
                     invokeExact((String[]) null, 0, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                String x = (String) hs.get(am, methodType(String.class, Class.class, int.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, "foo");
             });
             hs.checkWMTEOrCCE(() -> { // value reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                String x = (String) hs.get(am, methodType(String.class, int.class, int.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, "foo");
             });
             checkWMTE(() -> { // index reference class
-                String x = (String) hs.get(am, methodType(String.class, String[].class, Class.class, String.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, Class.class, type)).
                     invokeExact(array, Void.class, "foo");
             });
             // Incorrect return type
             hs.checkWMTEOrCCE(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, String[].class, int.class, String.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, String[].class, int.class, type)).
                     invokeExact(array, 0, "foo");
             });
             checkWMTE(() -> { // primitive class
-                boolean x = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, String.class)).
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, String[].class, int.class, type)).
                     invokeExact(array, 0, "foo");
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                String x = (String) hs.get(am, methodType(String.class)).
+                String x = (String) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                String x = (String) hs.get(am, methodType(String.class, String[].class, int.class, String.class, Class.class)).
+                String x = (String) hs.get(am, methodType(type, String[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, "foo", Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -23,7 +23,6 @@
 
 #warn
 
-#if[Value]
 /*
  * @test
  * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccess$Type$
@@ -31,15 +30,6 @@
  * @run testng/othervm -Diters=20000                         VarHandleTestAccess$Type$
  * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccess$Type$
  */
-#else[Value]
-/*
- * @test
- * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccess$Type$
- * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccess$Type$
- * @run testng/othervm -Diters=20000                         VarHandleTestAccess$Type$
- * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccess$Type$
- */
-#end[Value]
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -54,6 +54,12 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
+#if[Point]
+    static final Class<?> type = $type$.class.asValueType();
+#else[Point]
+    static final Class<?> type = $type$.class;
+#end[Point]
+
     static final $type$ static_final_v = $value1$;
 
     static $type$ static_v;
@@ -80,9 +86,9 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-#if[Object]]
+#if[Object]
     VarHandle vhArrayObject;
-#end[Object]]
+#end[Object]
 #if[Value]
     VarHandle vhValueTypeField;
 #end[Value]
@@ -94,19 +100,19 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         VarHandle vh;
         try {
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccess$Type$.class, "final_v" + postfix, $type$.class);
+                    VarHandleTestAccess$Type$.class, "final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findVarHandle(
-                    VarHandleTestAccess$Type$.class, "v" + postfix, $type$.class);
+                    VarHandleTestAccess$Type$.class, "v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccess$Type$.class, "static_final_v" + postfix, $type$.class);
+                VarHandleTestAccess$Type$.class, "static_final_v" + postfix, type);
             vhs.add(vh);
 
             vh = MethodHandles.lookup().findStaticVarHandle(
-                VarHandleTestAccess$Type$.class, "static_v" + postfix, $type$.class);
+                VarHandleTestAccess$Type$.class, "static_v" + postfix, type);
             vhs.add(vh);
 
             if (same) {
@@ -129,25 +135,25 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccess$Type$.class, "final_v", $type$.class);
+                VarHandleTestAccess$Type$.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccess$Type$.class, "v", $type$.class);
+                VarHandleTestAccess$Type$.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccess$Type$.class, "static_final_v", $type$.class);
+            VarHandleTestAccess$Type$.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestAccess$Type$.class, "static_v", $type$.class);
+            VarHandleTestAccess$Type$.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle($type$[].class);
-#if[Object]]
+#if[Object]
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
-#end[Object]]
+#end[Object]
 
 #if[Value]
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "$varType$_v", $type$.class);
+                    Value.class, "$varType$_v", type);
 #end[Value]
     }
 
@@ -265,7 +271,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 
     @Test(dataProvider = "typesProvider")
     public void testTypes(VarHandle vh, List<Class<?>> pts) {
-        assertEquals(vh.varType(), $type$.class);
+        assertEquals(vh.varType(), type);
 
         assertEquals(vh.coordinateTypes(), pts);
 
@@ -277,12 +283,12 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
     public void testLookupInstanceToStatic() {
         checkIAE("Lookup of static final field to instance final field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccess$Type$.class, "final_v", $type$.class);
+                    VarHandleTestAccess$Type$.class, "final_v", type);
         });
 
         checkIAE("Lookup of static field to instance field", () -> {
             MethodHandles.lookup().findStaticVarHandle(
-                    VarHandleTestAccess$Type$.class, "v", $type$.class);
+                    VarHandleTestAccess$Type$.class, "v", type);
         });
     }
 
@@ -290,12 +296,12 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
     public void testLookupStaticToInstance() {
         checkIAE("Lookup of instance final field to static final field", () -> {
             MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccess$Type$.class, "static_final_v", $type$.class);
+                VarHandleTestAccess$Type$.class, "static_final_v", type);
         });
 
         checkIAE("Lookup of instance field to static field", () -> {
             vhStaticField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestAccess$Type$.class, "static_v", $type$.class);
+                VarHandleTestAccess$Type$.class, "static_v", type);
         });
     }
 
@@ -330,21 +336,21 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 
         cases.add(new VarHandleAccessTestCase("Array",
                                               vhArray, VarHandleTestAccess$Type$::testArray));
-#if[Object]]
+#if[Object]
         cases.add(new VarHandleAccessTestCase("Array Object[]",
                                               vhArrayObject, VarHandleTestAccess$Type$::testArray));
-#end[Object]]
+#end[Object]
         cases.add(new VarHandleAccessTestCase("Array unsupported",
                                               vhArray, VarHandleTestAccess$Type$::testArrayUnsupported,
                                               false));
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccess$Type$::testArrayIndexOutOfBounds,
                                               false));
-#if[Object]]
+#if[Object]
         cases.add(new VarHandleAccessTestCase("Array store exception",
                                               vhArrayObject, VarHandleTestAccess$Type$::testArrayStoreException,
                                               false));
-#end[Object]]
+#end[Object]
 #if[Value]
         cases.add(new VarHandleAccessTestCase("Value type field",
                                               vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
@@ -1948,7 +1954,7 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         }
     }
 
-#if[Object]]
+#if[Object]
     static void testArrayStoreException(VarHandle vh) throws Throwable {
         Object[] array = new $type$[10];
         Arrays.fill(array, $value1$);
@@ -2029,6 +2035,6 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
             $type$ x = ($type$) vh.getAndSetRelease(array, 0, value);
         });
     }
-#end[Object]]
+#end[Object]
 }
 

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -45,6 +45,12 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
+#if[Point]
+    static final Class<?> type = $type$.class.asValueType();
+#else[Point]
+    static final Class<?> type = $type$.class;
+#end[Point]
+
     static final $type$ static_final_v = $value1$;
 
     static $type$ static_v;
@@ -70,22 +76,22 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccess$Type$.class, "final_v", $type$.class);
+                VarHandleTestMethodHandleAccess$Type$.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodHandleAccess$Type$.class, "v", $type$.class);
+                VarHandleTestMethodHandleAccess$Type$.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccess$Type$.class, "static_final_v", $type$.class);
+            VarHandleTestMethodHandleAccess$Type$.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodHandleAccess$Type$.class, "static_v", $type$.class);
+            VarHandleTestMethodHandleAccess$Type$.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle($type$[].class);
 
 #if[Value]
         vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "$varType$_v", $type$.class);
+                    Value.class, "$varType$_v", type);
 #end[Value]
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -25,11 +25,7 @@
 
 /*
  * @test
-#if[Value]
- * @run testng/othervm -Diters=2000 VarHandleTestMethodHandleAccess$Type$
-#else[Value]
  * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccess$Type$
-#end[Value]
  */
 
 import org.testng.annotations.BeforeClass;

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -56,6 +56,12 @@ import static org.testng.Assert.*;
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
+#if[Point]
+    static final Class<?> type = $type$.class.asValueType();
+#else[Point]
+    static final Class<?> type = $type$.class;
+#end[Point]
+
     static final $type$ static_final_v = $value1$;
 
     static $type$ static_v = $value1$;
@@ -77,16 +83,16 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
     @BeforeClass
     public void setup() throws Exception {
         vhFinalField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodType$Type$.class, "final_v", $type$.class);
+                VarHandleTestMethodType$Type$.class, "final_v", type);
 
         vhField = MethodHandles.lookup().findVarHandle(
-                VarHandleTestMethodType$Type$.class, "v", $type$.class);
+                VarHandleTestMethodType$Type$.class, "v", type);
 
         vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodType$Type$.class, "static_final_v", $type$.class);
+            VarHandleTestMethodType$Type$.class, "static_final_v", type);
 
         vhStaticField = MethodHandles.lookup().findStaticVarHandle(
-            VarHandleTestMethodType$Type$.class, "static_v", $type$.class);
+            VarHandleTestMethodType$Type$.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle($type$[].class);
     }
@@ -1020,15 +1026,15 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class)).
                     invokeExact((VarHandleTestMethodType$Type$) null);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class)).
                     invokeExact(0);
             });
             // Incorrect return type
@@ -1042,11 +1048,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
         }
@@ -1054,11 +1060,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                hs.get(am, methodType(void.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                hs.get(am, methodType(void.class, Class.class, $type$.class)).
+                hs.get(am, methodType(void.class, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
@@ -1066,7 +1072,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, $type$.class)).
+                hs.get(am, methodType(void.class, int.class, type)).
                     invokeExact(0, $value1$);
             });
             // Incorrect arity
@@ -1075,7 +1081,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, VarHandleTestMethodType$Type$.class, $type$.class, Class.class)).
+                hs.get(am, methodType(void.class, VarHandleTestMethodType$Type$.class, type, Class.class)).
                     invokeExact(recv, $value1$, Void.class);
             });
         }
@@ -1084,23 +1090,23 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, type, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
                     invokeExact(Void.class, $value1$, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, Class.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, Class.class, type)).
                     invokeExact(recv, Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, type, Class.class)).
                     invokeExact(recv, $value1$, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
                     invokeExact(0, $value1$, $value1$);
             });
             // Incorrect arity
@@ -1109,85 +1115,85 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, $type$.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodType$Type$.class, type, type, Class.class)).
                     invokeExact(recv, $value1$, $value1$, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, type, type)).
                     invokeExact(Void.class, $value1$, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, Class.class, type)).
                     invokeExact(recv, Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type, Class.class)).
                     invokeExact(recv, $value1$, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class , $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class , type, type)).
                     invokeExact(0, $value1$, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class , $type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class , type, type)).
                     invokeExact(recv, $value1$, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class , $type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class , type, type)).
                     invokeExact(recv, $value1$, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type, type, Class.class)).
                     invokeExact(recv, $value1$, $value1$, Void.class);
             });
         }
 
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$, Void.class);
             });
         }
@@ -1196,37 +1202,37 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
 #if[AtomicAdd]
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$, Void.class);
             });
         }
@@ -1235,37 +1241,37 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
 #if[Bitwise]
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact((VarHandleTestMethodType$Type$) null, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, Class.class)).
                     invokeExact(recv, Void.class);
             });
             checkWMTE(() -> { // reciever primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, type)).
                     invokeExact(0, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, VarHandleTestMethodType$Type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, VarHandleTestMethodType$Type$.class, type)).
                     invokeExact(recv, $value1$, Void.class);
             });
         }
@@ -1890,7 +1896,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                hs.get(am, methodType(void.class, $type$.class, Class.class)).
+                hs.get(am, methodType(void.class, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
         }
@@ -1898,11 +1904,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
             // Incorrect arity
@@ -1911,7 +1917,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
                     invokeExact($value1$, $value1$, Void.class);
             });
         }
@@ -1919,29 +1925,29 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, type)).
                     invokeExact(Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
                     invokeExact($value1$, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, type, type)).
                     invokeExact($value1$, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, type, type, Class.class)).
                     invokeExact($value1$, $value1$, Void.class);
             });
         }
@@ -1949,25 +1955,25 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact($value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, type)).
                     invokeExact($value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
         }
@@ -1977,25 +1983,25 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             check{#if[Object]?CCE:WMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             check{#if[Object]?CCE:WMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact($value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, type)).
                     invokeExact($value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
         }
@@ -2005,25 +2011,25 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             check{#if[Object]?CCE:WMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class)).
                     invokeExact(Void.class);
             });
             // Incorrect return type
             check{#if[Object]?CCE:WMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
                     invokeExact($value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, type)).
                     invokeExact($value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, type, Class.class)).
                     invokeExact($value1$, Void.class);
             });
         }
@@ -3018,19 +3024,19 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class)).
                     invokeExact(($type$[]) null, 0);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, int.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, int.class)).
                     invokeExact(Void.class, 0);
             });
             checkWMTE(() -> { // array primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, int.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, int.class)).
                     invokeExact(0, 0);
             });
             checkWMTE(() -> { // index reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, Class.class)).
                     invokeExact(array, Void.class);
             });
             // Incorrect return type
@@ -3044,11 +3050,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
         }
@@ -3056,11 +3062,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                hs.get(am, methodType(void.class, $type$[].class, int.class, $type$.class)).
+                hs.get(am, methodType(void.class, $type$[].class, int.class, type)).
                     invokeExact(($type$[]) null, 0, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                hs.get(am, methodType(void.class, Class.class, int.class, $type$.class)).
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
@@ -3068,11 +3074,11 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                hs.get(am, methodType(void.class, int.class, int.class, $type$.class)).
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
                     invokeExact(0, 0, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                hs.get(am, methodType(void.class, $type$[].class, Class.class, $type$.class)).
+                hs.get(am, methodType(void.class, $type$[].class, Class.class, type)).
                     invokeExact(array, Void.class, $value1$);
             });
             // Incorrect arity
@@ -3089,27 +3095,27 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, type, type)).
                     invokeExact(($type$[]) null, 0, $value1$, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // receiver reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, $value1$, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, Class.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, $value1$, Void.class);
             });
             checkWMTE(() -> { // receiver primitive class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
                     invokeExact(0, 0, $value1$, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, Class.class, $type$.class, $type$.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, $value1$, $value1$);
             });
             // Incorrect arity
@@ -3118,7 +3124,7 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, $type$.class, $type$.class, Class.class)).
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, $type$[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, $value1$, $value1$, Void.class);
             });
         }
@@ -3126,45 +3132,45 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
             // Incorrect argument types
             checkNPE(() -> { // null receiver
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, type)).
                     invokeExact(($type$[]) null, 0, $value1$, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, int.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, int.class, type, type)).
                     invokeExact(Void.class, 0, $value1$, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // expected reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, Class.class, type)).
                     invokeExact(array, 0, Void.class, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // actual reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, $value1$, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, int.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, int.class, type, type)).
                     invokeExact(0, 0, $value1$, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, Class.class, $type$.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, Class.class, type, type)).
                     invokeExact(array, Void.class, $value1$, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, $type$.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, type, type)).
                     invokeExact(array, 0, $value1$, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, $type$.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, type, type)).
                     invokeExact(array, 0, $value1$, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, type, Class.class)).
                     invokeExact(array, 0, $value1$, $value1$, Void.class);
             });
         }
@@ -3172,41 +3178,41 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type)).
                     invokeExact(($type$[]) null, 0, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, Class.class, type)).
                     invokeExact(array, Void.class, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, $value1$, Void.class);
             });
         }
@@ -3216,41 +3222,41 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type)).
                     invokeExact(($type$[]) null, 0, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, Class.class, type)).
                     invokeExact(array, Void.class, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, $value1$, Void.class);
             });
         }
@@ -3260,41 +3266,41 @@ public class VarHandleTestMethodType$Type$ extends VarHandleBaseTest {
         for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
             // Incorrect argument types
             checkNPE(() -> { // null array
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type)).
                     invokeExact(($type$[]) null, 0, $value1$);
             });
             hs.checkWMTEOrCCE(() -> { // array reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, Class.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, Class.class, int.class, type)).
                     invokeExact(Void.class, 0, $value1$);
             });
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // value reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, Class.class)).
                     invokeExact(array, 0, Void.class);
             });
             checkWMTE(() -> { // array primitive class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, int.class, int.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, int.class, int.class, type)).
                     invokeExact(0, 0, $value1$);
             });
             checkWMTE(() -> { // index reference class
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, Class.class, $type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, Class.class, type)).
                     invokeExact(array, Void.class, $value1$);
             });
             // Incorrect return type
             {#if[Object]?hs.checkWMTEOrCCE:checkWMTE}(() -> { // reference class
-                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, $type$.class)).
+                Void r = (Void) hs.get(am, methodType(Void.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             checkWMTE(() -> { // primitive class
-                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, $type$.class)).
+                $wrong_primitive_type$ x = ($wrong_primitive_type$) hs.get(am, methodType($wrong_primitive_type$.class, $type$[].class, int.class, type)).
                     invokeExact(array, 0, $value1$);
             });
             // Incorrect arity
             checkWMTE(() -> { // 0
-                $type$ x = ($type$) hs.get(am, methodType($type$.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type)).
                     invokeExact();
             });
             checkWMTE(() -> { // >
-                $type$ x = ($type$) hs.get(am, methodType($type$.class, $type$[].class, int.class, $type$.class, Class.class)).
+                $type$ x = ($type$) hs.get(am, methodType(type, $type$[].class, int.class, type, Class.class)).
                     invokeExact(array, 0, $value1$, Void.class);
             });
         }

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -23,14 +23,6 @@
 
 #warn
 
-#if[Value]
-/*
- * @test
- * @bug 8156486
- * @run testng/othervm VarHandleTestMethodType$Type$
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false VarHandleTestMethodType$Type$
- */
-#else[Value]
 /*
  * @test
  * @bug 8156486
@@ -39,7 +31,6 @@
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodType$Type$
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
  */
-#end[Value]
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;


### PR DESCRIPTION
test/jdk/java/lang/invoke/VarHandles are generated from the template files.   Redo the fix for JDK-8269956 and update the template files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271405](https://bugs.openjdk.java.net/browse/JDK-8271405): [lworld] Redo test/jdk/java/lang/invoke/VarHandles changes  for JDK-8269956


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/516/head:pull/516` \
`$ git checkout pull/516`

Update a local copy of the PR: \
`$ git checkout pull/516` \
`$ git pull https://git.openjdk.java.net/valhalla pull/516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 516`

View PR using the GUI difftool: \
`$ git pr show -t 516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/516.diff">https://git.openjdk.java.net/valhalla/pull/516.diff</a>

</details>
