### PR TITLE
8273301: Bootstrap of instance-capturing lambda fails for reference favoring primitive types.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -416,8 +416,9 @@ public class LambdaToMethod extends TreeTranslator {
         if (localContext.methodReferenceReceiver != null) {
             syntheticInits.append(localContext.methodReferenceReceiver);
         } else if (!sym.isStatic()) {
+            Type thisType = sym.owner.enclClass().asType();
             syntheticInits.append(makeThis(
-                    sym.owner.enclClass().asType(),
+                    thisType.isPrimitiveReferenceType() ? thisType.asValueType() : thisType,
                     localContext.owner.enclClass()));
         }
 

--- a/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/CheckRefLambda.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/RefDefault/CheckRefLambda.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8273301
+ * @summary [lworld] Bootstrap of instance-capturing lambda fails for reference favoring primitive types
+ * @run main CheckRefLambda
+ */
+
+import java.util.function.Supplier;
+
+public primitive class CheckRefLambda.val {
+
+    int theInteger;
+
+    CheckRefLambda(int newValue) {
+        theInteger = newValue;
+    }
+
+    public Supplier<CheckRefLambda> makeCopier() {
+        return () -> new CheckRefLambda(this.theInteger + 1); 
+    }
+
+    public static void main(String[] args) {
+        CheckRefLambda rec = new CheckRefLambda(42);
+        CheckRefLambda rec2 = rec.makeCopier().get();
+        if (rec2 != new CheckRefLambda(43)) {
+            throw new AssertionError("Classes should be equal");
+        }
+    }
+}


### PR DESCRIPTION
Fix the test by adjusting bootstrap parameters, like it was fixed in JDK-8271583.