### PR TITLE
8280440: [lworld] Scalarization does not properly handle speculative types

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -750,12 +750,6 @@ void Parse::do_call() {
              "mismatched return types: rtype=%s, ctype=%s", rtype->name(), ctype->name());
     }
 
-    if (rtype->basic_type() == T_INLINE_TYPE && !peek()->is_InlineType() && !gvn().type(peek())->maybe_null()) {
-      Node* retnode = pop();
-      retnode = InlineTypeNode::make_from_oop(this, retnode, rtype->as_inline_klass());
-      push_node(T_INLINE_TYPE, retnode);
-    }
-
     // If the return type of the method is not loaded, assert that the
     // value we got is a null.  Otherwise, we need to recompile.
     if (!rtype->is_loaded()) {
@@ -775,6 +769,11 @@ void Parse::do_call() {
     BasicType ct = ctype->basic_type();
     if (is_reference_type(ct)) {
       record_profiled_return_for_speculation();
+    }
+    if (rtype->basic_type() == T_INLINE_TYPE && !peek()->is_InlineTypeBase()) {
+      Node* retnode = pop();
+      retnode = InlineTypeNode::make_from_oop(this, retnode, rtype->as_inline_klass(), !gvn().type(retnode)->maybe_null());
+      push_node(T_INLINE_TYPE, retnode);
     }
   }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -738,6 +738,9 @@ Node* InlineTypeNode::make_from_oop(GraphKit* kit, Node* oop, ciInlineKlass* vk,
 
       vt = vt->clone_with_phis(&gvn, region);
       vt->merge_with(&gvn, null_vt, 2, true);
+      if (!null_free) {
+        vt->set_oop(oop);
+      }
       kit->set_control(gvn.transform(region));
     }
   } else {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -602,15 +602,15 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   }
 
   // Handle inline type arguments
