### PR TITLE
8279377: [lworld] Javac Parser still has stale code supporting nullable projection types from a previous era

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -317,13 +317,6 @@ public class JavacParser implements Parser {
                 tk3.test(S.token(lookahead + 3).kind);
     }
 
-    protected boolean peekToken(int lookahead, Predicate<TokenKind> tk1, Predicate<TokenKind> tk2, Predicate<TokenKind> tk3, Predicate<TokenKind> tk4) {
-        return tk1.test(S.token(lookahead + 1).kind) &&
-                tk2.test(S.token(lookahead + 2).kind) &&
-                tk3.test(S.token(lookahead + 3).kind) &&
-                tk4.test(S.token(lookahead + 4).kind);
-    }
-
     @SuppressWarnings("unchecked")
     protected boolean peekToken(Predicate<TokenKind>... kinds) {
         return peekToken(0, kinds);
@@ -1824,8 +1817,8 @@ public class JavacParser implements Parser {
                 case ASSERT:
                 case ENUM:
                 case IDENTIFIER:
-                    if (peekToken(lookahead, LAX_IDENTIFIER) || (peekToken(lookahead, QUES, LAX_IDENTIFIER) && (peekToken(lookahead + 2, RPAREN) || peekToken(lookahead + 2, COMMA)))) {
-                        // Identifier[?], Identifier/'_'/'assert'/'enum' -> explicit lambda
+                    if (peekToken(lookahead, LAX_IDENTIFIER)) {
+                        // Identifier, Identifier/'_'/'assert'/'enum' -> explicit lambda
                         return ParensResult.EXPLICIT_LAMBDA;
                     } else if (peekToken(lookahead, RPAREN, ARROW)) {
                         // Identifier, ')' '->' -> implicit lambda
@@ -1877,8 +1870,6 @@ public class JavacParser implements Parser {
                             return ParensResult.CAST;
                         } else if (peekToken(lookahead, LAX_IDENTIFIER, COMMA) ||
                                 peekToken(lookahead, LAX_IDENTIFIER, RPAREN, ARROW) ||
-                                peekToken(lookahead, QUES, LAX_IDENTIFIER, COMMA) ||
-                                peekToken(lookahead, QUES, LAX_IDENTIFIER, RPAREN, ARROW) ||
                                 peekToken(lookahead, ELLIPSIS)) {
                             // '>', Identifier/'_'/'assert'/'enum', ',' -> explicit lambda
                             // '>', Identifier/'_'/'assert'/'enum', ')', '->' -> explicit lambda


### PR DESCRIPTION
Garbage collect stale code handling nullable projection types using the ? syntax

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279377](https://bugs.openjdk.java.net/browse/JDK-8279377): [lworld] Javac Parser still has stale code supporting nullable projection types from a previous era


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/591/head:pull/591` \
`$ git checkout pull/591`

Update a local copy of the PR: \
`$ git checkout pull/591` \
`$ git pull https://git.openjdk.java.net/valhalla pull/591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 591`

View PR using the GUI difftool: \
`$ git pr show -t 591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/591.diff">https://git.openjdk.java.net/valhalla/pull/591.diff</a>

</details>
