### PR TITLE
8275824: [lworld] C2 generates unused code (klass ptr check) when oop value of scalarized return is not used

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3758,7 +3758,7 @@ encode %{
       // Check that stack depth is unchanged: find majik cookie on stack
       __ call_Unimplemented();
     }
-    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic() && return_value_is_used()) {
       // An inline type is returned as fields in multiple registers.
       // R0 either contains an oop if the inline type is buffered or a pointer
       // to the corresponding InlineKlass with the lowest bit set to 1. Zero r0

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2424,7 +2424,7 @@ encode %{
       __ int3();
       __ bind(L);
     }
-    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic()) {
+    if (tf()->returns_inline_type_as_fields() && !_method->is_method_handle_intrinsic() && return_value_is_used()) {
       // An inline type is returned as fields in multiple registers.
       // Rax either contains an oop if the inline type is buffered or a pointer
       // to the corresponding InlineKlass with the lowest bit set to 1. Zero rax

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -697,14 +697,11 @@ void MachCallNode::dump_spec(outputStream *st) const {
 }
 #endif
 
-#ifndef _LP64
 bool MachCallNode::return_value_is_used() const {
   if (tf()->range_sig()->cnt() == TypeFunc::Parms) {
     // void return
     return false;
   }
-
-  assert(tf()->returns_inline_type_as_fields(), "multiple return values not supported");
 
   // find the projection corresponding to the return value
   for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
@@ -716,7 +713,6 @@ bool MachCallNode::return_value_is_used() const {
   }
   return false;
 }
-#endif
 
 // Similar to cousin class CallNode::returns_pointer
 // Because this is used in deoptimization, we want the type info, not the data

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -949,7 +949,7 @@ public:
   virtual const RegMask &in_RegMask(uint) const;
   virtual int ret_addr_offset() { return 0; }
 
-  NOT_LP64(bool return_value_is_used() const;)
+  bool return_value_is_used() const;
 
   // Similar to cousin class CallNode::returns_pointer
   bool returns_pointer() const;


### PR DESCRIPTION
When an inline type is returned as fields in registers, one register (`rax` on x86) either contains an oop if the inline type is buffered or a pointer to the corresponding `InlineKlass` with the lowest bit set to 1 (used by the interpreter and C1 to buffer). To use the oop, C2 emits code to zero that register if the lowest bit is set after a call. However, that code should not be emitted if the oop is never used.

Thanks to @kuksenko for reporting!

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8275824](https://bugs.openjdk.java.net/browse/JDK-8275824): [lworld] C2 generates unused code (klass ptr check) when oop value of scalarized return is not used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/570/head:pull/570` \
`$ git checkout pull/570`

Update a local copy of the PR: \
`$ git checkout pull/570` \
`$ git pull https://git.openjdk.java.net/valhalla pull/570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 570`

View PR using the GUI difftool: \
`$ git pr show -t 570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/570.diff">https://git.openjdk.java.net/valhalla/pull/570.diff</a>

</details>