-  int arg_size_sig = tf()->domain_sig()->cnt();
-  for (uint i = 0; i < (uint)arg_size_sig; i++) {
-    Node* parm = map()->in(i);
+  int arg_size = method()->arg_size();
+  for (int i = 0; i < arg_size; i++) {
+    Node* parm = local(i);
     const Type* t = _gvn.type(parm);
     if (t->is_inlinetypeptr()) {
       // Create InlineTypeNode from the oop and replace the parameter
       Node* vt = InlineTypeNode::make_from_oop(this, parm, t->inline_klass(), !t->maybe_null());
-      map()->replace_edge(parm, vt);
-    } else if (UseTypeSpeculation && (i == (uint)(arg_size_sig - 1)) && !is_osr_parse() &&
+      set_local(i, vt);
+    } else if (UseTypeSpeculation && (i == (arg_size - 1)) && !is_osr_parse() &&
                method()->has_vararg() && t->isa_aryptr() != NULL && !t->is_aryptr()->is_not_null_free()) {
       // Speculate on varargs Object array being not null-free (and therefore also not flattened)
       const TypePtr* spec_type = t->speculative();
@@ -618,7 +618,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
       spec_type = spec_type->remove_speculative()->is_aryptr()->cast_to_not_null_free();
       spec_type = TypeOopPtr::make(TypePtr::BotPTR, Type::Offset::bottom, TypeOopPtr::InstanceBot, spec_type);
       Node* cast = _gvn.transform(new CheckCastPPNode(control(), parm, t->join_speculative(spec_type)));
-      replace_in_map(parm, cast);
+      set_local(i, cast);
     }
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -148,5 +148,6 @@ public class InlineTypes {
         protected static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
         protected static final String FIELD_ACCESS = "(.*Field: *" + END;
         protected static final String SUBSTITUTABILITY_TEST = START + "CallStaticJava" + MID + "java.lang.runtime.PrimitiveObjectMethods::isSubstitutable" + END;
+        protected static final String CMPP = START + "(CmpP|CmpN)" + MID + "" + END;
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -182,7 +182,7 @@ public class TestNullableInlineTypes {
     @Run(test = "test5")
     public void test5_verifier() {
         MyValue1.ref vt = test5(nullField);
-        Asserts.assertEquals((Object)vt, null);
+        Asserts.assertEquals(vt, null);
     }
 
     @DontInline
@@ -477,7 +477,7 @@ public class TestNullableInlineTypes {
 
     @DontInline
     public boolean test16_dontinline(MyValue1.ref vt) {
-        return (Object)vt == null;
+        return vt == null;
     }
 
     // Test c2c call passing null for an inline type
@@ -2468,5 +2468,51 @@ public class TestNullableInlineTypes {
         } catch (ClassCastException e) {
             // Expected
         }
+    }
+
+    @ForceInline
+    public boolean test90_inline(MyValue1.ref vt) {
+        return vt == null;
+    }
+
+    // Test scalarization with speculative NULL type
+    @Test
+    @IR(failOn = {ALLOC})
+    public boolean test90(Method m) throws Exception {
+        Object arg = null;
+        return (boolean)m.invoke(this, arg);
+    }
+
+    @Run(test = "test90")
+    @Warmup(10000)
+    public void test90_verifier() throws Exception {
+        Method m = getClass().getMethod("test90_inline", MyValue1.ref.class);
+        Asserts.assertTrue(test90(m));
+    }
+
+    // Test that scalarization does not introduce redundant/unused checks
+    @Test
+    @IR(failOn = {ALLOC, CMPP})
+    public Object test91(MyValue1.ref vt) {
+        return vt;
+    }
+
+    @Run(test = "test91")
+    public void test91_verifier() {
+        Asserts.assertEQ(test91(testValue1), testValue1);
+    }
+
+    MyValue1.ref test92Field = testValue1;
+
+    // Same as test91 but with field access
+    @Test
+    @IR(failOn = {ALLOC, CMPP})
+    public Object test92() {
+        return test92Field;
+    }
+
+    @Run(test = "test92")
+    public void test92_verifier() {
+        Asserts.assertEQ(test92(), testValue1);
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithSpeculativeTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithSpeculativeTypes.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8280440
+ * @summary Test that speculative types are properly handled by scalarization.
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=dontinline,TestWithSpeculativeTypes::*
+ *                   -XX:TypeProfileLevel=222 -XX:-TieredCompilation -Xbatch
+ *                   TestWithSpeculativeTypes
+ */
+
+import jdk.test.lib.Asserts;
+
+public class TestWithSpeculativeTypes {
+
+    static primitive class MyValue {
+        int x = 0;
+    }
+
+    static MyValue.ref getNull() {
+        return null;
+    }
+
+    // Return value has speculative type NULL
+    static boolean test1() {
+        return getNull() == null;
+    }
+
+    // Argument has speculative type NULL
+    static boolean test2(MyValue.ref vt) {
+        return vt == null;
+    }
+
+    public static void main(String[] args) {
+        // Make sure class is loaded
+        MyValue val = new MyValue();
+        for (int i = 0; i < 100_000; ++i) {
+            Asserts.assertTrue(test1());
+            Asserts.assertTrue(test2(null));
+        }
+    }
+}


### PR DESCRIPTION
This patch fixes several issues with handling speculative types in combination with scalarization in C2 (wrong results and asserts). I added tests that cover all cases.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280440](https://bugs.openjdk.java.net/browse/JDK-8280440): [lworld] Scalarization does not properly handle speculative types


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/610/head:pull/610` \
`$ git checkout pull/610`

Update a local copy of the PR: \
`$ git checkout pull/610` \
`$ git pull https://git.openjdk.java.net/valhalla pull/610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 610`

View PR using the GUI difftool: \
`$ git pr show -t 610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/610.diff">https://git.openjdk.java.net/valhalla/pull/610.diff</a>

</details>
