### PR TITLE
8271583: [lworld] primitive records can't be reference favoring

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2526,7 +2526,8 @@ public class Lower extends TreeTranslator {
                             syms.typeDescriptorType).appendList(staticArgTypes),
                     staticArgsValues, bootstrapName, name, false);
 
-            VarSymbol _this = new VarSymbol(SYNTHETIC, names._this, tree.sym.type, tree.sym);
+            Type receiverType = tree.sym.type.isPrimitiveReferenceType() ? tree.sym.type.asValueType() : tree.sym.type;
+            VarSymbol _this = new VarSymbol(SYNTHETIC, names._this, receiverType, tree.sym);
 
             JCMethodInvocation proxyCall;
             if (!isEquals) {
@@ -2610,8 +2611,9 @@ public class Lower extends TreeTranslator {
                 bootstrapName, staticArgTypes, List.nil());
 
         MethodType indyType = msym.type.asMethodType();
+        Type receiverType = tree.sym.type.isPrimitiveReferenceType() ? tree.sym.type.asValueType() : tree.sym.type;
         indyType = new MethodType(
-                isStatic ? List.nil() : indyType.argtypes.prepend(tree.sym.type),
+                isStatic ? List.nil() : indyType.argtypes.prepend(receiverType),
                 indyType.restype,
                 indyType.thrown,
                 syms.methodClass

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4062,6 +4062,15 @@ public class JavacParser implements Parser {
         nextToken();
         mods.flags |= Flags.RECORD;
         Name name = typeName();
+        if ((mods.flags & Flags.PRIMITIVE_CLASS) != 0) {
+            if (token.kind == DOT) {
+                final Token pastDot = S.token(1);
+                if (pastDot.kind == IDENTIFIER && pastDot.name() == names.val) {
+                    nextToken(); nextToken(); // discard .val
+                    mods.flags |= Flags.REFERENCE_FAVORING;
+                }
+            }
+        }
 
         List<JCTypeParameter> typarams = typeParametersOpt();
 
@@ -4497,6 +4506,7 @@ public class JavacParser implements Parser {
         if (token.kind == IDENTIFIER && token.name() == names.record &&
             (peekToken(TokenKind.IDENTIFIER, TokenKind.LPAREN) ||
              peekToken(TokenKind.IDENTIFIER, TokenKind.EOF) ||
+             peekToken(TokenKind.IDENTIFIER, TokenKind.DOT) ||
              peekToken(TokenKind.IDENTIFIER, TokenKind.LT))) {
             checkSourceLevel(Feature.RECORDS);
             return true;

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8271583
  * @summary [lworld] primitive records can't be reference favoring
- * @compile -XDallowWithFieldOperator RefFlavoredRecord.java
  * @run main/othervm RefFlavoredRecord
  */
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
@@ -23,22 +23,21 @@
 
 /**
  * @test
- * @bug 8251041
- * @summary [lworld] Investigate interplay between Records and Inline types
+ * @bug 8271583
+ * @summary [lworld] primitive records can't be reference favoring
  * @compile -XDallowWithFieldOperator RefFlavoredRecord.java
  * @run main/othervm RefFlavoredRecord
  */
 
 public primitive record RefFlavoredRecord.val(int theInteger, String theString) {
-	public static void main(String[] args) {
-		RefFlavoredRecord rec = RefFlavoredRecord.default;
-		if (rec != null) {
+    public static void main(String[] args) {
+        RefFlavoredRecord rec = RefFlavoredRecord.default;
+        if (rec != null) {
             throw new AssertionError("Ref-favoring record .default should be null?");
         }
-		
+
         if (! new RefFlavoredRecord(42, "Fortytwo").equals(new RefFlavoredRecord(42, "Fortytwo"))) {
             throw new AssertionError("Records should be equal");
         }
-
-    }	
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/RefFlavoredRecord.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8251041
+ * @summary [lworld] Investigate interplay between Records and Inline types
+ * @compile -XDallowWithFieldOperator RefFlavoredRecord.java
+ * @run main/othervm RefFlavoredRecord
+ */
+
+public primitive record RefFlavoredRecord.val(int theInteger, String theString) {
+	public static void main(String[] args) {
+		RefFlavoredRecord rec = RefFlavoredRecord.default;
+		if (rec != null) {
+            throw new AssertionError("Ref-favoring record .default should be null?");
+        }
+		
+        if (! new RefFlavoredRecord(42, "Fortytwo").equals(new RefFlavoredRecord(42, "Fortytwo"))) {
+            throw new AssertionError("Records should be equal");
+        }
+
+    }	
+}


### PR DESCRIPTION
This patch lets the compiler pick up a record which can be primitive records and reference favoring, such as
```java
primitive record Point.val(int x, int y) {}
```

The lowering had to be adjusted so that the correct receiver type is generated.

See https://bugs.openjdk.java.net/browse/JDK-8271583

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8271583](https://bugs.openjdk.java.net/browse/JDK-8271583): [lworld] primitive records can't be reference favoring


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer) ⚠️ Review applies to d9f744b05fa34c13a0eb94f812b4224de059864a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/533/head:pull/533` \
`$ git checkout pull/533`

Update a local copy of the PR: \
`$ git checkout pull/533` \
`$ git pull https://git.openjdk.java.net/valhalla pull/533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 533`

View PR using the GUI difftool: \
`$ git pr show -t 533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/533.diff">https://git.openjdk.java.net/valhalla/pull/533.diff</a>

</details>
