### PR TITLE
8272448: [lworld] C2 compilation fails with "Bad graph detected in build_loop_late"

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1579,8 +1579,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
     }
   }
 
-  // TODO Disabled until JDK-8272448 is fixed.
-  // try_sink_out_of_loop(n);
+  try_sink_out_of_loop(n);
 
   try_move_store_after_loop(n);
 


### PR DESCRIPTION
The assert does not reproduce anymore after merging with mainline and has most likely been resolved by one of the upstream fixes. I'm re-enabling the optimization.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8272448](https://bugs.openjdk.java.net/browse/JDK-8272448): [lworld] C2 compilation fails with "Bad graph detected in build_loop_late"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/567/head:pull/567` \
`$ git checkout pull/567`

Update a local copy of the PR: \
`$ git checkout pull/567` \
`$ git pull https://git.openjdk.java.net/valhalla pull/567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 567`

View PR using the GUI difftool: \
`$ git pr show -t 567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/567.diff">https://git.openjdk.java.net/valhalla/pull/567.diff</a>

</details>
