### PR TITLE
8275606: [lworld] ClassInitializationFailuresTest triggers assert with -XX:-UseTLAB

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -287,6 +287,9 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ConstantPoolCa
   }
   Handle ref_h(THREAD, ref);
   InlineKlass* ik = InlineKlass::cast(old_value_h()->klass());
+  // Ensure that the class is initialized or being initialized
+  // If the class is in error state, the creation of a new value should not be allowed
+  ik->initialize(CHECK_(ret_adj));
   instanceOop new_value = ik->allocate_instance_buffer(CHECK_(ret_adj));
   Handle new_value_h = Handle(THREAD, new_value);
   ik->inline_copy_oop_to_new_oop(old_value_h(), new_value_h());
@@ -402,7 +405,6 @@ JRT_ENTRY(void, InterpreterRuntime::read_inlined_field(JavaThread* current, oopD
   assert(klass->field_is_inlined(index), "Sanity check");
 
   InlineKlass* field_vklass = InlineKlass::cast(klass->get_inline_type_field_klass(index));
-  assert(field_vklass->is_initialized(), "Must be initialized at this point");
 
   oop res = field_vklass->read_inlined_field(obj_h(), klass->field_offset(index), CHECK);
   current->set_vm_result(res);

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -118,7 +118,8 @@ int InlineKlass::nonstatic_oop_count() {
 
 oop InlineKlass::read_inlined_field(oop obj, int offset, TRAPS) {
   oop res = NULL;
-  this->initialize(CHECK_NULL); // will throw an exception if in error state
+  assert(is_initialized() || is_being_initialized()|| is_in_error_state(),
+        "Must be initialized, initializing or in a corner case of an escaped instance of a class that failed its initialization");
   if (is_empty_inline_type()) {
     res = (instanceOop)default_value();
   } else {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java
@@ -38,9 +38,9 @@ public class ClassInitializationFailuresTest {
     static primitive class BadOne {
         int i = 0;
         static {
-        if (ClassInitializationFailuresTest.failingInitialization) {
-            throw new RuntimeException("Failing initialization");
-        }
+            if (ClassInitializationFailuresTest.failingInitialization) {
+                throw new RuntimeException("Failing initialization");
+            }
         }
     }
 
@@ -61,9 +61,9 @@ public class ClassInitializationFailuresTest {
     static void testClassInitialization() {
         Throwable e = null;
         try {
-        TestClass1 t1 = new TestClass1();
+            TestClass1 t1 = new TestClass1();
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Exception should have been thrown");
         Asserts.assertTrue(e.getClass() == ExceptionInInitializerError.class, "Must be an ExceptionInInitializerError");
@@ -71,9 +71,9 @@ public class ClassInitializationFailuresTest {
         // Second attempt because it doesn't fail the same way
         e = null;
         try {
-        TestClass1 t1 = new TestClass1();
+            TestClass1 t1 = new TestClass1();
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == NoClassDefFoundError.class, "Must be a NoClassDefFoundError");
@@ -83,18 +83,18 @@ public class ClassInitializationFailuresTest {
     static primitive class BadTwo {
         int i = 0;
         static {
-        if (ClassInitializationFailuresTest.failingInitialization) {
-            throw new RuntimeException("Failing initialization");
-        }
+            if (ClassInitializationFailuresTest.failingInitialization) {
+                throw new RuntimeException("Failing initialization");
+            }
         }
     }
 
     static primitive class BadThree {
         int i = 0;
         static {
-        if (ClassInitializationFailuresTest.failingInitialization) {
-            throw new RuntimeException("Failing initialization");
-        }
+            if (ClassInitializationFailuresTest.failingInitialization) {
+                throw new RuntimeException("Failing initialization");
+            }
         }
     }
 
@@ -103,34 +103,34 @@ public class ClassInitializationFailuresTest {
         // Testing anewarray when the primitive element class fails to initialize properly
         Throwable e = null;
         try {
-        BadTwo[] array = new BadTwo[10];
+            BadTwo[] array = new BadTwo[10];
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == ExceptionInInitializerError.class, " Must be an ExceptionInInitializerError");
         // Second attempt because it doesn't fail the same way
         try {
-        BadTwo[] array = new BadTwo[10];
+            BadTwo[] array = new BadTwo[10];
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == NoClassDefFoundError.class, "Must be a NoClassDefFoundError");
         Asserts.assertTrue(e.getCause().getClass() == ExceptionInInitializerError.class, "Must be an ExceptionInInitializerError");
         // Testing multianewarray when the primitive element class fails to initialize properly
         try {
-        BadThree[][] array = new BadThree[10][20];
+            BadThree[][] array = new BadThree[10][20];
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == ExceptionInInitializerError.class, " Must be an ExceptionInInitializerError");
         // Second attempt because it doesn't fail the same way
         try {
-        BadThree[][][] array = new BadThree[10][30][10];
+            BadThree[][][] array = new BadThree[10][30][10];
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == NoClassDefFoundError.class, "Must be a NoClassDefFoundError");
@@ -141,10 +141,10 @@ public class ClassInitializationFailuresTest {
         int i = 0;
         static BadFour[] array;
         static {
-        array = new BadFour[10];
-        if (ClassInitializationFailuresTest.failingInitialization) {
-            throw new RuntimeException("Failing initialization");
-        }
+            array = new BadFour[10];
+            if (ClassInitializationFailuresTest.failingInitialization) {
+                throw new RuntimeException("Failing initialization");
+            }
         }
     }
 
@@ -155,17 +155,17 @@ public class ClassInitializationFailuresTest {
     static void testEscapedValueInArray() {
         Throwable e = null;
         try {
-        BadFour bt = new BadFour();
+            BadFour bt = new BadFour();
         } catch (Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error must have been thrown");
         Asserts.assertTrue(e.getClass() == ExceptionInInitializerError.class, " Must be an ExceptionInInitializerError");
         e = null;
         try {
-        BadFour t = BadFour.array[0];
+            BadFour t = BadFour.array[0];
         } catch(Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error should have been thrown");
         Asserts.assertTrue(e.getClass() == NoClassDefFoundError.class, "Must be a NoClassDefFoundError");
@@ -175,10 +175,10 @@ public class ClassInitializationFailuresTest {
     static primitive class BadFive {
         int i = 0;
         static {
-        ClassInitializationFailuresTest.bo = new BadSix();
-        if (ClassInitializationFailuresTest.failingInitialization) {
-            throw new RuntimeException("Failing initialization");
-        }
+            ClassInitializationFailuresTest.bo = new BadSix();
+            if (ClassInitializationFailuresTest.failingInitialization) {
+                throw new RuntimeException("Failing initialization");
+            }
         }
     }
 
@@ -190,9 +190,9 @@ public class ClassInitializationFailuresTest {
     static void testEscapedValueInObject() {
         Throwable e = null;
         try {
-        BadSix bt = new BadSix();
+            BadSix bt = new BadSix();
         } catch (Throwable t) {
-        e = t;
+            e = t;
         }
         Asserts.assertNotNull(e, "Error must have been thrown");
         Asserts.assertNotNull(ClassInitializationFailuresTest.bo, "bo object should have been set");


### PR DESCRIPTION
Please review those small changes fixing the handling of values with a class that failed to initialized properly.
Changes in the test file are only code formatting.
Tested with Mach5, tiers 1 to 3.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8275606](https://bugs.openjdk.java.net/browse/JDK-8275606): [lworld] ClassInitializationFailuresTest triggers assert with -XX:-UseTLAB


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/574/head:pull/574` \
`$ git checkout pull/574`

Update a local copy of the PR: \
`$ git checkout pull/574` \
`$ git pull https://git.openjdk.java.net/valhalla pull/574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 574`

View PR using the GUI difftool: \
`$ git pr show -t 574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/574.diff">https://git.openjdk.java.net/valhalla/pull/574.diff</a>

</details>
