### PR TITLE
8279672: [lworld] Implement semantic checks for value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -420,6 +420,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return (flags() & PRIMITIVE_CLASS) != 0;
     }
 
+    public boolean isValueClass() {
+        return (flags() & VALUE_CLASS) != 0;
+    }
+
     public boolean isPublic() {
         return (flags_field & Flags.AccessFlags) == PUBLIC;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -241,6 +241,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         return false;
     }
 
+    public boolean isValueClass() {
+        return false;
+    }
+
     /**
      * Return the `flavor' associated with a ClassType.
      * @see ClassType.Flavor
@@ -1322,6 +1326,11 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         @Override
         public boolean isPrimitiveClass() {
             return !isReferenceProjection() && tsym != null && tsym.isPrimitiveClass();
+        }
+
+        @Override
+        public boolean isValueClass() {
+            return tsym != null && tsym.isValueClass();
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1013,6 +1013,10 @@ public class Types {
         return t != null && t.isPrimitiveClass();
     }
 
+    public boolean isValueClass(Type t) {
+        return t != null && t.isValueClass();
+    }
+
     // <editor-fold defaultstate="collapsed" desc="isSubtype">
     /**
      * Is t an unchecked subtype of s?
@@ -2260,7 +2264,7 @@ public class Types {
                 return null;
             if (t.hasTag(ARRAY))
                 return syms.identityObjectType;
-            if (t.hasTag(CLASS) && !t.isReferenceProjection() && !t.tsym.isInterface() && !t.tsym.isAbstract()) {
+            if (t.hasTag(CLASS) && !t.isValueClass() && !t.isReferenceProjection() && !t.tsym.isInterface() && !t.tsym.isAbstract()) {
                 return syms.identityObjectType;
             }
             if (implicitIdentityType(t)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1228,12 +1228,12 @@ public class Attr extends JCTree.Visitor {
                         // generated one.
                         log.error(tree.body.stats.head.pos(),
                                   Errors.CallToSuperNotAllowedInEnumCtor(env.enclClass.sym));
-                    } else if ((env.enclClass.sym.flags() & PRIMITIVE_CLASS) != 0 &&
+                    } else if ((env.enclClass.sym.flags() & VALUE_CLASS) != 0 &&
                         (tree.mods.flags & GENERATEDCONSTR) == 0 &&
                         TreeInfo.isSuperCall(body.stats.head)) {
-                        // primitive constructors are not allowed to call super directly,
-                        // but tolerate compiler generated ones
-                        log.error(tree.body.stats.head.pos(), Errors.CallToSuperNotAllowedInPrimitiveCtor);
+                        // value constructors are not allowed to call super directly,
+                        // but tolerate compiler generated ones, these are ignored during code generation
+                        log.error(tree.body.stats.head.pos(), Errors.CallToSuperNotAllowedInValueCtor);
                     }
                     if (env.enclClass.sym.isRecord() && (tree.sym.flags_field & RECORD) != 0) { // we are seeing the canonical constructor
                         List<Name> recordComponentNames = TreeInfo.recordFields(env.enclClass).map(vd -> vd.sym.name);
@@ -5555,11 +5555,11 @@ public class Attr extends JCTree.Visitor {
                     env.info.isSerializable = true;
                 }
 
-                if ((c.flags() & (PRIMITIVE_CLASS | ABSTRACT)) == PRIMITIVE_CLASS) { // for non-intersection, concrete primitive classes.
+                if ((c.flags() & (VALUE_CLASS | ABSTRACT)) == VALUE_CLASS) { // for non-intersection, concrete primitive/value classes.
                     Assert.check(env.tree.hasTag(CLASSDEF));
                     JCClassDecl classDecl = (JCClassDecl) env.tree;
                     if (classDecl.extending != null) {
-                        chk.checkSuperConstraintsOfPrimitiveClass(env.tree.pos(), c);
+                        chk.checkSuperConstraintsOfValueClass(env.tree.pos(), c);
                     }
                 }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -748,14 +748,14 @@ public class Check {
                                     : t;
         }
 
-    void checkSuperConstraintsOfPrimitiveClass(DiagnosticPosition pos, ClassSymbol c) {
+    void checkSuperConstraintsOfValueClass(DiagnosticPosition pos, ClassSymbol c) {
         for(Type st = types.supertype(c.type); st != Type.noType; st = types.supertype(st)) {
             if (st == null || st.tsym == null || st.tsym.kind == ERR)
                 return;
             if  (st.tsym == syms.objectType.tsym)
                 return;
             if (!st.tsym.isAbstract()) {
-                log.error(pos, Errors.ConcreteSupertypeForPrimitiveClass(c, st));
+                log.error(pos, Errors.ConcreteSupertypeForValueClass(c, st));
             }
             if ((st.tsym.flags() & HASINITBLOCK) != 0) {
                 log.error(pos, Errors.SuperClassDeclaresInitBlock(c, st));
@@ -868,7 +868,7 @@ public class Check {
      */
     Type checkIdentityType(DiagnosticPosition pos, Type t) {
 
-        if (t.isPrimitive() || t.isPrimitiveClass() || t.isReferenceProjection())
+        if (t.isPrimitive() || t.isValueClass() || t.isReferenceProjection())
             return typeTagError(pos,
                     diags.fragment(Fragments.TypeReqIdentity),
                     t);
@@ -1369,7 +1369,7 @@ public class Check {
                 mask = implicit = InterfaceVarFlags;
             else {
                 mask = VarFlags;
-                if (types.isPrimitiveClass(sym.owner.type) && (flags & STATIC) == 0) {
+                if (types.isValueClass(sym.owner.type) && (flags & STATIC) == 0) {
                     implicit |= FINAL;
                 }
             }
@@ -1399,9 +1399,10 @@ public class Check {
                 }
             } else if ((sym.owner.flags_field & RECORD) != 0) {
                 mask = RecordMethodFlags;
+                // FIXME: We tolerate synchronized methods in value records
             } else {
-                // instance methods of primitive classes do not have a monitor associated with their `this'
-                mask = ((sym.owner.flags_field & PRIMITIVE_CLASS) != 0 && (flags & Flags.STATIC) == 0) ?
+                // value objects do not have an associated monitor/lock
+                mask = ((sym.owner.flags_field & VALUE_CLASS) != 0 && (flags & Flags.STATIC) == 0) ?
                         MethodFlags & ~SYNCHRONIZED : MethodFlags;
             }
             if ((flags & STRICTFP) != 0) {
@@ -1439,8 +1440,8 @@ public class Check {
             if ((flags & INTERFACE) != 0) implicit |= ABSTRACT;
 
             if ((flags & ENUM) != 0) {
-                // enums can't be declared abstract, final, sealed or non-sealed or primitive
-                mask &= ~(ABSTRACT | FINAL | SEALED | NON_SEALED | PRIMITIVE_CLASS);
+                // enums can't be declared abstract, final, sealed or non-sealed or primitive/value
+                mask &= ~(ABSTRACT | FINAL | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS);
                 implicit |= implicitEnumFinalFlag(tree);
             }
             if ((flags & RECORD) != 0) {
@@ -1453,6 +1454,15 @@ public class Check {
             }
             // Imply STRICTFP if owner has STRICTFP set.
             implicit |= sym.owner.flags_field & STRICTFP;
+
+            // primitive classes are implicitly final value classes.
+            if ((flags & PRIMITIVE_CLASS) != 0)
+                implicit |= VALUE_CLASS | FINAL;
+
+            // value classes are implicitly final
+            if ((flags & VALUE_CLASS) != 0)
+                implicit |= FINAL;
+
             break;
         default:
             throw new AssertionError();
@@ -1481,7 +1491,7 @@ public class Check {
                  &&
                  checkDisjoint(pos, flags,
                                ABSTRACT | INTERFACE,
-                               FINAL | NATIVE | SYNCHRONIZED | PRIMITIVE_CLASS)
+                               FINAL | NATIVE | SYNCHRONIZED | PRIMITIVE_CLASS | VALUE_CLASS)
                  &&
                  checkDisjoint(pos, flags,
                                PUBLIC,
@@ -2013,10 +2023,10 @@ public class Check {
             return;
         }
 
-        if (origin.isPrimitiveClass() && other.owner == syms.objectType.tsym && m.type.getParameterTypes().size() == 0) {
+        if (origin.isValueClass() && other.owner == syms.objectType.tsym && m.type.getParameterTypes().size() == 0) {
             if (m.name == names.clone || m.name == names.finalize) {
                 log.error(TreeInfo.diagnosticPositionFor(m, tree),
-                        Errors.PrimitiveClassMayNotOverride(m.name));
+                        Errors.ValueClassMayNotOverride(m.name));
                 m.flags_field |= BAD_OVERRIDE;
                 return;
             }
@@ -2750,8 +2760,8 @@ public class Check {
 
         boolean implementsIdentityObject = types.asSuper(c.referenceProjectionOrSelf(), syms.identityObjectType.tsym) != null;
         boolean implementsPrimitiveObject = types.asSuper(c.referenceProjectionOrSelf(), syms.primitiveObjectType.tsym) != null;
-        if (c.isPrimitiveClass() && implementsIdentityObject) {
-            log.error(pos, Errors.PrimitiveClassMustNotImplementIdentityObject(c));
+        if (c.isValueClass() && implementsIdentityObject) {
+            log.error(pos, Errors.ValueClassMustNotImplementIdentityObject(c));
         } else if (implementsPrimitiveObject && !c.isPrimitiveClass() && !c.isReferenceProjection() && !c.tsym.isInterface() && !c.tsym.isAbstract()) {
             log.error(pos, Errors.IdentityClassMustNotImplementPrimitiveObject(c));
         } else if (implementsPrimitiveObject && implementsIdentityObject) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1739,7 +1739,7 @@ public class Flow {
      */
     enum ThisExposability {
         ALLOWED,     // identity Object classes - NOP
-        BANNED,      // primitive classes - Error
+        BANNED,      // primitive/value classes - Error
     }
 
     /**
@@ -2202,7 +2202,7 @@ public class Flow {
                         firstadr = nextadr;
                         this.thisExposability = ALLOWED;
                     } else {
-                        if (types.isPrimitiveClass(tree.sym.owner.type))
+                        if (types.isValueClass(tree.sym.owner.type))
                             this.thisExposability = BANNED;
                         else
                             this.thisExposability = ALLOWED;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -2377,8 +2377,7 @@ public class JavacParser implements Parser {
         case BYTE: case SHORT: case CHAR: case INT: case LONG: case FLOAT:
         case DOUBLE: case BOOLEAN:
             if (mods.flags != 0) {
-                long badModifiers = (mods.flags & (Flags.PRIMITIVE_CLASS | Flags.VALUE_CLASS)) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
-                log.error(token.pos, Errors.ModNotAllowedHere(asFlagSet(badModifiers)));
+                log.error(token.pos, Errors.ModNotAllowedHere(asFlagSet(mods.flags)));
             }
             if (typeArgs == null) {
                 if (newAnnotations.isEmpty()) {
@@ -2457,8 +2456,7 @@ public class JavacParser implements Parser {
             }
             JCNewClass newClass = classCreatorRest(newpos, null, typeArgs, t, mods.flags);
             if ((newClass.def == null) && (mods.flags != 0)) {
-                badModifiers = (mods.flags & (Flags.PRIMITIVE_CLASS | Flags.VALUE_CLASS)) != 0 ? mods.flags & ~Flags.FINAL : mods.flags;
-                log.error(newClass.pos, Errors.ModNotAllowedHere(asFlagSet(badModifiers)));
+                log.error(newClass.pos, Errors.ModNotAllowedHere(asFlagSet(mods.flags)));
             }
             return newClass;
         } else {
@@ -3392,16 +3390,6 @@ public class JavacParser implements Parser {
          * has no text position. */
         if ((flags & (Flags.ModifierFlags | Flags.ANNOTATION)) == 0 && annotations.isEmpty())
             pos = Position.NOPOS;
-
-        // Force primitive classes to be automatically final.
-        if ((flags & (Flags.PRIMITIVE_CLASS | Flags.ABSTRACT | Flags.INTERFACE | Flags.ENUM)) == Flags.PRIMITIVE_CLASS) {
-            flags |= Flags.FINAL;
-        }
-
-        // Force value classes to be automatically final.
-        if ((flags & (Flags.VALUE_CLASS | Flags.ABSTRACT | Flags.INTERFACE | Flags.ENUM)) == Flags.VALUE_CLASS) {
-            flags |= Flags.FINAL;
-        }
 
         JCModifiers mods = F.at(pos).Modifiers(flags, annotations.toList());
         if (pos != Position.NOPOS)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3923,15 +3923,15 @@ compiler.warn.get.class.compared.with.interface=\
     return value of getClass() can never equal the class literal of an interface
 
 # 0: name (of method)
-compiler.err.primitive.class.may.not.override=\
-    primitive classes may not override the method {0} from Object
+compiler.err.value.class.may.not.override=\
+    value classes may not override the method {0} from Object
 
 # 0: name (of method)
 compiler.err.primitive.class.does.not.support=\
     primitive classes do not support {0}
 
-compiler.err.primitive.class.may.not.extend=\
-    inappropriate super class declaration for a primitive class
+compiler.err.value.class.may.not.extend=\
+    inappropriate super class declaration for a value class
 
 compiler.err.primitive.class.instance.field.expected.here=\
     withfield operator requires an instance field of a primitive class here
@@ -3940,15 +3940,15 @@ compiler.err.with.field.operator.disallowed=\
     WithField operator is allowed only with -XDallowWithFieldOperator
 
 compiler.err.this.exposed.prematurely=\
-    primitive class instance should not be passed around before being fully initialized
+    value class instance should not be passed around before being fully initialized
 
 # 0: type
 compiler.err.generic.parameterization.with.primitive.class=\
     Inferred type {0} involves generic parameterization by a primitive class
 
 # 0: type
-compiler.err.primitive.class.must.not.implement.identity.object=\
-    The primitive class {0} attempts to implement the incompatible interface IdentityObject
+compiler.err.value.class.must.not.implement.identity.object=\
+    The value class {0} attempts to implement the incompatible interface IdentityObject
 
 # 0: type
 compiler.err.primitive.class.must.not.implement.cloneable=\
@@ -3963,38 +3963,38 @@ compiler.err.mutually.incompatible.super.interfaces=\
     The type {0} attempts to implement the mutually incompatible interfaces PrimitiveObject and IdentityObject
 
 # 0: symbol, 1: type
-compiler.err.concrete.supertype.for.primitive.class=\
-    The concrete class {1} is not allowed to be a super class of the primitive class {0} either directly or indirectly
+compiler.err.concrete.supertype.for.value.class=\
+    The concrete class {1} is not allowed to be a super class of the value class {0} either directly or indirectly
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.method.cannot.be.synchronized=\
-    The method {0} in the super class {2} of the primitive class {1} is synchronized. This is disallowed
+    The method {0} in the super class {2} of the value class {1} is synchronized. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.constructor.cannot.take.arguments=\
-    The super class {2} of the primitive class {1} defines a constructor {0} that takes arguments. This is disallowed
+    The super class {2} of the value class {1} defines a constructor {0} that takes arguments. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.field.not.allowed=\
-    The super class {2} of the primitive class {1} defines an instance field {0}. This is disallowed
+    The super class {2} of the value class {1} defines an instance field {0}. This is disallowed
 
 # 0: symbol, 1: symbol, 2: type
 compiler.err.super.no.arg.constructor.must.be.empty=\
-    The super class {2} of the primitive class {1} defines a nonempty no-arg constructor {0}. This is disallowed
+    The super class {2} of the value class {1} defines a nonempty no-arg constructor {0}. This is disallowed
 
 # 0: symbol, 1: type
 compiler.err.super.class.declares.init.block=\
-    The super class {1} of the primitive class {0} declares one or more non-empty instance initializer blocks. This is disallowed.
+    The super class {1} of the value class {0} declares one or more non-empty instance initializer blocks. This is disallowed.
 
 # 0: symbol, 1: type
 compiler.err.super.class.cannot.be.inner=\
-    The super class {1} of the primitive class {0} is an inner class. This is disallowed.
+    The super class {1} of the value class {0} is an inner class. This is disallowed.
 
 compiler.err.projection.cant.be.instantiated=\
     Illegal attempt to instantiate a projection type
 
-compiler.err.call.to.super.not.allowed.in.primitive.ctor=\
-    call to super not allowed in primitive class constructor
+compiler.err.call.to.super.not.allowed.in.value.ctor=\
+    call to super not allowed in value class constructor
 
 # 0: kind name, 1: symbol
 compiler.warn.declared.using.preview=\

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -210,10 +210,10 @@ compiler.err.preview.without.source.or.release
 # Value types
 compiler.err.cyclic.primitive.class.membership
 compiler.err.primitive.class.does.not.support
-compiler.err.primitive.class.may.not.extend
+compiler.err.value.class.may.not.extend
 compiler.err.this.exposed.prematurely
-compiler.err.primitive.class.must.not.implement.identity.object
-compiler.err.concrete.supertype.for.primitive.class
+compiler.err.value.class.must.not.implement.identity.object
+compiler.err.concrete.supertype.for.value.class
 compiler.err.super.class.cannot.be.inner
 compiler.err.super.class.declares.init.block
 compiler.err.super.constructor.cannot.take.arguments

--- a/test/langtools/tools/javac/diags/examples/PrimitiveClassMayNotOverride.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveClassMayNotOverride.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-// key: compiler.err.primitive.class.may.not.override
+// key: compiler.err.value.class.may.not.override
 
 primitive class InlineBogusOverride {
     int x = 42;

--- a/test/langtools/tools/javac/diags/examples/SuperNotAllowedInPrimitiveCtor.java
+++ b/test/langtools/tools/javac/diags/examples/SuperNotAllowedInPrimitiveCtor.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-// key: compiler.err.call.to.super.not.allowed.in.primitive.ctor
+// key: compiler.err.call.to.super.not.allowed.in.value.ctor
 
 primitive class SuperNotAllowedInPrimitiveCtor {
 

--- a/test/langtools/tools/javac/records/RecordReading.java
+++ b/test/langtools/tools/javac/records/RecordReading.java
@@ -161,7 +161,7 @@ public class RecordReading extends TestRunner {
         String expected =
                 """
                 \n\
-                public primitive record R(int i, @A long j, java.util.List<java.lang.String> l) {
+                public primitive value record R(int i, @A long j, java.util.List<java.lang.String> l) {
                   private final int i;
                   @A
                   private final long j;

--- a/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/BinarySuperclassConstraints.out
@@ -1,4 +1,4 @@
-BinarySuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.primitive.class: BinarySuperclassConstraints.I0, SuperclassCollections.BadSuper
+BinarySuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.value.class: BinarySuperclassConstraints.I0, SuperclassCollections.BadSuper
 BinarySuperclassConstraints.java:29:15: compiler.err.super.field.not.allowed: x, BinarySuperclassConstraints.I6, SuperclassCollections.SuperWithInstanceField
 BinarySuperclassConstraints.java:38:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassCollections.SuperWithNonEmptyNoArgCtor(), BinarySuperclassConstraints.I9, SuperclassCollections.SuperWithNonEmptyNoArgCtor
 BinarySuperclassConstraints.java:40:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassCollections.SuperWithArgedCtor(java.lang.String), BinarySuperclassConstraints.I10, SuperclassCollections.SuperWithArgedCtor

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckClone.out
@@ -2,5 +2,5 @@ CheckClone.java:11:21: compiler.err.primitive.class.does.not.support: clone
 CheckClone.java:12:18: compiler.err.primitive.class.does.not.support: clone
 CheckClone.java:16:16: compiler.err.primitive.class.does.not.support: clone
 CheckClone.java:17:14: compiler.err.primitive.class.does.not.support: clone
-CheckClone.java:20:22: compiler.err.primitive.class.may.not.override: clone
+CheckClone.java:20:22: compiler.err.value.class.may.not.override: clone
 5 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckExtends.out
@@ -1,2 +1,2 @@
-CheckExtends.java:10:22: compiler.err.concrete.supertype.for.primitive.class: CheckExtends.NestedPrimitive, CheckExtends.NestedConcrete
+CheckExtends.java:10:22: compiler.err.concrete.supertype.for.value.class: CheckExtends.NestedPrimitive, CheckExtends.NestedConcrete
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckFinalize.out
@@ -1,4 +1,4 @@
-CheckFinalize.java:10:20: compiler.err.primitive.class.may.not.override: finalize
+CheckFinalize.java:10:20: compiler.err.value.class.may.not.override: finalize
 CheckFinalize.java:15:12: compiler.err.report.access: finalize(), protected, java.lang.Object
 CheckFinalize.java:15:21: compiler.err.primitive.class.does.not.support: finalize
 CheckFinalize.java:16:20: compiler.err.primitive.class.does.not.support: finalize

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckObjectMethodsUsage.out
@@ -1,5 +1,5 @@
-CheckObjectMethodsUsage.java:11:17: compiler.err.primitive.class.may.not.override: finalize
-CheckObjectMethodsUsage.java:12:19: compiler.err.primitive.class.may.not.override: clone
+CheckObjectMethodsUsage.java:11:17: compiler.err.value.class.may.not.override: finalize
+CheckObjectMethodsUsage.java:12:19: compiler.err.value.class.may.not.override: clone
 CheckObjectMethodsUsage.java:15:23: compiler.err.primitive.class.does.not.support: finalize
 CheckObjectMethodsUsage.java:16:13: compiler.err.primitive.class.does.not.support: wait
 CheckObjectMethodsUsage.java:17:19: compiler.err.primitive.class.does.not.support: wait

--- a/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/IllegalByValueTest2.out
@@ -1,3 +1,3 @@
 IllegalByValueTest2.java:19:30: compiler.err.duplicate.annotation.missing.container: IllegalByValueTest2.Annot
-IllegalByValueTest2.java:19:59: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: IllegalByValueTest2$1, IllegalByValueTest2
+IllegalByValueTest2.java:19:59: compiler.err.concrete.supertype.for.value.class: compiler.misc.anonymous.class: IllegalByValueTest2$1, IllegalByValueTest2
 2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/QTypeTest.java
@@ -46,8 +46,8 @@ public class QTypeTest {
                                             Paths.get(System.getProperty("test.classes"),
                                                 "QTypedValue.class").toString() };
         runCheck(params, new String [] {
-              "final primitive class QTypedValue",
-              "  flags: (0x0830) ACC_FINAL, ACC_SUPER, ACC_PRIMITIVE",
+              "final primitive value class QTypedValue",
+              "  flags: (0x0930) ACC_FINAL, ACC_SUPER, ACC_PRIMITIVE, ACC_VALUE",
               "  this_class: #1                          // QTypedValue",
               "   #1 = Class              #2             // QTypedValue",
               "   #2 = Utf8               QTypedValue",

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperCallInCtor.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperCallInCtor.out
@@ -1,2 +1,2 @@
-SuperCallInCtor.java:24:13: compiler.err.call.to.super.not.allowed.in.primitive.ctor
+SuperCallInCtor.java:24:13: compiler.err.call.to.super.not.allowed.in.value.ctor
 1 error

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,4 +1,4 @@
-SuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.primitive.class: SuperclassConstraints.I0, SuperclassConstraints.BadSuper
+SuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.value.class: SuperclassConstraints.I0, SuperclassConstraints.BadSuper
 SuperclassConstraints.java:44:15: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
 SuperclassConstraints.java:76:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
 SuperclassConstraints.java:85:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceNegativeTest.out
@@ -7,6 +7,6 @@ TopInterfaceNegativeTest.java:20:32: compiler.err.cant.resolve.location: kindnam
 TopInterfaceNegativeTest.java:24:48: compiler.err.repeated.interface
 TopInterfaceNegativeTest.java:30:42: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
 TopInterfaceNegativeTest.java:30:56: compiler.err.cant.resolve.location: kindname.class, InlineObject, , , (compiler.misc.location: kindname.class, TopInterfaceNegativeTest, null)
-TopInterfaceNegativeTest.java:28:22: compiler.err.primitive.class.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
+TopInterfaceNegativeTest.java:28:22: compiler.err.value.class.must.not.implement.identity.object: TopInterfaceNegativeTest.V1
 TopInterfaceNegativeTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TopInterfaceNegativeTest.V2, java.lang.IdentityObject)
 11 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueModifierTest.out
@@ -1,4 +1,4 @@
 ValueModifierTest.java:15:13: compiler.err.cant.inherit.from.final: Value
 ValueModifierTest.java:16:23: compiler.err.cant.inherit.from.final: Value
-ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.primitive.class: compiler.misc.anonymous.class: ValueModifierTest$3, Value
+ValueModifierTest.java:16:31: compiler.err.concrete.supertype.for.value.class: compiler.misc.anonymous.class: ValueModifierTest$3, Value
 3 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
@@ -1,0 +1,88 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279672
+ * @summary Implement semantic checks for value classes
+ * @compile/fail/ref=SemanticsViolationsTest.out -XDrawDiagnostics --should-stop=at=FLOW -XDdev SemanticsViolationsTest.java
+ */
+
+public class SemanticsViolationsTest {
+
+    // A value class is implicitly final, so cannot be extended.
+    value class Base {}
+    class Subclass extends Base {} // Error: Base is implicitly final, cannot be extended.
+
+
+    // The class may not be declared abstract.
+    abstract value class AbsValue {}  // Error: value class cannot be abstract
+    value interface ValueInterface {} // Error: interface cannot modified with value.
+
+    // All instance fields are implicitly final, so must be assigned exactly
+    // once by constructors or initializers, and cannot be assigned outside
+    // of a constructor or initializer.
+    value class Point {
+
+        int x = 10;
+        int y;
+        int z;
+
+        Point (int x, int y, int z) {
+            this.x = x; // Error, final field 'x' is already assigned to.
+            this.y = y; // OK.
+            // Error, final z is unassigned.
+        }
+        void foo(Point p) {
+            this.y = p.y; // Error, y is final and can't be written outside of ctor.
+        }
+    }
+
+    // The class does not implement—directly or indirectly—IdentityObject.
+    // This implies that the superclass is either Object or a stateless abstract class.
+    value class IdentityValue implements IdentityObject { // Error, can't implement this
+    }
+    value class IdentityValue2 extends SemanticsViolationsTest { // Error, can't extend identity class
+    }
+    abstract static class AbstractWithState {
+       int xx;
+    }
+    value class BrokenValue3 extends AbstractWithState { // Error, super class has state.
+    }
+    abstract static class AbstractWithoutState {
+        static int ss;
+    }
+    value class GoodValue1 extends AbstractWithoutState {}
+    value class GoodValue2 extends Object {} // allowed.
+
+    // No constructor makes a super constructor call. Instance creation will
+    // occur without executing any superclass initialization code.
+    value class BrokenValue4 {
+        BrokenValue4() {
+            super(); // Error, can't chain to super's ctor.
+        }
+    }
+
+    // No instance methods are declared synchronized.
+    value class BrokenValue5 {
+        synchronized void foo() {} // Error;
+        synchronized static void soo() {} // OK.
+        { synchronized(this) { /* Error.*/  } }
+    }
+
+    // The class does not declare a finalize() method.
+    value class BrokenValue6 {
+        public void finalize() {} // Error
+    }
+
+    // (Possibly) The constructor does not make use of this except to set
+    // the fields in the constructor body, or perhaps after all fields are
+    // definitely assigned.
+    value class BrokenValue7 {
+        int x;
+        BrokenValue7() {
+            foo(this); // Error.
+            x = 10;
+            foo(this); // Ok.
+        }
+        void foo(BrokenValue7 bv) {
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
@@ -1,0 +1,16 @@
+SemanticsViolationsTest.java:16:20: compiler.err.illegal.combination.of.modifiers: abstract, value
+SemanticsViolationsTest.java:17:11: compiler.err.illegal.combination.of.modifiers: interface, value
+SemanticsViolationsTest.java:12:28: compiler.err.cant.inherit.from.final: SemanticsViolationsTest.Base
+SemanticsViolationsTest.java:65:27: compiler.err.mod.not.allowed.here: synchronized
+SemanticsViolationsTest.java:29:17: compiler.err.cant.assign.val.to.final.var: x
+SemanticsViolationsTest.java:34:17: compiler.err.cant.assign.val.to.final.var: y
+SemanticsViolationsTest.java:40:11: compiler.err.value.class.must.not.implement.identity.object: SemanticsViolationsTest.IdentityValue
+SemanticsViolationsTest.java:42:11: compiler.err.concrete.supertype.for.value.class: SemanticsViolationsTest.IdentityValue2, SemanticsViolationsTest
+SemanticsViolationsTest.java:47:11: compiler.err.super.field.not.allowed: xx, SemanticsViolationsTest.BrokenValue3, SemanticsViolationsTest.AbstractWithState
+SemanticsViolationsTest.java:59:13: compiler.err.call.to.super.not.allowed.in.value.ctor
+SemanticsViolationsTest.java:67:11: compiler.err.type.found.req: SemanticsViolationsTest.BrokenValue5, (compiler.misc.type.req.identity)
+SemanticsViolationsTest.java:72:21: compiler.err.value.class.may.not.override: finalize
+SemanticsViolationsTest.java:32:9: compiler.err.var.might.not.have.been.initialized: z
+SemanticsViolationsTest.java:81:17: compiler.err.this.exposed.prematurely
+SemanticsViolationsTest.java:81:16: compiler.err.this.exposed.prematurely
+15 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
@@ -1,3 +1,4 @@
 ValueAnnotationTest.java:10:50: compiler.err.cant.inherit.from.final: ValueAnnotationTest.X
 ValueAnnotationTest.java:11:28: compiler.err.cant.inherit.from.final: ValueAnnotationTest.Y
-2 errors
+ValueAnnotationTest.java:10:34: compiler.err.concrete.supertype.for.value.class: ValueAnnotationTest.Y, ValueAnnotationTest.X
+3 errors


### PR DESCRIPTION
Push down various sematic/behavioral restrictions/checks and the associated diagnostics from primitive to value classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279672](https://bugs.openjdk.java.net/browse/JDK-8279672): [lworld] Implement semantic checks for value classes


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.java.net/valhalla pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/597.diff">https://git.openjdk.java.net/valhalla/pull/597.diff</a>

</details>
