### PR TITLE
8277062: [lworld] C2 compilation fails with "not drained yet" assert

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2776,6 +2776,7 @@ void Compile::Optimize() {
   }
 
   DEBUG_ONLY( _modified_nodes = NULL; )
+  DEBUG_ONLY( _late_inlines.clear(); )
 
   assert(igvn._worklist.size() == 0, "not empty");
  } // (End scope of igvn; run destructor if necessary for asserts.)


### PR DESCRIPTION
Trivial follow-up fix after [JDK-8273715](https://bugs.openjdk.java.net/browse/JDK-8273715). We need to clear the late inlines worklist to make the assert happy.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8277062](https://bugs.openjdk.java.net/browse/JDK-8277062): [lworld] C2 compilation fails with "not drained yet" assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/583/head:pull/583` \
`$ git checkout pull/583`

Update a local copy of the PR: \
`$ git checkout pull/583` \
`$ git pull https://git.openjdk.java.net/valhalla pull/583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 583`

View PR using the GUI difftool: \
`$ git pr show -t 583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/583.diff">https://git.openjdk.java.net/valhalla/pull/583.diff</a>

</details>
