### PR TITLE
8275797: [lworld] Scalar replacement fails with ShouldNotReachHere() due to unexpected load type

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -578,7 +578,7 @@ Node* PhaseMacroExpand::inline_type_from_mem(Node* mem, Node* ctl, ciInlineKlass
       value = inline_type_from_mem(mem, ctl, field_type->as_inline_klass(), adr_type, field_offset, alloc);
     } else {
       const Type* ft = Type::get_const_type(field_type);
-      BasicType bt = field_type->basic_type();
+      BasicType bt = type2field[field_type->basic_type()];
       if (UseCompressedOops && !is_java_primitive(bt)) {
         ft = ft->make_narrowoop();
         bt = T_NARROWOOP;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3491,4 +3491,22 @@ public class TestArrays {
         int res = test147(!info.isWarmUp());
         Asserts.assertEquals(res, MyValue2.createWithFieldsInline(rI, rD).x + (info.isWarmUp() ? 0 : 42));
     }
+
+    // Test that correct basic types are used when folding field
+    // loads from a scalar replaced array through an arraycopy.
+    @Test
+    public void test148(MyValue1 vt) {
+        MyValue1[] src = new MyValue1[1];
+        MyValue1[] dst = new MyValue1[1];
+        src[0] = vt;
+        System.arraycopy(src, 0, dst, 0, 1);
+        if (src[0].hash() != dst[0].hash()) {
+          throw new RuntimeException("Unexpected hash");
+        }
+    }
+
+    @Run(test = "test148")
+    public void test148_verifier() {
+        test148(MyValue1.createWithFieldsInline(rI, rL));
+    }
 }


### PR DESCRIPTION
When folding a field load from a scalar replaced, flat inline type array through an array copy, `T_ARRAY` is used instead of `T_OBJECT`. The fix is to simply convert the basic type of the field via `type2field` like we do in `InlineTypeBaseNode::load` and at other places.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8275797](https://bugs.openjdk.java.net/browse/JDK-8275797): [lworld] Scalar replacement fails with ShouldNotReachHere() due to unexpected load type


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/569/head:pull/569` \
`$ git checkout pull/569`

Update a local copy of the PR: \
`$ git checkout pull/569` \
`$ git pull https://git.openjdk.java.net/valhalla pull/569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 569`

View PR using the GUI difftool: \
`$ git pr show -t 569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/569.diff">https://git.openjdk.java.net/valhalla/pull/569.diff</a>

</details>
