### PR TITLE
8276187: [lworld] [lw3] Handling of pre-loaded fields is inefficient

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -145,6 +145,7 @@ class ClassFileParser {
   ClassAnnotationCollector* _parsed_annotations;
   FieldAllocationCount* _fac;
   FieldLayoutInfo* _field_info;
+  Array<InlineKlass*>* _inline_type_field_klasses;
   const intArray* _method_ordering;
   GrowableArray<Method*>* _all_mirandas;
 

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -244,13 +244,12 @@ class FieldLayoutBuilder : public ResourceObj {
   ConstantPool* _constant_pool;
   Array<u2>* _fields;
   FieldLayoutInfo* _info;
+  Array<InlineKlass*>* _inline_type_field_klasses;
   FieldGroup* _root_group;
   GrowableArray<FieldGroup*> _contended_groups;
   FieldGroup* _static_fields;
   FieldLayout* _layout;
   FieldLayout* _static_layout;
-  ClassLoaderData* _class_loader_data;
-  Handle _protection_domain;
   int _nonstatic_oopmap_count;
   int _alignment;
   int _first_field_offset;
@@ -267,8 +266,7 @@ class FieldLayoutBuilder : public ResourceObj {
 
  public:
   FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-      Array<u2>* fields, bool is_contended, bool is_inline_type, ClassLoaderData* class_loader_data,
-      Handle protection_domain, FieldLayoutInfo* info);
+      Array<u2>* fields, bool is_contended, bool is_inline_type, FieldLayoutInfo* info, Array<InlineKlass*>* inline_type_field_klasses);
 
   int get_alignment() {
     assert(_alignment != -1, "Uninitialized");


### PR DESCRIPTION
Please review those changes reducing the number of time pre-loaded fields are fetched from the system dictionary.
The changes would also help supporting field circularity in the future if needed.
Tested with Mach5, tier 1 to 3.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8276187](https://bugs.openjdk.java.net/browse/JDK-8276187): [lworld] [lw3] Handling of pre-loaded fields is inefficient


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/576/head:pull/576` \
`$ git checkout pull/576`

Update a local copy of the PR: \
`$ git checkout pull/576` \
`$ git pull https://git.openjdk.java.net/valhalla pull/576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 576`

View PR using the GUI difftool: \
`$ git pr show -t 576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/576.diff">https://git.openjdk.java.net/valhalla/pull/576.diff</a>

</details>
