### PR TITLE
8275195: [lworld] Revisit use of TypePtr::meet_aryptr() after merge

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4839,12 +4839,12 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
     bool res_xk = false;
     bool res_not_flat = false;
     bool res_not_null_free = false;
-    const Type* elem = tary->_elem;
-    if (meet_aryptr(ptr, elem, this->klass(), tap->klass(),
+    const Type* res_elem = NULL;
+    if (meet_aryptr(ptr, _ary->_elem, tap->_ary->_elem, this->klass(), tap->klass(),
                     this->klass_is_exact(), tap->klass_is_exact(), this->ptr(), tap->ptr(),
                     this->is_not_flat(), tap->is_not_flat(),
                     this->is_not_null_free(), tap->is_not_null_free(),
-                    res_klass, res_xk, res_not_flat, res_not_null_free) == NOT_SUBTYPE) {
+                    res_elem, res_klass, res_xk, res_not_flat, res_not_null_free) == NOT_SUBTYPE) {
       instance_id = InstanceBot;
     } else if (klass() != NULL && tap->klass() != NULL && klass()->is_flat_array_klass() != tap->klass()->is_flat_array_klass()) {
       // Meeting flattened inline type array with non-flattened array. Adjust (field) offset accordingly.
@@ -4874,7 +4874,7 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
         ptr = NotNull;
       }
     }
-    return make(ptr, o, TypeAry::make(elem, tary->_size, tary->_stable, res_not_flat, res_not_null_free), res_klass, res_xk, off, field_off, instance_id, speculative, depth);
+    return make(ptr, o, TypeAry::make(res_elem, tary->_size, tary->_stable, res_not_flat, res_not_null_free), res_klass, res_xk, off, field_off, instance_id, speculative, depth);
   }
 
   // All arrays inherit from Object class
@@ -4945,17 +4945,20 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
 }
 
 
-TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* this_klass, ciKlass* tap_klass,
+TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type* this_elem, const Type* tap_elem,
+                                         ciKlass* this_klass, ciKlass* tap_klass,
                                          bool this_xk, bool tap_xk, PTR this_ptr, PTR tap_ptr,
                                          bool this_not_flat, bool tap_not_flat,
                                          bool this_not_null_free, bool tap_not_null_free,
-                                         ciKlass*& res_klass, bool& res_xk, bool& res_not_flat, bool& res_not_null_free) {
+                                         const Type*& res_elem, ciKlass*& res_klass,
+                                         bool& res_xk, bool& res_not_flat, bool& res_not_null_free) {
   res_klass = NULL;
   MeetResult result = SUBTYPE;
+  res_elem = this_elem->meet(tap_elem);
   res_not_flat = this_not_flat && tap_not_flat;
   res_not_null_free = this_not_null_free && tap_not_null_free;
 
-  if (elem->isa_int()) {
+  if (res_elem->isa_int()) {
     // Integral array element types have irrelevant lattice relations.
     // It is the klass that determines array layout, not the element type.
     if (this_klass == NULL) {
@@ -4966,7 +4969,7 @@ TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* t
       // Something like byte[int+] meets char[int+].
       // This must fall to bottom, not (int[-128..65535])[int+].
       // instance_id = InstanceBot;
-      elem = Type::BOTTOM;
+      res_elem = Type::BOTTOM;
       result = NOT_SUBTYPE;
     }
   } else // Non integral arrays.
@@ -4981,9 +4984,9 @@ TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* t
          (tap_xk && !tap_klass->is_subtype_of(this_klass)) ||
          // 'this' is exact and super or unrelated:
          (this_xk && !this_klass->is_subtype_of(tap_klass)))) {
-      if (above_centerline(ptr) || (elem->make_ptr() && above_centerline(elem->make_ptr()->_ptr)) ||
-          elem->isa_inlinetype()) {
-        elem = Type::BOTTOM;
+      if (above_centerline(ptr) || (res_elem->make_ptr() && above_centerline(res_elem->make_ptr()->_ptr)) ||
+          res_elem->isa_inlinetype()) {
+        res_elem = Type::BOTTOM;
       }
       ptr = NotNull;
       res_xk = false;
@@ -4997,10 +5000,13 @@ TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* t
       // Compute new klass on demand, do not use tap->_klass
       if (below_centerline(this_ptr)) {
         res_xk = this_xk;
+        if (this_elem->isa_inlinetype()) {
+          res_elem = this_elem;
+        }
       } else {
         res_xk = (tap_xk || this_xk);
       }
-      return result;
+      break;
     case Constant: {
       if (this_ptr == Constant) {
         res_xk = true;
@@ -5010,23 +5016,27 @@ TypePtr::MeetResult TypePtr::meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* t
         // Only precise for identical arrays
         res_xk = this_xk && (this_klass == tap_klass);
       }
-      return result;
+      break;
     }
     case NotNull:
     case BotPTR:
       // Compute new klass on demand, do not use tap->_klass
       if (above_centerline(this_ptr)) {
         res_xk = tap_xk;
+        if (tap_elem->isa_inlinetype()) {
+          res_elem = tap_elem;
+        }
       } else {
         res_xk = (tap_xk && this_xk) &&
           (this_klass == tap_klass); // Only precise for identical arrays
       }
-      return result;
+      break;
     default:  {
       ShouldNotReachHere();
       return result;
     }
   }
+
   return result;
 }
 
