### PR TITLE
8277057: [lworld] array code needs some name cleanup

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1594,7 +1594,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
   } else {
     __ load_klass(klass, op->array()->as_register());
     __ ldrw(klass, Address(klass, Klass::layout_helper_offset()));
-    __ tst(klass, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ tst(klass, Klass::_lh_array_tag_flat_value_bit_inplace);
     __ br(Assembler::NE, *op->stub()->entry());
   }
   if (!op->value()->is_illegal()) {
@@ -1605,7 +1605,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
     if (UseArrayMarkWordCheck) {
       __ test_null_free_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
     } else {
-      __ tst(klass, Klass::_lh_null_free_bit_inplace);
+      __ tst(klass, Klass::_lh_null_free_array_bit_inplace);
       __ br(Assembler::NE, *op->stub()->entry());
     }
     __ bind(skip);
@@ -1628,7 +1628,7 @@ void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
     Register klass = op->tmp()->as_register();
     __ load_klass(klass, op->array()->as_register());
     __ ldr(klass, Address(klass, Klass::layout_helper_offset()));
-    __ tst(klass, Klass::_lh_null_free_bit_inplace);
+    __ tst(klass, Klass::_lh_null_free_array_bit_inplace);
   }
 }
 
@@ -2413,9 +2413,9 @@ void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeS
     __ ldr(tmp, Address(tmp, Klass::layout_helper_offset()));
     if (is_dest) {
       // Take the slow path if it's a null_free destination array, in case the source array contains NULLs.
-      __ tst(tmp, Klass::_lh_null_free_bit_inplace);
+      __ tst(tmp, Klass::_lh_null_free_array_bit_inplace);
     } else {
-      __ tst(tmp, Klass::_lh_array_tag_vt_value_bit_inplace);
+      __ tst(tmp, Klass::_lh_array_tag_flat_value_bit_inplace);
     }
     __ br(Assembler::NE, *slow_path->entry());
   }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1379,7 +1379,7 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
   }
 #endif
   ldrw(temp_reg, Address(klass, InstanceKlass::misc_flags_offset()));
-  andr(temp_reg, temp_reg, InstanceKlass::misc_flags_is_empty_inline_type());
+  andr(temp_reg, temp_reg, InstanceKlass::misc_flag_is_empty_inline_type());
   cbnz(temp_reg, is_empty_inline_type);
 }
 
