### PR TITLE
8273323: [lworld] Fix post-parse call devirtualization with inline type receiver

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2037,7 +2037,9 @@ Node *PhaseCCP::transform_once( Node *n ) {
 
   // TEMPORARY fix to ensure that 2nd GVN pass eliminates NULL checks
   switch( n->Opcode() ) {
-  case Op_FastLock:      // Revisit FastLocks for lock coarsening
+  case Op_CallStaticJava:  // Give post-parse call devirtualization a chance
+  case Op_CallDynamicJava:
+  case Op_FastLock:        // Revisit FastLocks for lock coarsening
   case Op_If:
   case Op_CountedLoopEnd:
   case Op_Region:

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -115,6 +115,8 @@ public class IRNode {
     public static final String COUNTEDLOOP_MAIN = START + "CountedLoop\\b" + MID + "main" + END;
 
     public static final String CALL = START + "CallStaticJava" + MID + END;
+    public static final String DYNAMIC_CALL_OF_METHOD = COMPOSITE_PREFIX + START + "CallDynamicJava" + MID + IS_REPLACED + END;
+    public static final String STATIC_CALL_OF_METHOD = COMPOSITE_PREFIX + START + "CallStaticJava" + MID + IS_REPLACED + END;
     public static final String TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*reason" + END;
     public static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
     public static final String UNSTABLE_IF_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unstable_if" + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4098,6 +4098,8 @@ public class TestLWorld {
     @Test
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
         failOn = {ALLOC})
+    @IR(failOn = {compiler.lib.ir_framework.IRNode.DYNAMIC_CALL_OF_METHOD, "MyValue2::hash"},
+        counts = {compiler.lib.ir_framework.IRNode.STATIC_CALL_OF_METHOD, "MyValue2::hash", "= 1"})
     public long test150() {
         MyValue2 val = MyValue2.createWithFieldsInline(rI, rD);
         MyInterface receiver = MyValue1.createWithFieldsInline(rI, rL);
@@ -4112,8 +4114,31 @@ public class TestLWorld {
         return receiver.hash();
     }
 
-    @DontCompile
-    public void test150_verifier(boolean warmup) {
+    @Run(test = "test150")
+    public void test150_verifier() {
         Asserts.assertEquals(test150(), testValue2.hash());
+    }
+
+    // Same as test150 but with val not being allocated in the scope of the method
+    @Test
+    @IR(failOn = {compiler.lib.ir_framework.IRNode.DYNAMIC_CALL_OF_METHOD, "MyValue2::hash"},
+        counts = {compiler.lib.ir_framework.IRNode.STATIC_CALL_OF_METHOD, "MyValue2::hash", "= 1"})
+    public long test151(MyValue2 val) {
+        MyAbstract receiver = MyValue1.createWithFieldsInline(rI, rL);
+
+        for (int i = 0; i < 100; i++) {
+            if ((i % 2) == 0) {
+                receiver = val;
+            }
+        }
+        // Trigger post parse call devirtualization (strength-reducing
+        // virtual calls to direct calls).
+        return receiver.hash();
+    }
+
+    @Run(test = "test151")
+    @Warmup(0) // Make sure there is no receiver type profile
+    public void test151_verifier() {
+        Asserts.assertEquals(test151(testValue2), testValue2.hash());
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4093,4 +4093,27 @@ public class TestLWorld {
         Asserts.assertEQ(test149(testValue1), testValue1);
         Asserts.assertEQ(test149(null), null);
     }
+
+    // Test post-parse call devirtualization with inline type receiver
+    @Test
+    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
+        failOn = {ALLOC})
+    public long test150() {
+        MyValue2 val = MyValue2.createWithFieldsInline(rI, rD);
+        MyInterface receiver = MyValue1.createWithFieldsInline(rI, rL);
+
+        for (int i = 0; i < 4; i++) {
+            if ((i % 2) == 0) {
+                receiver = val;
+            }
+        }
+        // Trigger post parse call devirtualization (strength-reducing
+        // virtual calls to direct calls).
+        return receiver.hash();
+    }
+
+    @DontCompile
+    public void test150_verifier(boolean warmup) {
+        Asserts.assertEquals(test150(), testValue2.hash());
+    }
 }


### PR DESCRIPTION
Post-parse call devirtualization ([JDK-8257211](https://bugs.openjdk.java.net/browse/JDK-8257211)) converts virtual calls to static calls which allows an inline type receiver to be passed as fields and the corresponding buffer allocation to become useless.

Currently, new inline type nodes created during that optimization and also such useless buffer allocations are not removed, leading to missed optimization opportunities and asserts. The problem is that call devirtualization is only executed after macro expansion which removes useless buffer allocations. I've moved the optimization to before macro expansion and added an assert to ensure that we are not missing any optimization opportunities.

I had to cherry-pick the mainline fix for [JDK-8273409](https://bugs.openjdk.java.net/browse/JDK-8273409).

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8273323](https://bugs.openjdk.java.net/browse/JDK-8273323): [lworld] Fix post-parse call devirtualization with inline type receiver


### Reviewers
 * [Vladimir Ivanov](https://openjdk.java.net/census#vlivanov) (@iwanowww - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/549/head:pull/549` \
`$ git checkout pull/549`

Update a local copy of the PR: \
`$ git checkout pull/549` \
`$ git pull https://git.openjdk.java.net/valhalla pull/549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 549`

View PR using the GUI difftool: \
`$ git pr show -t 549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/549.diff">https://git.openjdk.java.net/valhalla/pull/549.diff</a>

</details>
