### PR TITLE
8276538: [lworld] [AArch64] LIR_Assembler::emit_profile_inline_type temporary register conflict

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -3063,7 +3063,6 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
 void LIR_Assembler::emit_profile_inline_type(LIR_OpProfileInlineType* op) {
   Register obj = op->obj()->as_register();
   Register tmp = op->tmp()->as_pointer_register();
-  Address mdo_addr = as_Address(op->mdp()->as_address_ptr());
   bool not_null = op->not_null();
   int flag = op->flag();
 
@@ -3074,6 +3073,7 @@ void LIR_Assembler::emit_profile_inline_type(LIR_OpProfileInlineType* op) {
 
   __ test_oop_is_not_inline_type(obj, tmp, not_inline_type);
 
+  Address mdo_addr = as_Address(op->mdp()->as_address_ptr(), rscratch2);
   __ ldrb(rscratch1, mdo_addr);
   __ orr(rscratch1, rscratch1, flag);
   __ strb(rscratch1, mdo_addr);


### PR DESCRIPTION
LIR_Assembler::as_Address() may use rscratch1 as a temporary register
for the address offset if it's too large to fit in an immediate, but
rscratch1 is also used at the same time to hold the updated MDO value.
See the discussion on JDK-8276108.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8276538](https://bugs.openjdk.java.net/browse/JDK-8276538): [lworld] [AArch64] LIR_Assembler::emit_profile_inline_type temporary register conflict


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/577/head:pull/577` \
`$ git checkout pull/577`

Update a local copy of the PR: \
`$ git checkout pull/577` \
`$ git pull https://git.openjdk.java.net/valhalla pull/577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 577`

View PR using the GUI difftool: \
`$ git pr show -t 577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/577.diff">https://git.openjdk.java.net/valhalla/pull/577.diff</a>

</details>
