### PR TITLE
8279838: [lworld] PrimitiveObject is dead, long live ValueObject

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -474,15 +474,15 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
   {
     bool identity_object_implemented = false;
     bool identity_object_specified = false;
-    bool primitive_object_implemented = false;
-    bool primitive_object_specified = false;
+    bool value_object_implemented = false;
+    bool value_object_specified = false;
     for (i = 0; i < actual_num_interfaces; i++) {
       if (k->local_interfaces()->at(i) == vmClasses::IdentityObject_klass()) {
         identity_object_implemented = true;
         break;
       }
       if (k->local_interfaces()->at(i) == vmClasses::ValueObject_klass()) {
-        primitive_object_implemented = true;
+        value_object_implemented = true;
         break;
       }
     }
@@ -492,13 +492,13 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
         break;
       }
       if (lookup_class_by_id(_interfaces->at(i)) == vmClasses::ValueObject_klass()) {
-        primitive_object_specified = true;
+        value_object_specified = true;
         break;
       }
     }
 
     if ( (identity_object_implemented  && !identity_object_specified) ||
-         (primitive_object_implemented && !primitive_object_specified) ){
+         (value_object_implemented && !value_object_specified) ){
       // Backwards compatibility -- older classlists do not know about
       // java.lang.IdentityObject or java.lang.ValueObject
       expected_num_interfaces--;

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -481,7 +481,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
         identity_object_implemented = true;
         break;
       }
-      if (k->local_interfaces()->at(i) == vmClasses::PrimitiveObject_klass()) {
+      if (k->local_interfaces()->at(i) == vmClasses::ValueObject_klass()) {
         primitive_object_implemented = true;
         break;
       }
@@ -491,7 +491,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
         identity_object_specified = true;
         break;
       }
-      if (lookup_class_by_id(_interfaces->at(i)) == vmClasses::PrimitiveObject_klass()) {
+      if (lookup_class_by_id(_interfaces->at(i)) == vmClasses::ValueObject_klass()) {
         primitive_object_specified = true;
         break;
       }
@@ -500,7 +500,7 @@ InstanceKlass* ClassListParser::load_class_from_source(Symbol* class_name, TRAPS
     if ( (identity_object_implemented  && !identity_object_specified) ||
          (primitive_object_implemented && !primitive_object_specified) ){
       // Backwards compatibility -- older classlists do not know about
-      // java.lang.IdentityObject or java.lang.PrimitiveObject
+      // java.lang.IdentityObject or java.lang.ValueObject
       expected_num_interfaces--;
     }
   }
@@ -738,10 +738,10 @@ InstanceKlass* ClassListParser::lookup_interface_for_current_class(Symbol* inter
     // java.lang.IdentityObject.
     return vmClasses::IdentityObject_klass();
   }
-  if (interface_name == vmSymbols::java_lang_PrimitiveObject()) {
+  if (interface_name == vmSymbols::java_lang_ValueObject()) {
     // Backwards compatibility -- older classlists do not know about
-    // java.lang.PrimitiveObject.
-    return vmClasses::PrimitiveObject_klass();
+    // java.lang.ValueObject.
+    return vmClasses::ValueObject_klass();
   }
 
   const int n = _interfaces->length();

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -925,7 +925,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* stream,
       if (ik->name() == vmSymbols::java_lang_ValueObject()) {
         // further checks for "is_invalid_super_for_inline_type()" needed later
         // needs field parsing, delay unitl post_process_parse_stream()
-        _implements_primitiveObject = true;
+        _implements_valueObject = true;
       }
       _temp_local_interfaces->append(ik);
     }
@@ -4487,7 +4487,7 @@ static Array<InstanceKlass*>* compute_transitive_interfaces(const InstanceKlass*
       return Universe::the_single_IdentityObject_klass_array();
     }
     if (length == 1 && result->at(0) == vmClasses::ValueObject_klass()) {
-      return Universe::the_single_PrimitiveObject_klass_array();
+      return Universe::the_single_ValueObject_klass_array();
     }
 
     Array<InstanceKlass*>* const new_result =
@@ -5585,7 +5585,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   if (_has_injected_identityObject) {
     ik->set_has_injected_identityObject();
   }
-  if (_has_injected_primitiveObject) {
+  if (_has_injected_valueObject) {
     ik->set_has_injected_primitiveObject();
   }
 
@@ -5829,7 +5829,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
     Universe::initialize_the_single_IdentityObject_klass_array(ik, CHECK);
   }
   if (ik->name() == vmSymbols::java_lang_ValueObject()) {
-    Universe::initialize_the_single_PrimitiveObject_klass_array(ik, CHECK);
+    Universe::initialize_the_single_ValueObject_klass_array(ik, CHECK);
   }
 
   debug_only(ik->verify();)
@@ -5928,8 +5928,8 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
   _invalid_identity_super(false),
   _implements_identityObject(false),
   _has_injected_identityObject(false),
-  _implements_primitiveObject(false),
-  _has_injected_primitiveObject(false),
+  _implements_valueObject(false),
+  _has_injected_valueObject(false),
   _has_finalizer(false),
   _has_empty_finalizer(false),
   _has_vanilla_constructor(false),
@@ -6403,7 +6403,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
     _has_injected_identityObject = true;
   }
   // Check if declared as PrimitiveObject...else add if needed
