### PR TITLE
8278350: [lworld] Compiler test failures after merge with mainline

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -957,6 +957,7 @@ public class TestCallingConvention {
     static primitive class EmptyContainer {
         private MyValueEmpty empty;
 
+        @ForceInline
         EmptyContainer(MyValueEmpty empty) {
             this.empty = empty;
         }
@@ -972,6 +973,7 @@ public class TestCallingConvention {
         public int val;
         private EmptyContainer empty;
 
+        @ForceInline
         MixedContainer(int val, EmptyContainer empty) {
             this.val = val;
             this.empty = empty;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
@@ -164,6 +164,7 @@ public class TestMethodHandles {
     }
 
     @Run(test = "test1")
+    @Warmup(10000)
     public void test1_verifier() throws Throwable {
         MyValue3 vt = test1();
         test1_vt.verify(vt);


### PR DESCRIPTION
Added two missing `@ForceInline` annotations and increased warmup iterations for a test now that [JDK-8276546](https://bugs.openjdk.java.net/browse/JDK-8276546) was merged in and IR verification is enabled with `-XX:CICompileThreshold=100`.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8278350](https://bugs.openjdk.java.net/browse/JDK-8278350): [lworld] Compiler test failures after merge with mainline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/589/head:pull/589` \
`$ git checkout pull/589`

Update a local copy of the PR: \
`$ git checkout pull/589` \
`$ git pull https://git.openjdk.java.net/valhalla pull/589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 589`

View PR using the GUI difftool: \
`$ git pr show -t 589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/589.diff">https://git.openjdk.java.net/valhalla/pull/589.diff</a>

</details>
