### PR TITLE
8280164: [lworld] Generate Preload attribute to enumerate value classes encountered

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -846,6 +846,17 @@ public class ClassWriter extends ClassFile {
         endAttr(alenIdx);
     }
 
+     /** Write out "Preload" attribute by enumerating the value classes encountered during this compilation.
+      */
+     void writeValueClasses() {
+        int alenIdx = writeAttr(names.Preload);
+        databuf.appendChar(poolWriter.valueClasses.size());
+        for (ClassSymbol c : poolWriter.valueClasses) {
+            databuf.appendChar(poolWriter.putClass(c));
+        }
+        endAttr(alenIdx);
+     }
+
     int writeRecordAttribute(ClassSymbol csym) {
         int alenIdx = writeAttr(names.Record);
         Scope s = csym.members();
@@ -1576,14 +1587,14 @@ public class ClassWriter extends ClassFile {
             case VAR: fieldsCount++; break;
             case MTH: if ((sym.flags() & HYPOTHETICAL) == 0) methodsCount++;
                       break;
-            case TYP: poolWriter.enterInner((ClassSymbol)sym); break;
+            case TYP: poolWriter.enterInnerAndValueClass((ClassSymbol)sym); break;
             default : Assert.error();
             }
         }
 
         if (c.trans_local != null) {
             for (ClassSymbol local : c.trans_local) {
-                poolWriter.enterInner(local);
+                poolWriter.enterInnerAndValueClass(local);
             }
         }
 
