### PR TITLE
8279912: [lworld] The test jdk/java/lang/instrument/valhalla/RedefinePrimitive.java has started failing

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3321,7 +3321,7 @@ u2 ClassFileParser::parse_classfile_inner_classes_attribute(const ClassFileStrea
     }
     // JVM_ACC_INLINE is defined for class file version 55 and later
     if (supports_inline_types()) {
-      recognized_modifiers |= JVM_ACC_INLINE;
+      recognized_modifiers |= JVM_ACC_INLINE | JVM_ACC_VALUE;
     }
 
     // Access flags
@@ -6113,7 +6113,7 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
   }
   // JVM_ACC_INLINE is defined for class file version 55 and later
   if (supports_inline_types()) {
-    recognized_modifiers |= JVM_ACC_INLINE;
+    recognized_modifiers |= JVM_ACC_INLINE | JVM_ACC_VALUE;
   }
 
   // Access flags

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -883,7 +883,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   copy_cpool_bytes(writeable_address(cpool_size()));
 
   // JVMSpec|           u2 access_flags;
-  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_INLINE));
+  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_INLINE | JVM_ACC_VALUE));
 
   // JVMSpec|           u2 this_class;
   // JVMSpec|           u2 super_class;

--- a/src/java.base/share/native/include/classfile_constants.h.template
+++ b/src/java.base/share/native/include/classfile_constants.h.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ enum {
     JVM_ACC_TRANSIENT     = 0x0080,
     JVM_ACC_VARARGS       = 0x0080,
     JVM_ACC_NATIVE        = 0x0100,
+    JVM_ACC_VALUE         = 0x0100,
     JVM_ACC_INTERFACE     = 0x0200,
     JVM_ACC_ABSTRACT      = 0x0400,
     JVM_ACC_INLINE        = 0x0800,


### PR DESCRIPTION
Updated class parser and class reconstituter to handle JVM_ACC_VALUE flag for primitive classes.

Filed JDK-8279922: [lworld] ClassParser should verify primitive class is value class
to add check for JVM_ACC_INLINE/JVM_ACC_VALUE consistency

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279912](https://bugs.openjdk.java.net/browse/JDK-8279912): [lworld] The test jdk/java/lang/instrument/valhalla/RedefinePrimitive.java has started failing


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/600/head:pull/600` \
`$ git checkout pull/600`

Update a local copy of the PR: \
`$ git checkout pull/600` \
`$ git pull https://git.openjdk.java.net/valhalla pull/600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 600`

View PR using the GUI difftool: \
`$ git pr show -t 600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/600.diff">https://git.openjdk.java.net/valhalla/pull/600.diff</a>

</details>