-  if (_implements_primitiveObject) {
+  if (_implements_valueObject) {
     if (!is_inline_type() && invalid_inline_super()) {
       classfile_icce_error("class %s can not implement %s, neither valid inline classes or valid supertype",
                             vmClasses::ValueObject_klass(), THREAD);
@@ -6411,7 +6411,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
     }
   } else if (is_inline_type()) {
     _temp_local_interfaces->append(vmClasses::ValueObject_klass());
-    _has_injected_primitiveObject = true;
+    _has_injected_valueObject = true;
   }
 
   int itfs_len = _temp_local_interfaces->length();
@@ -6420,7 +6420,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
   } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == vmClasses::IdentityObject_klass()) {
     _local_interfaces = Universe::the_single_IdentityObject_klass_array();
   } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == vmClasses::ValueObject_klass()) {
-    _local_interfaces = Universe::the_single_PrimitiveObject_klass_array();
+    _local_interfaces = Universe::the_single_ValueObject_klass_array();
   } else {
     _local_interfaces = MetadataFactory::new_array<InstanceKlass*>(_loader_data, itfs_len, NULL, CHECK);
     for (int i = 0; i < itfs_len; i++) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -922,7 +922,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* stream,
       if (ik->name() == vmSymbols::java_lang_IdentityObject()) {
         _implements_identityObject = true;
       }
-      if (ik->name() == vmSymbols::java_lang_PrimitiveObject()) {
+      if (ik->name() == vmSymbols::java_lang_ValueObject()) {
         // further checks for "is_invalid_super_for_inline_type()" needed later
         // needs field parsing, delay unitl post_process_parse_stream()
         _implements_primitiveObject = true;
@@ -4486,7 +4486,7 @@ static Array<InstanceKlass*>* compute_transitive_interfaces(const InstanceKlass*
     if (length == 1 && result->at(0) == vmClasses::IdentityObject_klass()) {
       return Universe::the_single_IdentityObject_klass_array();
     }
-    if (length == 1 && result->at(0) == vmClasses::PrimitiveObject_klass()) {
+    if (length == 1 && result->at(0) == vmClasses::ValueObject_klass()) {
       return Universe::the_single_PrimitiveObject_klass_array();
     }
 
@@ -5828,7 +5828,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   if (ik->name() == vmSymbols::java_lang_IdentityObject()) {
     Universe::initialize_the_single_IdentityObject_klass_array(ik, CHECK);
   }
-  if (ik->name() == vmSymbols::java_lang_PrimitiveObject()) {
+  if (ik->name() == vmSymbols::java_lang_ValueObject()) {
     Universe::initialize_the_single_PrimitiveObject_klass_array(ik, CHECK);
   }
 
@@ -6406,11 +6406,11 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
   if (_implements_primitiveObject) {
     if (!is_inline_type() && invalid_inline_super()) {
       classfile_icce_error("class %s can not implement %s, neither valid inline classes or valid supertype",
-                            vmClasses::PrimitiveObject_klass(), THREAD);
+                            vmClasses::ValueObject_klass(), THREAD);
       return;
     }
   } else if (is_inline_type()) {
-    _temp_local_interfaces->append(vmClasses::PrimitiveObject_klass());
+    _temp_local_interfaces->append(vmClasses::ValueObject_klass());
     _has_injected_primitiveObject = true;
   }
 
@@ -6419,7 +6419,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
     _local_interfaces = Universe::the_empty_instance_klass_array();
   } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == vmClasses::IdentityObject_klass()) {
     _local_interfaces = Universe::the_single_IdentityObject_klass_array();
-  } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == vmClasses::PrimitiveObject_klass()) {
+  } else if (itfs_len == 1 && _temp_local_interfaces->at(0) == vmClasses::ValueObject_klass()) {
     _local_interfaces = Universe::the_single_PrimitiveObject_klass_array();
   } else {
     _local_interfaces = MetadataFactory::new_array<InstanceKlass*>(_loader_data, itfs_len, NULL, CHECK);

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -209,8 +209,8 @@ class ClassFileParser {
   bool _invalid_identity_super; // if true, invalid super type for an identity type.
   bool _implements_identityObject;
   bool _has_injected_identityObject;
-  bool _implements_primitiveObject;
-  bool _has_injected_primitiveObject;
+  bool _implements_valueObject;
+  bool _has_injected_valueObject;
 
   // precomputed flags
   bool _has_finalizer;

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -51,7 +51,7 @@
   /* well-known classes */                                                                                      \
   do_klass(Object_klass,                                java_lang_Object                                      ) \
   do_klass(IdentityObject_klass,                        java_lang_IdentityObject                              ) \
-  do_klass(PrimitiveObject_klass,                       java_lang_PrimitiveObject                             ) \
+  do_klass(ValueObject_klass,                           java_lang_ValueObject                             ) \
   do_klass(String_klass,                                java_lang_String                                      ) \
   do_klass(Class_klass,                                 java_lang_Class                                       ) \
   do_klass(Cloneable_klass,                             java_lang_Cloneable                                   ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -56,7 +56,7 @@
   template(java_lang_System,                          "java/lang/System")                         \
   template(java_lang_Object,                          "java/lang/Object")                         \
   template(java_lang_IdentityObject,                  "java/lang/IdentityObject")                 \
-  template(java_lang_PrimitiveObject,                 "java/lang/PrimitiveObject")                \
+  template(java_lang_ValueObject,                     "java/lang/ValueObject")                \
   template(java_lang_Class,                           "java/lang/Class")                          \
   template(java_lang_Package,                         "java/lang/Package")                        \
   template(java_lang_Module,                          "java/lang/Module")                         \

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -132,7 +132,7 @@ Array<u2>* Universe::_the_empty_short_array           = NULL;
 Array<Klass*>* Universe::_the_empty_klass_array     = NULL;
 Array<InstanceKlass*>* Universe::_the_empty_instance_klass_array  = NULL;
 Array<InstanceKlass*>* Universe::_the_single_IdentityObject_klass_array = NULL;
-Array<InstanceKlass*>* Universe::_the_single_PrimitiveObject_klass_array = NULL;
+Array<InstanceKlass*>* Universe::_the_single_ValueObject_klass_array = NULL;
 Array<Method*>* Universe::_the_empty_method_array   = NULL;
 
 // These variables are guarded by FullGCALot_lock.
@@ -224,7 +224,7 @@ void Universe::metaspace_pointers_do(MetaspaceClosure* it) {
   it->push(&_the_empty_method_array);
   it->push(&_the_array_interfaces_array);
   it->push(&_the_single_IdentityObject_klass_array);
-  it->push(&_the_single_PrimitiveObject_klass_array);
+  it->push(&_the_single_ValueObject_klass_array);
 
   _finalizer_register_cache->metaspace_pointers_do(it);
   _loader_addClass_cache->metaspace_pointers_do(it);
@@ -276,7 +276,7 @@ void Universe::serialize(SerializeClosure* f) {
   f->do_ptr((void**)&_the_empty_klass_array);
   f->do_ptr((void**)&_the_empty_instance_klass_array);
   f->do_ptr((void**)&_the_single_IdentityObject_klass_array);
-  f->do_ptr((void**)&_the_single_PrimitiveObject_klass_array);
+  f->do_ptr((void**)&_the_single_ValueObject_klass_array);
   _finalizer_register_cache->serialize(f);
   _loader_addClass_cache->serialize(f);
   _throw_illegal_access_error_cache->serialize(f);
@@ -365,7 +365,7 @@ void Universe::genesis(TRAPS) {
 
       assert(_the_single_IdentityObject_klass_array->at(0) ==
           vmClasses::IdentityObject_klass(), "u3");
-      assert(_the_single_PrimitiveObject_klass_array->at(0) ==
+      assert(_the_single_ValueObject_klass_array->at(0) ==
           vmClasses::ValueObject_klass(), "u3");
     } else
 #endif
@@ -486,12 +486,12 @@ void Universe::initialize_the_single_IdentityObject_klass_array(InstanceKlass* i
     _the_single_IdentityObject_klass_array = array;
 }
 
-void Universe::initialize_the_single_PrimitiveObject_klass_array(InstanceKlass* ik, TRAPS) {
-    assert(_the_single_PrimitiveObject_klass_array == NULL, "Must not be initialized twice");
+void Universe::initialize_the_single_ValueObject_klass_array(InstanceKlass* ik, TRAPS) {
+    assert(_the_single_ValueObject_klass_array == NULL, "Must not be initialized twice");
     assert(ik->name() == vmSymbols::java_lang_ValueObject(), "Must be");
     Array<InstanceKlass*>* array = MetadataFactory::new_array<InstanceKlass*>(ik->class_loader_data(), 1, NULL, CHECK);
     array->at_put(0, ik);
-    _the_single_PrimitiveObject_klass_array = array;
+    _the_single_ValueObject_klass_array = array;
 }
 
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -366,7 +366,7 @@ void Universe::genesis(TRAPS) {
       assert(_the_single_IdentityObject_klass_array->at(0) ==
           vmClasses::IdentityObject_klass(), "u3");
       assert(_the_single_PrimitiveObject_klass_array->at(0) ==
-          vmClasses::PrimitiveObject_klass(), "u3");
+          vmClasses::ValueObject_klass(), "u3");
     } else
 #endif
     {
@@ -488,7 +488,7 @@ void Universe::initialize_the_single_IdentityObject_klass_array(InstanceKlass* i
 
 void Universe::initialize_the_single_PrimitiveObject_klass_array(InstanceKlass* ik, TRAPS) {
     assert(_the_single_PrimitiveObject_klass_array == NULL, "Must not be initialized twice");
-    assert(ik->name() == vmSymbols::java_lang_PrimitiveObject(), "Must be");
+    assert(ik->name() == vmSymbols::java_lang_ValueObject(), "Must be");
     Array<InstanceKlass*>* array = MetadataFactory::new_array<InstanceKlass*>(ik->class_loader_data(), 1, NULL, CHECK);
     array->at_put(0, ik);
     _the_single_PrimitiveObject_klass_array = array;

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -125,7 +125,7 @@ class Universe: AllStatic {
   static Array<Klass*>*         _the_empty_klass_array;          // Canonicalized klass array
   static Array<InstanceKlass*>* _the_empty_instance_klass_array; // Canonicalized instance klass array
   static Array<InstanceKlass*>* _the_single_IdentityObject_klass_array;  // Common single interface array for IdentityObjects
-  static Array<InstanceKlass*>* _the_single_PrimitiveObject_klass_array; // Common single interface array for PrimitiveObjects
+  static Array<InstanceKlass*>* _the_single_ValueObject_klass_array; // Common single interface array for PrimitiveObjects
   static Array<Method*>*        _the_empty_method_array;         // Canonicalized method array
 
   static Array<Klass*>*  _the_array_interfaces_array;
@@ -292,12 +292,12 @@ class Universe: AllStatic {
     return _the_single_IdentityObject_klass_array;
   }
   static void initialize_the_single_IdentityObject_klass_array(InstanceKlass* ik, TRAPS);
-  static Array<InstanceKlass*>*  the_single_PrimitiveObject_klass_array() {
-    assert(_the_single_PrimitiveObject_klass_array != NULL, "Must be initialized before use");
-    assert(_the_single_PrimitiveObject_klass_array->length() == 1, "Sanity check");
-    return _the_single_PrimitiveObject_klass_array;
+  static Array<InstanceKlass*>*  the_single_ValueObject_klass_array() {
+    assert(_the_single_ValueObject_klass_array != NULL, "Must be initialized before use");
+    assert(_the_single_ValueObject_klass_array->length() == 1, "Sanity check");
+    return _the_single_ValueObject_klass_array;
   }
-  static void initialize_the_single_PrimitiveObject_klass_array(InstanceKlass* ik, TRAPS);
+  static void initialize_the_single_ValueObject_klass_array(InstanceKlass* ik, TRAPS);
 
   // OutOfMemoryError support. Returns an error with the required message. The returned error
   // may or may not have a backtrace. If error has a backtrace then the stack trace is already

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -586,7 +586,7 @@ void InstanceKlass::deallocate_interfaces(ClassLoaderData* loader_data,
                     InstanceKlass::cast(super_klass)->transitive_interfaces();
     if (ti != sti && ti != NULL && !ti->is_shared() &&
         ti != Universe::the_single_IdentityObject_klass_array() &&
-        ti != Universe::the_single_PrimitiveObject_klass_array()) {
+        ti != Universe::the_single_ValueObject_klass_array()) {
       MetadataFactory::free_array<InstanceKlass*>(loader_data, ti);
     }
   }
@@ -595,7 +595,7 @@ void InstanceKlass::deallocate_interfaces(ClassLoaderData* loader_data,
   if (local_interfaces != Universe::the_empty_instance_klass_array() &&
       local_interfaces != NULL && !local_interfaces->is_shared() &&
       local_interfaces != Universe::the_single_IdentityObject_klass_array() &&
-      local_interfaces != Universe::the_single_PrimitiveObject_klass_array()) {
+      local_interfaces != Universe::the_single_ValueObject_klass_array()) {
     MetadataFactory::free_array<InstanceKlass*>(loader_data, local_interfaces);
   }
 }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -480,7 +480,7 @@ class InstanceKlass: public Klass {
     _misc_flags |= _misc_has_injected_identityObject;
   }
 
-  bool has_injected_primitiveObject() const {
+  bool has_injected_valueObject() const {
     return (_misc_flags & _misc_has_injected_primitiveObject);
   }
 

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -903,7 +903,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
     HandleMark hm(thread());
     InstanceKlass* iik = interfaces->at(index);
     if ( (!ik()->has_injected_identityObject() || iik != vmClasses::IdentityObject_klass()) &&
-         (!ik()->has_injected_primitiveObject() || iik != vmClasses::PrimitiveObject_klass())) {
+         (!ik()->has_injected_primitiveObject() || iik != vmClasses::ValueObject_klass())) {
       write_u2(class_symbol_to_cpool_index(iik->name()));
     }
   }

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -897,13 +897,13 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   Array<InstanceKlass*>* interfaces =  ik()->local_interfaces();
   int num_interfaces = interfaces->length();
   write_u2(num_interfaces -
-           (ik()->has_injected_identityObject() || ik()->has_injected_primitiveObject() ? 1 : 0));
+           (ik()->has_injected_identityObject() || ik()->has_injected_valueObject() ? 1 : 0));
 
   for (int index = 0; index < num_interfaces; index++) {
     HandleMark hm(thread());
     InstanceKlass* iik = interfaces->at(index);
     if ( (!ik()->has_injected_identityObject() || iik != vmClasses::IdentityObject_klass()) &&
-         (!ik()->has_injected_primitiveObject() || iik != vmClasses::ValueObject_klass())) {
+         (!ik()->has_injected_valueObject() || iik != vmClasses::ValueObject_klass())) {
       write_u2(class_symbol_to_cpool_index(iik->name()));
     }
   }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -337,8 +337,8 @@ bool VM_RedefineClasses::is_modifiable_class(oop klass_mirror) {
   if (k->name() == vmSymbols::java_lang_IdentityObject()) {
     return false;
   }
-  // Cannot redefine or retransform interface java.lang.PrimitiveObject.
-  if (k->name() == vmSymbols::java_lang_PrimitiveObject()) {
+  // Cannot redefine or retransform interface java.lang.ValueObject.
+  if (k->name() == vmSymbols::java_lang_ValueObject()) {
     return false;
   }
 

--- a/src/java.base/share/classes/java/lang/IdentityObject.java
+++ b/src/java.base/share/classes/java/lang/IdentityObject.java
@@ -36,7 +36,7 @@ package java.lang;
  * two objects created by different instance creation operations can have the same
  * identity.
  *
- * Every object is either an *identity object* or a *primitive object*. Primitive
+ * Every object is either an *identity object* or a *value object*. Value
  * objects lack identity.
  *
  * The following operations have special behavior when applied to identity objects:
@@ -52,14 +52,14 @@ package java.lang;
  * - The `synchronized` modifier and `synchronized` statement are only able to
  * successfully acquire a lock when applied to an identity object.
  *
- * A class may implement `IdentityObject` or `PrimitiveObject`, but never both.
- * Primitive classes always implement `PrimitiveObject`, while all other concrete
+ * A class may implement `IdentityObject` or `ValueObject`, but never both.
+ * Value classes always implement `ValueObject`, while all other concrete
  * classes (except `Object`) implicitly implement `IdentityObject`.
  *
  * Abstract classes and interfaces may implement or extend this interface if they
  * wish to guarantee that all instances of the class or interface have identity.
  *
- * @since 1.16
+ * @since 1.18
  */
 public interface IdentityObject {
 }

--- a/src/java.base/share/classes/java/lang/ValueObject.java
+++ b/src/java.base/share/classes/java/lang/ValueObject.java
@@ -26,41 +26,41 @@
 package java.lang;
 
 /**
- * A restricted interface implemented by all primitive objects.
+ * A restricted interface implemented by all value objects.
  *
- * A primitive object is an instance of a primitive class, lacking identity.
+ * A value object is an instance of a value class, lacking identity.
  *
- * Every object is either an *identity object* or a *primitive object*. Identity
+ * Every object is either an *identity object* or a *value object*. Identity
  * objects have a unique identity determined for them at instance creation time and
  * preserved throughout their life.
  *
- * Primitive objects do *not* have an identity. Instead, they simply aggregate a
+ * value objects do *not* have an identity. Instead, they simply aggregate a
  * set of immutable field values. The lack of identity enables certain performance
  * optimizations by Java Virtual Machine implementations.
- * The following operations have special behavior when applied to primitive
+ * The following operations have special behavior when applied to value
  * objects:
  *
  * - The `==` operator, and the default implementation of the `Object.equals`
- * method, compare the values of the operands' fields. Primitive objects
+ * method, compare the values of the operands' fields. Value objects
  * created at different points in a program may be `==`.
  *
  * - The `System.identityHashCode` method, and the default implementation of the
  * `Object.hashCode` method, generate a hash code from the hash codes of a
- * primitive object's fields.
+ * value object's fields.
  *
  * - The `synchronized` modifier and `synchronized` statement always fail when
- * applied to a primitive object.
+ * applied to a value object.
  *
- * A class may implement `PrimitiveObject` or `IdentityObject`, but never both.
- * Primitive classes always implement `PrimitiveObject`, while all other concrete
+ * A class may implement `ValueObject` or `IdentityObject`, but never both.
+ * Value classes always implement `ValueObject`, while all other concrete
  * classes (except `Object`) implicitly implement `IdentityObject`.
  *
  * Abstract classes and interfaces may implement or extend this interface if they
- * wish to guarantee that all instances of the class or interface are primitive
+ * wish to guarantee that all instances of the class or interface are value
  * objects.
  *
- * @since 1.16
+ * @since 1.18
  */
 
-public interface PrimitiveObject {
+public interface ValueObject {
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -223,7 +223,7 @@ public class Symtab {
     public final Type typeDescriptorType;
     public final Type recordType;
     public final Type identityObjectType;
-    public final Type primitiveObjectType;
+    public final Type valueObjectType;
     public final Type switchBootstrapsType;
     public final Type valueBasedType;
     public final Type valueBasedInternalType;
@@ -609,7 +609,7 @@ public class Symtab {
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
         identityObjectType = enterClass("java.lang.IdentityObject");
-        primitiveObjectType = enterClass("java.lang.PrimitiveObject");
+        valueObjectType = enterClass("java.lang.ValueObject");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");
         valueBasedType = enterClass("jdk.internal.ValueBased");
         valueBasedInternalType = enterSyntheticAnnotation("jdk.internal.ValueBased+Annotation");
@@ -628,7 +628,7 @@ public class Symtab {
         synthesizeEmptyInterfaceIfMissing(serializedLambdaType);
         synthesizeEmptyInterfaceIfMissing(stringConcatFactory);
         synthesizeEmptyInterfaceIfMissing(identityObjectType);
-        synthesizeEmptyInterfaceIfMissing(primitiveObjectType);
+        synthesizeEmptyInterfaceIfMissing(valueObjectType);
         synthesizeBoxTypeIfMissing(doubleType);
         synthesizeBoxTypeIfMissing(floatType);
         synthesizeBoxTypeIfMissing(voidType);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2270,9 +2270,9 @@ public class Types {
             if (implicitIdentityType(t)) {
                 return syms.identityObjectType;
             } // else fall through and look for explicit coded super interface
-        } else if (sym == syms.primitiveObjectType.tsym) {
-            if (t.isReferenceProjection())
-                return syms.primitiveObjectType;
+        } else if (sym == syms.valueObjectType.tsym) {
+            if (t.isValueClass() || t.isReferenceProjection())
+                return syms.valueObjectType;
             if (t.hasTag(ARRAY) || t.tsym == syms.objectType.tsym)
                 return null;
             // else fall through and look for explicit coded super interface
@@ -2340,7 +2340,7 @@ public class Types {
 
         // where
         private boolean implicitIdentityType(Type t) {
-            /* An abstract class can be declared to implement either IdentityObject or PrimitiveObject;
+            /* An abstract class can be declared to implement either IdentityObject or ValueObject;
              * or, if it declares a field, an instance initializer, a non-empty constructor, or
              * a synchronized method, it implicitly implements IdentityObject.
              */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2759,12 +2759,12 @@ public class Check {
         checkCompatibleConcretes(pos, c);
 
         boolean implementsIdentityObject = types.asSuper(c.referenceProjectionOrSelf(), syms.identityObjectType.tsym) != null;
-        boolean implementsPrimitiveObject = types.asSuper(c.referenceProjectionOrSelf(), syms.primitiveObjectType.tsym) != null;
+        boolean implementsValueObject = types.asSuper(c.referenceProjectionOrSelf(), syms.valueObjectType.tsym) != null;
         if (c.isValueClass() && implementsIdentityObject) {
             log.error(pos, Errors.ValueClassMustNotImplementIdentityObject(c));
-        } else if (implementsPrimitiveObject && !c.isPrimitiveClass() && !c.isReferenceProjection() && !c.tsym.isInterface() && !c.tsym.isAbstract()) {
-            log.error(pos, Errors.IdentityClassMustNotImplementPrimitiveObject(c));
-        } else if (implementsPrimitiveObject && implementsIdentityObject) {
+        } else if (implementsValueObject && !c.isValueClass() && !c.isReferenceProjection() && !c.tsym.isInterface() && !c.tsym.isAbstract()) {
+            log.error(pos, Errors.IdentityClassMustNotImplementValueObject(c));
+        } else if (implementsValueObject && implementsIdentityObject) {
             log.error(pos, Errors.MutuallyIncompatibleSuperInterfaces(c));
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3955,12 +3955,12 @@ compiler.err.primitive.class.must.not.implement.cloneable=\
     The primitive class {0} attempts to implement the incompatible interface Cloneable
 
 # 0: type
-compiler.err.identity.class.must.not.implement.primitive.object=\
-    The identity class {0} attempts to implement the incompatible interface PrimitiveObject
+compiler.err.identity.class.must.not.implement.value.object=\
+    The identity class {0} attempts to implement the incompatible interface ValueObject
 
 # 0: type
 compiler.err.mutually.incompatible.super.interfaces=\
-    The type {0} attempts to implement the mutually incompatible interfaces PrimitiveObject and IdentityObject
+    The type {0} attempts to implement the mutually incompatible interfaces ValueObject and IdentityObject
 
 # 0: symbol, 1: type
 compiler.err.concrete.supertype.for.value.class=\

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/AbstractSpecified.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/AbstractSpecified.java
@@ -22,6 +22,6 @@
  *
  */
 
-public abstract class AbstractSpecified implements PrimitiveObject {
+public abstract class AbstractSpecified implements ValueObject {
 
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/InterfaceSpecified.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/InterfaceSpecified.java
@@ -21,6 +21,6 @@
  * questions.
  *
  */
-public interface InterfaceSpecified extends PrimitiveObject {
+public interface InterfaceSpecified extends ValueObject {
 
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/PrimitiveTypeSpecified.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/PrimitiveTypeSpecified.java
@@ -21,6 +21,6 @@
  * questions.
  *
  */
-public primitive class PrimitiveTypeSpecified implements PrimitiveObject {
+public primitive class PrimitiveTypeSpecified implements ValueObject {
 
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/TestPrimitiveObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/primitiveObject/TestPrimitiveObject.java
@@ -23,7 +23,7 @@
  */
 /*
  * @test
- * @summary test that PrimitiveObject interface is injected correctly
+ * @summary test that ValueObject interface is injected correctly
  * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
  * @build jdk.experimental.bytecode.BasicClassBuilder
  * @compile TestPrimitiveObject.java
@@ -67,21 +67,21 @@ public class TestPrimitiveObject {
     static void checkPrimitiveObject(Class c, boolean subtype) {
         boolean s;
         try {
-            c.asSubclass(PrimitiveObject.class);
+            c.asSubclass(ValueObject.class);
             s = true;
         } catch(ClassCastException e) {
             s = false;
         }
         if (subtype != s) {
             if (subtype) {
-                throw new RuntimeException("Type " + c.getName() + " is missing PrimitiveObject");
+                throw new RuntimeException("Type " + c.getName() + " is missing ValueObject");
             } else {
-                throw new RuntimeException("Type " + c.getName() + " should not implement PrimitiveObject");
+                throw new RuntimeException("Type " + c.getName() + " should not implement ValueObject");
             }
         }
     }
 
-    // Define classes that implement PrimitiveObject but are invalid supers
+    // Define classes that implement ValueObject but are invalid supers
     static void checkIcceOnInvalidSupers() {
         MethodHandles.Lookup mhLookup = MethodHandles.lookup();
         checkIcce(mhLookup, createClass().build());
@@ -93,7 +93,7 @@ public class TestPrimitiveObject {
     static ClassBuilder createClass() {
         return new BasicClassBuilder("ANormalClass", 62, 0)
             .withSuperclass("java/lang/Object")
-            .withSuperinterface("java/lang/PrimitiveObject");
+            .withSuperinterface("java/lang/ValueObject");
     }
 
     static ClassBuilder createAbstractWithField() {
@@ -101,7 +101,7 @@ public class TestPrimitiveObject {
             .withSuperclass("java/lang/Object")
             .withFlags(Flag.ACC_ABSTRACT)
             .withField("aFieldWhichIsIllegalAsAnAbstractSuperToPrimitiveObject", "I")
-            .withSuperinterface("java/lang/PrimitiveObject");
+            .withSuperinterface("java/lang/ValueObject");
     }
 
     static ClassBuilder createAbstractIdentity() {
@@ -109,14 +109,14 @@ public class TestPrimitiveObject {
             .withSuperclass("java/lang/Object")
             .withFlags(Flag.ACC_ABSTRACT)
             .withSuperinterface("java/lang/IdentityObject")
-            .withSuperinterface("java/lang/PrimitiveObject");
+            .withSuperinterface("java/lang/ValueObject");
     }
 
   static ClassBuilder createIdentity() {
         return new BasicClassBuilder("Identity", 62, 0)
             .withSuperclass("java/lang/Object")
             .withSuperinterface("java/lang/IdentityObject")
-            .withSuperinterface("java/lang/PrimitiveObject");
+            .withSuperinterface("java/lang/ValueObject");
     }
 
     static void checkIcce(MethodHandles.Lookup mhLookup, byte[] clazzBytes) {

--- a/test/jdk/valhalla/valuetypes/BasicTest.java
+++ b/test/jdk/valhalla/valuetypes/BasicTest.java
@@ -241,7 +241,7 @@ public class BasicTest {
     }
 
     class C implements IdentityObject { }
-    primitive class T implements PrimitiveObject { }
+    primitive class T implements ValueObject { }
 
     @DataProvider(name="intfs")
     Object[][] intfs() {
@@ -249,8 +249,8 @@ public class BasicTest {
         Point[] array = new Point[] { point };
         return new Object[][]{
                 new Object[]{ new BasicTest(), new Class<?>[] { IdentityObject.class }},
-                new Object[]{ point, new Class<?>[] { PrimitiveObject.class }},
-                new Object[]{ new T(), new Class<?>[] { PrimitiveObject.class }},
+                new Object[]{ point, new Class<?>[] { ValueObject.class }},
+                new Object[]{ new T(), new Class<?>[] { ValueObject.class }},
                 new Object[]{ new C(), new Class<?>[] { IdentityObject.class }},
                 new Object[]{ Objects.newIdentity(), new Class<?>[] { IdentityObject.class }},
                 new Object[]{ array, new Class<?>[] { Cloneable.class, Serializable.class, IdentityObject.class }},
@@ -262,8 +262,8 @@ public class BasicTest {
         Class<?> type = o.getClass();
         assertEquals(type.getInterfaces(), expectedInterfaces);
         if (type.isPrimitiveClass()) {
-            assertTrue(PrimitiveObject.class.isAssignableFrom(type));
-            assertTrue(o instanceof PrimitiveObject);
+            assertTrue(ValueObject.class.isAssignableFrom(type));
+            assertTrue(o instanceof ValueObject);
         } else {
             assertTrue(IdentityObject.class.isAssignableFrom(type));
             assertTrue(o instanceof IdentityObject);

--- a/test/langtools/tools/javac/diags/examples/TopInterfaces.java
+++ b/test/langtools/tools/javac/diags/examples/TopInterfaces.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
-// key: compiler.err.identity.class.must.not.implement.primitive.object
+// key: compiler.err.identity.class.must.not.implement.value.object
 // key: compiler.err.mutually.incompatible.super.interfaces
 
-class Identity implements PrimitiveObject {
-    abstract class Inner implements IdentityObject, PrimitiveObject {}
+class Identity implements ValueObject {
+    abstract class Inner implements IdentityObject, ValueObject {}
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/InstanceOfTopTypeTest.java
@@ -38,26 +38,26 @@ public class InstanceOfTopTypeTest {
         Object o = new InstanceOfTopTypeTest();
         if (o instanceof IdentityObject)
             points++;     // 1
-        if (o instanceof PrimitiveObject)
+        if (o instanceof ValueObject)
             throw new AssertionError("Broken");
         o = new V();
         if (o instanceof IdentityObject)
             throw new AssertionError("Broken");
-        if (o instanceof PrimitiveObject)
+        if (o instanceof ValueObject)
             points++; // 2
         Object [] oa = new InstanceOfTopTypeTest[] { new InstanceOfTopTypeTest() };
         if (oa instanceof IdentityObject)
             points++; // 3
         if (oa[0] instanceof IdentityObject)
             points++; // 4
-        if (oa[0] instanceof PrimitiveObject)
+        if (oa[0] instanceof ValueObject)
             throw new AssertionError("Broken");
         oa = new V[] { new V() };
         if (oa instanceof IdentityObject)
             points++; // 5
         if (oa[0] instanceof IdentityObject)
             throw new AssertionError("Broken");
-        if (oa[0] instanceof PrimitiveObject)
+        if (oa[0] instanceof ValueObject)
             points++; // 6
         if (points != 6)
             throw new AssertionError("Broken top type set up " + points);

--- a/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TopInterfaceTest.java
@@ -49,7 +49,7 @@ public class TopInterfaceTest  {
 
 
         Class<?> [] ca = inln_o.getClass().getInterfaces();
-        if (ca.length != 1 || !ca[0].getCanonicalName().equals("java.lang.PrimitiveObject"))
+        if (ca.length != 1 || !ca[0].getCanonicalName().equals("java.lang.ValueObject"))
             throw new AssertionError("Found wrong super interfaces");
 
         // Check that V's super class is Object in class file.

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
@@ -49,7 +49,7 @@ public primitive class UnifiedPrimitiveClassNestHostTest implements java.io.Seri
 
         if (!superInterfaces[0].equals(java.io.Serializable.class))
             throw new AssertionError("Wrong super interfaces for UnifiedPrimitiveClassNestHostTest");
-        if (!superInterfaces[1].equals(PrimitiveObject.class))
+        if (!superInterfaces[1].equals(ValueObject.class))
             throw new AssertionError("Wrong super interfaces for UnifiedPrimitiveClassNestHostTest");
 
         Class<?> nestHost = UnifiedPrimitiveClassNestHostTest.class.getNestHost();

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
@@ -2,6 +2,7 @@ SemanticsViolationsTest.java:16:20: compiler.err.illegal.combination.of.modifier
 SemanticsViolationsTest.java:17:11: compiler.err.illegal.combination.of.modifiers: interface, value
 SemanticsViolationsTest.java:12:28: compiler.err.cant.inherit.from.final: SemanticsViolationsTest.Base
 SemanticsViolationsTest.java:65:27: compiler.err.mod.not.allowed.here: synchronized
+SemanticsViolationsTest.java:12:5: compiler.err.identity.class.must.not.implement.value.object: SemanticsViolationsTest.Subclass
 SemanticsViolationsTest.java:29:17: compiler.err.cant.assign.val.to.final.var: x
 SemanticsViolationsTest.java:34:17: compiler.err.cant.assign.val.to.final.var: y
 SemanticsViolationsTest.java:40:11: compiler.err.value.class.must.not.implement.identity.object: SemanticsViolationsTest.IdentityValue
@@ -13,4 +14,4 @@ SemanticsViolationsTest.java:72:21: compiler.err.value.class.may.not.override: f
 SemanticsViolationsTest.java:32:9: compiler.err.var.might.not.have.been.initialized: z
 SemanticsViolationsTest.java:81:17: compiler.err.this.exposed.prematurely
 SemanticsViolationsTest.java:81:16: compiler.err.this.exposed.prematurely
-15 errors
+16 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueAnnotationTest.out
@@ -1,4 +1,5 @@
 ValueAnnotationTest.java:10:50: compiler.err.cant.inherit.from.final: ValueAnnotationTest.X
 ValueAnnotationTest.java:11:28: compiler.err.cant.inherit.from.final: ValueAnnotationTest.Y
 ValueAnnotationTest.java:10:34: compiler.err.concrete.supertype.for.value.class: ValueAnnotationTest.Y, ValueAnnotationTest.X
-3 errors
+ValueAnnotationTest.java:11:12: compiler.err.identity.class.must.not.implement.value.object: ValueAnnotationTest.Z
+4 errors


### PR DESCRIPTION
Javac, hotspot and jdk changes to cope with PrimitiveObject in its new avatar as ValueObject

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279838](https://bugs.openjdk.java.net/browse/JDK-8279838): [lworld] PrimitiveObject is dead, long live ValueObject


### Reviewers
 * @biboudis (no known github.com user name / role) ⚠️ Review applies to 55b23355575985c9843e60b7f0a3eb97b92ac34e
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer) ⚠️ Review applies to 55b23355575985c9843e60b7f0a3eb97b92ac34e
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/599/head:pull/599` \
`$ git checkout pull/599`

Update a local copy of the PR: \
`$ git checkout pull/599` \
`$ git pull https://git.openjdk.java.net/valhalla pull/599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 599`

View PR using the GUI difftool: \
`$ git pr show -t 599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/599.diff">https://git.openjdk.java.net/valhalla/pull/599.diff</a>

</details>
