### PR TITLE
8272760: [lworld] Aarch64 part of JDK-8272753

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1967,7 +1967,7 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   C2_MacroAssembler _masm(&cbuf);
   int framesize = C->output()->frame_slots() << LogBytesPerInt;
 
-  __ remove_frame(framesize, C->needs_stack_repair(), C->output()->sp_inc_offset());
+  __ remove_frame(framesize, C->needs_stack_repair());
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -457,9 +457,7 @@ int LIR_Assembler::emit_unwind_handler() {
 
   // remove the activation and dispatch to the unwind handler
   __ block_comment("remove_frame and dispatch to the unwind handler");
-  int initial_framesize = initial_frame_size_in_bytes();
-  int sp_inc_offset = initial_framesize - 3*wordSize;  // Below saved FP and LR
-  __ remove_frame(initial_framesize, needs_stack_repair(), sp_inc_offset);
+  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
   __ far_jump(RuntimeAddress(Runtime1::entry_for(Runtime1::unwind_exception_id)));
 
   // Emit the slow path assembly
@@ -523,9 +521,7 @@ void LIR_Assembler::return_op(LIR_Opr result, C1SafepointPollStub* code_stub) {
   }
 
   // Pop the stack before the safepoint code
-  int initial_framesize = initial_frame_size_in_bytes();
-  int sp_inc_offset = initial_framesize - 3*wordSize;  // Below saved FP and LR
-  __ remove_frame(initial_framesize, needs_stack_repair(), sp_inc_offset);
+  __ remove_frame(initial_frame_size_in_bytes(), needs_stack_repair());
 
   if (StackReservedPages > 0 && compilation()->has_reserved_stack_access()) {
     __ reserved_stack_check();

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -305,8 +305,7 @@ void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_inc, 
   MacroAssembler::build_frame(frame_size_in_bytes);
 
   if (needs_stack_repair) {
-    int sp_inc_offset = frame_size_in_bytes - 3 * wordSize;  // Immediately below saved LR and FP
-    save_stack_increment(sp_inc, frame_size_in_bytes, sp_inc_offset);
+    save_stack_increment(sp_inc, frame_size_in_bytes);
   }
 }
 
@@ -335,11 +334,6 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
     // for packing scalarized arguments and therefore already created the frame.
     bind(*verified_inline_entry_label);
   }
-}
-
-void C1_MacroAssembler::remove_frame(int frame_size_in_bytes, bool needs_stack_repair,
-                                     int sp_inc_offset) {
-  MacroAssembler::remove_frame(frame_size_in_bytes, needs_stack_repair, sp_inc_offset);
 }
 
 void C1_MacroAssembler::verified_entry() {

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
@@ -110,6 +110,4 @@ using MacroAssembler::null_check;
 
   void load_parameter(int offset_in_words, Register reg);
 
-  void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
-
 #endif // CPU_AARCH64_C1_MACROASSEMBLER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4588,7 +4588,7 @@ void MacroAssembler::remove_frame(int framesize) {
   }
 }
 
-void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset) {
+void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair) {
   if (needs_stack_repair) {
     // Remove the extension of the caller's frame used for inline type unpacking
     //
@@ -4616,6 +4616,8 @@ void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair
     // The sp_inc stack slot holds the total size of the frame including the
     // extension space minus two words for the saved FP and LR.
 
+    int sp_inc_offset = initial_framesize - 3 * wordSize;  // Immediately below saved LR and FP
+
     ldr(rscratch1, Address(sp, sp_inc_offset));
     add(sp, sp, rscratch1);
     ldp(rfp, lr, Address(post(sp, 2 * wordSize)));
@@ -4624,11 +4626,13 @@ void MacroAssembler::remove_frame(int initial_framesize, bool needs_stack_repair
   }
 }
 
-void MacroAssembler::save_stack_increment(int sp_inc, int frame_size, int sp_inc_offset) {
+void MacroAssembler::save_stack_increment(int sp_inc, int frame_size) {
   int real_frame_size = frame_size + sp_inc;
   assert(sp_inc == 0 || sp_inc > 2*wordSize, "invalid sp_inc value");
   assert(real_frame_size >= 2*wordSize, "frame size must include FP/LR space");
   assert((real_frame_size & (StackAlignmentInBytes-1)) == 0, "frame size not aligned");
+
+  int sp_inc_offset = frame_size - 3 * wordSize;  // Immediately below saved LR and FP
 
   // Subtract two words for the saved FP and LR as these will be popped
   // separately. See remove_frame above.
@@ -5483,7 +5487,7 @@ void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
   build_frame(framesize);
 
   if (C->needs_stack_repair()) {
-    save_stack_increment(sp_inc, framesize, C->output()->sp_inc_offset());
+    save_stack_increment(sp_inc, framesize);
   }
 
   if (VerifyStackAtCalls) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1253,9 +1253,9 @@ public:
                           VMRegPair* from, int from_count, int& from_index, VMReg to,
                           RegState reg_state[], Register val_array);
   int extend_stack_for_inline_args(int args_on_stack);
-  void remove_frame(int initial_framesize, bool needs_stack_repair, int sp_inc_offset);
+  void remove_frame(int initial_framesize, bool needs_stack_repair);
   VMReg spill_reg_for(VMReg reg);
-  void save_stack_increment(int sp_inc, int frame_size, int sp_inc_offset);
+  void save_stack_increment(int sp_inc, int frame_size);
 
   void tableswitch(Register index, jint lowbound, jint highbound,
                    Label &jumptable, Label &jumptable_end, int stride = 1) {

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -311,7 +311,6 @@ PhaseOutput::PhaseOutput()
     _orig_pc_slot(0),
     _orig_pc_slot_offset_in_bytes(0),
     _sp_inc_slot(0),
-    _sp_inc_slot_offset_in_bytes(0),
     _buf_sizes(),
     _block(NULL),
     _index(0) {
@@ -1314,10 +1313,6 @@ void PhaseOutput::estimate_buffer_size(int& const_req) {
   // Compute the byte offset where we can store the deopt pc.
   if (C->fixed_slots() != 0) {
     _orig_pc_slot_offset_in_bytes = C->regalloc()->reg2offset(OptoReg::stack2reg(_orig_pc_slot));
-  }
-  if (C->needs_stack_repair()) {
-    // Compute the byte offset of the stack increment value
-    _sp_inc_slot_offset_in_bytes = C->regalloc()->reg2offset(OptoReg::stack2reg(_sp_inc_slot));
   }
 
   // Compute prolog code size

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -243,8 +243,6 @@ public:
 
   int               bang_size_in_bytes() const;
 
-  int               sp_inc_offset()      const  { return _sp_inc_slot_offset_in_bytes; }
-
   uint              node_bundling_limit();
   Bundle*           node_bundling_base();
   void          set_node_bundling_limit(uint n) { _node_bundling_limit = n; }


### PR DESCRIPTION
Remove the explicit sp_inc_offset argument to build/remove frame functions to match x86: it's always the word beneath the saved FP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272760](https://bugs.openjdk.java.net/browse/JDK-8272760): [lworld] Aarch64 part of JDK-8272753


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.java.net/valhalla pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/539.diff">https://git.openjdk.java.net/valhalla/pull/539.diff</a>

</details>