@@ -1435,22 +1435,22 @@ void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_re
 }
 
 void MacroAssembler::test_flattened_array_layout(Register lh, Label& is_flattened_array) {
-  tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  tst(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   br(Assembler::NE, is_flattened_array);
 }
 
 void MacroAssembler::test_non_flattened_array_layout(Register lh, Label& is_non_flattened_array) {
-  tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  tst(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   br(Assembler::EQ, is_non_flattened_array);
 }
 
 void MacroAssembler::test_null_free_array_layout(Register lh, Label& is_null_free_array) {
-  tst(lh, Klass::_lh_null_free_bit_inplace);
+  tst(lh, Klass::_lh_null_free_array_bit_inplace);
   br(Assembler::NE, is_null_free_array);
 }
 
 void MacroAssembler::test_non_null_free_array_layout(Register lh, Label& is_non_null_free_array) {
-  tst(lh, Klass::_lh_null_free_bit_inplace);
+  tst(lh, Klass::_lh_null_free_array_bit_inplace);
   br(Assembler::EQ, is_non_null_free_array);
 }
 

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -2109,11 +2109,11 @@ class StubGenerator: public StubCodeGenerator {
     __ cbnz(rscratch2, L_failed);
 
     // Check for flat inline type array -> return -1
-    __ tst(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ tst(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
     __ br(Assembler::NE, L_failed);
 
     // Check for null-free (non-flat) inline type array -> handle as object array
-    __ tst(lh, Klass::_lh_null_free_bit_inplace);
+    __ tst(lh, Klass::_lh_null_free_array_bit_inplace);
     __ br(Assembler::NE, L_failed);
 
     //  if (!src->is_Array()) return -1;

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1997,7 +1997,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
     Register tmp_load_klass = LP64_ONLY(rscratch1) NOT_LP64(noreg);
     __ load_klass(klass, op->array()->as_register(), tmp_load_klass);
     __ movl(klass, Address(klass, Klass::layout_helper_offset()));
-    __ testl(klass, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ testl(klass, Klass::_lh_array_tag_flat_value_bit_inplace);
     __ jcc(Assembler::notZero, *op->stub()->entry());
   }
   if (!op->value()->is_illegal()) {
@@ -2009,7 +2009,7 @@ void LIR_Assembler::emit_opFlattenedArrayCheck(LIR_OpFlattenedArrayCheck* op) {
     if (UseArrayMarkWordCheck) {
       __ test_null_free_array_oop(op->array()->as_register(), op->tmp()->as_register(), *op->stub()->entry());
     } else {
-      __ testl(klass, Klass::_lh_null_free_bit_inplace);
+      __ testl(klass, Klass::_lh_null_free_array_bit_inplace);
       __ jcc(Assembler::notZero, *op->stub()->entry());
     }
     __ bind(skip);
@@ -2033,7 +2033,7 @@ void LIR_Assembler::emit_opNullFreeArrayCheck(LIR_OpNullFreeArrayCheck* op) {
     Register klass = op->tmp()->as_register();
     __ load_klass(klass, op->array()->as_register(), tmp_load_klass);
     __ movl(klass, Address(klass, Klass::layout_helper_offset()));
-    __ testl(klass, Klass::_lh_null_free_bit_inplace);
+    __ testl(klass, Klass::_lh_null_free_array_bit_inplace);
   }
 }
 
@@ -3252,9 +3252,9 @@ void LIR_Assembler::arraycopy_inlinetype_check(Register obj, Register tmp, CodeS
     __ movl(tmp, Address(tmp, Klass::layout_helper_offset()));
     if (is_dest) {
       // Take the slow path if it's a null_free destination array, in case the source array contains NULLs.
-      __ testl(tmp, Klass::_lh_null_free_bit_inplace);
+      __ testl(tmp, Klass::_lh_null_free_array_bit_inplace);
     } else {
-      __ testl(tmp, Klass::_lh_array_tag_vt_value_bit_inplace);
+      __ testl(tmp, Klass::_lh_array_tag_flat_value_bit_inplace);
     }
     __ jcc(Assembler::notZero, *slow_path->entry());
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2768,7 +2768,7 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
   }
 #endif
   movl(temp_reg, Address(klass, InstanceKlass::misc_flags_offset()));
-  testl(temp_reg, InstanceKlass::misc_flags_is_empty_inline_type());
+  testl(temp_reg, InstanceKlass::misc_flag_is_empty_inline_type());
   jcc(Assembler::notZero, is_empty_inline_type);
 }
 
@@ -2856,22 +2856,22 @@ void MacroAssembler::test_non_null_free_array_oop(Register oop, Register temp_re
 }
 
 void MacroAssembler::test_flattened_array_layout(Register lh, Label& is_flattened_array) {
-  testl(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  testl(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   jcc(Assembler::notZero, is_flattened_array);
 }
 
 void MacroAssembler::test_non_flattened_array_layout(Register lh, Label& is_non_flattened_array) {
-  testl(lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+  testl(lh, Klass::_lh_array_tag_flat_value_bit_inplace);
   jcc(Assembler::zero, is_non_flattened_array);
 }
 
 void MacroAssembler::test_null_free_array_layout(Register lh, Label& is_null_free_array) {
-  testl(lh, Klass::_lh_null_free_bit_inplace);
+  testl(lh, Klass::_lh_null_free_array_bit_inplace);
   jcc(Assembler::notZero, is_null_free_array);
 }
 
 void MacroAssembler::test_non_null_free_array_layout(Register lh, Label& is_non_null_free_array) {
-  testl(lh, Klass::_lh_null_free_bit_inplace);
+  testl(lh, Klass::_lh_null_free_array_bit_inplace);
   jcc(Assembler::zero, is_non_null_free_array);
 }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3152,11 +3152,11 @@ class StubGenerator: public StubCodeGenerator {
     __ movl(rax_lh, Address(r10_src_klass, lh_offset));
 
     // Check for flat inline type array -> return -1
-    __ testl(rax_lh, Klass::_lh_array_tag_vt_value_bit_inplace);
+    __ testl(rax_lh, Klass::_lh_array_tag_flat_value_bit_inplace);
     __ jcc(Assembler::notZero, L_failed);
 
     // Check for null-free (non-flat) inline type array -> handle as object array
-    __ testl(rax_lh, Klass::_lh_null_free_bit_inplace);
+    __ testl(rax_lh, Klass::_lh_null_free_array_bit_inplace);
     __ jcc(Assembler::notZero, L_objArray);
 
     //  if (!src->is_Array()) return -1;
@@ -3288,7 +3288,7 @@ class StubGenerator: public StubCodeGenerator {
         BLOCK_COMMENT("assert not null-free array {");
         Label L;
         __ movl(rklass_tmp, Address(rax, lh_offset));
-        __ testl(rklass_tmp, Klass::_lh_null_free_bit_inplace);
+        __ testl(rklass_tmp, Klass::_lh_null_free_array_bit_inplace);
         __ jcc(Assembler::zero, L);
         __ stop("unexpected null-free array");
         __ bind(L);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -440,7 +440,7 @@ JRT_ENTRY(void, Runtime1::new_flat_array(JavaThread* current, Klass* array_klass
   assert(elem_klass->is_inline_klass(), "must be");
   // Logically creates elements, ensure klass init
   elem_klass->initialize(CHECK);
-  arrayOop obj = oopFactory::new_flatArray(elem_klass, length, CHECK);
+  arrayOop obj = oopFactory::new_valueArray(elem_klass, length, CHECK);
   current->set_vm_result(obj);
   // This is pretty rare but this runtime patch is stressful to deoptimization
   // if we deoptimize here so force a deopt to stress the path.

--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -110,7 +110,7 @@ ciArrayKlass* ciArrayKlass::make(ciType* element_type, bool null_free) {
     if (null_free && klass->is_loaded()) {
       GUARDED_VM_ENTRY(
         EXCEPTION_CONTEXT;
-        Klass* ak = InlineKlass::cast(klass->get_Klass())->null_free_inline_array_klass(THREAD);
+        Klass* ak = InlineKlass::cast(klass->get_Klass())->value_array_klass(THREAD);
         if (HAS_PENDING_EXCEPTION) {
           CLEAR_PENDING_EXCEPTION;
         } else if (ak->is_flatArray_klass()) {

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1098,7 +1098,7 @@ class CompileReplay : public StackObj {
         } else if (field_signature[0] == JVM_SIGNATURE_ARRAY &&
                    field_signature[1] == JVM_SIGNATURE_INLINE_TYPE) {
           Klass* kelem = resolve_klass(field_signature + 1, CHECK_(true));
-          value = oopFactory::new_flatArray(kelem, length, CHECK_(true));
+          value = oopFactory::new_valueArray(kelem, length, CHECK_(true));
         } else {
           report_error("unhandled array staticfield");
         }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -320,7 +320,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
         if (!k->is_inline_klass()) {
           THROW_MSG_NULL(vmSymbols::java_lang_IncompatibleClassChangeError(), "L/Q mismatch on bottom type");
         }
-        k = InlineKlass::cast(k)->null_free_inline_array_klass(ndims, CHECK_NULL);
+        k = InlineKlass::cast(k)->value_array_klass(ndims, CHECK_NULL);
       } else {
         k = k->array_klass(ndims, CHECK_NULL);
       }
@@ -861,7 +861,7 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
     }
     if (k != NULL) {
       if (class_name->is_Q_array_signature()) {
-        k = InlineKlass::cast(k)->null_free_inline_array_klass_or_null(ndims);
+        k = InlineKlass::cast(k)->value_array_klass_or_null(ndims);
       } else {
         k = k->array_klass_or_null(ndims);
       }
@@ -1861,7 +1861,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     // If element class already loaded, allocate array klass
     if (klass != NULL) {
       if (class_name->is_Q_array_signature()) {
-        klass = InlineKlass::cast(klass)->null_free_inline_array_klass_or_null(ndims);
+        klass = InlineKlass::cast(klass)->value_array_klass_or_null(ndims);
       } else {
         klass = klass->array_klass_or_null(ndims);
       }

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -422,7 +422,7 @@ JRT_ENTRY(void, InterpreterRuntime::anewarray(JavaThread* current, ConstantPool*
   arrayOop obj;
   if ((!klass->is_array_klass()) && is_qtype_desc) { // Logically creates elements, ensure klass init
     klass->initialize(CHECK);
-    obj = oopFactory::new_flatArray(klass, size, CHECK);
+    obj = oopFactory::new_valueArray(klass, size, CHECK);
   } else {
     obj = oopFactory::new_objArray(klass, size, CHECK);
   }

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -127,10 +127,10 @@ objArrayOop oopFactory::new_objArray(Klass* klass, int length, TRAPS) {
   }
 }
 
-arrayOop oopFactory::new_flatArray(Klass* k, int length, TRAPS) {
+arrayOop oopFactory::new_valueArray(Klass* k, int length, TRAPS) {
   InlineKlass* klass = InlineKlass::cast(k);
   // Request flattened, but we might not actually get it...either way "null-free" are the aaload/aastore semantics
-  Klass* array_klass = klass->null_free_inline_array_klass(CHECK_NULL);
+  Klass* array_klass = klass->value_array_klass(CHECK_NULL);
   assert(array_klass->is_null_free_array_klass(), "Expect a null-free array class here");
 
   arrayOop oop;

--- a/src/hotspot/share/memory/oopFactory.hpp
+++ b/src/hotspot/share/memory/oopFactory.hpp
@@ -63,7 +63,7 @@ class oopFactory: AllStatic {
   //
   // Method specifically null free and possibly flattened if possible
   // i.e. flatArrayOop if flattening can be done, else "null free" objArrayOop
-  static arrayOop        new_flatArray(Klass* klass, int length, TRAPS);
+  static arrayOop        new_valueArray(Klass* klass, int length, TRAPS);
 
   // Helper conversions from value to obj array...
   static objArrayHandle  copy_flatArray_to_objArray(flatArrayHandle array, TRAPS);

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -129,7 +129,7 @@ FlatArrayKlass* FlatArrayKlass::allocate_klass(Klass* eklass, TRAPS) {
           elem_super->array_klass(CHECK_NULL);
         }
         // Now retry from the beginning
-        ek = element_klass->null_free_inline_array_klass(CHECK_NULL);
+        ek = element_klass->value_array_klass(CHECK_NULL);
       }  // re-lock
       return FlatArrayKlass::cast(ek);
     }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -75,13 +75,13 @@ class InlineKlass: public InstanceKlass {
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(default_value_offset_offset());
   }
 
-  ArrayKlass* volatile* adr_null_free_inline_array_klasses() const {
+  ArrayKlass* volatile* adr_value_array_klasses() const {
     assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
     return (ArrayKlass* volatile*) ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _null_free_inline_array_klasses));
   }
 
-  ArrayKlass* null_free_inline_array_klasses() const {
-    return *adr_null_free_inline_array_klasses();
+  ArrayKlass* value_array_klasses() const {
+    return *adr_value_array_klasses();
   }
 
   address adr_alignment() const {
@@ -190,12 +190,12 @@ class InlineKlass: public InstanceKlass {
 
   // null free inline array klass, akin to InstanceKlass::array_klass()
   // Returns the array class for the n'th dimension
-  Klass* null_free_inline_array_klass(int n, TRAPS);
-  Klass* null_free_inline_array_klass_or_null(int n);
+  Klass* value_array_klass(int n, TRAPS);
+  Klass* value_array_klass_or_null(int n);
 
   // Returns the array class with this class as element type
-  Klass* null_free_inline_array_klass(TRAPS);
-  Klass* null_free_inline_array_klass_or_null();
+  Klass* value_array_klass(TRAPS);
+  Klass* value_array_klass_or_null();
 
 
   // General store methods

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -683,7 +683,7 @@ public:
 
   static ByteSize kind_offset() { return in_ByteSize(offset_of(InstanceKlass, _kind)); }
   static ByteSize misc_flags_offset() { return in_ByteSize(offset_of(InstanceKlass, _misc_flags)); }
-  static u4 misc_flags_is_empty_inline_type() { return _misc_is_empty_inline_type; }
+  static u4 misc_flag_is_empty_inline_type() { return _misc_is_empty_inline_type; }
 
   // initialization (virtuals from Klass)
   bool should_be_initialized() const;  // means that initialize should be called

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -381,8 +381,8 @@ protected:
   static const int _lh_null_free_shift = _lh_array_tag_shift - 1;
   static const int _lh_null_free_mask  = 1;
 
-  static const jint _lh_array_tag_vt_value_bit_inplace = (jint) (1 << _lh_array_tag_shift);
-  static const jint _lh_null_free_bit_inplace = (jint) (_lh_null_free_mask << _lh_null_free_shift);
+  static const jint _lh_array_tag_flat_value_bit_inplace = (jint) (1 << _lh_array_tag_shift);
+  static const jint _lh_null_free_array_bit_inplace = (jint) (_lh_null_free_mask << _lh_null_free_shift);
 
   static int layout_helper_size_in_bytes(jint lh) {
     assert(lh > (jint)_lh_neutral_value, "must be instance");

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -105,7 +105,7 @@ ObjArrayKlass* ObjArrayKlass::allocate_objArray_klass(ClassLoaderData* loader_da
           }
           // Now retry from the beginning
           if (null_free) {
-            ek = InlineKlass::cast(element_klass)->null_free_inline_array_klass(CHECK_NULL);
+            ek = InlineKlass::cast(element_klass)->value_array_klass(CHECK_NULL);
           } else {
             ek = element_klass->array_klass(n, CHECK_NULL);
           }
@@ -205,7 +205,7 @@ oop ObjArrayKlass::multi_allocate(int rank, jint* sizes, TRAPS) {
   int length = *sizes;
   if (rank == 1) { // last dim may be flatArray, check if we have any special storage requirements
     if (name()->char_at(1) != JVM_SIGNATURE_ARRAY &&  name()->is_Q_array_signature()) {
-      return oopFactory::new_flatArray(element_klass(), length, CHECK_NULL);
+      return oopFactory::new_valueArray(element_klass(), length, CHECK_NULL);
     } else {
       return oopFactory::new_objArray(element_klass(), length, CHECK_NULL);
     }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3765,7 +3765,7 @@ Node* GraphKit::flat_array_test(Node* ary, bool flat) {
 }
 
 Node* GraphKit::null_free_array_test(Node* klass, bool null_free) {
-  return array_lh_test(klass, Klass::_lh_null_free_bit_inplace, 0, !null_free);
+  return array_lh_test(klass, Klass::_lh_null_free_array_bit_inplace, 0, !null_free);
 }
 
 // Deoptimize if 'ary' is a null-free inline type array and 'val' is null
@@ -4393,7 +4393,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
     Node* r = new RegionNode(3);
     default_value = new PhiNode(r, TypeInstPtr::BOTTOM);
 
-    Node* bol = array_lh_test(klass_node, Klass::_lh_array_tag_vt_value_bit_inplace | Klass::_lh_null_free_bit_inplace, Klass::_lh_null_free_bit_inplace);
+    Node* bol = array_lh_test(klass_node, Klass::_lh_array_tag_flat_value_bit_inplace | Klass::_lh_null_free_array_bit_inplace, Klass::_lh_null_free_array_bit_inplace);
     IfNode* iff = create_and_map_if(control(), bol, PROB_FAIR, COUNT_UNKNOWN);
 
     // Null-free, non-flattened inline type array, initialize with the default value

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3690,7 +3690,7 @@ Node* LibraryCallKit::generate_array_guard_common(Node* kls, RegionNode* region,
     case FlatArray:
     case NonFlatArray: {
       value = 0;
-      layout_val = _gvn.transform(new AndINode(layout_val, intcon(Klass::_lh_array_tag_vt_value_bit_inplace)));
+      layout_val = _gvn.transform(new AndINode(layout_val, intcon(Klass::_lh_array_tag_flat_value_bit_inplace)));
       btest = (kind == FlatArray) ? BoolTest::ne : BoolTest::eq;
       break;
     }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2764,7 +2764,7 @@ void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
       Node* lh_val = _igvn.transform(LoadNode::make(_igvn, NULL, C->immutable_memory(), lh_addr, lh_addr->bottom_type()->is_ptr(), TypeInt::INT, T_INT, MemNode::unordered));
       lhs = _igvn.transform(new OrINode(lhs, lh_val));
     }
-    Node* masked = transform_later(new AndINode(lhs, intcon(Klass::_lh_array_tag_vt_value_bit_inplace)));
+    Node* masked = transform_later(new AndINode(lhs, intcon(Klass::_lh_array_tag_flat_value_bit_inplace)));
     Node* cmp = transform_later(new CmpINode(masked, intcon(0)));
     Node* bol = transform_later(new BoolNode(cmp, BoolTest::eq));
     Node* old_bol = check->unique_out();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -300,12 +300,12 @@ Node* PhaseMacroExpand::array_lh_test(Node* array, jint mask) {
 
 Node* PhaseMacroExpand::generate_flat_array_guard(Node** ctrl, Node* array, RegionNode* region) {
   assert(UseFlatArray, "can never be flattened");
-  return generate_fair_guard(ctrl, array_lh_test(array, Klass::_lh_array_tag_vt_value_bit_inplace), region);
+  return generate_fair_guard(ctrl, array_lh_test(array, Klass::_lh_array_tag_flat_value_bit_inplace), region);
 }
 
 Node* PhaseMacroExpand::generate_null_free_array_guard(Node** ctrl, Node* array, RegionNode* region) {
   assert(EnableValhalla, "can never be null free");
-  return generate_fair_guard(ctrl, array_lh_test(array, Klass::_lh_null_free_bit_inplace), region);
+  return generate_fair_guard(ctrl, array_lh_test(array, Klass::_lh_null_free_array_bit_inplace), region);
 }
 
 void PhaseMacroExpand::finish_arraycopy_call(Node* call, Node** ctrl, MergeMemNode** mem, const TypePtr* adr_type) {

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -253,7 +253,7 @@ JRT_BLOCK_ENTRY(void, OptoRuntime::new_array_C(Klass* array_type, int len, JavaT
 
   if (array_type->is_flatArray_klass()) {
     Klass* elem_type = FlatArrayKlass::cast(array_type)->element_klass();
-    result = oopFactory::new_flatArray(elem_type, len, THREAD);
+    result = oopFactory::new_valueArray(elem_type, len, THREAD);
   } else if (array_type->is_typeArray_klass()) {
     // The oopFactory likes to work with the element type.
     // (We could bypass the oopFactory, since it doesn't add much value.)

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -350,7 +350,7 @@ arrayOop Reflection::reflect_new_array(oop element_mirror, jint length, TRAPS) {
       THROW_0(vmSymbols::java_lang_IllegalArgumentException());
     }
     if (k->is_inline_klass() && java_lang_Class::is_secondary_mirror(element_mirror)) {
-      return oopFactory::new_flatArray(k, length, THREAD);
+      return oopFactory::new_valueArray(k, length, THREAD);
     } else {
       return oopFactory::new_objArray(k, length, THREAD);
     }
@@ -395,7 +395,7 @@ arrayOop Reflection::reflect_new_multi_array(oop element_mirror, typeArrayOop di
     }
   }
   if (klass->is_inline_klass() && java_lang_Class::is_secondary_mirror(element_mirror)) {
-    klass = InlineKlass::cast(klass)->null_free_inline_array_klass(dim, CHECK_NULL);
+    klass = InlineKlass::cast(klass)->value_array_klass(dim, CHECK_NULL);
   } else {
     klass = klass->array_klass(dim, CHECK_NULL);
   }


### PR DESCRIPTION
Please review this changeset which renames some flags and methods to align them with the current semantics and behavior. Clearer names would help introducing nullable inline types later.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8277057](https://bugs.openjdk.java.net/browse/JDK-8277057): [lworld] array code needs some name cleanup


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer) ⚠️ Review applies to b1e6140affe453277fe2521230e1854e7679d792


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/582/head:pull/582` \
`$ git checkout pull/582`

Update a local copy of the PR: \
`$ git checkout pull/582` \
`$ git pull https://git.openjdk.java.net/valhalla pull/582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 582`

View PR using the GUI difftool: \
`$ git pr show -t 582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/582.diff">https://git.openjdk.java.net/valhalla/pull/582.diff</a>

</details>
