### PR TITLE
8274792: [lworld] Final fields should be flattened

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -633,7 +633,6 @@ void FieldLayoutBuilder::regular_field_sorting() {
       group->add_oop_field(fs);
       break;
     case T_INLINE_TYPE:
-//      fs.set_inline(true);
       _has_inline_type_fields = true;
       if (group == _static_fields) {
         // static fields are never inlined
@@ -659,7 +658,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
           //too_volatile_to_flatten = false; //FIXME
           // volatile fields are currently never inlined, this could change in the future
         }
-        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten)) {
+        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten) || fs.access_flags().is_final()) {
           group->add_inlined_field(fs, vk);
           _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
           fs.set_inlined(true);
@@ -760,7 +759,7 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
           //too_volatile_to_flatten = false; //FIXME
           // volatile fields are currently never inlined, this could change in the future
         }
-        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten)) {
+        if (!(too_big_to_flatten | too_atomic_to_flatten | too_volatile_to_flatten) || fs.access_flags().is_final()) {
           group->add_inlined_field(fs, vk);
           _nonstatic_oopmap_count += vk->nonstatic_oop_map_count();
           field_alignment = vk->get_alignment();


### PR DESCRIPTION
Small fix triggering flattening of non-static fields.

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8274792](https://bugs.openjdk.java.net/browse/JDK-8274792): [lworld] Final fields should be flattened


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/558/head:pull/558` \
`$ git checkout pull/558`

Update a local copy of the PR: \
`$ git checkout pull/558` \
`$ git pull https://git.openjdk.java.net/valhalla pull/558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 558`

View PR using the GUI difftool: \
`$ git pr show -t 558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/558.diff">https://git.openjdk.java.net/valhalla/pull/558.diff</a>

</details>
