### PR TITLE
8271234: [lworld] InlineTypeBaseNode::merge_with fails with assert(i < _cnt)

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1936,8 +1936,9 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     }
     if (i == req()) {
       InlineTypeBaseNode* vt = in(1)->as_InlineTypeBase()->clone_with_phis(phase, in(0));
-      for (uint i = 2; i < req(); ++i) {
-        vt->merge_with(phase, in(i)->as_InlineTypeBase(), i, i == (req()-1));
+      for (i = 2; i < req(); ++i) {
+        bool transform = !can_reshape && (i == (req()-1)); // Transform phis on last merge
+        vt->merge_with(phase, in(i)->as_InlineTypeBase(), i, transform);
       }
       return vt;
     }

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -42,6 +42,7 @@ InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* reg
   const Type* phi_type = Type::get_const_type(inline_klass());
   PhiNode* oop = PhiNode::make(region, vt->get_oop(), phi_type);
   gvn->set_type(oop, phi_type);
+  gvn->record_for_igvn(oop);
   vt->set_oop(oop);
 
   // Create a PhiNode each for merging the field values
@@ -55,10 +56,12 @@ InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* reg
       phi_type = Type::get_const_type(type);
       value = PhiNode::make(region, value, phi_type);
       gvn->set_type(value, phi_type);
+      gvn->record_for_igvn(value);
     }
     vt->set_field_value(i, value);
   }
   gvn->set_type(vt, vt->bottom_type());
+  gvn->record_for_igvn(vt);
   return vt;
 }
 
@@ -90,7 +93,6 @@ InlineTypeBaseNode* InlineTypeBaseNode::merge_with(PhaseGVN* gvn, const InlineTy
   phi->set_req(pnum, other->get_oop());
   if (transform) {
     set_oop(gvn->transform(phi));
-    gvn->record_for_igvn(phi);
   }
   // Merge field values
   for (uint i = 0; i < field_count(); ++i) {
@@ -104,7 +106,6 @@ InlineTypeBaseNode* InlineTypeBaseNode::merge_with(PhaseGVN* gvn, const InlineTy
     }
     if (transform) {
       set_field_value(i, gvn->transform(val1));
-      gvn->record_for_igvn(val1);
     }
   }
   return this;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3941,4 +3941,23 @@ public class TestLWorld {
             // Expected
         }
     }
+
+    // Test merging of buffer default and non-default inline types
+    @Test
+    public Object test144(int i) {
+        if (i == 0) {
+            return MyValue1.default;
+        } else if (i == 1) {
+            return testValue1;
+        } else {
+            return MyValue1.default;
+        }
+    }
+
+    @Run(test = "test144")
+    public void test144_verifier() {
+        Asserts.assertEquals(test144(0), MyValue1.default);
+        Asserts.assertEquals(test144(1), testValue1);
+        Asserts.assertEquals(test144(2), MyValue1.default);
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3942,7 +3942,7 @@ public class TestLWorld {
         }
     }
 
-    // Test merging of buffer default and non-default inline types
+    // Test merging of buffered default and non-default inline types
     @Test
     public Object test144(int i) {
         if (i == 0) {


### PR DESCRIPTION
Transformation of phis in `InlineTypeBaseNode::merge_with` during IGVN can lead to other, not yet processed, phi nodes to be transformed as well, before their inputs are adjusted. In the failing case, a phi input is removed. The fix is to delay transformation of the phis during IGVN by adding them to the worklist.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271234](https://bugs.openjdk.java.net/browse/JDK-8271234): [lworld] InlineTypeBaseNode::merge_with fails with assert(i < _cnt)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/517/head:pull/517` \
`$ git checkout pull/517`

Update a local copy of the PR: \
`$ git checkout pull/517` \
`$ git pull https://git.openjdk.java.net/valhalla pull/517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 517`

View PR using the GUI difftool: \
`$ git pr show -t 517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/517.diff">https://git.openjdk.java.net/valhalla/pull/517.diff</a>

</details>
