### PR TITLE
8275583: [lworld] C2 fails to scalarize inline types in safepoint debug info in rare cases

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -590,13 +590,6 @@ Node* InlineTypeBaseNode::allocate_fields(GraphKit* kit) {
 }
 
 Node* InlineTypeBaseNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  if (phase->C->scalarize_in_safepoints() && can_reshape) {
-    PhaseIterGVN* igvn = phase->is_IterGVN();
-    make_scalar_in_safepoints(igvn);
-    if (outcnt() == 0) {
-      return NULL;
-    }
-  }
   Node* is_init = get_is_init();
   if (is_init->isa_InlineTypePtr()) {
     set_req(IsInit, is_init->as_InlineTypePtr()->get_is_init());

--- a/src/hotspot/share/opto/locknode.cpp
+++ b/src/hotspot/share/opto/locknode.cpp
@@ -149,6 +149,14 @@ bool FastLockNode::cmp( const Node &n ) const {
   return (&n == this);                // Always fail except on self
 }
 
+const Type* FastLockNode::Value(PhaseGVN* phase) const {
+  if (phase->type(in(1))->is_inlinetypeptr()) {
+    // Locking on inline types always fails
+    return TypeInt::CC_GT;
+  }
+  return TypeInt::CC;
+}
+
 //=============================================================================
 //-----------------------------hash--------------------------------------------
 uint FastUnlockNode::hash() const { return NO_HASH; }

--- a/src/hotspot/share/opto/locknode.hpp
+++ b/src/hotspot/share/opto/locknode.hpp
@@ -93,7 +93,7 @@ public:
   virtual uint size_of() const;
   virtual bool cmp( const Node &n ) const ;    // Always fail, except on self
   virtual int Opcode() const;
-  virtual const Type* Value(PhaseGVN* phase) const { return TypeInt::CC; }
+  virtual const Type* Value(PhaseGVN* phase) const;
   const Type *sub(const Type *t1, const Type *t2) const { return TypeInt::CC;}
 
   void create_rtm_lock_counter(JVMState* state);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3683,6 +3683,7 @@ public class TestLWorld {
     }
 
     @Test
+    @IR(failOn = {ALLOC, LOAD, STORE})
     public void test130() {
         Object obj = test130_inlinee();
         synchronized (obj) {
@@ -3727,6 +3728,7 @@ public class TestLWorld {
 
     // Test locking on object that is known to be an inline type only after CCP
     @Test
+    @IR(failOn = {ALLOC, LOAD, STORE})
     public void test132() {
         MyValue2 vt = MyValue2.createWithFieldsInline(rI, rD);
         Object obj = Integer.valueOf(42);


### PR DESCRIPTION
In rare cases, it can happen that inline types are not scalarized in safepoint debug info and we hit an assert. The problem is that `InlineTypeBaseNode::Ideal` is only called by IGVN if the node (or one of its inputs) has been modified but not if folding of output nodes leads to a direct connection to a SafePointNode. Usually, the node is still scalarized when we visit all inline type nodes via ` Compile::process_inline_types` but there are cases when that's too late and not scalarizing the node early (prevents other nodes from being removed (for example, during macro expansion).

The fix is to simply move the code to `SafePointNode::Ideal` which will be invoked whenever one of the (debug) inputs changed.

I also fixed an issue where `FastLockNodes` with an `InlineTypePtrNode` input are not folded and keep allocations alive.

Best regards,
Tobias