### PR TITLE
8273018: [lworld] Property annotation propagation to <init> lacks in primitive records

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1015,7 +1015,10 @@ public class ClassWriter extends ClassFile {
             endAttr(alenIdx);
             acount++;
         }
-        if (target.hasMethodParameters() && (options.isSet(PARAMETERS) || m.isConstructor() && (m.flags_field & RECORD) != 0)) {
+        if (target.hasMethodParameters() && (
+                options.isSet(PARAMETERS)
+                || m.isConstructor() && (m.flags_field & RECORD) != 0
+                || m.isPrimitiveObjectFactory() && (m.flags_field & RECORD) != 0)) {
             if (!m.isLambdaMethod()) // Per JDK-8138729, do not emit parameters table for lambda bodies.
                 acount += writeMethodParametersAttr(m);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1017,8 +1017,7 @@ public class ClassWriter extends ClassFile {
         }
         if (target.hasMethodParameters() && (
                 options.isSet(PARAMETERS)
-                || m.isConstructor() && (m.flags_field & RECORD) != 0
-                || m.isPrimitiveObjectFactory() && (m.flags_field & RECORD) != 0)) {
+                || ((m.flags_field & RECORD) != 0 && (m.isConstructor() || m.isPrimitiveObjectFactory())))) {
             if (!m.isLambdaMethod()) // Per JDK-8138729, do not emit parameters table for lambda bodies.
                 acount += writeMethodParametersAttr(m);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
@@ -389,7 +389,7 @@ public class TransPrimitiveClass extends TreeTranslator {
         if (factory != null)
             return factory;
 
-        MethodType factoryType = new MethodType(init.erasure(types).getParameterTypes(),
+        MethodType factoryType = new MethodType(init.type.getParameterTypes(),
                                                 init.owner.type.asValueType(),
                                                 init.type.getThrownTypes(),
                                                 init.owner.type.tsym);
@@ -398,6 +398,11 @@ public class TransPrimitiveClass extends TreeTranslator {
                                         factoryType,
                                         init.owner);
         factory.params = init.params;
+        // Re-patch the return type on the erased method type, or code generation will fail
+        factory.erasure_field = new MethodType(init.erasure(types).getParameterTypes(),
+                init.owner.type.asValueType(),
+                init.type.getThrownTypes(),
+                init.owner.type.tsym);
         factory.setAttributes(init);
         init2factory.put(init, factory);
         return factory;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
@@ -397,6 +397,7 @@ public class TransPrimitiveClass extends TreeTranslator {
                                         names.init,
                                         factoryType,
                                         init.owner);
+        factory.params = init.params;
         factory.setAttributes(init);
         init2factory.put(init, factory);
         return factory;

--- a/test/langtools/tools/javac/records/RecordReading.java
+++ b/test/langtools/tools/javac/records/RecordReading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @summary test the records can be read by javac properly
  * @library /tools/lib
+ * @bug 8273018
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox toolbox.JavacTask

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/ApplicableAnnotationsOnPrimitiveRecords.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/ApplicableAnnotationsOnPrimitiveRecords.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @summary [lworld] test for equal treatment of annotations on primitive records (copy of ApplicableAnnotationsOnRecords)
+ * @bug 8273018
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.util
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @run main ApplicableAnnotationsOnPrimitiveRecords
+ */
+import com.sun.tools.classfile.*;
+import com.sun.tools.javac.util.Assert;
+import java.lang.annotation.*;
+import java.io.InputStream;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@interface FieldAnnotation {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@interface MethodAnnotation {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@interface ParameterAnnotation {
+}
+
+public primitive record ApplicableAnnotationsOnPrimitiveRecords(@FieldAnnotation @MethodAnnotation @ParameterAnnotation String s, @FieldAnnotation @MethodAnnotation @ParameterAnnotation int i) {
+
+    public static void main(String... args) throws Exception {
+        try ( InputStream in = ApplicableAnnotationsOnPrimitiveRecords.class.getResourceAsStream("ApplicableAnnotationsOnPrimitiveRecords.class")) {
+            ClassFile cf = ClassFile.read(in);
+            Assert.check(cf.methods.length > 5);
+            for (Method m : cf.methods) {
+                String methodName = m.getName(cf.constant_pool);
+                if (methodName.equals("toString") || methodName.equals("hashCode") || methodName.equals("equals") || methodName.equals("main")) {
+                    // ignore
+                } else if (methodName.equals("<init>")) {
+                    var paAnnos = ((RuntimeVisibleParameterAnnotations_attribute) m.attributes.get(Attribute.RuntimeVisibleParameterAnnotations)).parameter_annotations;
+                    Assert.check(paAnnos != null && paAnnos.length > 0);
+                    for (var pa : paAnnos) {
+                        Assert.check(pa.length == 1);
+                        Assert.check(cf.constant_pool.getUTF8Value(pa[0].type_index).equals("LParameterAnnotation;"));
+                    }
+                } else {
+                    var annos = ((RuntimeAnnotations_attribute) m.attributes.get(Attribute.RuntimeVisibleAnnotations)).annotations;
+                    Assert.check(annos.length == 1);
+                    Assert.check(cf.constant_pool.getUTF8Value(annos[0].type_index).equals("LMethodAnnotation;"));
+                }
+            }
+            Assert.check(cf.fields.length > 0);
+            for (Field field : cf.fields) {
+                var annos = ((RuntimeAnnotations_attribute) field.attributes.get(Attribute.RuntimeVisibleAnnotations)).annotations;
+                Assert.check(annos.length == 1);
+                Assert.check(cf.constant_pool.getUTF8Value(annos[0].type_index).equals("LFieldAnnotation;"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fix copies parameter names and annotations from constructor into primitive class factory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8273018](https://bugs.openjdk.java.net/browse/JDK-8273018): [lworld] Property annotation propagation to <init> lacks in primitive records
 * [JDK-8273202](https://bugs.openjdk.java.net/browse/JDK-8273202): [lworld] MethodParameters are not generated for factories for primitive records


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/541/head:pull/541` \
`$ git checkout pull/541`

Update a local copy of the PR: \
`$ git checkout pull/541` \
`$ git pull https://git.openjdk.java.net/valhalla pull/541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 541`

View PR using the GUI difftool: \
`$ git pr show -t 541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/541.diff">https://git.openjdk.java.net/valhalla/pull/541.diff</a>

</details>