@@ -5934,6 +5944,11 @@ const TypeAryKlassPtr *TypeAryKlassPtr::make(PTR ptr, ciKlass* klass, Offset off
     // Element is an object array. Recursively call ourself.
     ciKlass* eklass = klass->as_obj_array_klass()->element_klass();
     const TypeKlassPtr *etype = TypeKlassPtr::make(eklass)->cast_to_exactness(false);
+
+    if (etype->klass_is_exact() && etype->isa_instklassptr() && etype->is_instklassptr()->klass()->is_inlinetype() && !null_free) {
+      etype = TypeInstKlassPtr::make(NotNull, etype->is_instklassptr()->klass(), Offset(etype->is_instklassptr()->offset()), etype->is_instklassptr()->flatten_array());
+    }
+
     const TypeAryKlassPtr* res = TypeAryKlassPtr::make(ptr, etype, NULL, offset, not_flat, not_null_free, null_free ? 1 : 0);
     assert(res->klass() == klass, "");
     return res;
@@ -6212,39 +6227,29 @@ const Type    *TypeAryKlassPtr::xmeet( const Type *t ) const {
   case AryKlassPtr: {  // Meet two KlassPtr types
     const TypeAryKlassPtr *tap = t->is_aryklassptr();
     Offset off = meet_offset(tap->offset());
-    const Type* elem = _elem->meet(tap->_elem);
+    const Type* res_elem = NULL;
     PTR ptr = meet_ptr(tap->ptr());
     ciKlass* res_klass = NULL;
     bool res_xk = false;
     bool res_not_flat = false;
     bool res_not_null_free = false;
-    MeetResult res = meet_aryptr(ptr, elem, this->klass(), tap->klass(), this->klass_is_exact(), tap->klass_is_exact(),
+    MeetResult res = meet_aryptr(ptr, _elem, tap->_elem, this->klass(), tap->klass(),
+                                 this->klass_is_exact(), tap->klass_is_exact(),
                                  this->ptr(), tap->ptr(), this->is_not_flat(), tap->is_not_flat(),
                                  this->is_not_null_free(), tap->is_not_null_free(),
-                                 res_klass, res_xk, res_not_flat, res_not_null_free);
+                                 res_elem, res_klass, res_xk, res_not_flat, res_not_null_free);
     assert(res_xk == (ptr == Constant), "");
     int null_free = _null_free & tap->_null_free;
     if (res == NOT_SUBTYPE) {
       null_free = 0;
     } else if (res == SUBTYPE) {
-      // FIXME: should this be done for TypeAryPtr::xmeet() as well? Does this need to be moved into meet_aryptr()?
-      if (above_centerline(tap->ptr()) && _elem->isa_inlinetype()) {
-        elem = _elem;
-      } else if (above_centerline(_ptr) && tap->_elem->isa_inlinetype()) {
-        elem = tap->_elem;
-      } else if (below_centerline(tap->ptr()) && _elem->isa_inlinetype()) {
-        elem = tap->_elem;
-      } else if (below_centerline(_ptr) && tap->_elem->isa_inlinetype()) {
-        elem = _elem;
-      }
-
       if (above_centerline(tap->ptr()) && !above_centerline(this->ptr())) {
         null_free = _null_free;
       } else if (above_centerline(this->ptr()) && !above_centerline(tap->ptr())) {
         null_free = tap->_null_free;
       }
     }
-    return make(ptr, elem, res_klass, off, res_not_flat, res_not_null_free, null_free);
+    return make(ptr, res_elem, res_klass, off, res_not_flat, res_not_null_free, null_free);
   } // End of case KlassPtr
   case InstKlassPtr: {
     const TypeInstKlassPtr *tp = t->is_instklassptr();

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1016,11 +1016,11 @@ protected:
   meet_instptr(PTR &ptr, ciKlass* this_klass, ciKlass* tinst_klass, bool this_xk, bool tinst_xk, PTR this_ptr,
                PTR tinst_ptr, bool this_flatten_array, bool tinst_flatten_array, ciKlass*&res_klass, bool &res_xk,
                bool& res_flatten_array);
-  static MeetResult
-  meet_aryptr(PTR& ptr, const Type*& elem, ciKlass* this_klass, ciKlass* tap_klass, bool this_xk, bool tap_xk,
-              PTR this_ptr, PTR tap_ptr, bool this_not_flat, bool tap_not_flat,
-              bool this_not_null_free, bool tap_not_null_free, ciKlass*& res_klass,
-              bool& res_xk, bool& res_not_flat, bool& res_not_null_free);
+
+  static MeetResult meet_aryptr(PTR &ptr, const Type* this_elem, const Type* tap_elem, ciKlass* this_klass, ciKlass* tap_klass,
+                                bool this_xk, bool tap_xk, PTR this_ptr, PTR tap_ptr, bool this_not_flat, bool tap_not_flat,
+                                bool this_not_null_free, bool tap_not_null_free, const Type*& res_elem, ciKlass*&res_klass,
+                                bool &res_xk, bool &res_not_flat, bool &res_not_null_free);
 
 public:
   const Offset _offset;         // Offset into oop, with TOP & BOT

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -114,7 +114,7 @@ public class InlineTypes {
         protected static final String ALLOC_G  = "(.*call,static.*wrapper for: _new_instance_Java" + END;
         protected static final String ALLOCA_G = "(.*call,static.*wrapper for: _new_array_Java" + END;
         // Inline type allocation
-        protected static final String MYVALUE_ARRAY_KLASS = "\\[precise compiler/valhalla/inlinetypes/MyValue";
+        protected static final String MYVALUE_ARRAY_KLASS = "\\[(precise )?compiler/valhalla/inlinetypes/MyValue";
         protected static final String ALLOC  = "(.*precise compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_instance_Java" + END;
         protected static final String ALLOCA = "(.*" + MYVALUE_ARRAY_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
         protected static final String LOAD   = START + "Load(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/.*" + END;


### PR DESCRIPTION
I tried to move the logic that I added to TypeAryKlassPtr into
meet_aryptr() where it's shared between TypeAryPtr and
TypeAryKlassPtr. When running tests, I ran into a failure that I fixed
by making the element klass of an array of nullable inline types
to be non constant similar to this logic:

    // Even if MyValue is exact, [LMyValue is not exact due to [QMyValue <: [LMyValue.
    bool xk = etype->klass_is_exact() && (!etype->is_inlinetypeptr() || null_free);

in TypeOopPtr::make_from_klass_common().

Actually, shouldn't the element type be non exact in the TypeAryPtr
case too?

