### PR TITLE
8272290: [lworld] Disable CDS if InlineTypePassFieldsAsArgs has changed

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -160,8 +160,14 @@ void CDSMustMatchFlags::init() {
 bool CDSMustMatchFlags::runtime_check() const {
 #define CHECK_CDS_MUST_MATCH_FLAG(n) \
   if (_v_##n != n) { \
-    print_info(); \
-    FileMapInfo::fail_continue("VM option %s is different between dumptime and runtime", #n); \
+    ResourceMark rm; \
+    stringStream ss; \
+    ss.print("VM option %s is different between dumptime (", #n);  \
+    do_print(&ss, _v_ ## n); \
+    ss.print(") and runtime ("); \
+    do_print(&ss, n); \
+    ss.print(")"); \
+    FileMapInfo::fail_continue("%s", ss.as_string()); \
     return false; \
   }
   CDS_MUST_MATCH_FLAGS_DO(CHECK_CDS_MUST_MATCH_FLAG);

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -130,6 +130,65 @@ void FileMapInfo::fail_continue(const char *msg, ...) {
   va_end(ap);
 }
 
+inline void CDSMustMatchFlags::do_print(outputStream* st, bool v) {
+  st->print("%s", v ? "true" : "false");
+}
+
+inline void CDSMustMatchFlags::do_print(outputStream* st, intx v) {
+  st->print(INTX_FORMAT, v);
+}
+
+inline void CDSMustMatchFlags::do_print(outputStream* st, uintx v) {
+  st->print(UINTX_FORMAT, v);
+}
+
+inline void CDSMustMatchFlags::do_print(outputStream* st, double v) {
+  st->print("%f", v);
+}
+
+void CDSMustMatchFlags::init() {
+  Arguments::assert_is_dumping_archive();  
+  _max_name_width = 0;
+
+#define INIT_CDS_MUST_MATCH_FLAG(n) \
+  _v_##n = n; \
+  _max_name_width = MAX2(_max_name_width,strlen(#n));
+  CDS_MUST_MATCH_FLAGS_DO(INIT_CDS_MUST_MATCH_FLAG);
+#undef INIT_CDS_MUST_MATCH_FLAG
+}
+
+bool CDSMustMatchFlags::runtime_check() const {
+#define CHECK_CDS_MUST_MATCH_FLAG(n) \
+  if (_v_##n != n) { \
+    print_info(); \
+    FileMapInfo::fail_continue("VM option %s is different between dumptime and runtime", #n); \
+    return false; \
+  }
+  CDS_MUST_MATCH_FLAGS_DO(CHECK_CDS_MUST_MATCH_FLAG);
+#undef CHECK_CDS_MUST_MATCH_FLAG
+
+  return true;
+}
+
+void CDSMustMatchFlags::print_info() const {
+  LogTarget(Info, cds) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print_cr("Recorded VM flags during dumptime:");
+    print(&ls);
+  }
+}
+
+void CDSMustMatchFlags::print(outputStream* st) const {
+#define PRINT_CDS_MUST_MATCH_FLAG(n) \
+  st->print("- %-s ", #n);                   \
+  st->sp(int(_max_name_width - strlen(#n))); \
+  do_print(st, _v_##n);                      \
+  st->cr();
+  CDS_MUST_MATCH_FLAGS_DO(PRINT_CDS_MUST_MATCH_FLAG);
+#undef PRINT_CDS_MUST_MATCH_FLAG
+}
+
 // Fill in the fileMapInfo structure with data about this VM instance.
 
 // This method copies the vm version info into header_version.  If the version is too
@@ -248,6 +307,7 @@ void FileMapHeader::populate(FileMapInfo* mapinfo, size_t core_region_alignment)
   // the following 2 fields will be set in write_header for dynamic archive header
   _base_archive_name_size = 0;
   _base_archive_is_default = false;
+  _must_match.init();
 
   if (!DynamicDumpSharedSpaces) {
     set_shared_path_table(mapinfo->_shared_path_table);
@@ -302,6 +362,7 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- use_optimized_module_handling:  %d", _use_optimized_module_handling);
   st->print_cr("- use_full_module_graph           %d", _use_full_module_graph);
   st->print_cr("- ptrmap_size_in_bits:            " SIZE_FORMAT, _ptrmap_size_in_bits);
+  _must_match.print(st);
 }
 
 void SharedClassPathEntry::init_as_non_existent(const char* path, TRAPS) {
@@ -1181,6 +1242,10 @@ bool FileMapInfo::init_from_file(int fd) {
       fail_continue("The shared archive file has been truncated.");
       return false;
     }
+  }
+
+  if (!header()->check_must_match_flags()) {
+    return false;
   }
 
   return true;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -147,7 +147,7 @@ inline void CDSMustMatchFlags::do_print(outputStream* st, double v) {
 }
 
 void CDSMustMatchFlags::init() {
-  Arguments::assert_is_dumping_archive();  
+  Arguments::assert_is_dumping_archive();
   _max_name_width = 0;
 
 #define INIT_CDS_MUST_MATCH_FLAG(n) \

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -29,6 +29,7 @@
 #include "include/cds.h"
 #include "oops/array.hpp"
 #include "oops/compressedOops.hpp"
+#include "runtime/globals.hpp"
 #include "utilities/align.hpp"
 
 // To understand the layout of the CDS archive file:
@@ -179,6 +180,33 @@ public:
   void print(outputStream* st, int region_index);
 };
 
+#define CDS_MUST_MATCH_FLAGS_DO(f) \
+  f(FlatArrayElementMaxOops) \
+  f(FlatArrayElementMaxSize) \
+  f(InlineFieldMaxFlatSize) \
+  f(InlineTypePassFieldsAsArgs) \
+  f(InlineTypeReturnedAsFields)
+
+class CDSMustMatchFlags {
+private:
+  size_t _max_name_width;
+#define DECLARE_CDS_MUST_MATCH_FLAG(n) \
+  decltype(n) _v_##n;
+  CDS_MUST_MATCH_FLAGS_DO(DECLARE_CDS_MUST_MATCH_FLAG);
+#undef DECLARE_CDS_MUST_MATCH_FLAG
+
+  inline static void do_print(outputStream* st, bool v);
+  inline static void do_print(outputStream* st, intx v);
+  inline static void do_print(outputStream* st, uintx v);
+  inline static void do_print(outputStream* st, double v);
+  void print_info() const;
+
+public:
+  void init();
+  bool runtime_check() const;
+  void print(outputStream* st) const;
+};
+
 class FileMapHeader: private CDSFileMapHeaderBase {
   friend class CDSOffsets;
   friend class VMStructs;
@@ -238,6 +266,7 @@ class FileMapHeader: private CDSFileMapHeaderBase {
   bool   _use_full_module_graph;        // Can we use the full archived module graph?
   size_t _ptrmap_size_in_bits;          // Size of pointer relocation bitmap
   narrowOop _heap_obj_roots;            // An objArray that stores all the roots of archived heap objects
+  CDSMustMatchFlags _must_match;        // These flags must be the same between dumptime and runtime
   char* from_mapped_offset(size_t offset) const {
     return mapped_base_address() + offset;
   }
@@ -321,6 +350,10 @@ public:
 
   static bool is_valid_region(int region) {
     return (0 <= region && region < NUM_CDS_REGIONS);
+  }
+
+  bool check_must_match_flags() const {
+    return _must_match.runtime_check();
   }
 
   void print(outputStream* st);

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -181,6 +181,7 @@ public:
 };
 
 #define CDS_MUST_MATCH_FLAGS_DO(f) \
+  f(EnableValhalla) \
   f(FlatArrayElementMaxOops) \
   f(FlatArrayElementMaxSize) \
   f(InlineFieldMaxFlatSize) \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4065,8 +4065,10 @@ jint Arguments::apply_ergo() {
     log_info(verification)("Turning on remote verification because local verification is on");
     FLAG_SET_DEFAULT(BytecodeVerificationRemote, true);
   }
-  if (!EnableValhalla || (is_interpreter_only() && !is_dumping_archive())) {
-    // Disable calling convention optimizations if inline types are not supported
+  if (!EnableValhalla || (is_interpreter_only() && !is_dumping_archive() && !UseSharedSpaces)) {
+    // Disable calling convention optimizations if inline types are not supported.
+    // Also these aren't useful in -Xint. However, don't disable them when dumping or using
+    // the CDS archive, as the values must match between dumptime and runtime.
     InlineTypePassFieldsAsArgs = false;
     InlineTypeReturnedAsFields = false;
   }


### PR DESCRIPTION
If any of the following VM options have different values between CDS dump time and runtime, we cannot load the CDS archive:

- `FlatArrayElementMaxOops`
- `FlatArrayElementMaxSize`
- `InlineFieldMaxFlatSize`
- `InlineTypePassFieldsAsArgs`
- `InlineTypeReturnedAsFields`

Testing with mach5 tiers 1-2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272290](https://bugs.openjdk.java.net/browse/JDK-8272290): [lworld] Disable CDS if InlineTypePassFieldsAsArgs has changed


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/526/head:pull/526` \
`$ git checkout pull/526`

Update a local copy of the PR: \
`$ git checkout pull/526` \
`$ git pull https://git.openjdk.java.net/valhalla pull/526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 526`

View PR using the GUI difftool: \
`$ git pr show -t 526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/526.diff">https://git.openjdk.java.net/valhalla/pull/526.diff</a>

</details>
