### PR TITLE
8279368: [lworld] Add parser support for declaration of value classes

### DIFF
--- a/src/java.base/share/classes/java/lang/__value__.java
+++ b/src/java.base/share/classes/java/lang/__value__.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.lang.annotation.*;
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * A class annotated {@code @__value__} is a value class.
+ * This is a temporary workaround to enable use of value classes
+ * in editors and IDEs that do not yet understand the 'value' modifier.
+ * @since 18
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(value={ElementType.TYPE, ElementType.TYPE_USE})
+public @interface __value__ {
+}

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -63,11 +63,6 @@ public enum Modifier {
      * @since 1.8
      */
      DEFAULT,
-    /**
-     * The modifier {@code primitive}
-     * @since 1.17
-     */
-    PRIMITIVE,
 
     /** The modifier {@code static} */          STATIC,
 
@@ -86,6 +81,19 @@ public enum Modifier {
             return "non-sealed";
         }
     },
+
+    /**
+     * The modifier {@code primitive}
+     * @since 18
+     */
+    PRIMITIVE,
+
+    /**
+     * The modifier {@code value}
+     * @since 18
+     */
+    VALUE,
+
     /** The modifier {@code final} */           FINAL,
     /** The modifier {@code transient} */       TRANSIENT,
     /** The modifier {@code volatile} */        VOLATILE,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -114,6 +114,7 @@ public class Flags {
     public static final int ACC_SUPER    = 0x0020;
     public static final int ACC_BRIDGE   = 0x0040;
     public static final int ACC_VARARGS  = 0x0080;
+    public static final int ACC_VALUE    = 0x0100;
     public static final int ACC_PRIMITIVE = 0x0800;
     public static final int ACC_MODULE   = 0x8000;
 
@@ -148,9 +149,8 @@ public class Flags {
      */
     public static final int BLOCK            = 1<<20;
 
-    /** Flag bit 21 is available. (used earlier to tag compiler-generated abstract methods that implement
-     *  an interface method (Miranda methods)).
-     */
+    /** Marks a type as a value class */
+    public static final int VALUE_CLASS  = 1<<21;
 
     /** Flag is set for nested classes that do not access instance members
      *  or `this' of an outer class and therefore don't need to be passed
@@ -416,7 +416,7 @@ public class Flags {
      */
     public static final int
         AccessFlags                       = PUBLIC | PROTECTED | PRIVATE,
-        LocalClassFlags                   = FINAL | ABSTRACT | ENUM | SYNTHETIC  | ACC_PRIMITIVE,
+        LocalClassFlags                   = FINAL | ABSTRACT | ENUM | SYNTHETIC  | ACC_PRIMITIVE | ACC_VALUE,
         StaticLocalClassFlags             = LocalClassFlags | STATIC | INTERFACE,
         MemberClassFlags                  = LocalClassFlags | INTERFACE | AccessFlags,
         MemberStaticClassFlags            = MemberClassFlags | STATIC,
@@ -431,13 +431,13 @@ public class Flags {
         RecordMethodFlags                 = AccessFlags | ABSTRACT | STATIC |
                                             SYNCHRONIZED | FINAL | STRICTFP;
     public static final long
-        ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS,
-        ExtendedMemberClassFlags          = (long)MemberClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS,
-        ExtendedMemberStaticClassFlags    = (long) MemberStaticClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS,
-        ExtendedClassFlags                = (long)ClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS,
-        ExtendedLocalClassFlags           = (long) LocalClassFlags | PRIMITIVE_CLASS,
-        ExtendedStaticLocalClassFlags     = (long) StaticLocalClassFlags | PRIMITIVE_CLASS,
-        ModifierFlags                     = ((long)StandardFlags & ~INTERFACE) | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS,
+        ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
+        ExtendedMemberClassFlags          = (long)MemberClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
+        ExtendedMemberStaticClassFlags    = (long) MemberStaticClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
+        ExtendedClassFlags                = (long)ClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
+        ExtendedLocalClassFlags           = (long) LocalClassFlags | PRIMITIVE_CLASS | VALUE_CLASS,
+        ExtendedStaticLocalClassFlags     = (long) StaticLocalClassFlags | PRIMITIVE_CLASS | VALUE_CLASS,
+        ModifierFlags                     = ((long)StandardFlags & ~INTERFACE) | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
         InterfaceMethodMask               = ABSTRACT | PRIVATE | STATIC | PUBLIC | STRICTFP | DEFAULT,
         AnnotationTypeElementMask         = ABSTRACT | PUBLIC,
         LocalVarFlags                     = FINAL | PARAMETER,
@@ -464,6 +464,7 @@ public class Flags {
             if (0 != (flags & STRICTFP))  modifiers.add(Modifier.STRICTFP);
             if (0 != (flags & DEFAULT))   modifiers.add(Modifier.DEFAULT);
             if (0 != (flags & PRIMITIVE_CLASS))     modifiers.add(Modifier.PRIMITIVE);
+            if (0 != (flags & VALUE_CLASS))     modifiers.add(Modifier.VALUE);
             modifiers = Collections.unmodifiableSet(modifiers);
             modifierSets.put(flags, modifiers);
         }
@@ -511,6 +512,7 @@ public class Flags {
         ENUM(Flags.ENUM),
         MANDATED(Flags.MANDATED),
         PRIMITIVE(Flags.PRIMITIVE_CLASS),
+        VALUE(Flags.VALUE_CLASS),
         NOOUTERTHIS(Flags.NOOUTERTHIS),
         EXISTS(Flags.EXISTS),
         COMPOUND(Flags.COMPOUND),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -229,11 +229,12 @@ public enum Source {
         PATTERN_MATCHING_IN_INSTANCEOF(JDK16, Fragments.FeaturePatternMatchingInstanceof, DiagKind.NORMAL),
         REIFIABLE_TYPES_INSTANCEOF(JDK16, Fragments.FeatureReifiableTypesInstanceof, DiagKind.PLURAL),
         RECORDS(JDK16, Fragments.FeatureRecords, DiagKind.PLURAL),
-        PRIMITIVE_CLASSES(JDK17, Fragments.FeaturePrimitiveClasses, DiagKind.NORMAL),
         SEALED_CLASSES(JDK17, Fragments.FeatureSealedClasses, DiagKind.PLURAL),
         CASE_NULL(JDK17, Fragments.FeatureCaseNull, DiagKind.NORMAL),
         PATTERN_SWITCH(JDK17, Fragments.FeaturePatternSwitch, DiagKind.PLURAL),
         REDUNDANT_STRICTFP(JDK17),
+        PRIMITIVE_CLASSES(JDK18, Fragments.FeaturePrimitiveClasses, DiagKind.PLURAL),
+        VALUE_CLASSES(JDK18, Fragments.FeatureValueClasses, DiagKind.PLURAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -110,6 +110,10 @@ public class ClassReader {
      */
     boolean allowPrimitiveClasses;
 
+    /** Switch: allow value classes.
+     */
+    boolean allowValueClasses;
+
     /** Switch: allow sealed
      */
     boolean allowSealedTypes;
@@ -282,7 +286,10 @@ public class ClassReader {
         Source source = Source.instance(context);
         preview = Preview.instance(context);
         allowModules     = Feature.MODULES.allowedInSource(source);
-        allowPrimitiveClasses = Feature.PRIMITIVE_CLASSES.allowedInSource(source);
+        allowPrimitiveClasses = (!preview.isPreview(Feature.PRIMITIVE_CLASSES) || preview.isEnabled()) &&
+                Feature.PRIMITIVE_CLASSES.allowedInSource(source);
+        allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
+                Feature.VALUE_CLASSES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         allowSealedTypes = Feature.SEALED_CLASSES.allowedInSource(source);
 
@@ -2787,6 +2794,12 @@ public class ClassReader {
             flags &= ~ACC_PRIMITIVE;
             if (allowPrimitiveClasses) {
                 flags |= PRIMITIVE_CLASS;
+            }
+        }
+        if ((flags & ACC_VALUE) != 0) {
+            flags &= ~ACC_VALUE;
+            if (allowValueClasses) {
+                flags |= VALUE_CLASS;
             }
         }
         return flags & ~ACC_SUPER; // SUPER and SYNCHRONIZED bits overloaded

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1719,6 +1719,8 @@ public class ClassWriter extends ClassFile {
             result &= ~ABSTRACT;
         if ((flags & PRIMITIVE_CLASS) != 0)
             result |= ACC_PRIMITIVE;
+        if ((flags & VALUE_CLASS) != 0)
+            result |= ACC_VALUE;
         return result;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3912,6 +3912,9 @@ compiler.err.preview.without.source.or.release=\
 compiler.misc.feature.primitive.classes=\
     primitive classes
 
+compiler.misc.feature.value.classes=\
+    value classes
+
 # 0: symbol
 compiler.err.cyclic.primitive.class.membership=\
     cyclic primitive class membership involving {0}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -116,6 +116,8 @@ public class Names {
     public final Name java_lang_System;
     public final Name __primitive__;
     public final Name java_lang___primitive__;
+    public final Name __value__;
+    public final Name java_lang___value__;
     public final Name java_lang_IdentityObject;
 
     // names of builtin classes
@@ -309,6 +311,8 @@ public class Names {
         java_lang_System = fromString("java.lang.System");
         __primitive__ = fromString("__primitive__");
         java_lang___primitive__ = fromString("java.lang.__primitive__");
+        __value__ = fromString("__value__");
+        java_lang___value__ = fromString("java.lang.__value__");
         java_lang_IdentityObject = fromString("java.lang.IdentityObject");
 
         // names of builtin classes

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
@@ -49,6 +49,7 @@ public class AccessFlags {
     public static final int ACC_BRIDGE        = 0x0040; //                      method
     public static final int ACC_TRANSIENT     = 0x0080; //               field
     public static final int ACC_VARARGS       = 0x0080; //                      method
+    public static final int ACC_VALUE         = 0x0100; //                      class
     public static final int ACC_NATIVE        = 0x0100; //                      method
     public static final int ACC_INTERFACE     = 0x0200; // class, inner
     public static final int ACC_ABSTRACT      = 0x0400; // class, inner,        method
@@ -83,12 +84,12 @@ public class AccessFlags {
     }
 
     private static final int[] classModifiers = {
-        ACC_PUBLIC, ACC_FINAL, ACC_ABSTRACT, ACC_PRIMITIVE
+        ACC_PUBLIC, ACC_FINAL, ACC_ABSTRACT, ACC_PRIMITIVE, ACC_VALUE
     };
 
     private static final int[] classFlags = {
         ACC_PUBLIC, ACC_FINAL, ACC_SUPER, ACC_INTERFACE, ACC_ABSTRACT,
-        ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_MODULE, ACC_PRIMITIVE
+        ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_MODULE, ACC_PRIMITIVE, ACC_VALUE
     };
 
     public Set<String> getClassModifiers() {
@@ -102,12 +103,12 @@ public class AccessFlags {
 
     private static final int[] innerClassModifiers = {
         ACC_PUBLIC, ACC_PRIVATE, ACC_PROTECTED, ACC_STATIC, ACC_FINAL,
-        ACC_ABSTRACT, ACC_PRIMITIVE
+        ACC_ABSTRACT, ACC_PRIMITIVE, ACC_VALUE
     };
 
     private static final int[] innerClassFlags = {
         ACC_PUBLIC, ACC_PRIVATE, ACC_PROTECTED, ACC_STATIC, ACC_FINAL, ACC_SUPER,
-        ACC_INTERFACE, ACC_ABSTRACT, ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_PRIMITIVE
+        ACC_INTERFACE, ACC_ABSTRACT, ACC_SYNTHETIC, ACC_ANNOTATION, ACC_ENUM, ACC_PRIMITIVE, ACC_VALUE
     };
 
     public Set<String> getInnerClassModifiers() {
@@ -204,8 +205,8 @@ public class AccessFlags {
                 return (t == Kind.Field ? "transient" : null);
             case ACC_VOLATILE:
                 return "volatile";
-            case ACC_NATIVE:
-                return "native";
+            case 0x100:
+                return (t == Kind.Class || t == Kind.InnerClass) ? "value" : "native";
             case ACC_ABSTRACT:
                 return "abstract";
             case 0x800:
@@ -235,8 +236,8 @@ public class AccessFlags {
             return (t == Kind.Field ? "ACC_VOLATILE" : "ACC_BRIDGE");
         case 0x80:
             return (t == Kind.Field ? "ACC_TRANSIENT" : "ACC_VARARGS");
-        case ACC_NATIVE:
-            return "ACC_NATIVE";
+        case 0x100:
+            return (t == Kind.Class || t == Kind.InnerClass) ? "ACC_VALUE" : "ACC_NATIVE";
         case ACC_INTERFACE:
             return "ACC_INTERFACE";
         case ACC_ABSTRACT:

--- a/test/langtools/tools/javac/diags/CheckResourceKeys.java
+++ b/test/langtools/tools/javac/diags/CheckResourceKeys.java
@@ -310,7 +310,8 @@ public class CheckResourceKeys {
             "javac.",
             "verbose.",
             "locn.",
-            "java.lang.__primitive__"
+            "java.lang.__primitive__",
+            "java.lang.__value__"
     ));
 
     /**

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -222,3 +222,4 @@ compiler.err.super.method.cannot.be.synchronized
 compiler.err.super.no.arg.constructor.must.be.empty
 compiler.err.generic.parameterization.with.primitive.class
 compiler.misc.feature.primitive.classes
+compiler.misc.feature.value.classes

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate1.out
@@ -1,4 +1,2 @@
-CheckFeatureGate1.java:10:12: compiler.warn.restricted.type.not.allowed.preview: primitive, 17
-CheckFeatureGate1.java:10:21: compiler.err.expected: token.identifier
+CheckFeatureGate1.java:10:12: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 13, 18
 1 error
-1 warning

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFeatureGate2.out
@@ -1,2 +1,2 @@
-CheckFeatureGate2.java:11:17: compiler.err.feature.not.supported.in.source: (compiler.misc.feature.primitive.classes), 13, 17
+CheckFeatureGate2.java:11:17: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 13, 18
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/PrimitiveAsTypeName.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/PrimitiveAsTypeName.java
@@ -9,5 +9,6 @@ public class PrimitiveAsTypeName {
     public class primitive {
         primitive x;
         primitive foo(int l) {}
+        Object o = new primitive primitive() {};
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/PrimitiveAsTypeName.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/PrimitiveAsTypeName.out
@@ -1,7 +1,7 @@
 - compiler.warn.source.no.system.modules.path: 16
-PrimitiveAsTypeName.java:9:18: compiler.warn.restricted.type.not.allowed.preview: primitive, 17
-PrimitiveAsTypeName.java:10:9: compiler.warn.restricted.type.not.allowed.preview: primitive, 17
-PrimitiveAsTypeName.java:11:9: compiler.warn.restricted.type.not.allowed.preview: primitive, 17
-PrimitiveAsTypeName.java:11:31: compiler.err.missing.ret.stmt
+PrimitiveAsTypeName.java:9:18: compiler.warn.restricted.type.not.allowed.preview: primitive, 18
+PrimitiveAsTypeName.java:10:9: compiler.warn.restricted.type.not.allowed.preview: primitive, 18
+PrimitiveAsTypeName.java:11:9: compiler.warn.restricted.type.not.allowed.preview: primitive, 18
+PrimitiveAsTypeName.java:12:24: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 16, 18
 1 error
 4 warnings

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.java
@@ -6,14 +6,14 @@
  */
 
 public class ValueModifierTest {
-    interface value {}
+    interface Value {}
     void foo() {
-        new primitive value() {};
+        new primitive Value() {};
     }
     void goo() {
-        primitive class value {}
-        new value() {};
-        new primitive value() {};
-        new value();
+        primitive class Value {}
+        new Value() {};
+        new primitive Value() {};
+        new Value();
     }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -1,4 +1,4 @@
-ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:16:23: compiler.err.cant.inherit.from.final: value
-ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: ValueModifierTest$3, value
+ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: Value
+ValueModifierTest.java:16:23: compiler.err.cant.inherit.from.final: Value
+ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: ValueModifierTest$3, Value
 3 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/CheckFeatureSourceLevel.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/CheckFeatureSourceLevel.java
@@ -1,0 +1,13 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279368
+ * @summary Add parser support for value classes
+ * @compile/fail/ref=CheckFeatureSourceLevel.out --release=13 -XDrawDiagnostics CheckFeatureSourceLevel.java
+ */
+
+public class CheckFeatureSourceLevel {
+
+    static value class Value {
+        public int v = 42;
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/CheckFeatureSourceLevel.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/CheckFeatureSourceLevel.out
@@ -1,0 +1,2 @@
+CheckFeatureSourceLevel.java:10:12: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.value.classes), 13, 18
+1 error

--- a/test/langtools/tools/javac/valhalla/value-objects/Substring.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/Substring.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8279368
+ * @summary Add parser support for declaration of value classes
+ * @compile Substring.java
+ */
+
+public value class Substring implements CharSequence {
+    private String str;
+    private int start;
+    private int end;
+
+    public Substring(String str, int start, int end) {
+        checkBounds(start, end, str.length());
+        this.str = str;
+        this.start = start;
+        this.end = end;
+    }
+
+    public int length() {
+        return end - start;
+    }
+
+    public char charAt(int i) {
+        checkBounds(0, i, length());
+        return str.charAt(start + i);
+    }
+
+    public Substring subSequence(int s, int e) {
+        checkBounds(s, e, length());
+        return new Substring(str, start + s, start + e);
+    }
+
+    public String toString() {
+        return str.substring(start, end);
+    }
+
+    private static void checkBounds(int start, int end, int length) {
+        if (start < 0 || end < start || length < end)
+            throw new IndexOutOfBoundsException();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.java
@@ -1,0 +1,12 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279368
+ * @summary Test that value classes can be declared using annotations instead of modifiers
+ * @compile/fail/ref=ValueAnnotationTest.out -XDrawDiagnostics -XDdev ValueAnnotationTest.java
+ */
+
+public class ValueAnnotationTest {
+    @__value__ public class X {}
+    @java.lang.__value__  public class Y extends X {}
+    public class Z extends Y {}
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
@@ -1,0 +1,3 @@
+ValueAnnotationTest.java:10:50: compiler.err.cant.inherit.from.final: ValueAnnotationTest.X
+ValueAnnotationTest.java:11:28: compiler.err.cant.inherit.from.final: ValueAnnotationTest.Y
+2 errors


### PR DESCRIPTION
Enhance the parser to accept value class declarations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279368](https://bugs.openjdk.java.net/browse/JDK-8279368): [lworld] Add parser support for declaration of value classes


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/596/head:pull/596` \
`$ git checkout pull/596`

Update a local copy of the PR: \
`$ git checkout pull/596` \
`$ git pull https://git.openjdk.java.net/valhalla pull/596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 596`

View PR using the GUI difftool: \
`$ git pr show -t 596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/596.diff">https://git.openjdk.java.net/valhalla/pull/596.diff</a>

</details>
