### PR TITLE
8276812: [lworld] [lw3] JVM_ACC_FIELD_INLINED flag creates a conflict with an existing flag

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1184,6 +1184,7 @@ class java_lang_invoke_MemberName: AllStatic {
     MN_IS_TYPE               = 0x00080000, // nested type
     MN_CALLER_SENSITIVE      = 0x00100000, // @CallerSensitive annotation detected
     MN_TRUSTED_FINAL         = 0x00200000, // trusted final field
+    MN_FLATTENED             = 0x00400000, // flattened field
     MN_REFERENCE_KIND_SHIFT  = 24, // refKind
     MN_REFERENCE_KIND_MASK   = 0x0F000000 >> MN_REFERENCE_KIND_SHIFT,
     // The SEARCH_* bits are not for MN.flags but for the matchFlags argument of MHN.getMembers:

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -131,7 +131,8 @@ enum {
   IS_FIELD              = java_lang_invoke_MemberName::MN_IS_FIELD,
   IS_TYPE               = java_lang_invoke_MemberName::MN_IS_TYPE,
   CALLER_SENSITIVE      = java_lang_invoke_MemberName::MN_CALLER_SENSITIVE,
-  TRUSTED_FINAL        = java_lang_invoke_MemberName::MN_TRUSTED_FINAL,
+  TRUSTED_FINAL         = java_lang_invoke_MemberName::MN_TRUSTED_FINAL,
+  FLATTENED             = java_lang_invoke_MemberName::MN_FLATTENED,
   REFERENCE_KIND_SHIFT  = java_lang_invoke_MemberName::MN_REFERENCE_KIND_SHIFT,
   REFERENCE_KIND_MASK   = java_lang_invoke_MemberName::MN_REFERENCE_KIND_MASK,
   SEARCH_SUPERCLASSES   = java_lang_invoke_MemberName::MN_SEARCH_SUPERCLASSES,
@@ -351,6 +352,7 @@ oop MethodHandles::init_field_MemberName(Handle mname, fieldDescriptor& fd, bool
   int flags = (jushort)( fd.access_flags().as_short() & JVM_RECOGNIZED_FIELD_MODIFIERS );
   flags |= IS_FIELD | ((fd.is_static() ? JVM_REF_getStatic : JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   if (fd.is_trusted_final()) flags |= TRUSTED_FINAL;
+  if (fd.is_inlined()) flags |= FLATTENED;;
   if (is_setter)  flags += ((JVM_REF_putField - JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   int vmindex        = fd.offset();  // determines the field uniquely when combined with static bit
 
@@ -1124,6 +1126,7 @@ void MethodHandles::trace_method_handle_interpreter_entry(MacroAssembler* _masm,
     template(java_lang_invoke_MemberName,MN_IS_TYPE) \
     template(java_lang_invoke_MemberName,MN_CALLER_SENSITIVE) \
     template(java_lang_invoke_MemberName,MN_TRUSTED_FINAL) \
+    template(java_lang_invoke_MemberName,MN_FLATTENED) \
     template(java_lang_invoke_MemberName,MN_SEARCH_SUPERCLASSES) \
     template(java_lang_invoke_MemberName,MN_SEARCH_INTERFACES) \
     template(java_lang_invoke_MemberName,MN_REFERENCE_KIND_SHIFT) \

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -350,9 +350,6 @@ oop MethodHandles::init_field_MemberName(Handle mname, fieldDescriptor& fd, bool
   InstanceKlass* ik = fd.field_holder();
   int flags = (jushort)( fd.access_flags().as_short() & JVM_RECOGNIZED_FIELD_MODIFIERS );
   flags |= IS_FIELD | ((fd.is_static() ? JVM_REF_getStatic : JVM_REF_getField) << REFERENCE_KIND_SHIFT);
-  if (fd.is_inlined()) {
-    flags |= JVM_ACC_FIELD_INLINED;
-  }
   if (fd.is_trusted_final()) flags |= TRUSTED_FINAL;
   if (is_setter)  flags += ((JVM_REF_putField - JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   int vmindex        = fd.offset();  // determines the field uniquely when combined with static bit

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -350,6 +350,13 @@ UNSAFE_ENTRY(jlong, Unsafe_ValueHeaderSize(JNIEnv *env, jobject unsafe, jclass c
   return vk->first_field_offset();
 } UNSAFE_END
 
+UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedField(JNIEnv *env, jobject unsafe, jobject o)) {
+  oop f = JNIHandles::resolve_non_null(o);
+  Klass* k = java_lang_Class::as_Klass(java_lang_reflect_Field::clazz(f));
+  int slot = java_lang_reflect_Field::slot(f);
+  return InstanceKlass::cast(k)->field_is_inlined(slot);
+} UNSAFE_END
+
 UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedArray(JNIEnv *env, jobject unsafe, jclass c)) {
   Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(c));
   return k->is_flatArray_klass();
@@ -1039,6 +1046,7 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "putReferenceVolatile", CC "(" OBJ "J" OBJ ")V",  FN_PTR(Unsafe_PutReferenceVolatile)},
 
     {CC "isFlattenedArray", CC "(" CLS ")Z",                     FN_PTR(Unsafe_IsFlattenedArray)},
+    {CC "isFlattenedField0", CC "(" OBJ ")Z",                    FN_PTR(Unsafe_IsFlattenedField)},
     {CC "getValue",         CC "(" OBJ "J" CLS ")" OBJ,          FN_PTR(Unsafe_GetValue)},
     {CC "putValue",         CC "(" OBJ "J" CLS OBJ ")V",         FN_PTR(Unsafe_PutValue)},
     {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,         FN_PTR(Unsafe_UninitializedDefaultValue)},

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -878,9 +878,6 @@ oop Reflection::new_field(fieldDescriptor* fd, TRAPS) {
   }
   // Note the ACC_ANNOTATION bit, which is a per-class access flag, is never set here.
   int modifiers = fd->access_flags().as_int() & JVM_RECOGNIZED_FIELD_MODIFIERS;
-  if (fd->is_inlined()) {
-    modifiers |= JVM_ACC_FIELD_INLINED;
-  }
   java_lang_reflect_Field::set_modifiers(rh(), modifiers);
   java_lang_reflect_Field::set_override(rh(), false);
   if (fd->has_generic_signature()) {

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -88,14 +88,12 @@ enum {
   JVM_ACC_FIELD_STABLE                    = 0x00000020, // @Stable field, same as JVM_ACC_SYNCHRONIZED and JVM_ACC_SUPER
   JVM_ACC_FIELD_INITIALIZED_FINAL_UPDATE  = 0x00000200, // (static) final field updated outside (class) initializer, same as JVM_ACC_NATIVE
   JVM_ACC_FIELD_HAS_GENERIC_SIGNATURE     = 0x00000800, // field has generic signature
-  JVM_ACC_FIELD_INLINED                   = 0x00008000, // field is inlined
 
   JVM_ACC_FIELD_INTERNAL_FLAGS       = JVM_ACC_FIELD_ACCESS_WATCHED |
                                        JVM_ACC_FIELD_MODIFICATION_WATCHED |
                                        JVM_ACC_FIELD_INTERNAL |
                                        JVM_ACC_FIELD_STABLE |
-                                       JVM_ACC_FIELD_HAS_GENERIC_SIGNATURE |
-                                       JVM_ACC_FIELD_INLINED,
+                                       JVM_ACC_FIELD_HAS_GENERIC_SIGNATURE,
 
                                                     // flags accepted by set_field_flags()
   JVM_ACC_FIELD_FLAGS                = JVM_RECOGNIZED_FIELD_MODIFIERS | JVM_ACC_FIELD_INTERNAL_FLAGS

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -458,7 +458,6 @@ final class MemberName implements Member, Cloneable {
     static final int SYNTHETIC   = 0x00001000;
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
-    static final int FLATTENED   = 0x00008000;
 
     /** Utility method to query the modifier flags of this member; returns false if the member is not a method. */
     public boolean isBridge() {
@@ -474,7 +473,7 @@ final class MemberName implements Member, Cloneable {
     }
 
     /** Query whether this member is a flattened field */
-    public boolean isFlattened() { return (flags & FLATTENED) == FLATTENED; }
+    public boolean isFlattened() { return (flags & MN_FLATTENED) == MN_FLATTENED; }
 
     /** Query whether this member is a field of a primitive class. */
     public boolean isInlineableField()  {
@@ -487,6 +486,7 @@ final class MemberName implements Member, Cloneable {
 
     static final String CONSTRUCTOR_NAME = "<init>";  // the ever-popular
 
+    // modifiers exported by the JVM:
     // modifiers exported by the JVM:
     static final int RECOGNIZED_MODIFIERS = 0xFFFF;
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -118,6 +118,7 @@ class MethodHandleNatives {
             MN_IS_TYPE               = 0x00080000, // nested type
             MN_CALLER_SENSITIVE      = 0x00100000, // @CallerSensitive annotation detected
             MN_TRUSTED_FINAL         = 0x00200000, // trusted final field
+            MN_FLATTENED             = 0x00400000, // flattened field
             MN_REFERENCE_KIND_SHIFT  = 24, // refKind
             MN_REFERENCE_KIND_MASK   = 0x0F000000 >> MN_REFERENCE_KIND_SHIFT,
             // The SEARCH_* bits are not for MN.flags but for the matchFlags argument of MHN.getMembers:

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -333,7 +333,6 @@ public class Modifier {
     static final int ANNOTATION  = 0x00002000;
     static final int ENUM        = 0x00004000;
     static final int MANDATED    = 0x00008000;
-    static final int FLATTENED   = 0x00008000;      // HotSpot-specific bit
     static boolean isSynthetic(int mod) {
       return (mod & SYNTHETIC) != 0;
     }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -177,14 +177,15 @@ public final class Unsafe {
     @IntrinsicCandidate
     public native void putInt(Object o, long offset, int x);
 
-    private static final int JVM_ACC_FIELD_INLINED = 0x00008000; // HotSpot-specific bit
 
     /**
      * Returns true if the given field is flattened.
      */
     public boolean isFlattened(Field f) {
-        return (f.getModifiers() & JVM_ACC_FIELD_INLINED) == JVM_ACC_FIELD_INLINED;
+        return isFlattenedField0(f);
     }
+
+    private native boolean isFlattenedField0(Object o);
 
     /**
      * Returns true if the given class is a flattened array.

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -182,6 +182,9 @@ public final class Unsafe {
      * Returns true if the given field is flattened.
      */
     public boolean isFlattened(Field f) {
+        if (f == null) {
+            throw new NullPointerException();
+        }
         return isFlattenedField0(f);
     }
 


### PR DESCRIPTION
Please review this changeset removing the JVM_ACC_FIELD_INLINED flag from AccessFlags which was conflicting with an existing JVMTI flag.
The flag was use by Unsafe and reflection.
Thanks to Mandy for her fix to the MemberName code.

Tested locally with hotspot_valhalla and jdk_valhalla test suites on x86.
Testing in progress with Mach5 tiers 1 to 3 (no failure related to these changes yet).

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8276812](https://bugs.openjdk.java.net/browse/JDK-8276812): [lworld] [lw3] JVM_ACC_FIELD_INLINED flag creates a conflict with an existing flag


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer) ⚠️ Review applies to e6a9ac4a301f699fa700698d0af76886045104c8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/580/head:pull/580` \
`$ git checkout pull/580`

Update a local copy of the PR: \
`$ git checkout pull/580` \
`$ git pull https://git.openjdk.java.net/valhalla pull/580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 580`

View PR using the GUI difftool: \
`$ git pr show -t 580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/580.diff">https://git.openjdk.java.net/valhalla/pull/580.diff</a>

</details>
