### PR TITLE
8272793: [lworld] Test CustomClassListDump.java fails with Pattern "CustomLoadee id: [0-9]+ super: [0-9]+ source: .*/custom.jar" not found in classlist

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/CustomClassListDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/CustomClassListDump.java
@@ -74,13 +74,13 @@ public class CustomClassListDump {
 
         String listData = new String(Files.readAllBytes(Paths.get(classList)));
         check(listData, true, "CustomLoaderApp id: [0-9]+");
-        check(listData, true, "CustomLoadee id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomInterface2_ia id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomInterface2_ib id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee2 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee3 id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee2 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ [0-9]+ [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee3 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomLoadee3Child id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee4WithLambda id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee4WithLambda id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
 
         // We don't support archiving of Lambda proxies for custom loaders.
         check(listData, false, "@lambda-proxy.*CustomLoadee4WithLambda");


### PR DESCRIPTION
Fixing test by taking into account the injected IdentityObject interface in patterns used to analyze the output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272793](https://bugs.openjdk.java.net/browse/JDK-8272793): [lworld] Test CustomClassListDump.java fails with Pattern "CustomLoadee id: [0-9]+ super: [0-9]+ source: .*/custom.jar" not found in classlist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/537/head:pull/537` \
`$ git checkout pull/537`

Update a local copy of the PR: \
`$ git checkout pull/537` \
`$ git pull https://git.openjdk.java.net/valhalla pull/537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 537`

View PR using the GUI difftool: \
`$ git pr show -t 537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/537.diff">https://git.openjdk.java.net/valhalla/pull/537.diff</a>

</details>
