### PR TITLE
8278352: [lworld] nmethod assembly snippet in hs_err file misses method name and parameters

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/MachCodeFramesInErrorFile.java
@@ -154,7 +154,7 @@ public class MachCodeFramesInErrorFile {
             return;
         }
 
-        Matcher matcher = Pattern.compile("\\[MachCode\\]\\s*\\[Verified Entry Point\\]\\s*  # \\{method\\} \\{[^}]*\\} '([^']+)' '([^']+)' in '([^']+)'", Pattern.DOTALL).matcher(hsErr);
+        Matcher matcher = Pattern.compile("\\[MachCode\\]\\s[^{]+\\{method\\} \\{[^}]*\\} '([^']+)' '([^']+)' in '([^']+)'", Pattern.DOTALL).matcher(hsErr);
         List<String> machCodeHeaders = matcher.results().map(mr -> String.format("'%s' '%s' in '%s'", mr.group(1), mr.group(2), mr.group(3))).collect(Collectors.toList());
         int minExpectedMachCodeSections = Math.max(1, compiledJavaFrames);
         if (machCodeHeaders.size() < minExpectedMachCodeSections) {


### PR DESCRIPTION
Some users of `nmethod::maybe_print_nmethod` do not set the `_nmethod_to_print` field and as a result, the method name and arguments are not printed. Now that the `ProtectionDomainSet_lock` has been removed by [JDK-8259242](https://bugs.openjdk.java.net/browse/JDK-8259242) we can also remove the workaround code and move the computation of the calling convention into the print method.

In addition, the regex in the MachCodeFramesInErrorFile test does not properly handle the labels for multiple entry points (for details, see bug report). I adjusted it accordingly.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8278352](https://bugs.openjdk.java.net/browse/JDK-8278352): [lworld] nmethod assembly snippet in hs_err file misses method name and parameters


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/590/head:pull/590` \
`$ git checkout pull/590`

Update a local copy of the PR: \
`$ git checkout pull/590` \
`$ git pull https://git.openjdk.java.net/valhalla pull/590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 590`

View PR using the GUI difftool: \
`$ git pr show -t 590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/590.diff">https://git.openjdk.java.net/valhalla/pull/590.diff</a>

</details>
