### PR TITLE
8272307: [lworld] [AArch64] TestCallingConventionC1 test63 and test64 get incorrect result

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -385,14 +385,6 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->nmethod_entry_barrier(this);
 
-  // The runtime call returns the new array in r0 which is also j_rarg7
-  // so we must avoid clobbering that. Temporarily save r0 in a
-  // non-argument register and pass the buffered array in r20 instead.
-  // This is safe because the runtime stub saves all registers.
-  Register val_array = r20;
-  Register tmp1 = r21;
-  mov(tmp1, j_rarg7);
-
   // FIXME -- call runtime only if we cannot in-line allocate all the incoming inline type args.
   mov(r19, (intptr_t) ces->method());
   if (is_inline_ro_entry) {
@@ -402,8 +394,9 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   }
   int rt_call_offset = offset();
 
-  mov(val_array, r0);
-  mov(j_rarg7, tmp1);
+  // The runtime call returns the new array in r20 instead of the usual r0
+  // because r0 is also j_rarg7 which may be holding a live argument here.
+  Register val_array = r20;
 
   // Remove the temp frame
   MacroAssembler::remove_frame(frame_size_in_bytes);


### PR DESCRIPTION
These two were hidden by the earlier IR test failures.  The errors look like:

```
  Caused by: java.lang.RuntimeException: assertEquals: expected -1163019586 to equal 777
  at jdk.test.lib.Asserts.fail(Asserts.java:594)
  at jdk.test.lib.Asserts.assertEquals(Asserts.java:205)
  at jdk.test.lib.Asserts.assertEquals(Asserts.java:189)
  at jdk.test.lib.Asserts.assertEQ(Asserts.java:166)
  at compiler.valhalla.inlinetypes.TestCallingConventionC1.test64_verifier(TestCallingConventionC1.java:1518)
  ... 9 more
```

In the C1 scalarised entry point we call a runtime stub to allocate objects for buffering the incoming inline types.  The runtime stub returns its result in r0 which is also j_rarg7 and might be holding a live argument value.  To work around this we temporarily move j_rarg7 into r21 which is known to be free at this point and then move it back after the call.  However if a GC occurs during the runtime call and an object held in j_rarg7 is moved, r21 will still be pointing at the old from-space copy after the call returns because it's not recorded in the oop map.  Fix that by having the stub return the object array in r20 and leave r0-r7 untouched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272307](https://bugs.openjdk.java.net/browse/JDK-8272307): [lworld] [AArch64] TestCallingConventionC1 test63 and test64 get incorrect result


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/527/head:pull/527` \
`$ git checkout pull/527`

Update a local copy of the PR: \
`$ git checkout pull/527` \
`$ git pull https://git.openjdk.java.net/valhalla pull/527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 527`

View PR using the GUI difftool: \
`$ git pr show -t 527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/527.diff">https://git.openjdk.java.net/valhalla/pull/527.diff</a>

</details>
