### PR TITLE
8279624: [lworld] interpreter should avoid value copies in withfield when possible

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -312,6 +312,12 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ConstantPoolCa
     case ltos:
       if (old_value_h()->long_field(offset) == *(jlong*)ptr) can_skip = true;
       break;
+    case ftos:
+      if (memcmp(old_value_h()->field_addr<jfloat>(offset), (jfloat*)ptr, sizeof(jfloat)) == 0) can_skip = true;
+      break;
+    case dtos:
+      if (memcmp(old_value_h()->field_addr<jdouble>(offset), (jdouble*)ptr, sizeof(jdouble)) == 0) can_skip = true;
+      break;
     case atos:
       if (!cpe->is_inlined() && old_value_h()->obj_field(offset) == ref_h()) can_skip = true;
       break;

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -274,6 +274,7 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ConstantPoolCa
   int recv_offset = type2size[as_BasicType(cpe->flag_state())];
   assert(frame::interpreter_frame_expression_stack_direction() == -1, "currently is -1 on all platforms");
   int ret_adj = (recv_offset + type2size[T_OBJECT] )* AbstractInterpreter::stackElementSize;
+  int offset = cpe->f2_as_offset();
   obj = (oopDesc*)(((uintptr_t*)ptr)[recv_offset * Interpreter::stackElementWords]);
   if (obj == NULL) {
     THROW_(vmSymbols::java_lang_NullPointerException(), ret_adj);
@@ -290,10 +291,41 @@ JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ConstantPoolCa
   // Ensure that the class is initialized or being initialized
   // If the class is in error state, the creation of a new value should not be allowed
   ik->initialize(CHECK_(ret_adj));
+
+  bool can_skip = false;
+  switch(cpe->flag_state()) {
+    case ztos:
+      if (old_value_h()->bool_field(offset) == (jboolean)(*(jint*)ptr)) can_skip = true;
+      break;
+    case btos:
+      if (old_value_h()->byte_field(offset) == (jbyte)(*(jint*)ptr)) can_skip = true;
+      break;
+    case ctos:
+      if (old_value_h()->char_field(offset) == (jchar)(*(jint*)ptr)) can_skip = true;
+      break;
+    case stos:
+      if (old_value_h()->short_field(offset) == (jshort)(*(jint*)ptr)) can_skip = true;
+      break;
+    case itos:
+      if (old_value_h()->int_field(offset) == *(jint*)ptr) can_skip = true;
+      break;
+    case ltos:
+      if (old_value_h()->long_field(offset) == *(jlong*)ptr) can_skip = true;
+      break;
+    case atos:
+      if (!cpe->is_inlined() && old_value_h()->obj_field(offset) == ref_h()) can_skip = true;
+      break;
+    default:
+      break;
+  }
+  if (can_skip) {
+    current->set_vm_result(old_value_h());
+    return ret_adj;
+  }
+
   instanceOop new_value = ik->allocate_instance_buffer(CHECK_(ret_adj));
   Handle new_value_h = Handle(THREAD, new_value);
   ik->inline_copy_oop_to_new_oop(old_value_h(), new_value_h());
-  int offset = cpe->f2_as_offset();
   switch(cpe->flag_state()) {
     case ztos:
       new_value_h()->bool_field_put(offset, (jboolean)(*(jint*)ptr));


### PR DESCRIPTION
Please review this small change to reduce the number of copies the interpreter does when executing the withfield bytecode.
If the new value of the field to be updated is identical to the old value of the field, the interpreter simply returns the original value instance instead of creating a new copy.
This change removes more than 8K value copies when running the hotspot_valhalla test suite.

Tested with Mach5, tiers 1 to 3.

Thank you

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279624](https://bugs.openjdk.java.net/browse/JDK-8279624): [lworld] interpreter should avoid value copies in withfield when possible


### Reviewers
 * [David Simms](https://openjdk.java.net/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/595/head:pull/595` \
`$ git checkout pull/595`

Update a local copy of the PR: \
`$ git checkout pull/595` \
`$ git pull https://git.openjdk.java.net/valhalla pull/595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 595`

View PR using the GUI difftool: \
`$ git pr show -t 595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/595.diff">https://git.openjdk.java.net/valhalla/pull/595.diff</a>

</details>
