### PR TITLE
8275331: [lworld] TestArrays.java fails IR verification on aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -108,6 +108,7 @@ applications/jcstress/copy.java 8229852 linux-x64
 # Valhalla
 
 runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java 8274131 linux-aarch64-debug,macosx-aarch64-debug
+compiler/c2/irTests/TestPostParseCallDevirtualization.java 8274973 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -143,7 +143,7 @@ public class InlineTypes {
         protected static final String UNHANDLED_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unhandled" + END;
         protected static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
         protected static final String MEMBAR = START + "MemBar" + MID + END;
-        protected static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*;:.*\\R.*(cmp|CMP|CLR))" + END;
+        protected static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*:.*\\R.*(cmp|CMP|CLR))" + END;
         protected static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
         protected static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
         protected static final String FIELD_ACCESS = "(.*Field: *" + END;


### PR DESCRIPTION
IR verification fails after the recent merge with mainline because the fix for [JDK-8273825](https://bugs.openjdk.java.net/browse/JDK-8273825) needs to be applied to Valhalla specific matching rules.

I also problem listed `TestPostParseCallDevirtualization` until [JDK-8274973](https://bugs.openjdk.java.net/browse/JDK-8274973) is fixed.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8275331](https://bugs.openjdk.java.net/browse/JDK-8275331): [lworld] TestArrays.java fails IR verification on aarch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.java.net/valhalla pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/565.diff">https://git.openjdk.java.net/valhalla/pull/565.diff</a>

</details>
