### PR TITLE
8280006: [lworld] Compiler interface uses wrong class loader when looking up field type

### DIFF
--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ class ciField : public ResourceObj {
 private:
   ciFlags          _flags;
   ciInstanceKlass* _holder;
+  ciInstanceKlass* _original_holder; // For flattened fields
   ciSymbol*        _name;
   ciSymbol*        _signature;
   ciType*          _type;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Verify that certain array accesses do not trigger deoptimization.
  * @library /test/lib
- * @run main/othervm TestArrayAccessDeopt
+ * @run driver TestArrayAccessDeopt
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/InstallBootstrapClasses.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/InstallBootstrapClasses.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import jdk.test.lib.Utils;
+
+// Copy classes into a separate folder to put them on the bootclasspath
+public class InstallBootstrapClasses {
+
+    private static void copyClass(String name) throws IOException {
+        Path source = Path.of(Utils.TEST_CLASSES).resolve(name);
+        Path dest = Path.of("boot");
+        Path target = dest.resolve(name);
+        Files.createDirectories(dest);
+        Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public static void main(String[] args) throws IOException {
+        copyClass(ValueOnBootclasspath.class.getSimpleName() + ".class");
+        copyClass(MyClass.class.getSimpleName() + ".class");
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/TestBootClassloader.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/TestBootClassloader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Method;
+import jdk.test.lib.Asserts;
+import sun.hotspot.WhiteBox;
+
+/*
+ * @test
+ * @key randomness
+ * @bug 8280006
+ * @summary Test that field flattening works as expected if primitive classes of
+ *          holder and field were loaded by different class loaders (bootstrap + app).
+ * @library /test/lib /
+ * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
+ * @build sun.hotspot.WhiteBox TestBootClassloader InstallBootstrapClasses
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver InstallBootstrapClasses
+ * @run main/othervm -Xbootclasspath/a:boot -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xbatch -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestBootClassloader::test*
+ *                   -XX:CompileCommand=inline,*::get* TestBootClassloader
+ */
+
+public class TestBootClassloader {
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final int COMP_LEVEL_FULL_OPTIMIZATION = 4;
+
+    static primitive class Wrapper1 {
+        ValueOnBootclasspath val; // Type will be loaded by boot classloader
+
+        public Wrapper1(ValueOnBootclasspath val) {
+            this.val = val;
+        }
+
+        Object get() {
+            return val.get();
+        }
+    }
+
+    static primitive class Wrapper2 {
+        Wrapper1 val;
+
+        public Wrapper2(Wrapper1 val) {
+            this.val = val;
+        }
+
+        Object get() {
+            return val.get();
+        }
+    }
+
+    static Object test1(Wrapper1 w) {
+        return w.get();
+    }
+
+    static Object test2(Wrapper2 w) {
+        return w.get();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Wrapper1 wrapper1 = new Wrapper1(new ValueOnBootclasspath());
+        Wrapper2 wrapper2 = new Wrapper2(wrapper1);
+        for (int i = 0; i < 50_000; ++i) {
+            test1(wrapper1);
+            test2(wrapper2);
+        }
+        Method method = TestBootClassloader.class.getDeclaredMethod("test1", Wrapper1.class.asValueType());
+        Asserts.assertTrue(WB.isMethodCompilable(method, COMP_LEVEL_FULL_OPTIMIZATION, false), "Test1 method not compilable");
+        Asserts.assertTrue(WB.isMethodCompiled(method), "Test1 method not compiled");
+
+        method = TestBootClassloader.class.getDeclaredMethod("test2", Wrapper2.class.asValueType());
+        Asserts.assertTrue(WB.isMethodCompilable(method, COMP_LEVEL_FULL_OPTIMIZATION, false), "Test2 method not compilable");
+        Asserts.assertTrue(WB.isMethodCompiled(method), "Test2 method not compiled");
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/ValueOnBootclasspath.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/bootstrap/ValueOnBootclasspath.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+class MyClass {
+
+}
+
+// Loaded by boot classloader
+public primitive class ValueOnBootclasspath {
+    private MyClass field = new MyClass();
+
+    private MyClass getField() {
+        return field;
+    }
+
+    public Object get() {
+        return getField();
+    }
+}


### PR DESCRIPTION
In the test, the primitive type `ValueOnBootclasspath` of flattened `Wrapper1.field` and the type `MyClass` of its flattened `field` are loaded by the boot classloader (`loader` is NULL):
```
<ciInlineKlass name=ValueOnBootclasspath loader=0x0000000000000000 loaded=true initialized=true finalized=false subklass=false size=16 flags=public,final,super super=java/lang/Object ident=1288 address=0x00007f5108540288>
<ciInstanceKlass name=MyClass loader=0x0000000000000000 loaded=true initialized=true finalized=false subklass=false size=16 flags=DEFAULT_ACCESS,super ident=1292 address=0x00007f5108541160> 
```

During JIT compilation, when the type of `Wrapper1.field` is computed in `ciField::compute_type_impl()`, `Wrapper1` is used as the holder klass and therefore its class loader (`loader=0x000000062c754858`) is used as context for the lookup:

```
<ciField name=TestBootClassloader$Wrapper1.field signature=LMyClass; offset=12 type=(reference) flags=0010 is_constant=true is_flattened=false is_null_free=false>
<ciInlineKlass name=TestBootClassloader$Wrapper1 loader=0x000000062c754858 loaded=true initialized=true finalized=false subklass=false size=16 flags=DEFAULT_ACCESS,final,super super=java/lang/Object ident=1284 address=0x00007f510853f440>
```

But since `MyClass` was loaded by the boot classloader, the lookup via the application class loader fails and leads to an unloaded klass:
```
<ciInstanceKlass name=MyClass loader=0x000000062c754858 loaded=false ident=1289 address=0x00007f5108540708>
```

C2's type system then gets confused when mixing both `MyClass` types and bails out with `COMPILE SKIPPED: Can't determine return type. (retry at different tier)`.

The fix is to use the "original holder", i.e., the klass that defined the field in the source code and not the one that contains it at runtime due to flattening, for the lookup instead.

While debugging, I also noticed that loading of signature classes before JIT compilation does not apply to fields that came in through flattening. I filed [JDK-8280230](https://bugs.openjdk.java.net/browse/JDK-8280230) to investigate this separately.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280006](https://bugs.openjdk.java.net/browse/JDK-8280006): [lworld] Compiler interface uses wrong class loader when looking up field type


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/606/head:pull/606` \
`$ git checkout pull/606`

Update a local copy of the PR: \
`$ git checkout pull/606` \
`$ git pull https://git.openjdk.java.net/valhalla pull/606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 606`

View PR using the GUI difftool: \
`$ git pr show -t 606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/606.diff">https://git.openjdk.java.net/valhalla/pull/606.diff</a>

</details>
