### PR TITLE
8274972: [lworld] TestLWorld.test151() fails with IR verification errors

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1913,12 +1913,12 @@ bool PhiNode::wait_for_region_igvn(PhaseGVN* phase) {
 }
 
 // Push inline type input nodes (and null) down through the phi recursively (can handle data loops).
-InlineTypeBaseNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk, bool not_null) {
+InlineTypeBaseNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk, bool is_init) {
   InlineTypeBaseNode* vt = NULL;
   if (_type->isa_ptr()) {
-    vt = InlineTypePtrNode::make_null(*phase, vk)->clone_with_phis(phase, in(0), not_null);
+    vt = InlineTypePtrNode::make_null(*phase, vk)->clone_with_phis(phase, in(0), is_init);
   } else {
-    vt = InlineTypeNode::make_null(*phase, vk)->clone_with_phis(phase, in(0), not_null);
+    vt = InlineTypeNode::make_null(*phase, vk)->clone_with_phis(phase, in(0), is_init);
   }
   if (can_reshape) {
     // Replace phi right away to be able to use the inline
@@ -1941,7 +1941,7 @@ InlineTypeBaseNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can
       other = InlineTypePtrNode::make_null(*phase, vk);
     } else {
       assert(can_reshape, "can only handle phis during IGVN");
-      other = phase->transform(n->as_Phi()->push_inline_types_through(phase, can_reshape, vk, not_null));
+      other = phase->transform(n->as_Phi()->push_inline_types_through(phase, can_reshape, vk, is_init));
     }
     bool transform = !can_reshape && (i == (req()-1)); // Transform phis on last merge
     vt->merge_with(phase, other->as_InlineTypeBase(), i, transform);
@@ -2509,7 +2509,8 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     worklist.push(this);
     bool can_optimize = true;
     ciInlineKlass* vk = NULL;
-    bool not_null = true;
+    // true if all IsInit inputs of all InlineType* nodes are true
+    bool is_init = true;
 
     for (uint next = 0; next < worklist.size() && can_optimize; next++) {
       Node* phi = worklist.at(next);
@@ -2524,21 +2525,21 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         if (n->is_InlineTypeBase() && n->as_InlineTypeBase()->can_merge() &&
             (vk == NULL || vk == t->inline_klass())) {
           vk = (vk == NULL) ? t->inline_klass() : vk;
-          if (phase->type(n->as_InlineTypeBase()->get_oop())->maybe_null()) {
-            not_null = false;
+          if (phase->find_int_con(n->as_InlineTypeBase()->get_is_init(), 0) != 1) {
+            is_init = false;
           }
         } else if (n->is_Phi() && can_reshape) {
           worklist.push(n);
         } else if (t->is_zero_type()) {
-          not_null = false;
+          is_init = false;
         } else {
           can_optimize = false;
         }
       }
     }
     if (can_optimize && vk != NULL) {
-      assert(!_type->isa_ptr() || _type->maybe_null() || not_null, "Phi not null but a null input was seen");
-      progress = push_inline_types_through(phase, can_reshape, vk, not_null);
+//      assert(!_type->isa_ptr() || _type->maybe_null() || is_init, "Phi not null but a possible null was seen");
+      progress = push_inline_types_through(phase, can_reshape, vk, is_init);
     }
   }
 

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -215,7 +215,7 @@ public:
   }
   Node* try_clean_mem_phi(PhaseGVN *phase);
 
-  InlineTypeBaseNode* push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk, bool not_null);
+  InlineTypeBaseNode* push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk, bool is_init);
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -35,7 +35,7 @@
 
 // Clones the inline type to handle control flow merges involving multiple inline types.
 // The inputs are replaced by PhiNodes to represent the merged values for the given region.
-InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* region, bool not_null) {
+InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* region, bool is_init) {
   InlineTypeBaseNode* vt = clone()->as_InlineTypeBase();
   if (vt->is_InlineTypePtr()) {
     // Use nullable type
@@ -46,20 +46,22 @@ InlineTypeBaseNode* InlineTypeBaseNode::clone_with_phis(PhaseGVN* gvn, Node* reg
 
   // Create a PhiNode for merging the oop values
   const Type* phi_type = Type::get_const_type(inline_klass());
-  if (not_null) {
-    phi_type = phi_type->join_speculative(TypePtr::NOTNULL);
-  }
   PhiNode* oop = PhiNode::make(region, vt->get_oop(), phi_type);
   gvn->set_type(oop, phi_type);
   gvn->record_for_igvn(oop);
   vt->set_oop(oop);
 
   // Create a PhiNode for merging the is_init values
-  phi_type = Type::get_const_basic_type(T_BOOLEAN);
-  PhiNode* is_init = PhiNode::make(region, vt->get_is_init(), phi_type);
-  gvn->set_type(is_init, phi_type);
-  gvn->record_for_igvn(is_init);
-  vt->set_req(IsInit, is_init);
+  Node* is_init_node;
+  if (is_init) {
+    is_init_node = gvn->intcon(1);
+  } else {
+    phi_type = Type::get_const_basic_type(T_BOOLEAN);
+    is_init_node = PhiNode::make(region, vt->get_is_init(), phi_type);
+    gvn->set_type(is_init_node, phi_type);
+    gvn->record_for_igvn(is_init_node);
+  }
+  vt->set_req(IsInit, is_init_node);
 
   // Create a PhiNode each for merging the field values
   for (uint i = 0; i < vt->field_count(); ++i) {
@@ -124,10 +126,15 @@ InlineTypeBaseNode* InlineTypeBaseNode::merge_with(PhaseGVN* gvn, const InlineTy
     set_oop(gvn->transform(phi));
   }
 
-  phi = get_is_init()->as_Phi();
-  phi->set_req(pnum, other->get_is_init());
-  if (transform) {
-    set_req(IsInit, gvn->transform(phi));
+  Node* is_init = get_is_init();
+  if (is_init->is_Phi()) {
+    phi = is_init->as_Phi();
+    phi->set_req(pnum, other->get_is_init());
+    if (transform) {
+      set_req(IsInit, gvn->transform(phi));
+    }
+  } else {
+    assert(is_init->find_int_con(0) == 1, "only with a non null inline type");
   }
 
   // Merge field values

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -64,7 +64,7 @@ public:
 
   // Support for control flow merges
   bool has_phi_inputs(Node* region);
-  InlineTypeBaseNode* clone_with_phis(PhaseGVN* gvn, Node* region, bool not_null = false);
+  InlineTypeBaseNode* clone_with_phis(PhaseGVN* gvn, Node* region, bool is_init = false);
   bool can_merge();
   InlineTypeBaseNode* merge_with(PhaseGVN* gvn, const InlineTypeBaseNode* other, int pnum, bool transform);
   void add_new_path(Node* region);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4120,8 +4120,6 @@ public class TestLWorld {
     }
 
     // Same as test150 but with val not being allocated in the scope of the method
-// TODO 8274972
-/*
     @Test
     @IR(failOn = {compiler.lib.ir_framework.IRNode.DYNAMIC_CALL_OF_METHOD, "MyValue2::hash"},
         counts = {compiler.lib.ir_framework.IRNode.STATIC_CALL_OF_METHOD, "MyValue2::hash", "= 1"})
@@ -4143,5 +4141,4 @@ public class TestLWorld {
     public void test151_verifier() {
         Asserts.assertEquals(test151(testValue2), testValue2.hash());
     }
-*/
 }


### PR DESCRIPTION
The test failure is caused by this check:
bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms) {
  // Method handle linker case is handled in CallDynamicJavaNode::Ideal().
  // Unless inlining is performed, _override_symbolic_info bit will be set in DirectCallGenerator::generate().
  // Implicit receiver null checks introduce problems when exception states are combined.
  Node* receiver = jvms->map()->argument(jvms, 0);
  const Type* recv_type = C->initial_gvn()->type(receiver);
  if (recv_type->maybe_null()) {
    return false;
  }
  
That code came with the recent merge. receiver should be not null
(it's a InlineTypePtrNode) but it's not. The InlineTypePtrNode is
created when pushed down through Phis. The fix I propose is to set the
type of the phi that's the Oop input to InlineTypeBase to non null
when it's created if it's observed that all InlineTypeBase nodes
encountered when following Phi inputs are non null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8274972](https://bugs.openjdk.java.net/browse/JDK-8274972): [lworld] TestLWorld.test151() fails with IR verification errors


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/563/head:pull/563` \
`$ git checkout pull/563`

Update a local copy of the PR: \
`$ git checkout pull/563` \
`$ git pull https://git.openjdk.java.net/valhalla pull/563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 563`

View PR using the GUI difftool: \
`$ git pr show -t 563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/563.diff">https://git.openjdk.java.net/valhalla/pull/563.diff</a>

</details>
