### PR TITLE
8273554: [lworld] Runtime tests should not explicitly set -Xint/-Xcomp

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CheckcastTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CheckcastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@ import jdk.test.lib.Asserts;
  * @summary checkcast bytecode test
  * @library /test/lib
  * @compile VDefaultTest.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.CheckcastTest
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.CheckcastTest
+ * @run main runtime.valhalla.inlinetypes.CheckcastTest
  */
 
 public class CheckcastTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
@@ -29,7 +29,7 @@ import jdk.test.lib.Asserts;
  * @summary Test initialization of static inline fields with circularity
  * @library /test/lib
  * @compile CircularityTest.java
- * @run main runtime.valhalla.inlinetypes.CircularityTest
+ * @run main/othervm -Xint runtime.valhalla.inlinetypes.CircularityTest
  */
 
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CircularityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import jdk.test.lib.Asserts;
  * @summary Test initialization of static inline fields with circularity
  * @library /test/lib
  * @compile CircularityTest.java
- * @run main/othervm -Xint -XX:+EnableValhalla runtime.valhalla.inlinetypes.CircularityTest
+ * @run main runtime.valhalla.inlinetypes.CircularityTest
  */
 
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,7 @@ import javax.tools.*;
  * @summary Test data movement with inline types
  * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
  * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
- * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError
- *                   -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xmx128m
  *                   runtime.valhalla.inlinetypes.CreationErrorTest
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlattenableSemanticTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/FlattenableSemanticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,8 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java JumboInline.java
  * @compile -XDallowWithFieldOperator FlattenableSemanticTest.java
- * @run main/othervm -Xint -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.FlattenableSemanticTest
- * @run main/othervm -Xint -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.FlattenableSemanticTest
- * @run main/othervm -Xcomp -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.FlattenableSemanticTest
- * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.FlattenableSemanticTest
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.FlattenableSemanticTest
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.FlattenableSemanticTest
  * // debug: -XX:+PrintInlineLayout -XX:-ShowMessageBoxOnError
  */
 public class FlattenableSemanticTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Ifacmp.java
@@ -30,9 +30,7 @@ import java.lang.ref.*;
  * @requires vm.gc == null
  * @summary if_acmpeq/ne bytecode test
  * @compile Ifacmp.java
