### PR TITLE
8279901: [lworld] Javac should verify/ensure that a Functional interface implements neither IdentityObject nor ValueObject 

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -795,10 +795,10 @@ public class Types {
                 }
             }
             // Not functional if extending either of the top interface types.
-            Type topInferface;
-            if ((topInferface = asSuper(origin.type, syms.identityObjectType.tsym)) != null ||
-                    (topInferface = asSuper(origin.type, syms.valueObjectType.tsym)) != null) {
-                throw failure("not.a.functional.intf.1", origin, diags.fragment(Fragments.MayNotExtendTopInterfaceType(topInferface)));
+            Type topInterface;
+            if ((topInterface = asSuper(origin.type, syms.identityObjectType.tsym)) != null ||
+                    (topInterface = asSuper(origin.type, syms.valueObjectType.tsym)) != null) {
+                throw failure("not.a.functional.intf.1", origin, diags.fragment(Fragments.MayNotExtendTopInterfaceType(topInterface)));
             }
             return descRes;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -769,10 +769,12 @@ public class Types {
                 //t must define a suitable non-generic method
                 throw failure("not.a.functional.intf.1", origin,
                             diags.fragment(Fragments.NoAbstracts(Kinds.kindName(origin), origin)));
-            } else if (abstracts.size() == 1) {
-                return new FunctionDescriptor(abstracts.first());
+            }
+            FunctionDescriptor descRes;
+            if (abstracts.size() == 1) {
+                descRes = new FunctionDescriptor(abstracts.first());
             } else { // size > 1
-                FunctionDescriptor descRes = mergeDescriptors(origin, abstracts.toList());
+                descRes = mergeDescriptors(origin, abstracts.toList());
                 if (descRes == null) {
                     //we can get here if the functional interface is ill-formed
                     ListBuffer<JCDiagnostic> descriptors = new ListBuffer<>();
@@ -791,8 +793,14 @@ public class Types {
                             new JCDiagnostic.MultilineDiagnostic(msg, descriptors.toList());
                     throw failure(incompatibleDescriptors);
                 }
-                return descRes;
             }
+            // Not functional if extending either of the top interface types.
+            Type topInferface;
+            if ((topInferface = asSuper(origin.type, syms.identityObjectType.tsym)) != null ||
+                    (topInferface = asSuper(origin.type, syms.valueObjectType.tsym)) != null) {
+                throw failure("not.a.functional.intf.1", origin, diags.fragment(Fragments.MayNotExtendTopInterfaceType(topInferface)));
+            }
+            return descRes;
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -260,6 +260,10 @@ compiler.misc.no.abstracts=\
 compiler.misc.incompatible.abstracts=\
     multiple non-overriding abstract methods found in {0} {1}
 
+# 0: type
+compiler.misc.may.not.extend.top.interface.type=\
+    since it extends {0}
+
 compiler.err.bad.functional.intf.anno=\
     Unexpected @FunctionalInterface annotation
 

--- a/test/langtools/tools/javac/diags/examples/MayNotExtendTopInterfaceType.java
+++ b/test/langtools/tools/javac/diags/examples/MayNotExtendTopInterfaceType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.bad.functional.intf.anno.1
+// key: compiler.misc.not.a.functional.intf.1
+// key: compiler.misc.may.not.extend.top.interface.type
+
+@FunctionalInterface
+interface I extends ValueObject {
+    void m();
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/FunctionalInterfaceTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/FunctionalInterfaceTest.java
@@ -1,0 +1,35 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279901
+ * @summary Javac should verify/ensure that a Functional interface implements neither IdentityObject nor ValueObject
+ * @compile/fail/ref=FunctionalInterfaceTest.out -XDrawDiagnostics -XDdev FunctionalInterfaceTest.java
+ */
+
+public class FunctionalInterfaceTest {
+
+    @FunctionalInterface
+    interface I extends IdentityObject  { // Error
+        void m();
+    }
+
+    @FunctionalInterface
+    interface J extends I  {} // Error.
+
+    @FunctionalInterface
+    interface K extends ValueObject  { // Error
+        void m();
+    }
+
+    interface L extends IdentityObject {
+        void m();
+    }
+
+    interface M extends ValueObject {
+        void m();
+    }
+
+    void foo() {
+        var t = (L) () -> {}; // Error
+        var u = (M) () -> {}; // Error
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/FunctionalInterfaceTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/FunctionalInterfaceTest.out
@@ -1,0 +1,6 @@
+FunctionalInterfaceTest.java:10:5: compiler.err.bad.functional.intf.anno.1: (compiler.misc.not.a.functional.intf.1: FunctionalInterfaceTest.I, (compiler.misc.may.not.extend.top.interface.type: java.lang.IdentityObject))
+FunctionalInterfaceTest.java:15:5: compiler.err.bad.functional.intf.anno.1: (compiler.misc.not.a.functional.intf.1: FunctionalInterfaceTest.J, (compiler.misc.may.not.extend.top.interface.type: java.lang.IdentityObject))
+FunctionalInterfaceTest.java:18:5: compiler.err.bad.functional.intf.anno.1: (compiler.misc.not.a.functional.intf.1: FunctionalInterfaceTest.K, (compiler.misc.may.not.extend.top.interface.type: java.lang.ValueObject))
+FunctionalInterfaceTest.java:32:21: compiler.err.prob.found.req: (compiler.misc.not.a.functional.intf.1: FunctionalInterfaceTest.L, (compiler.misc.may.not.extend.top.interface.type: java.lang.IdentityObject))
+FunctionalInterfaceTest.java:33:21: compiler.err.prob.found.req: (compiler.misc.not.a.functional.intf.1: FunctionalInterfaceTest.M, (compiler.misc.may.not.extend.top.interface.type: java.lang.ValueObject))
+5 errors


### PR DESCRIPTION
Disqualify interfaces that extend either of the top interface types from being lambda target types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279901](https://bugs.openjdk.java.net/browse/JDK-8279901): [lworld] Javac should verify/ensure that a Functional interface implements neither IdentityObject nor ValueObject


### Reviewers
 * @biboudis (no known github.com user name / role) ⚠️ Review applies to 7ba6d9ddf4ab8d29a3bef6f8bb87fe3c3ea28a13


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/601/head:pull/601` \
`$ git checkout pull/601`

Update a local copy of the PR: \
`$ git checkout pull/601` \
`$ git pull https://git.openjdk.java.net/valhalla pull/601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 601`

View PR using the GUI difftool: \
`$ git pr show -t 601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/601.diff">https://git.openjdk.java.net/valhalla/pull/601.diff</a>

</details>
