### PR TITLE
8273202: Emit parameter names for primitive record factories

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1015,7 +1015,9 @@ public class ClassWriter extends ClassFile {
             endAttr(alenIdx);
             acount++;
         }
-        if (target.hasMethodParameters() && (options.isSet(PARAMETERS) || m.isConstructor() && (m.flags_field & RECORD) != 0)) {
+        if (target.hasMethodParameters() && (options.isSet(PARAMETERS)
+                        || m.isConstructor() && (m.flags_field & RECORD) != 0
+                        || m.isPrimitiveObjectFactory() && (m.flags_field & RECORD) != 0)) {
             if (!m.isLambdaMethod()) // Per JDK-8138729, do not emit parameters table for lambda bodies.
                 acount += writeMethodParametersAttr(m);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/TransPrimitiveClass.java
@@ -397,6 +397,7 @@ public class TransPrimitiveClass extends TreeTranslator {
                                         names.init,
                                         factoryType,
                                         init.owner);
+        factory.params = init.params;
         factory.setAttributes(init);
         init2factory.put(init, factory);
         return factory;

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/ApplicableAnnotationsOnPrimitiveRecords.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/ApplicableAnnotationsOnPrimitiveRecords.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @summary [lworld] test for equal treatment of annotations on primitive records (copy of ApplicableAnnotationsOnRecords)
+ * @bug 8273018
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.util
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @run main ApplicableAnnotationsOnPrimitiveRecords
+ */
+import com.sun.tools.classfile.*;
+import com.sun.tools.javac.util.Assert;
+import java.lang.annotation.*;
+import java.io.InputStream;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@interface FieldAnnotation {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@interface MethodAnnotation {
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+@interface ParameterAnnotation {
+}
+
+public primitive record ApplicableAnnotationsOnPrimitiveRecords(@FieldAnnotation @MethodAnnotation @ParameterAnnotation String s, @FieldAnnotation @MethodAnnotation @ParameterAnnotation int i) {
+
+    public static void main(String... args) throws Exception {
+        try ( InputStream in = ApplicableAnnotationsOnPrimitiveRecords.class.getResourceAsStream("ApplicableAnnotationsOnPrimitiveRecords.class")) {
+            ClassFile cf = ClassFile.read(in);
+            Assert.check(cf.methods.length > 5);
+            for (Method m : cf.methods) {
+                String methodName = m.getName(cf.constant_pool);
+                if (methodName.equals("toString") || methodName.equals("hashCode") || methodName.equals("equals") || methodName.equals("main")) {
+                    // ignore
+                } else if (methodName.equals("<init>")) {
+                    var paAnnos = ((RuntimeVisibleParameterAnnotations_attribute) m.attributes.get(Attribute.RuntimeVisibleParameterAnnotations)).parameter_annotations;
+                    Assert.check(paAnnos != null && paAnnos.length > 0);
+                    for (var pa : paAnnos) {
+                        Assert.check(pa.length == 1);
+                        Assert.check(cf.constant_pool.getUTF8Value(pa[0].type_index).equals("LParameterAnnotation;"));
+                    }
+                } else {
+                    var annos = ((RuntimeAnnotations_attribute) m.attributes.get(Attribute.RuntimeVisibleAnnotations)).annotations;
+                    Assert.check(annos.length == 1);
+                    Assert.check(cf.constant_pool.getUTF8Value(annos[0].type_index).equals("LMethodAnnotation;"));
+                }
+            }
+            Assert.check(cf.fields.length > 0);
+            for (Field field : cf.fields) {
+                var annos = ((RuntimeAnnotations_attribute) field.attributes.get(Attribute.RuntimeVisibleAnnotations)).annotations;
+                Assert.check(annos.length == 1);
+                Assert.check(cf.constant_pool.getUTF8Value(annos[0].type_index).equals("LFieldAnnotation;"));
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/lworld-values/records/ParametersOnPrimitiveRecords.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/records/ParametersOnPrimitiveRecords.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @summary [lworld] test for equal treatment of primitive records from reflection
+ * @bug 8273202
+ * @run main ParametersOnPrimitiveRecords
+ */
+import java.lang.reflect.Parameter;
+
+public class ParametersOnPrimitiveRecords {
+
+    public record Simple(int i, String s) {
+    }
+
+    public primitive record PrimitiveSimple(int i, String s) {
+    }
+
+    public static void main(String[] args) throws Throwable {
+        checkSimpleRecordClass(Simple.class);
+        checkSimpleRecordClass(PrimitiveSimple.class);
+    }
+
+    private static void checkSimpleRecordClass(Class<? extends Record> recordClass) throws Throwable {
+        // Test that a class can be introspected and constructed.
+        // If it's a primitive class, it will be wrapped in a .ref flavour implicitly.
+        var r1 = checkAndConstructRecord(recordClass);
+        var r2 = checkAndConstructRecord(recordClass);
+        if (! r1.equals(r2)) {
+            throw new AssertionError(recordClass.getCanonicalName() + ": " + r1 + " should be equal to " + r2);
+        }
+    }
+
+    private static Object checkAndConstructRecord(Class<? extends Record> recordClass) throws Throwable {
+        var className = recordClass.getCanonicalName();
+        if (recordClass.getConstructors().length != 1) {
+            throw new AssertionError(className
+                    + ": Expected 1 constructor, got " + recordClass.getConstructors().length);
+        }
+        var ctor = recordClass.getConstructors()[0];
+        var parameters = ctor.getParameters();
+        if (parameters.length != 2) {
+            throw new AssertionError(className + ": Expected 2 parameters on <init>");
+        }
+        checkParamName(className, parameters, 0, "i");
+        checkParamName(className, parameters, 1, "s");
+        return ctor.newInstance(123, "One two three");
+    }
+
+    private static void checkParamName(String className, Parameter[] parameters, int position, String name) throws AssertionError {
+        if (! parameters[0].getName().equals("i")) {
+            throw new AssertionError(
+                    "%s: Parameter %d should be '%s' but was '%s'".formatted(
+                            className,
+                            position,
+                            name,
+                            parameters[position].getName()));
+        }
+    }
+}


### PR DESCRIPTION
8273202: Ensure that parameter primitive record factories are generated.

Note that this fix requires JDK-8273018 (PR #541).