### PR TITLE
[lworld] Removed TestNativeClone.java from ProblemList now that 8270098 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -44,5 +44,3 @@ serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#id0                       8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#id1                       8248912   generic-all
-
-compiler/valhalla/inlinetypes/TestNativeClone.java            8270098   generic-all


### PR DESCRIPTION
Mainline bug [JDK-8270098](https://bugs.openjdk.java.net/browse/JDK-8270098) is fixed in Valhalla. We can remove the test from the problem list.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/544/head:pull/544` \
`$ git checkout pull/544`

Update a local copy of the PR: \
`$ git checkout pull/544` \
`$ git pull https://git.openjdk.java.net/valhalla pull/544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 544`

View PR using the GUI difftool: \
`$ git pr show -t 544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/544.diff">https://git.openjdk.java.net/valhalla/pull/544.diff</a>

</details>