- * @run main/othervm -Xint -Xms16m -Xmx16m -XX:+UseSerialGC
- *                   runtime.valhalla.inlinetypes.Ifacmp
- * @run main/othervm -Xcomp -Xms16m -Xmx16m -XX:+UseSerialGC
+ * @run main/othervm -Xms16m -Xmx16m -XX:+UseSerialGC
  *                   runtime.valhalla.inlinetypes.Ifacmp
  */
 public class Ifacmp {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint -XX:+UseSerialGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
+ * @run main/othervm -XX:+UseSerialGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -57,7 +57,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint  -XX:+UseG1GC -Xmx128m -XX:InlineFieldMaxFlatSize=128
+ * @run main/othervm -XX:+UseG1GC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops 20
  */
@@ -72,7 +72,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint -XX:+UseParallelGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
+ * @run main/othervm -XX:+UseParallelGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
@@ -87,68 +87,7 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @compile -XDallowWithFieldOperator InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xint -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=128
- *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   runtime.valhalla.inlinetypes.InlineOops
- */
-
-/**
- * @test InlineOops_comp_serial
- * @requires vm.gc.Serial
- * @summary Test embedding oops into Inline types
- * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
- * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
- * @compile -XDallowWithFieldOperator Person.java
- * @compile -XDallowWithFieldOperator InlineOops.java
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseSerialGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
- *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   runtime.valhalla.inlinetypes.InlineOops
- */
-
-/**
- * @test InlineOops_comp_G1
- * @requires vm.gc.G1
- * @summary Test embedding oops into Inline types
- * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
- * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
- * @compile -XDallowWithFieldOperator Person.java
- * @compile -XDallowWithFieldOperator InlineOops.java
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseG1GC -Xmx128m -XX:InlineFieldMaxFlatSize=128
- *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   runtime.valhalla.inlinetypes.InlineOops 20
- */
-
-/**
- * @test InlineOops_comp_Parallel
- * @requires vm.gc.Parallel
- * @summary Test embedding oops into Inline types
- * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
- * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
- * @compile -XDallowWithFieldOperator Person.java
- * @compile -XDallowWithFieldOperator InlineOops.java
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UseParallelGC -Xmx128m -XX:InlineFieldMaxFlatSize=128
- *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   runtime.valhalla.inlinetypes.InlineOops
- */
-
-/**
- * @test InlineOops_comp_Z
- * @requires vm.gc.Z
- * @summary Test embedding oops into Inline types
- * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
- * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
- * @compile -XDallowWithFieldOperator Person.java
- * @compile -XDallowWithFieldOperator InlineOops.java
- * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- *                   sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xcomp -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=128
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -35,11 +35,9 @@ import static jdk.test.lib.Asserts.*;
  * @summary Plain array test for Inline Types
  * @library /test/lib
  * @compile InlineTypeArray.java Point.java Long8Inline.java Person.java
- * @run main/othervm -Xint  -XX:FlatArrayElementMaxSize=-1 runtime.valhalla.inlinetypes.InlineTypeArray
- * @run main/othervm -Xint  -XX:FlatArrayElementMaxSize=0  runtime.valhalla.inlinetypes.InlineTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1 runtime.valhalla.inlinetypes.InlineTypeArray
- * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=0  runtime.valhalla.inlinetypes.InlineTypeArray
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.InlineTypeArray
+ * @run main/othervm -XX:FlatArrayElementMaxSize=-1 runtime.valhalla.inlinetypes.InlineTypeArray
+ * @run main/othervm -XX:FlatArrayElementMaxSize=0  runtime.valhalla.inlinetypes.InlineTypeArray
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=* runtime.valhalla.inlinetypes.InlineTypeArray
  */
 public class InlineTypeArray {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,8 @@ import jdk.test.lib.Asserts;
  * @test InlineTypeCreation
  * @summary Inline Type creation test
  * @library /test/lib
- * @compile  -XDallowWithFieldOperator -XDallowFlattenabilityModifiers InlineTypeCreation.java Point.java Long8Inline.java Person.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.InlineTypeCreation
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.InlineTypeCreation
+ * @compile -XDallowWithFieldOperator -XDallowFlattenabilityModifiers InlineTypeCreation.java Point.java Long8Inline.java Person.java
+ * @run main runtime.valhalla.inlinetypes.InlineTypeCreation
  */
 public class InlineTypeCreation {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeDensity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,16 +33,16 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDallowWithFieldOperator InlineTypeDensity.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xint -XX:FlatArrayElementMaxSize=-1 -XX:+UseCompressedOops
+ * @run main/othervm -XX:FlatArrayElementMaxSize=-1 -XX:+UseCompressedOops
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI InlineTypeDensity
- * @run main/othervm -Xint -XX:FlatArrayElementMaxSize=-1 -XX:-UseCompressedOops
+ * @run main/othervm -XX:FlatArrayElementMaxSize=-1 -XX:-UseCompressedOops
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                    -XX:+WhiteBoxAPI InlineTypeDensity
- * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1
+ * @run main/othervm -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI InlineTypeDensity
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:FlatArrayElementMaxSize=-1
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:ForceNonTearable=*
  *                   -XX:+WhiteBoxAPI InlineTypeDensity
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeGetField.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeGetField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,7 @@ import jdk.test.lib.Asserts;
  * @summary Inline Type get field test
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java InlineTypeGetField.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.InlineTypeGetField
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.InlineTypeGetField
+ * @run main runtime.valhalla.inlinetypes.InlineTypeGetField
  */
 public class InlineTypeGetField {
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,18 +50,11 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
  * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
  * @compile -XDallowWithFieldOperator TestValue1.java TestValue2.java TestValue3.java TestValue4.java InlineTypesTest.java
- * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError
- *                   -XX:+ExplicitGCInvokesConcurrent
+ * @run main/othervm -Xmx128m -XX:+ExplicitGCInvokesConcurrent
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
  *                   runtime.valhalla.inlinetypes.InlineTypesTest
- * @run main/othervm -Xcomp -Xmx128m -XX:-ShowMessageBoxOnError
- *                   -XX:+ExplicitGCInvokesConcurrent
- *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
- *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
- *                   runtime.valhalla.inlinetypes.InlineTypesTest
- * @run main/othervm -Xbatch -Xmx128m -XX:-ShowMessageBoxOnError
- *                   -XX:+ExplicitGCInvokesConcurrent
+ * @run main/othervm -Xmx128m -XX:+ExplicitGCInvokesConcurrent
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -Djava.lang.invoke.MethodHandle.DUMP_CLASS_FILES=false
  *                   -XX:ForceNonTearable=*

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,7 @@ package runtime.valhalla.inlinetypes;
 /* @test
  * @summary test JNI functions with inline types
  * @compile -XDallowWithFieldOperator InlineWithJni.java
- * @run main/othervm/native -Xint runtime.valhalla.inlinetypes.InlineWithJni
- * @run main/othervm/native -Xcomp runtime.valhalla.inlinetypes.InlineWithJni
+ * @run main/native runtime.valhalla.inlinetypes.InlineWithJni
  */
 public primitive final class InlineWithJni {
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,9 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
  * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
  * @compile -XDallowWithFieldOperator ObjectMethods.java
- * @run main/othervm -Xint -XX:+UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
- * @run main/othervm -Xint -XX:-UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
- * @run main/othervm -Xint -noverify runtime.valhalla.inlinetypes.ObjectMethods noverify
- * @run main/othervm -Xcomp -XX:+UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
- * @run main/othervm -Xcomp -XX:-UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
- * @run main/othervm -Xcomp -noverify runtime.valhalla.inlinetypes.ObjectMethods noverify
+ * @run main/othervm -XX:+UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
+ * @run main/othervm -XX:-UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods
+ * @run main/othervm -noverify runtime.valhalla.inlinetypes.ObjectMethods noverify
  */
 
 public class ObjectMethods {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/QuickeningTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/QuickeningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@ import jdk.test.lib.Asserts;
  * @summary Test quickening of getfield and putfield applied to inline fields
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java JumboInline.java QuickeningTest.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.QuickeningTest
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.QuickeningTest
+ * @run main runtime.valhalla.inlinetypes.QuickeningTest
  */
 
 public class QuickeningTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/StaticFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/StaticFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import jdk.test.lib.Asserts;
  * @summary Test circularity in static fields
  * @library /test/lib
  * @compile StaticFieldsTest.java
- * @run main/othervm -Xint -XX:+EnableValhalla runtime.valhalla.inlinetypes.StaticFieldsTest
+ * @run main runtime.valhalla.inlinetypes.StaticFieldsTest
  */
 
 public class StaticFieldsTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Test8186715.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/Test8186715.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,7 @@ package runtime.valhalla.inlinetypes;
  * @summary test return of buffered inline type passed in argument by caller
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Test8186715.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.Test8186715
- * @run main/othervm runtime.valhalla.inlinetypes.Test8186715
+ * @run main runtime.valhalla.inlinetypes.Test8186715
  */
 
 public class Test8186715 {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldNullability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestFieldNullability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test TestFieldNullability
  * @library /test/lib
  * @compile -XDallowWithFieldOperator TestFieldNullability.java
- * @run main/othervm -Xint -Xmx128m -XX:-ShowMessageBoxOnError -XX:InlineFieldMaxFlatSize=32
+ * @run main/othervm -Xmx128m -XX:InlineFieldMaxFlatSize=32
  *                   runtime.valhalla.inlinetypes.TestFieldNullability
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UninitializedInlineFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UninitializedInlineFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,7 @@ import jdk.test.lib.Asserts;
  * @summary Uninitialized inline fields test
  * @library /test/lib
  * @compile -XDallowWithFieldOperator -XDallowFlattenabilityModifiers Point.java JumboInline.java UninitializedInlineFieldsTest.java
- * @run main/othervm -Xint -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.UninitializedInlineFieldsTest
- * @run main/othervm -Xcomp -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.UninitializedInlineFieldsTest
+ * @run main/othervm -XX:InlineFieldMaxFlatSize=64 runtime.valhalla.inlinetypes.UninitializedInlineFieldsTest
  */
 public class UninitializedInlineFieldsTest {
     static Point.ref nonFlattenableStaticPoint;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,7 @@ package runtime.valhalla.inlinetypes;
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java UnsafeTest.java
- * @run main/othervm -Xint -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
- * @run main/othervm -Xcomp -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
+ * @run main/othervm -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
  */
 
 import jdk.internal.misc.Unsafe;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VDefaultTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VDefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,7 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java
  * @compile -XDallowWithFieldOperator -XDallowFlattenabilityModifiers VDefaultTest.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.VDefaultTest
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.VDefaultTest
+ * @run main runtime.valhalla.inlinetypes.VDefaultTest
  */
 
 public class VDefaultTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VWithFieldTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VWithFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,7 @@ import jdk.test.lib.Asserts;
  * @library /test/lib
  * @compile -XDallowWithFieldOperator Point.java
  * @compile -XDallowWithFieldOperator VWithFieldTest.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.VWithFieldTest
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.VWithFieldTest
+ * @run main runtime.valhalla.inlinetypes.VWithFieldTest
  */
 
 public class VWithFieldTest {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,26 +42,26 @@ import static jdk.test.lib.Asserts.*;
  * @library /test/lib
  * @compile ValueTearing.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
  *                   -DSTEP_COUNT=10000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xint  -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
  *                   -DSTEP_COUNT=10000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xbatch -DSTEP_COUNT=10000000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
+ * @run main/othervm -DSTEP_COUNT=10000000 -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
  *                   -DTEAR_MODE=fieldonly -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=
  *                   -DTEAR_MODE=arrayonly -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing
- * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:ForceNonTearable=*
  *                   -DTEAR_MODE=both -XX:InlineFieldMaxFlatSize=128 -XX:FlatArrayElementMaxSize=-1
  *                   -Xbootclasspath/a:. -XX:+WhiteBoxAPI
  *                                   runtime.valhalla.inlinetypes.ValueTearing

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VarArgsArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VarArgsArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,7 @@ import static jdk.test.lib.Asserts.*;
  * @summary Test if JVM API using varargs work with inline type arrays
  * @library /test/lib
  * @compile VarArgsArray.java NewInstanceFromConstructor.java IntValue.java
- * @run main/othervm -Xint runtime.valhalla.inlinetypes.VarArgsArray
- * @run main/othervm -Xcomp runtime.valhalla.inlinetypes.VarArgsArray
+ * @run main runtime.valhalla.inlinetypes.VarArgsArray
  */
 public class VarArgsArray {
 

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -25,9 +25,8 @@
 /*
  * @test
  * @summary test Object methods on primitive classes
- * @run testng/othervm -Xint -Dvalue.bsm.salt=1 ObjectMethods
+ * @run testng/othervm -Dvalue.bsm.salt=1 ObjectMethods
  * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
- * @run testng/othervm -Xcomp -Dvalue.bsm.salt=1 ObjectMethods
  */
 import java.lang.reflect.Modifier;
 import java.util.Arrays;

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -26,8 +26,7 @@
  * @summary test MethodHandle/VarHandle on primitive classes
  * @modules java.base/java.lang.runtime:open
  *          java.base/jdk.internal.org.objectweb.asm
- * @run testng/othervm -Xint SubstitutabilityTest
- * @run testng/othervm -Xcomp SubstitutabilityTest
+ * @run testng SubstitutabilityTest
  */
 
 import java.lang.reflect.Method;


### PR DESCRIPTION
Many of the runtime tests still specify multiple runs with `-Xint`/`-Xcomp`. Setting these flags explicitly reduces coverage because flag combinations set by the CI test jobs are overridden. We should simply not set them in the tests.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8273554](https://bugs.openjdk.java.net/browse/JDK-8273554): [lworld] Runtime tests should not explicitly set -Xint/-Xcomp


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer) ⚠️ Review applies to 9c8dbed6f8354d68fff370f658c5142bb4e95117


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/550/head:pull/550` \
`$ git checkout pull/550`

Update a local copy of the PR: \
`$ git checkout pull/550` \
`$ git pull https://git.openjdk.java.net/valhalla pull/550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 550`

View PR using the GUI difftool: \
`$ git pr show -t 550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/550.diff">https://git.openjdk.java.net/valhalla/pull/550.diff</a>

</details>
