### PR TITLE
8273715: [lworld] C2 compilation fails with "missed optimization opportunity"

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2778,7 +2778,6 @@ void Compile::Optimize() {
   DEBUG_ONLY( _modified_nodes = NULL; )
 
   assert(igvn._worklist.size() == 0, "not empty");
-  assert(_late_inlines.length() == 0, "missed optimization opportunity");
  } // (End scope of igvn; run destructor if necessary for asserts.)
 
  check_no_dead_use();


### PR DESCRIPTION
The assert is too strong and triggers due to class loading that happens in parallel to the compilation and changes the output of `Compile::optimize_virtual_call` -> `Compile::optimize_inlining` -> `callee->find_monomorphic_target` which leads to a call being added to the late inline worklist.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8273715](https://bugs.openjdk.java.net/browse/JDK-8273715): [lworld] C2 compilation fails with "missed optimization opportunity"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/581/head:pull/581` \
`$ git checkout pull/581`

Update a local copy of the PR: \
`$ git checkout pull/581` \
`$ git pull https://git.openjdk.java.net/valhalla pull/581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 581`

View PR using the GUI difftool: \
`$ git pr show -t 581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/581.diff">https://git.openjdk.java.net/valhalla/pull/581.diff</a>

</details>
