### PR TITLE
8279906: [lworld] Javac tolerates synchronized methods in value/primitive records

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1398,8 +1398,8 @@ public class Check {
                     mask = implicit = InterfaceMethodFlags;
                 }
             } else if ((sym.owner.flags_field & RECORD) != 0) {
-                mask = RecordMethodFlags;
-                // FIXME: We tolerate synchronized methods in value records
+                mask = ((sym.owner.flags_field & VALUE_CLASS) != 0 && (flags & Flags.STATIC) == 0) ?
+                        RecordMethodFlags & ~SYNCHRONIZED : RecordMethodFlags;
             } else {
                 // value objects do not have an associated monitor/lock
                 mask = ((sym.owner.flags_field & VALUE_CLASS) != 0 && (flags & Flags.STATIC) == 0) ?

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.java
@@ -34,4 +34,11 @@ primitive final class CheckSynchronized implements java.io.Serializable {
         }
     }
     static int x = 10;
+
+    primitive record CheckSynchronizedRecord(int x, int y) {
+        synchronized void foo() { // <<-- ERROR, no monitor associated with `this'
+        }
+        synchronized static void zoo() { // OK, static method.
+        }
+    }
 }

--- a/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/CheckSynchronized.out
@@ -1,6 +1,7 @@
 CheckSynchronized.java:9:23: compiler.err.mod.not.allowed.here: synchronized
+CheckSynchronized.java:39:27: compiler.err.mod.not.allowed.here: synchronized
 CheckSynchronized.java:12:9: compiler.err.type.found.req: CheckSynchronized, (compiler.misc.type.req.identity)
 CheckSynchronized.java:15:9: compiler.err.type.found.req: CheckSynchronized, (compiler.misc.type.req.identity)
 CheckSynchronized.java:19:9: compiler.err.type.found.req: CheckSynchronized.ref, (compiler.misc.type.req.identity)
 CheckSynchronized.java:23:9: compiler.err.type.found.req: int, (compiler.misc.type.req.identity)
-5 errors
+6 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
@@ -85,4 +85,9 @@ public class SemanticsViolationsTest {
         void foo(BrokenValue7 bv) {
         }
     }
+
+    value record BrokenValue8(int x, int y) {
+        synchronized void foo() { } // Error;
+        synchronized static void soo() {} // OK.
+    }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
@@ -2,6 +2,7 @@ SemanticsViolationsTest.java:16:20: compiler.err.illegal.combination.of.modifier
 SemanticsViolationsTest.java:17:11: compiler.err.illegal.combination.of.modifiers: interface, value
 SemanticsViolationsTest.java:12:28: compiler.err.cant.inherit.from.final: SemanticsViolationsTest.Base
 SemanticsViolationsTest.java:65:27: compiler.err.mod.not.allowed.here: synchronized
+SemanticsViolationsTest.java:90:27: compiler.err.mod.not.allowed.here: synchronized
 SemanticsViolationsTest.java:12:5: compiler.err.identity.class.must.not.implement.value.object: SemanticsViolationsTest.Subclass
 SemanticsViolationsTest.java:29:17: compiler.err.cant.assign.val.to.final.var: x
 SemanticsViolationsTest.java:34:17: compiler.err.cant.assign.val.to.final.var: y
@@ -14,4 +15,4 @@ SemanticsViolationsTest.java:72:21: compiler.err.value.class.may.not.override: f
 SemanticsViolationsTest.java:32:9: compiler.err.var.might.not.have.been.initialized: z
 SemanticsViolationsTest.java:81:17: compiler.err.this.exposed.prematurely
 SemanticsViolationsTest.java:81:16: compiler.err.this.exposed.prematurely
-16 errors
+17 errors


### PR DESCRIPTION
Fix JDK-8279906 by masking the record-specific flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279906](https://bugs.openjdk.java.net/browse/JDK-8279906): [lworld] Javac tolerates synchronized methods in value/primitive records


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/607/head:pull/607` \
`$ git checkout pull/607`

Update a local copy of the PR: \
`$ git checkout pull/607` \
`$ git pull https://git.openjdk.java.net/valhalla pull/607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 607`

View PR using the GUI difftool: \
`$ git pr show -t 607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/607.diff">https://git.openjdk.java.net/valhalla/pull/607.diff</a>

</details>
