### PR TITLE
8280381: [lworld] VM should accept static factory methods in value class files.

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1355,7 +1355,7 @@ void MacroAssembler::test_markword_is_inline_type(Register markword, Label& is_i
 
 void MacroAssembler::test_klass_is_inline_type(Register klass, Register temp_reg, Label& is_inline_type) {
   ldrw(temp_reg, Address(klass, Klass::access_flags_offset()));
-  andr(temp_reg, temp_reg, JVM_ACC_INLINE);
+  andr(temp_reg, temp_reg, JVM_ACC_VALUE);
   cbnz(temp_reg, is_inline_type);
 }
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3808,11 +3808,11 @@ void TemplateTable::_new() {
   __ membar(Assembler::StoreStore);
 }
 
-void TemplateTable::defaultvalue() {
+void TemplateTable::aconst_init() {
   transition(vtos, atos);
   __ get_unsigned_2_byte_index_at_bcp(c_rarg2, 1);
   __ get_constant_pool(c_rarg1);
-  call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::defaultvalue),
+  call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::aconst_init),
           c_rarg1, c_rarg2);
   __ verify_oop(r0);
   // Must prevent reordering of stores for object initialization with stores that publish the new object.

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -2744,7 +2744,7 @@ void MacroAssembler::test_markword_is_inline_type(Register markword, Label& is_i
 
 void MacroAssembler::test_klass_is_inline_type(Register klass, Register temp_reg, Label& is_inline_type) {
   movl(temp_reg, Address(klass, Klass::access_flags_offset()));
-  testl(temp_reg, JVM_ACC_INLINE);
+  testl(temp_reg, JVM_ACC_VALUE);
   jcc(Assembler::notZero, is_inline_type);
 }
 

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4326,7 +4326,7 @@ void TemplateTable::_new() {
   __ bind(done);
 }
 
-void TemplateTable::defaultvalue() {
+void TemplateTable::aconst_init() {
   transition(vtos, atos);
 
   Label slow_case;
@@ -4349,7 +4349,7 @@ void TemplateTable::defaultvalue() {
   __ cmpb(Address(rcx, InstanceKlass::kind_offset()), InstanceKlass::_kind_inline_type);
   __ jcc(Assembler::equal, is_value);
 
-  // in the future, defaultvalue will just return null instead of throwing an exception
+  // in the future, aconst_init will just return null instead of throwing an exception
   __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::throw_IncompatibleClassChangeError));
 
   __ bind(is_value);
@@ -4370,7 +4370,7 @@ void TemplateTable::defaultvalue() {
   __ get_unsigned_2_byte_index_at_bcp(rarg2, 1);
   __ get_constant_pool(rarg1);
 
-  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::defaultvalue),
+  call_VM(rax, CAST_FROM_FN_PTR(address, InterpreterRuntime::aconst_init),
       rarg1, rarg2);
 
   __ bind(done);

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3267,7 +3267,7 @@ BlockEnd* GraphBuilder::iterate_bytecodes_for_block(int bci) {
       case Bytecodes::_ifnonnull      : if_null(objectType, If::neq); break;
       case Bytecodes::_goto_w         : _goto(s.cur_bci(), s.get_far_dest()); break;
       case Bytecodes::_jsr_w          : jsr(s.get_far_dest()); break;
-      case Bytecodes::_defaultvalue   : default_value(s.get_index_u2()); break;
+      case Bytecodes::_aconst_init   : default_value(s.get_index_u2()); break;
       case Bytecodes::_withfield      : withfield(s.get_index_u2()); break;
       case Bytecodes::_breakpoint     : BAILOUT_("concurrent setting of breakpoint", NULL);
       default                         : ShouldNotReachHere(); break;

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -64,7 +64,7 @@ void LIR_Assembler::patching_epilog(PatchingStub* patch, LIR_PatchCode patch_cod
   } else if (patch->id() == PatchingStub::load_klass_id) {
     switch (code) {
       case Bytecodes::_new:
-      case Bytecodes::_defaultvalue:
+      case Bytecodes::_aconst_init:
       case Bytecodes::_anewarray:
       case Bytecodes::_multianewarray:
       case Bytecodes::_instanceof:

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2371,7 +2371,7 @@ void LIRGenerator::do_LoadIndexed(LoadIndexed* x) {
 }
 
 void LIRGenerator::do_Deoptimize(Deoptimize* x) {
-  // This happens only when a class X uses the withfield/defaultvalue bytecode
+  // This happens only when a class X uses the withfield/aconst_init bytecode
   // to refer to an inline class V, where V has not yet been loaded/resolved.
   // This is not a common case. Let's just deoptimize.
   CodeEmitInfo* info = state_for(x, x->state_before());

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1119,9 +1119,9 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
           k = caller_method->constants()->klass_at(bnew.index(), CHECK);
         }
         break;
-      case Bytecodes::_defaultvalue:
-        { Bytecode_defaultvalue bdefaultvalue(caller_method(), caller_method->bcp_from(bci));
-          k = caller_method->constants()->klass_at(bdefaultvalue.index(), CHECK);
+      case Bytecodes::_aconst_init:
+        { Bytecode_aconst_init baconst_init(caller_method(), caller_method->bcp_from(bci));
+          k = caller_method->constants()->klass_at(baconst_init.index(), CHECK);
         }
         break;
       case Bytecodes::_multianewarray:

--- a/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
+++ b/src/hotspot/share/ci/bcEscapeAnalyzer.cpp
@@ -942,7 +942,7 @@ void BCEscapeAnalyzer::iterate_one_block(ciBlock *blk, StateInfo &state, Growabl
         }
         break;
       case Bytecodes::_new:
-      case Bytecodes::_defaultvalue:
+      case Bytecodes::_aconst_init:
         state.apush(allocated_obj);
         break;
       case Bytecodes::_withfield: {

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -172,7 +172,7 @@ int ciBytecodeStream::get_klass_index() const {
   case Bytecodes::_anewarray:
   case Bytecodes::_multianewarray:
   case Bytecodes::_new:
-  case Bytecodes::_defaultvalue:
+  case Bytecodes::_aconst_init:
   case Bytecodes::_newarray:
     return get_index_u2();
   default:

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -846,8 +846,8 @@ void ciTypeFlow::StateVector::do_new(ciBytecodeStream* str) {
 }
 
 // ------------------------------------------------------------------
-// ciTypeFlow::StateVector::do_defaultvalue
-void ciTypeFlow::StateVector::do_defaultvalue(ciBytecodeStream* str) {
+// ciTypeFlow::StateVector::do_aconst_init
+void ciTypeFlow::StateVector::do_aconst_init(ciBytecodeStream* str) {
   bool will_link;
   ciKlass* klass = str->get_klass(will_link);
   if (!will_link || str->is_unresolved_klass() || !klass->is_inlinetype()) {
@@ -1544,7 +1544,7 @@ bool ciTypeFlow::StateVector::apply_one_bytecode(ciBytecodeStream* str) {
 
   case Bytecodes::_new:      do_new(str);                           break;
 
-  case Bytecodes::_defaultvalue: do_defaultvalue(str);              break;
+  case Bytecodes::_aconst_init: do_aconst_init(str);              break;
   case Bytecodes::_withfield: do_withfield(str);                    break;
 
   case Bytecodes::_newarray: do_newarray(str);                      break;

--- a/src/hotspot/share/ci/ciTypeFlow.hpp
+++ b/src/hotspot/share/ci/ciTypeFlow.hpp
@@ -362,7 +362,7 @@ public:
     void do_ldc(ciBytecodeStream* str);
     void do_multianewarray(ciBytecodeStream* str);
     void do_new(ciBytecodeStream* str);
-    void do_defaultvalue(ciBytecodeStream* str);
+    void do_aconst_init(ciBytecodeStream* str);
     void do_withfield(ciBytecodeStream* str);
     void do_newarray(ciBytecodeStream* str);
     void do_putfield(ciBytecodeStream* str);

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -592,7 +592,7 @@ class ClassFileParser {
 
   bool is_hidden() const { return _is_hidden; }
   bool is_interface() const { return _access_flags.is_interface(); }
-  bool is_inline_type() const { return _access_flags.is_inline_type(); }
+  bool is_inline_type() const { return _access_flags.is_value_class(); }
   bool is_value_capable_class() const;
   bool has_inline_fields() const { return _has_inline_type_fields; }
   bool invalid_inline_super() const { return _invalid_inline_super; }

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -64,7 +64,7 @@ bool VerificationType::resolve_and_check_assignability(InstanceKlass* klass, Sym
     }
   }
 
-  if (this_class->access_flags().is_inline_type()) return false;
+  if (this_class->access_flags().is_value_class()) return false;
   if (this_class->is_interface() && (!from_field_is_protected ||
       from_name != vmSymbols::java_lang_Object())) {
     // If we are not trying to access a protected field or method in

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -1752,11 +1752,11 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           current_frame.push_stack(type, CHECK_VERIFY(this));
           no_control_flow = false; break;
         }
-        case Bytecodes::_defaultvalue :
+        case Bytecodes::_aconst_init :
         {
           if (_klass->major_version() < INLINE_TYPE_MAJOR_VERSION) {
             class_format_error(
-              "defaultvalue not supported by this class file version (%d.%d), class %s",
+              "aconst_init not supported by this class file version (%d.%d), class %s",
               _klass->major_version(), _klass->minor_version(), _klass->external_name());
             return;
           }
@@ -1766,7 +1766,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
           if (!ref_type.is_object()) {
             verify_error(ErrorContext::bad_type(bci,
                 TypeOrigin::cp(index, ref_type)),
-                "Illegal defaultvalue instruction");
+                "Illegal aconst_init instruction");
             return;
           }
           VerificationType inline_type =

--- a/src/hotspot/share/compiler/methodLiveness.cpp
+++ b/src/hotspot/share/compiler/methodLiveness.cpp
@@ -477,7 +477,7 @@ void MethodLiveness::BasicBlock::compute_gen_kill_single(ciBytecodeStream *instr
     case Bytecodes::_goto_w:
     case Bytecodes::_aconst_null:
     case Bytecodes::_new:
-    case Bytecodes::_defaultvalue:
+    case Bytecodes::_aconst_init:
     case Bytecodes::_withfield:
     case Bytecodes::_iconst_m1:
     case Bytecodes::_iconst_0:

--- a/src/hotspot/share/interpreter/bytecode.hpp
+++ b/src/hotspot/share/interpreter/bytecode.hpp
@@ -294,13 +294,13 @@ class Bytecode_new: public Bytecode {
   long index() const   { return get_index_u2(Bytecodes::_new); };
 };
 
-class Bytecode_defaultvalue: public Bytecode {
+class Bytecode_aconst_init: public Bytecode {
  public:
-  Bytecode_defaultvalue(Method* method, address bcp): Bytecode(method, bcp) { verify(); }
-  void verify() const { assert(java_code() == Bytecodes::_defaultvalue, "check defaultvalue"); }
+  Bytecode_aconst_init(Method* method, address bcp): Bytecode(method, bcp) { verify(); }
+  void verify() const { assert(java_code() == Bytecodes::_aconst_init, "check aconst_init"); }
 
   // Returns index
-  long index() const   { return get_index_u2(Bytecodes::_defaultvalue); };
+  long index() const   { return get_index_u2(Bytecodes::_aconst_init); };
 };
 
 class Bytecode_multianewarray: public Bytecode {

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -570,7 +570,7 @@ void BytecodePrinter::print_attributes(int bci, outputStream* st) {
     case Bytecodes::_new:
     case Bytecodes::_checkcast:
     case Bytecodes::_instanceof:
-    case Bytecodes::_defaultvalue:
+    case Bytecodes::_aconst_init:
       { int i = get_index_u2();
         ConstantPool* constants = method()->constants();
         Symbol* name = constants->klass_name_at(i);

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -484,7 +484,7 @@ void Bytecodes::initialize() {
   def(_goto_w              , "goto_w"              , "boooo", NULL    , T_VOID   ,  0, false);
   def(_jsr_w               , "jsr_w"               , "boooo", NULL    , T_INT    ,  0, false);
   def(_breakpoint          , "breakpoint"          , ""     , NULL    , T_VOID   ,  0, true);
-  def(_defaultvalue        , "defaultvalue"        , "bkk"  , NULL    , T_OBJECT ,  1, true);
+  def(_aconst_init        , "aconst_init"        , "bkk"  , NULL    , T_OBJECT ,  1, true);
   def(_withfield           , "withfield"           , "bJJ"  , NULL    , T_OBJECT , -1, true );
 
   //  JVM bytecodes

--- a/src/hotspot/share/interpreter/bytecodes.hpp
+++ b/src/hotspot/share/interpreter/bytecodes.hpp
@@ -244,7 +244,7 @@ class Bytecodes: AllStatic {
     _breakpoint           = 202, // 0xca
 
     // value-type bytecodes
-    _defaultvalue         = 203, // 0xcb
+    _aconst_init          = 203, // 0xcb
     _withfield            = 204, // 0xcc
 
     number_of_java_codes,

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -253,15 +253,15 @@ JRT_ENTRY(void, InterpreterRuntime::_new(JavaThread* current, ConstantPool* pool
   current->set_vm_result(obj);
 JRT_END
 
-JRT_ENTRY(void, InterpreterRuntime::defaultvalue(JavaThread* current, ConstantPool* pool, int index))
+JRT_ENTRY(void, InterpreterRuntime::aconst_init(JavaThread* current, ConstantPool* pool, int index))
   // Getting the InlineKlass
   Klass* k = pool->klass_at(index, CHECK);
   if (!k->is_inline_klass()) {
     // inconsistency with 'new' which throws an InstantiationError
-    // in the future, defaultvalue will just return null instead of throwing an exception
+    // in the future, aconst_init will just return null instead of throwing an exception
     THROW(vmSymbols::java_lang_IncompatibleClassChangeError());
   }
-  assert(k->is_inline_klass(), "defaultvalue argument must be the inline type class");
+  assert(k->is_inline_klass(), "aconst_init argument must be the inline type class");
   InlineKlass* vklass = InlineKlass::cast(k);
 
   vklass->initialize(CHECK);

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -64,7 +64,7 @@ class InterpreterRuntime: AllStatic {
   static void    anewarray     (JavaThread* threcurrentad, ConstantPool* pool, int index, jint size);
   static void    multianewarray(JavaThread* current, jint* first_size_address);
   static void    register_finalizer(JavaThread* current, oopDesc* obj);
-  static void    defaultvalue  (JavaThread* current, ConstantPool* pool, int index);
+  static void    aconst_init  (JavaThread* current, ConstantPool* pool, int index);
   static int     withfield     (JavaThread* current, ConstantPoolCacheEntry* cpe, uintptr_t ptr);
   static void    uninitialized_static_inline_type_field(JavaThread* current, oopDesc* mirror, int offset);
   static void    write_heap_copy (JavaThread* current, oopDesc* value, int offset, oopDesc* rcv);

--- a/src/hotspot/share/interpreter/templateTable.cpp
+++ b/src/hotspot/share/interpreter/templateTable.cpp
@@ -437,7 +437,7 @@ void TemplateTable::initialize() {
   def(Bytecodes::_goto_w              , ubcp|____|clvm|____, vtos, vtos, goto_w              ,  _           );
   def(Bytecodes::_jsr_w               , ubcp|____|____|____, vtos, vtos, jsr_w               ,  _           );
   def(Bytecodes::_breakpoint          , ubcp|disp|clvm|____, vtos, vtos, _breakpoint         ,  _           );
-  def(Bytecodes::_defaultvalue        , ubcp|____|clvm|____, vtos, atos, defaultvalue        , _            );
+  def(Bytecodes::_aconst_init         , ubcp|____|clvm|____, vtos, atos, aconst_init        , _            );
   def(Bytecodes::_withfield           , ubcp|____|clvm|____, vtos, atos, withfield           , _            );
 
   // wide Java spec bytecodes

--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -295,7 +295,7 @@ class TemplateTable: AllStatic {
   static void withfield();
 
   static void _new();
-  static void defaultvalue();
+  static void aconst_init();
   static void newarray();
   static void anewarray();
   static void arraylength();

--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1379,7 +1379,7 @@ void GenerateOopMap::interp1(BytecodeStream *itr) {
     case Bytecodes::_new:               ppush1(CellTypeState::make_line_ref(itr->bci()));
                                         break;
 
-    case Bytecodes::_defaultvalue:      ppush1(CellTypeState::make_line_ref(itr->bci())); break;
+    case Bytecodes::_aconst_init:      ppush1(CellTypeState::make_line_ref(itr->bci())); break;
     case Bytecodes::_withfield:         do_withfield(itr->get_index_u2_cpcache(), itr->bci()); break;
 
     case Bytecodes::_iconst_m1:

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -141,6 +141,7 @@ class InlineKlass: public InstanceKlass {
  public:
   // Type testing
   bool is_inline_klass_slow() const        { return true; }
+  bool is_null_free() const { return access_flags().is_primitive_class(); }
 
   // ref and val mirror
   oop ref_mirror() const { return java_mirror(); }

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -519,7 +519,7 @@ class Parse : public GraphKit {
 
   // implementation of object creation bytecodes
   void do_new();
-  void do_defaultvalue();
+  void do_aconst_init();
   void do_withfield();
   void do_newarray(BasicType elemtype);
   void do_newarray();

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -3466,8 +3466,8 @@ void Parse::do_one_bytecode() {
   case Bytecodes::_new:
     do_new();
     break;
-  case Bytecodes::_defaultvalue:
-    do_defaultvalue();
+  case Bytecodes::_aconst_init:
+    do_aconst_init();
     break;
   case Bytecodes::_withfield:
     do_withfield();

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -321,11 +321,11 @@ void Parse::do_new() {
   }
 }
 
-//------------------------------do_defaultvalue---------------------------------
-void Parse::do_defaultvalue() {
+//------------------------------do_aconst_init---------------------------------
+void Parse::do_aconst_init() {
   bool will_link;
   ciInlineKlass* vk = iter().get_klass(will_link)->as_inline_klass();
-  assert(will_link && !iter().is_unresolved_klass(), "defaultvalue: typeflow responsibility");
+  assert(will_link && !iter().is_unresolved_klass(), "aconst_init: typeflow responsibility");
 
   if (C->needs_clinit_barrier(vk, method())) {
     clinit_barrier(vk, method());

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -883,7 +883,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   copy_cpool_bytes(writeable_address(cpool_size()));
 
   // JVMSpec|           u2 access_flags;
-  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_INLINE | JVM_ACC_VALUE));
+  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_PRIMITIVE | JVM_ACC_VALUE));
 
   // JVMSpec|           u2 this_class;
   // JVMSpec|           u2 super_class;

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -2241,7 +2241,7 @@ void VM_RedefineClasses::rewrite_cp_refs_in_method(methodHandle method,
       case Bytecodes::_checkcast      : // fall through
       case Bytecodes::_getfield       : // fall through
       case Bytecodes::_getstatic      : // fall through
-      case Bytecodes::_defaultvalue   : // fall through
+      case Bytecodes::_aconst_init   : // fall through
       case Bytecodes::_withfield      : // fall through
       case Bytecodes::_instanceof     : // fall through
       case Bytecodes::_invokedynamic  : // fall through

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -124,7 +124,8 @@ class AccessFlags {
   bool is_native      () const         { return (_flags & JVM_ACC_NATIVE      ) != 0; }
   bool is_interface   () const         { return (_flags & JVM_ACC_INTERFACE   ) != 0; }
   bool is_abstract    () const         { return (_flags & JVM_ACC_ABSTRACT    ) != 0; }
-  bool is_inline_type () const         { return (_flags & JVM_ACC_INLINE      ) != 0; }
+  bool is_value_class () const         { return (_flags & JVM_ACC_VALUE       ) != 0; }
+  bool is_primitive_class () const     { return (_flags & JVM_ACC_PRIMITIVE   ) != 0; }
 
   // Attribute flags
   bool is_synthetic   () const         { return (_flags & JVM_ACC_SYNTHETIC   ) != 0; }

--- a/src/java.base/share/native/include/classfile_constants.h.template
+++ b/src/java.base/share/native/include/classfile_constants.h.template
@@ -52,7 +52,7 @@ enum {
     JVM_ACC_VALUE         = 0x0100,
     JVM_ACC_INTERFACE     = 0x0200,
     JVM_ACC_ABSTRACT      = 0x0400,
-    JVM_ACC_INLINE        = 0x0800,
+    JVM_ACC_PRIMITIVE     = 0x0800,
     JVM_ACC_STRICT        = 0x0800,
     JVM_ACC_SYNTHETIC     = 0x1000,
     JVM_ACC_ANNOTATION    = 0x2000,

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GetfieldChains.jcod
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GetfieldChains.jcod
@@ -411,7 +411,7 @@ class compiler/valhalla/inlinetypes/PointN {
     Utf8 "Lookup"; // #37
   } // Constant Pool
 
-  0x0831; // access
+  0x0931; // access
   #1;// this_cpx
   #14;// super_cpx
 
@@ -615,7 +615,7 @@ class compiler/valhalla/inlinetypes/RectangleN {
     Utf8 "Lookup"; // #42
   } // Constant Pool
 
-  0x0831; // access
+  0x0931; // access
   #1;// this_cpx
   #20;// super_cpx
 
@@ -819,7 +819,7 @@ class compiler/valhalla/inlinetypes/RectangleP {
     Utf8 "Lookup"; // #42
   } // Constant Pool
 
-  0x0831; // access
+  0x0931; // access
   #1;// this_cpx
   #20;// super_cpx
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HiddenPoint.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HiddenPoint.jcod
@@ -139,7 +139,7 @@ class HiddenPoint {
     Utf8 "Lookup"; // #59     at 0x03D4
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_SUPER ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #26;// super_cpx
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WithFieldNoAccessTest.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WithFieldNoAccessTest.jcod
@@ -155,7 +155,7 @@ class WithFieldNoAccessTest$V {
     Utf8 "java/lang/invoke/MethodHandles"; // #57     at 0x0340
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #8;// super_cpx
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadACCValue.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadACCValue.java
@@ -46,6 +46,6 @@ public class BadACCValue {
 
         // Test ACC_PRIMITIVE causes a CFE unless -XX:+EnableValhalla is specified.
         runTest("ValueFieldNotFinal",
-                "Class modifier ACC_INLINE in class ValueFieldNotFinal requires option -XX:+EnableValhalla");
+                "Class modifier ACC_PRIMITIVE in class ValueFieldNotFinal requires option -XX:+EnableValhalla");
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
@@ -236,7 +236,7 @@ class ValueEnum {
     Utf8 "java/lang/Object"; // #27     at 0xD3
   } // Constant Pool
 
-  0x04830; // access [  ACC_PRIMITIVE ACC_ENUM(bad) ACC_SUPER ACC_FINAL ]
+  0x04930; // access [  ACC_VALUE ACC_PRIMITIVE ACC_ENUM(bad) ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -392,7 +392,7 @@ class ValueFieldNotFinal {
     Utf8 "java/lang/Object"; // #27     at 0xD3
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -673,7 +673,7 @@ class ValueMethodSynch {
     Utf8 "java/lang/invoke/MethodHandles"; // #45     at 0x02B6
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #6;// super_cpx
 
@@ -943,7 +943,7 @@ class Circ {
     Utf8 "java/lang/invoke/MethodHandles"; // #60     at 0x02D1
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #11;// super_cpx
 
@@ -1221,7 +1221,7 @@ class Circ2 {
     Utf8 "java/lang/invoke/MethodHandles"; // #59     at 0x02D4
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #10;// super_cpx
 
@@ -1536,7 +1536,7 @@ class CircStaticA {
     Utf8 "java/lang/invoke/MethodHandles"; // #60     at 0x031C
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #11;// super_cpx
 
@@ -1814,7 +1814,7 @@ class CircStaticB {
     Utf8 "java/lang/invoke/MethodHandles"; // #60     at 0x031C
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #11;// super_cpx
 
@@ -2086,7 +2086,7 @@ class ValueCloneable {
     Utf8 "java/lang/invoke/MethodHandles"; // #45     at 0x02B3
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #6;// super_cpx
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/testSupers/InlineClassWithBadSupers.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/testSupers/InlineClassWithBadSupers.jcod
@@ -94,7 +94,7 @@ class SuperNotAbstract {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -354,7 +354,7 @@ class SuperHasNonStaticFields {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -614,7 +614,7 @@ class SuperHasSynchMethod {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -873,7 +873,7 @@ class SuperCtorHasArgs {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -1134,7 +1134,7 @@ class SuperCtorIsNotEmpty {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -1396,7 +1396,7 @@ class InlineImplementsIdentityObject {
     Utf8 "Lookup"; // #52     at 0x032A
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -1658,7 +1658,7 @@ class SuperImplementsIdentityObject {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 
@@ -1918,7 +1918,7 @@ class SuperIntfImplementsIdentityObject {
     Utf8 "Lookup"; // #50     at 0x02ED
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #22;// super_cpx
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java
@@ -68,7 +68,7 @@ public class VerifierInlineTypes {
 
         // Test that ClassFormatError is thrown for a class file, with major version 54, that
         // contains a defaultvalue opcode.
-        runTestFormatError("defValBadMajorVersion", "defaultvalue not supported by this class file version");
+        runTestFormatError("defValBadMajorVersion", "aconst_init not supported by this class file version");
 
         // Test VerifyError is thrown if a defaultvalue's cp entry is not a class.
         runTestVerifyError("defValWrongCPType", "Illegal type at constant pool entry");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/verifierTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/verifierTests.jcod
@@ -91,7 +91,7 @@ class defValBadCP {
     Utf8 "java/lang/Object"; // #26     at 0xC6
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -192,7 +192,7 @@ class defValBadMajorVersion {
     Utf8 "java/lang/Object"; // #26     at 0xC6
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -255,7 +255,7 @@ class defValBadMajorVersion {
 
 ///////////////////////////////////////////////////////////
 
-// The constant pool index of a defaultvalue opcode (0xCB) in the Code
+// The constant pool index of a aconst_init opcode (0xCB) in the Code
 // attribute was changed to 2.  Since this index now points to a Field
 // entry instead of a Class entry, a VerifyError exception should get thrown.
 //
@@ -293,7 +293,7 @@ class defValWrongCPType {
     Utf8 "java/lang/Object"; // #26     at 0xC6
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -387,7 +387,7 @@ class wthFldBadCP {
     Utf8 "java/lang/Object"; // #19     at 0xB8
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #4;// super_cpx
 
@@ -478,7 +478,7 @@ class wthFldBadFldVal {
     Utf8 "java/lang/Object"; // #19     at 0xB8
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #4;// super_cpx
 
@@ -568,7 +568,7 @@ class wthFldBadFldRef {
     Utf8 "java/lang/Object"; // #19     at 0xB8
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #4;// super_cpx
 
@@ -666,7 +666,7 @@ class wthFldBadMajorVersion {
     Utf8 "java/lang/Object"; // #26     at 0xC6
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #7;// super_cpx
 
@@ -760,7 +760,7 @@ class wthFldWrongCPType {
     Utf8 "java/lang/Object"; // #19     at 0xB8
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #3;// this_cpx
   #4;// super_cpx
 
@@ -877,7 +877,7 @@ class defValueObj {
     Utf8 "java/lang/invoke/MethodHandles"; // #45     at 0x02A5
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #6;// super_cpx
 
@@ -1083,7 +1083,7 @@ class withfieldL {
     Utf8 "Point"; // #27     at 0xE2
   } // Constant Pool
 
-  0x0830; // access [ ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0930; // access [ ACC_VALUE ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #13;// super_cpx
 
@@ -1300,7 +1300,7 @@ class NoNullVT {
     Utf8 "java/lang/invoke/MethodHandles"; // #62     at 0x030D
   } // Constant Pool
 
-  0x0831; // access [ ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0931; // access [ ACC_VALUE ACC_PRIMITIVE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
   #11;// super_cpx
 


### PR DESCRIPTION
Please review this patch that enables loading of value classes.
Support for value classes is minimal, but this is the first step to implement them.
The patch also includes some renaming to align Hotspot code with the JVMS draft.

Tested with Mach5, tiers 1-3 (so it builds on all platforms)

Thank you,

Fred