### PR TITLE
8273360: [lworld] Invoking a reflection-generated constructor for primitive class gives InstantiationError

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
@@ -49,7 +49,7 @@ class ClassFileAssembler implements ClassFileConstants {
     public void emitMagicAndVersion() {
         emitInt(0xCAFEBABE);
         emitShort((short) 0);
-        emitShort((short) 62);
+        emitShort((short) 49);
     }
 
     public void emitInt(int val) {

--- a/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ClassFileAssembler.java
@@ -49,7 +49,7 @@ class ClassFileAssembler implements ClassFileConstants {
     public void emitMagicAndVersion() {
         emitInt(0xCAFEBABE);
         emitShort((short) 0);
-        emitShort((short) 49);
+        emitShort((short) 62);
     }
 
     public void emitInt(int val) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -60,6 +60,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
     // Constant pool index of CONSTANT_Class_info for first
     // non-primitive parameter type. Should be incremented by 2.
     private short nonPrimitiveParametersBaseIdx;
+    private boolean isConstructingPrimitive;
 
     MethodAccessorGenerator() {
     }
@@ -134,6 +135,10 @@ class MethodAccessorGenerator extends AccessorGenerator {
     {
         ByteVector vec = ByteVectorFactory.create();
         asm = new ClassFileAssembler(vec);
+        this.isConstructingPrimitive = isConstructor && declaringClass.isPrimitiveClass();
+        if (this.isConstructingPrimitive ) {
+            returnType = declaringClass.asValueType();
+        }
         this.declaringClass = declaringClass;
         this.parameterTypes = parameterTypes;
         this.returnType = returnType;
@@ -431,7 +436,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
 
         short illegalArgStartPC = 0;
 
-        if (isConstructor) {
+        if (isConstructor && !isConstructingPrimitive) {
             // Instantiate target class before continuing
             // new <target class type>
             // dup
@@ -621,7 +626,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
         short invokeStartPC = cb.getLength();
 
         // OK, ready to perform the invocation.
-        if (isConstructor) {
+        if (isConstructor && !isConstructingPrimitive) {
             cb.opc_invokespecial(targetMethodRef, count, 0);
         } else {
             if (isStatic()) {

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -52,6 +52,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
     private Class<?>[] parameterTypes;
     private Class<?>   returnType;
     private boolean    isConstructor;
+    private boolean    isStaticFactory;
     private boolean    forSerialization;
 
     private short targetMethodRef;
@@ -60,7 +61,6 @@ class MethodAccessorGenerator extends AccessorGenerator {
     // Constant pool index of CONSTANT_Class_info for first
     // non-primitive parameter type. Should be incremented by 2.
     private short nonPrimitiveParametersBaseIdx;
-    private boolean isConstructingPrimitive;
 
     MethodAccessorGenerator() {
     }
@@ -81,6 +81,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                          modifiers,
                                          false,
                                          false,
+                                         false,
                                          null);
     }
 
@@ -90,13 +91,15 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                                    Class<?>[] checkedExceptions,
                                                    int modifiers)
     {
+        boolean isStaticFactory = declaringClass.isPrimitiveClass();
         return (ConstructorAccessor) generate(declaringClass,
                                               "<init>",
                                               parameterTypes,
-                                              Void.TYPE,
+                                              isStaticFactory ? declaringClass.asValueType() : Void.TYPE,
                                               checkedExceptions,
                                               modifiers,
                                               true,
+                                              isStaticFactory,
                                               false,
                                               null);
     }
@@ -117,6 +120,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
                      checkedExceptions,
                      modifiers,
                      true,
+                     false,
                      true,
                      targetConstructorClass);
     }
@@ -130,20 +134,18 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                        Class<?>[] checkedExceptions,
                                        int modifiers,
                                        boolean isConstructor,
+                                       boolean isStaticFactory,
                                        boolean forSerialization,
                                        Class<?> serializationTargetClass)
     {
         ByteVector vec = ByteVectorFactory.create();
         asm = new ClassFileAssembler(vec);
-        this.isConstructingPrimitive = isConstructor && declaringClass.isPrimitiveClass();
-        if (this.isConstructingPrimitive ) {
-            returnType = declaringClass.asValueType();
-        }
         this.declaringClass = declaringClass;
         this.parameterTypes = parameterTypes;
         this.returnType = returnType;
         this.modifiers = modifiers;
         this.isConstructor = isConstructor;
+        this.isStaticFactory = isStaticFactory;
         this.forSerialization = forSerialization;
 
         asm.emitMagicAndVersion();
@@ -436,7 +438,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
 
         short illegalArgStartPC = 0;
 
-        if (isConstructor && !isConstructingPrimitive) {
+        if (isConstructor && !isStaticFactory) {
             // Instantiate target class before continuing
             // new <target class type>
             // dup
@@ -626,7 +628,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
         short invokeStartPC = cb.getLength();
 
         // OK, ready to perform the invocation.
-        if (isConstructor && !isConstructingPrimitive) {
+        if (isConstructor && !isStaticFactory) {
             cb.opc_invokespecial(targetMethodRef, count, 0);
         } else {
             if (isStatic()) {

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8273360
  * @summary Test reflection of constructors for primitive classes
- * @run testng/othervm StaticFactoryTest
+ * @run testng/othervm -Dsun.reflect.noInflation=true StaticFactoryTest
  */
 
 import java.lang.reflect.Constructor;
@@ -68,10 +68,8 @@ public class StaticFactoryTest {
     @Test
     public static void constructor() throws Exception {
         Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
-        for (int i = 0; i < 20; ++i) {
-            Object o = ctor.newInstance();
-            assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
-        }
+        Object o = ctor.newInstance();
+        assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
     }
 
     // Check that the class has the expected Constructors

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8273360
  * @summary Test reflection of constructors for primitive classes
+ * @run testng/othervm StaticFactoryTest
  * @run testng/othervm -Dsun.reflect.noInflation=true StaticFactoryTest
  */
 

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @bug 8273360
  * @summary Test reflection of constructors for primitive classes
  * @run testng/othervm StaticFactoryTest
  */
@@ -67,8 +68,10 @@ public class StaticFactoryTest {
     @Test
     public static void constructor() throws Exception {
         Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
-        Object o = ctor.newInstance();
-        assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
+        for (int i = 0; i < 20; ++i) {
+            Object o = ctor.newInstance();
+            assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
+        }
     }
 
     // Check that the class has the expected Constructors


### PR DESCRIPTION
Update constructor accessor code generation to invoke static factory method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8273360](https://bugs.openjdk.java.net/browse/JDK-8273360): [lworld] Invoking a reflection-generated constructor for primitive class gives InstantiationError


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer) ⚠️ Review applies to 8bdd85709ee65d89e9e3efd07f0b845811ad0e2c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.java.net/valhalla pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/546.diff">https://git.openjdk.java.net/valhalla/pull/546.diff</a>

</details>