@@ -1671,6 +1682,11 @@ public class ClassWriter extends ClassFile {
 
         if (!poolWriter.innerClasses.isEmpty()) {
             writeInnerClasses();
+            acount++;
+        }
+
+        if (!poolWriter.valueClasses.isEmpty()) {
+            writeValueClasses();
             acount++;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.sun.tools.javac.code.Kinds.Kind.TYP;
 import static com.sun.tools.javac.code.TypeTag.ARRAY;
@@ -95,7 +96,7 @@ public class PoolWriter {
     /** The inner classes to be written, as an ordered set (enclosing first). */
     LinkedHashSet<ClassSymbol> innerClasses = new LinkedHashSet<>();
 
-    HashSet<ClassSymbol> valueClasses = new HashSet<>();
+    Set<ClassSymbol> valueClasses = new HashSet<>();
 
     /** The list of entries in the BootstrapMethods attribute. */
     Map<BsmKey, Integer> bootstrapMethods = new LinkedHashMap<>();
@@ -256,7 +257,7 @@ public class PoolWriter {
             throw new AssertionError("Unexpected intersection type: " + c.type);
         }
         c.complete();
-        if (c.isValueClass()) {
+        if (c.isValueClass() && !c.isPrimitiveClass()) {
             valueClasses.add(c);
         }
         if (c.owner.enclClass() != null) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -155,6 +155,7 @@ public class Names {
     public final Name ModuleResolution;
     public final Name NestHost;
     public final Name NestMembers;
+    public final Name Preload;
     public final Name Record;
     public final Name RuntimeInvisibleAnnotations;
     public final Name RuntimeInvisibleParameterAnnotations;
@@ -350,6 +351,7 @@ public class Names {
         ModuleResolution = fromString("ModuleResolution");
         NestHost = fromString("NestHost");
         NestMembers = fromString("NestMembers");
+        Preload = fromString("Preload");
         Record = fromString("Record");
         RuntimeInvisibleAnnotations = fromString("RuntimeInvisibleAnnotations");
         RuntimeInvisibleParameterAnnotations = fromString("RuntimeInvisibleParameterAnnotations");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -60,6 +60,7 @@ public abstract class Attribute {
     public static final String ModuleTarget             = "ModuleTarget";
     public static final String NestHost                 = "NestHost";
     public static final String NestMembers              = "NestMembers";
+    public static final String Preload                  = "Preload";
     public static final String Record                   = "Record";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
     public static final String RuntimeInvisibleAnnotations = "RuntimeInvisibleAnnotations";
@@ -136,6 +137,7 @@ public abstract class Attribute {
             standardAttributes.put(ModuleTarget,      ModuleTarget_attribute.class);
             standardAttributes.put(NestHost, NestHost_attribute.class);
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
+            standardAttributes.put(Preload, Preload_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
             standardAttributes.put(RuntimeInvisibleParameterAnnotations, RuntimeInvisibleParameterAnnotations_attribute.class);
@@ -203,6 +205,7 @@ public abstract class Attribute {
         R visitModuleTarget(ModuleTarget_attribute attr, P p);
         R visitNestHost(NestHost_attribute attr, P p);
         R visitNestMembers(NestMembers_attribute attr, P p);
+        R visitPreload(Preload_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);
         R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -754,6 +754,14 @@ public class ClassWriter {
             return null;
         }
 
+        @Override
+        public Void visitPreload(Preload_attribute attr, ClassOutputStream out) {
+            out.writeShort(attr.value_class_info_index.length);
+            for (int index: attr.value_class_info_index)
+                out.writeShort(index);
+            return null;
+        }
+
         protected void writeAccessFlags(AccessFlags flags, ClassOutputStream out) {
             out.writeShort(flags.flags);
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Preload_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Preload_attribute.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+
+/**
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+public class Preload_attribute extends Attribute {
+    Preload_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        number_of_classes = cr.readUnsignedShort();
+        value_class_info_index = new int[number_of_classes];
+        for (int i = 0; i < number_of_classes; i++)
+            value_class_info_index[i] = cr.readUnsignedShort();
+    }
+
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitPreload(this, data);
+    }
+
+    public final int number_of_classes;
+    public final int value_class_info_index[];
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -80,6 +80,7 @@ import com.sun.tools.classfile.Type;
 
 import static com.sun.tools.classfile.AccessFlags.*;
 
+import com.sun.tools.classfile.Preload_attribute;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.StringUtils;
 
@@ -1109,6 +1110,27 @@ public class AttributeWriter extends BasicWriter
     @Override
     public Void visitSynthetic(Synthetic_attribute attr, Void ignore) {
         println("Synthetic: true");
+        return null;
+    }
+
+    @Override
+    public Void visitPreload(Preload_attribute attr, Void ignore) {
+        boolean first = true;
+        for (int index : attr.value_class_info_index) {
+            if (first) {
+                println("Classes to be preloaded:");
+                indent(+1);
+                first = false;
+            }
+            print("#" + index);
+            print(";");
+            tab();
+            print("// value ");
+            constantWriter.write(index);
+            println();
+        }
+        if (!first)
+            indent(-1);
         return null;
     }
 

--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1371,6 +1371,11 @@ public class ClassfileInspector {
         public Void visitRecord(Record_attribute attr, T p) {
             return null;
         }
+
+        @Override
+        public Void visitPreload(Preload_attribute attr, T p) {
+            return null;
+        }
     }
 
     private static final Attribute.Visitor<Void, ExpectedTypeAnnotation> typeAnnoMatcher

--- a/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
+++ b/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
@@ -66,4 +66,5 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitSynthetic(Synthetic_attribute attr, P p) { return null; }
     public R visitPermittedSubclasses(PermittedSubclasses_attribute attr, P p) { return null; }
     public R visitRecord(Record_attribute attr, P p) { return null; }
+    public R visitPreload(Preload_attribute attr, P p) { return null; }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/MultiValues.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/MultiValues.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+final value class V1 {}
+final value class V2 {}
+final value class V3 {}
+final value class V4 {}
+final value class V5 {}
+final value class V6 {}

--- a/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280164
+ * @summary Check emission of Preload attribute
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @compile MultiValues.java
+ * @compile -g PreloadAttributeTest.java
+ * @run main PreloadAttributeTest
+ */
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
+
+public class PreloadAttributeTest {
+
+    static final value class X {
+        final V1 [] v1 = null; // field descriptor 
+        V2[] foo() {  // method descriptor encoding value type
+            return null;
+        }
+        void foo(V3 v3) { // method descriptor encoding value type
+        }
+        void foo(int x) {
+            V4 [] v4 = null; // local variable.
+        }
+        void goo() {
+            V5 [] v5 = null;
+            if (v5 == null) {
+               V6 [] v61 = null;  // stack map table.
+            } else {
+               V5 [] v52 = null;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(PreloadAttributeTest.class.getResourceAsStream("PreloadAttributeTest$X.class"));
+
+        if (cls == null) {
+            throw new AssertionError("Could not locate the class files");
+        }
+
+        /* Check emission of Preload attribute */
+        Preload_attribute preloads = (Preload_attribute) cls.attributes.get(Attribute.Preload);
+        if (preloads == null) {
+            throw new AssertionError("Missing Preload attribute!");
+        }
+        if (preloads.number_of_classes != 6) {
+            throw new AssertionError("Incorrect number of Preload classes");
+        }
+        
+        int mask = 0x3F;
+        for (int i = 0; i < preloads.number_of_classes; i++) {
+            CONSTANT_Class_info clsInfo = cls.constant_pool.getClassInfo(
+                                  preloads.value_class_info_index[i]);
+            switch (clsInfo.getName()) {
+                case "V1":
+                    mask &= ~1; break;
+                case "V2":
+                    mask &= ~2; break;
+                case "V3":
+                    mask &= ~4; break;
+                case "V4":
+                    mask &= ~8; break;
+                case "V5":
+                    mask &= ~16; break;
+                case "PreloadAttributeTest$X":
+                    mask &= ~32; break;
+            }
+        }
+        if (mask != 0) {
+          throw new AssertionError("Some Preload class entries are missing!");  
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
@@ -37,7 +37,7 @@ import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
 public class PreloadAttributeTest {
 
     static final value class X {
-        final V1 [] v1 = null; // field descriptor 
+        final V1 [] v1 = null; // field descriptor
         V2[] foo() {  // method descriptor encoding value type
             return null;
         }
@@ -71,7 +71,7 @@ public class PreloadAttributeTest {
         if (preloads.number_of_classes != 6) {
             throw new AssertionError("Incorrect number of Preload classes");
         }
-        
+
         int mask = 0x3F;
         for (int i = 0; i < preloads.number_of_classes; i++) {
             CONSTANT_Class_info clsInfo = cls.constant_pool.getClassInfo(
@@ -92,7 +92,7 @@ public class PreloadAttributeTest {
             }
         }
         if (mask != 0) {
-          throw new AssertionError("Some Preload class entries are missing!");  
+          throw new AssertionError("Some Preload class entries are missing!");
         }
     }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/PreloadAttributeTest.java
@@ -49,7 +49,7 @@ public class PreloadAttributeTest {
         void goo() {
             V5 [] v5 = null;
             if (v5 == null) {
-               V6 [] v61 = null;  // stack map table.
+                // ...
             } else {
                V5 [] v52 = null;
             }


### PR DESCRIPTION
Modelled after InnerClasses attribute generation, we may be generating more information than necessary/useful but this is initial cut

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280164](https://bugs.openjdk.java.net/browse/JDK-8280164): [lworld] Generate Preload attribute to enumerate value classes encountered


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/605/head:pull/605` \
`$ git checkout pull/605`

Update a local copy of the PR: \
`$ git checkout pull/605` \
`$ git pull https://git.openjdk.java.net/valhalla pull/605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 605`

View PR using the GUI difftool: \
`$ git pr show -t 605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/605.diff">https://git.openjdk.java.net/valhalla/pull/605.diff</a>

</details>
