### PR TITLE
8272753: [lworld] "Invalid frame size" assert in frame::repair_sender_sp

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -484,8 +484,7 @@ int LIR_Assembler::emit_unwind_handler() {
   }
 
   // remove the activation and dispatch to the unwind handler
-  int initial_framesize = initial_frame_size_in_bytes();
-  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
+  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
   __ jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
   // Emit the slow path assembly
@@ -547,8 +546,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   }
 
   // Pop the stack before the safepoint code
-  int initial_framesize = initial_frame_size_in_bytes();
-  __ remove_frame(initial_framesize, needs_stack_repair(), initial_framesize - wordSize);
+  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1772,7 +1772,7 @@ public:
                           VMRegPair* from, int from_count, int& from_index, VMReg to,
                           RegState reg_state[], Register val_array);
   int extend_stack_for_inline_args(int args_on_stack);
-  void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
+  void remove_frame(int initial_framesize, bool needs_stack_repair);
   VMReg spill_reg_for(VMReg reg);
 
   // clear memory of size 'cnt' qwords, starting at 'base';

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -975,7 +975,7 @@ void MachEpilogNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
 
   // Subtract two words to account for return address and rbp
   int initial_framesize = C->output()->frame_size_in_bytes() - 2*wordSize;
-  __ remove_frame(initial_framesize, C->needs_stack_repair(), C->output()->sp_inc_offset());
+  __ remove_frame(initial_framesize, C->needs_stack_repair());
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1130,4 +1130,63 @@ public class TestCallingConvention {
         test50(true);
         test50(false);
     }
+
+    // Test stack repair with stack slots reserved for monitors
+    private static final Object lock1 = new Object();
+    private static final Object lock2 = new Object();
+    private static final Object lock3 = new Object();
+
+    @DontInline
+    static void test51_callee() { }
+
+    @Test
+    public void test51(MyValue1 val) {
+        synchronized (lock1) {
+            test51_callee();
+        }
+    }
+
+    @Run(test = "test51")
+    public void test51_verifier() {
+        MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
+        test51(vt);
+    }
+
+    @DontInline
+    static void test52_callee() { }
+
+    @Test
+    public void test52(MyValue1 val) {
+        synchronized (lock1) {
+            synchronized (lock2) {
+                test52_callee();
+            }
+        }
+    }
+
+    @Run(test = "test52")
+    public void test52_verifier() {
+        MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
+        test52(vt);
+    }
+
+    @DontInline
+    static void test53_callee() { }
+
+    @Test
+    public void test53(MyValue1 val) {
+        synchronized (lock1) {
+            synchronized (lock2) {
+                synchronized (lock3) {
+                    test53_callee();
+                }
+            }
+        }
+    }
+
+    @Run(test = "test53")
+    public void test53_verifier() {
+        MyValue1 vt = MyValue1.createWithFieldsInline(rI, rL);
+        test53(vt);
+    }
 }


### PR DESCRIPTION
Verification code asserts during stack walking when trying to repair the stack of a C2 compiled method with scalarized arguments because the stack increment is invalid. The problem is that `C->output()->sp_inc_offset()` used by `MacroAssembler::verified_entry` does not account for alignment of the frame size and therefore points to the wrong slot. Like we already do in C1, we should simply hard code the slot to right below where `rbp` was saved.

This patch only fixes x86, I've filed [JDK-8272760](https://bugs.openjdk.java.net/browse/JDK-8272760) for Aarch64.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272753](https://bugs.openjdk.java.net/browse/JDK-8272753): [lworld] "Invalid frame size" assert in frame::repair_sender_sp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/536/head:pull/536` \
`$ git checkout pull/536`

Update a local copy of the PR: \
`$ git checkout pull/536` \
`$ git pull https://git.openjdk.java.net/valhalla pull/536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 536`

View PR using the GUI difftool: \
`$ git pr show -t 536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/536.diff">https://git.openjdk.java.net/valhalla/pull/536.diff</a>

</details>
