### PR TITLE
8273594: [lworld] JITs need to properly handle static inline type field with unloaded type

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2372,7 +2372,7 @@ void LIRGenerator::do_Deoptimize(Deoptimize* x) {
   // to refer to an inline class V, where V has not yet been loaded/resolved.
   // This is not a common case. Let's just deoptimize.
   CodeEmitInfo* info = state_for(x, x->state_before());
-  CodeStub* stub = new DeoptimizeStub(info,
+  CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
                                       Deoptimization::Reason_unloaded,
                                       Deoptimization::Action_make_not_entrant);
   __ jump(stub);

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -271,7 +271,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_vectorizedMismatch(Intrinsic* x);
   void do_blackhole(Intrinsic* x);
 
-  bool inline_type_field_access_prolog(AccessField* x, CodeEmitInfo* info);
+  bool inline_type_field_access_prolog(AccessField* x);
   void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -323,6 +323,19 @@ int ciBytecodeStream::get_field_holder_index() {
 }
 
 // ------------------------------------------------------------------
+// ciBytecodeStream::get_field_signature_index
+//
+// Get the constant pool index of the signature of the field
+// referenced by the current bytecode.  Used for generating
+// deoptimization information.
+int ciBytecodeStream::get_field_signature_index() {
+  VM_ENTRY_MARK;
+  ConstantPool* cpool = _holder->get_instanceKlass()->constants();
+  int nt_index = cpool->name_and_type_ref_index_at(get_field_index());
+  return cpool->signature_ref_index_at(nt_index);
+}
+
+// ------------------------------------------------------------------
 // ciBytecodeStream::get_method_index
 //
 // If this is a method invocation bytecode, get the constant pool

--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -245,6 +245,7 @@ public:
 
   ciInstanceKlass* get_declared_field_holder();
   int      get_field_holder_index();
+  int      get_field_signature_index();
 
   ciMethod*     get_method(bool& will_link, ciSignature* *declared_signature_result);
   bool          has_appendix();

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -670,6 +670,12 @@ void ciTypeFlow::StateVector::do_getstatic(ciBytecodeStream* str) {
   } else {
     ciType* field_type = field->type();
     if (!field_type->is_loaded()) {
+      if (field->is_static() && field->is_null_free()) {
+        // Deoptimize if we load from a static field with an unloaded
+        // inline type because we need the default value if the field is null.
+        trap(str, field_type->as_klass(), str->get_field_signature_index());
+        return;
+      }
       // Normally, we need the field's type to be loaded if we are to
       // do anything interesting with its value.
       // We used to do this:  trap(str, str->get_field_signature_index());

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -240,8 +240,11 @@ public class TestVM {
     }
 
     private void setupTests() {
-        for (Class<?> clazz : testClass.getDeclaredClasses()) {
-            checkAnnotationsInClass(clazz, "inner");
+        // TODO remove this once JDK-8273591 is fixed
+        if (!IGNORE_COMPILER_CONTROLS) {
+            for (Class<?> clazz : testClass.getDeclaredClasses()) {
+                checkAnnotationsInClass(clazz, "inner");
+            }
         }
         if (DUMP_REPLAY) {
             addReplay();


### PR DESCRIPTION
Both C1 and C2 do not properly handle loads from static inline type fields with an unloaded type. For C1, the fix is to simply remove two asserts that are too strong. For C2, we need to trap during typeflow analysis.

I've added a corresponding test to `TestUnloadedInlineTypeField.java` and noticed that the new IR Test Framework often triggers class loading while the test was carefully designed to avoid that. As a workaround, I slightly modified the framework and run the test with `-DIgnoreCompilerControls=true`. I filed [JDK-8273591](https://bugs.openjdk.java.net/browse/JDK-8273591) to fix this upstream.

I also fixed a `-XX:-XX:+PatchALot` typo in the test that went unnoticed because `-XX:+IgnoreUnrecognizedVMOptions` is set.

Thanks,
Tobias