### PR TITLE
8276612: [lworld] runtime/valhalla/inlinetypes/InlineTypeArray.java crashes with " memory leak: allocating without ResourceMark"

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -53,6 +53,7 @@ void BarrierSet::set_barrier_set(BarrierSet* barrier_set) {
 }
 
 void BarrierSet::throw_array_null_pointer_store_exception(arrayOop src, arrayOop dst, TRAPS) {
+  ResourceMark rm(THREAD);
   Klass* bound = ObjArrayKlass::cast(dst->klass())->element_klass();
   stringStream ss;
   ss.print("arraycopy: can not copy null values into %s[]",


### PR DESCRIPTION
Missing ResourceMark

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8276612](https://bugs.openjdk.java.net/browse/JDK-8276612): [lworld] runtime/valhalla/inlinetypes/InlineTypeArray.java crashes with " memory leak: allocating without ResourceMark"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/578/head:pull/578` \
`$ git checkout pull/578`

Update a local copy of the PR: \
`$ git checkout pull/578` \
`$ git pull https://git.openjdk.java.net/valhalla pull/578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 578`

View PR using the GUI difftool: \
`$ git pr show -t 578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/578.diff">https://git.openjdk.java.net/valhalla/pull/578.diff</a>

</details>
