### PR TITLE
8277570: [lworld] Pre-allocated instance should be created during class initialization

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1777,7 +1777,6 @@ Value GraphBuilder::make_constant(ciConstant field_value, ciField* field) {
 }
 
 void GraphBuilder::copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* enclosing_field) {
-  assert(vk->nof_nonstatic_fields() > 0, "Empty inline type access should be removed");
   for (int i = 0; i < vk->nof_nonstatic_fields(); i++) {
     ciField* inner_field = vk->nonstatic_field_at(i);
     assert(!inner_field->is_flattened(), "the iteration over nested fields is handled by the loop itself");
@@ -1884,7 +1883,8 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
       if (!has_pending_field_access() && !has_pending_load_indexed()) {
         obj = apop();
         ObjectType* obj_type = obj->type()->as_ObjectType();
-        if (field->is_null_free() && field->type()->is_loaded() && field->type()->as_inline_klass()->is_empty()) {
+        if (field->is_null_free() && field->type()->as_instance_klass()->is_initialized()
+            && field->type()->as_inline_klass()->is_empty()) {
           // Loading from a field of an empty inline type. Just return the default instance.
           null_check(obj);
           constant = new Constant(new InstanceConstant(field->type()->as_inline_klass()->default_instance()));
@@ -1986,7 +1986,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
             scope()->set_wrote_final();
             scope()->set_wrote_fields();
             bool need_membar = false;
-            if (inline_klass->is_empty()) {
+            if (inline_klass->is_initialized() && inline_klass->is_empty()) {
               apush(append(new Constant(new InstanceConstant(inline_klass->default_instance()))));
               if (has_pending_field_access()) {
                 set_pending_field_access(NULL);

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5498,13 +5498,6 @@ InstanceKlass* ClassFileParser::create_instance_klass(bool changed_by_loadhook,
   fill_instance_klass(ik, changed_by_loadhook, cl_inst_info, CHECK_NULL);
 
   assert(_klass == ik, "invariant");
-
-  if (ik->is_inline_klass()) {
-    InlineKlass* vk = InlineKlass::cast(ik);
-    oop val = ik->allocate_instance(CHECK_NULL);
-    vk->set_default_value(val);
-  }
-
   return ik;
 }
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1260,12 +1260,6 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
 
   load_shared_class_misc(ik, loader_data);
 
-  if (ik->is_inline_klass()) {
-    InlineKlass* vk = InlineKlass::cast(ik);
-    oop val = ik->allocate_instance(CHECK_NULL);
-    vk->set_default_value(val);
-  }
-
   return ik;
 }
 

--- a/src/hotspot/share/oops/flatArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.inline.hpp
@@ -48,6 +48,7 @@ inline int flatArrayOopDesc::object_size() const {
 inline oop flatArrayOopDesc::value_alloc_copy_from_index(flatArrayHandle vah, int index, TRAPS) {
   FlatArrayKlass* vaklass = FlatArrayKlass::cast(vah->klass());
   InlineKlass* vklass = vaklass->element_klass();
+  assert(vklass->is_initialized(), "Should be");
   if (vklass->is_empty_inline_type()) {
     return vklass->default_value();
   } else {

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -67,7 +67,9 @@ InlineKlass::InlineKlass(const ClassFileParser& parser)
 }
 
 oop InlineKlass::default_value() {
+  assert(is_initialized() || is_being_initialized() || is_in_error_state(), "default value is set at the beginning of initialization");
   oop val = java_mirror()->obj_field_acquire(default_value_offset());
+  assert(val != NULL, "Sanity check");
   assert(oopDesc::is_oop(val), "Sanity check");
   assert(val->is_inline_type(), "Sanity check");
   assert(val->klass() == this, "sanity check");


### PR DESCRIPTION
Please review those changes moving the creation of the pre-allocated default instance from the loading phase to the class initialization phase. The changes also include fixes in C1 to ensure the class is initialized before optimizing empty classes.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8277570](https://bugs.openjdk.java.net/browse/JDK-8277570): [lworld] Pre-allocated instance should be created during class initialization


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/585/head:pull/585` \
`$ git checkout pull/585`

Update a local copy of the PR: \
`$ git checkout pull/585` \
`$ git pull https://git.openjdk.java.net/valhalla pull/585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 585`

View PR using the GUI difftool: \
`$ git pr show -t 585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/585.diff">https://git.openjdk.java.net/valhalla/pull/585.diff</a>

</details>
