### PR TITLE
8274950: [lworld] LoadNode::Identity optimization should not skip casts

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1910,6 +1910,8 @@ static bool return_val_keeps_allocations_alive(Node* ret_val) {
                n->in(1)->is_Proj() &&
                n->in(1)->in(0)->is_Allocate()) {
       some_allocations = true;
+    } else if (n->is_CheckCastPP()) {
+      wq.push(n->in(1));
     }
   }
   return some_allocations;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1241,9 +1241,8 @@ Node* LoadNode::Identity(PhaseGVN* phase) {
   Node* addr = in(Address);
   intptr_t offset;
   Node* base = AddPNode::Ideal_base_and_offset(addr, phase, offset);
-  InlineTypePtrNode* vt = (base != NULL) ? base->uncast()->isa_InlineTypePtr() : NULL;
-  if (vt != NULL && offset > oopDesc::klass_offset_in_bytes()) {
-    Node* value = vt->field_value_by_offset((int)offset, true);
+  if (base != NULL && base->is_InlineTypePtr() && offset > oopDesc::klass_offset_in_bytes()) {
+    Node* value = base->as_InlineTypePtr()->field_value_by_offset((int)offset, true);
     if (value->is_InlineType()) {
       // Non-flattened inline type field
       InlineTypeNode* vt = value->as_InlineType();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2353,7 +2353,7 @@ public class TestNullableInlineTypes {
 
     @Run(test = "test85")
     public void test85_verifier() {
-        Asserts.assertEquals(test82(), test82Result);
+        Asserts.assertEquals(test85(), test85Result);
     }
 
     static final class ObjectWrapper {
@@ -2410,9 +2410,63 @@ public class TestNullableInlineTypes {
     }
 
     @Run(test = "test87")
-    public void test87_verifier(RunInfo info) {
+    public void test87_verifier() {
         Test87C2 v = new Test87C2();
         Asserts.assertEQ(test87(true, v, v), v.field);
         Asserts.assertEQ(test87(false, v, v), v.field);
+    }
+
+    static primitive class Test88Value {
+        int x = 0;
+    }
+
+    static class Test88MyClass {
+        int x = 0;
+        int y = rI;
+    }
+
+    @ForceInline
+    Object test88Helper() {
+        return new Test88Value();
+    }
+
+    // Test LoadNode::Identity optimization with always failing checkcast
+    @Test
+    public int test88() {
+        Object obj = test88Helper();
+        return ((Test88MyClass)obj).y;
+    }
+
+    @Run(test = "test88")
+    public void test88_verifier() {
+        try {
+            test88();
+            throw new RuntimeException("No ClassCastException thrown");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+
+    // Same as test88 but with Phi
+    @Test
+    public int test89(boolean b) {
+        Test88MyClass obj = b ? (Test88MyClass)test88Helper() : (Test88MyClass)test88Helper();
+        return obj.y;
+    }
+
+    @Run(test = "test89")
+    public void test89_verifier() {
+        try {
+            test89(false);
+            throw new RuntimeException("No ClassCastException thrown");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+        try {
+            test89(true);
+            throw new RuntimeException("No ClassCastException thrown");
+        } catch (ClassCastException e) {
+            // Expected
+        }
     }
 }


### PR DESCRIPTION
When implementing scalarization of nullable inline types with [JDK-8267665](https://bugs.openjdk.java.net/browse/JDK-8267665), I added code to skip cast nodes. This allows the `LoadNode::Identity` optimization to fold loads from `InlineTypePtrNodes` that are hidden behind casts. However, skipping casts is often not correct because not only do we potentially lose type information but the cast could also fail. In the reported case, we hit an assert because we are loading from an offset that does not correspond to a field in the inline type (because the cast would fail).

This patch handles cast nodes properly by pushing them up through the InlineTypePtrNode oop input.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8274950](https://bugs.openjdk.java.net/browse/JDK-8274950): [lworld] LoadNode::Identity optimization should not skip casts


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/566/head:pull/566` \
`$ git checkout pull/566`

Update a local copy of the PR: \
`$ git checkout pull/566` \
`$ git pull https://git.openjdk.java.net/valhalla pull/566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 566`

View PR using the GUI difftool: \
`$ git pr show -t 566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/566.diff">https://git.openjdk.java.net/valhalla/pull/566.diff</a>

</details>
