### PR TITLE
8272511: [lworld] Disable PhaseIdealLoop::try_sink_out_of_loop until optimization is stable in mainline

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1575,7 +1575,8 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
     }
   }
 
-  try_sink_out_of_loop(n);
+  // TODO Disabled until JDK-8272448 is fixed.
+  // try_sink_out_of_loop(n);
 
   try_move_store_after_loop(n);
 


### PR DESCRIPTION
There are known (mainline) issues with JDK-8252372 (see JDK-8271954) that seem to manifest in Valhalla. Disable the optimization until it's stable in mainline.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272511](https://bugs.openjdk.java.net/browse/JDK-8272511): [lworld] Disable PhaseIdealLoop::try_sink_out_of_loop until optimization is stable in mainline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/531/head:pull/531` \
`$ git checkout pull/531`

Update a local copy of the PR: \
`$ git checkout pull/531` \
`$ git pull https://git.openjdk.java.net/valhalla pull/531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 531`

View PR using the GUI difftool: \
`$ git pr show -t 531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/531.diff">https://git.openjdk.java.net/valhalla/pull/531.diff</a>

</details>
