### PR TITLE
8275276: [lworld] C2 compilation fails with assert "adr_type for memory phis only"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1897,10 +1897,18 @@ Node* PhaseIdealLoop::clone_iff(PhiNode *phi, IdealLoopTree *loop) {
   } else {
     sample_bool = n;
   }
-  Node *sample_cmp = sample_bool->in(1);
+  Node* sample_cmp = sample_bool->in(1);
+  const Type* t = Type::TOP;
+  const TypePtr* at = NULL;
+  if (sample_cmp->is_FlatArrayCheck()) {
+    // Left input of a FlatArrayCheckNode is memory, set the (adr) type of the phi accordingly
+    assert(sample_cmp->in(1)->bottom_type() == Type::MEMORY, "unexpected input type");
+    t = Type::MEMORY;
+    at = TypeRawPtr::BOTTOM;
+  }
 
   // Make Phis to merge the Cmp's inputs.
-  PhiNode *phi1 = new PhiNode(phi->in(0), Type::TOP);
+  PhiNode *phi1 = new PhiNode(phi->in(0), t, at);
   PhiNode *phi2 = new PhiNode(phi->in(0), Type::TOP);
   for (i = 1; i < phi->req(); i++) {
     Node *n1 = sample_opaque == NULL ? phi->in(i)->in(1)->in(1) : phi->in(i)->in(1)->in(1)->in(1);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLoopUnswitchingWithFlatArrayCheck.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLoopUnswitchingWithFlatArrayCheck.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8275276
+ * @summary Test loop unswitching with flat array checks.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestLoopUnswitchingWithFlatArrayCheck::test TestLoopUnswitchingWithFlatArrayCheck
+ */
+
+public class TestLoopUnswitchingWithFlatArrayCheck {
+
+    Object[] objectArray = new Object[1000];
+
+    boolean test(Object o) {
+        return false;
+    }
+
+    private Object test(int start, int end) {
+        Object res = null;
+        Object[] array = objectArray;
+        if (array == null) {
+           return null;
+        }
+        for (int i = start; ; i++) {
+            if (test(array[i])) {
+                continue;
+            }
+            if (i == end) {
+                break;
+            }
+        }
+        for (int i = 0; i < 100; i++) {
+            for (; i < 100; i++) {
+                res = array[i];
+            }
+        }
+        return res;
+    }
+
+    public static void main(String[] args) {
+        TestLoopUnswitchingWithFlatArrayCheck t = new TestLoopUnswitchingWithFlatArrayCheck();
+        t.test(0, 10);
+    }
+}


### PR DESCRIPTION
`PhiNode::verify_adr_type` fails with an assert because the phi has `Type::MEMORY` but `_adr_type` is not set. The phi is created when pushing bool/cmp pairs through a Phi in `PhaseIdealLoop::clone_iff` for Loop Unswitching:

![Screenshot from 2021-10-14 12-58-37](https://user-images.githubusercontent.com/5312595/137304712-c1450fbf-dcf9-4d83-a5f6-36db8abb1c09.png)

Is converted to:

![Screenshot from 2021-10-14 12-59-00](https://user-images.githubusercontent.com/5312595/137304754-f686d862-4be4-4438-9d10-c7c6bca95f89.png)

The code does not correctly handle `FlatArrayCheckNodes` which have a memory input as left input. The fix is to properly set the `_adr_type` in that case.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8275276](https://bugs.openjdk.java.net/browse/JDK-8275276): [lworld] C2 compilation fails with assert "adr_type for memory phis only"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/564/head:pull/564` \
`$ git checkout pull/564`

Update a local copy of the PR: \
`$ git checkout pull/564` \
`$ git pull https://git.openjdk.java.net/valhalla pull/564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 564`

View PR using the GUI difftool: \
`$ git pr show -t 564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/564.diff">https://git.openjdk.java.net/valhalla/pull/564.diff</a>

</details>
