### PR TITLE
8274973: [lworld] compiler/c2/irTests/TestPostParseCallDevirtualization.java fails with valhalla

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1245,7 +1245,7 @@ CallGenerator* CallGenerator::for_method_handle_inline(JVMState* jvms, ciMethod*
         CallGenerator* cg = C->call_generator(target, vtable_index,
                                               false /* call_does_dispatch */,
                                               jvms,
-                                              true /* allow_inline */,
+                                              allow_inline,
                                               PROB_ALWAYS,
                                               NULL,
                                               true);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -114,7 +114,6 @@ applications/jcstress/copy.java 8229852 linux-x64
 # Valhalla
 
 runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java 8274131 linux-aarch64-debug,macosx-aarch64-debug
-compiler/c2/irTests/TestPostParseCallDevirtualization.java 8274973 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
This fixes a difference with upstream. It must be something that got dropped in a merge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8274973](https://bugs.openjdk.java.net/browse/JDK-8274973): [lworld] compiler/c2/irTests/TestPostParseCallDevirtualization.java fails with valhalla


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/584/head:pull/584` \
`$ git checkout pull/584`

Update a local copy of the PR: \
`$ git checkout pull/584` \
`$ git pull https://git.openjdk.java.net/valhalla pull/584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 584`

View PR using the GUI difftool: \
`$ git pr show -t 584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/584.diff">https://git.openjdk.java.net/valhalla/pull/584.diff</a>

</details>
