### PR TITLE
8280270: [lworld] JITs miss some klass initialization checks for defaultvalue

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1950,12 +1950,12 @@ InlineTypeBaseNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can
       n = phase->transform(n->as_Phi()->push_inline_types_through(phase, can_reshape, vk, is_init));
     }
     while (casts.size() != 0) {
-      // Update the cast input and let ConstraintCastNode::Ideal push it through the InlineTypePtrNode
-      Node* cast = casts.pop();
-      phase->hash_delete(cast);
-      cast->set_req(1, n);
-      n = phase->transform(cast);
-      assert(n->is_InlineTypePtr(), "Failed to push cast through InlineTypePtr");
+      // Push the cast(s) through the InlineTypePtrNode
+      Node* cast = casts.pop()->clone();
+      cast->set_req(1, n->as_InlineTypePtr()->get_oop());
+      n = n->clone();
+      n->as_InlineTypePtr()->set_oop(phase->transform(cast));
+      n = phase->transform(n);
     }
     bool transform = !can_reshape && (i == (req()-1)); // Transform phis on last merge
     vt->merge_with(phase, n->as_InlineTypeBase(), i, transform);

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -610,7 +610,7 @@ Node* InlineTypeBaseNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
 InlineTypeNode* InlineTypeNode::make_uninitialized(PhaseGVN& gvn, ciInlineKlass* vk) {
   // Create a new InlineTypeNode with uninitialized values and NULL oop
-  Node* oop = vk->is_empty() ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
+  Node* oop = (vk->is_empty() && vk->is_initialized()) ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
   InlineTypeNode* vt = new InlineTypeNode(vk, oop);
   vt->set_is_init(gvn);
   return vt;
@@ -623,7 +623,8 @@ Node* InlineTypeBaseNode::default_oop(PhaseGVN& gvn, ciInlineKlass* vk) {
 
 InlineTypeNode* InlineTypeNode::make_default(PhaseGVN& gvn, ciInlineKlass* vk) {
   // Create a new InlineTypeNode with default values
-  InlineTypeNode* vt = new InlineTypeNode(vk, default_oop(gvn, vk));
+  Node* oop = vk->is_initialized() ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
+  InlineTypeNode* vt = new InlineTypeNode(vk, oop);
   vt->set_is_init(gvn);
   for (uint i = 0; i < vt->field_count(); ++i) {
     ciType* field_type = vt->field_type(i);
@@ -978,7 +979,8 @@ static void replace_allocation(PhaseIterGVN* igvn, Node* res, Node* dom) {
 
 Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   Node* oop = get_oop();
-  if (is_default(phase) && (!oop->is_Con() || phase->type(oop)->is_zero_type())) {
+  if (is_default(phase) && inline_klass()->is_initialized() &&
+      (!oop->is_Con() || phase->type(oop)->is_zero_type())) {
     // Use the pre-allocated oop for default inline types
     set_oop(default_oop(*phase, inline_klass()));
     assert(is_allocated(phase), "should now be allocated");

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -834,7 +834,7 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
   if (vk == NULL) {
     vk = inline_klass();
   }
-  if (field_count() == 0) {
+  if (field_count() == 0 && vk->is_initialized()) {
     assert(is_allocated(phase), "must be allocated");
     return get_oop();
   }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1219,6 +1219,7 @@ public class TestCallingConvention {
     }
 
     @Run(test = "test54")
+    @Warmup(10000)
     public void test54_verifier(RunInfo info) throws Throwable {
         Asserts.assertEQ(test54(info.getTest(), true, false), -1L);
         Asserts.assertEQ(test54(info.getTest(), false, false), -1L);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,8 @@ public class TestIntrinsics {
         Scenario[] scenarios = InlineTypes.DEFAULT_SCENARIOS;
         for (Scenario scenario: scenarios) {
             scenario.addFlags("--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+            // Don't run with DeoptimizeALot until JDK-8239003 is fixed
+            scenario.addFlags("-XX:-DeoptimizeALot");
         }
         scenarios[3].addFlags("-XX:-MonomorphicArrayCheck", "-XX:FlatArrayElementMaxSize=-1");
         scenarios[4].addFlags("-XX:-MonomorphicArrayCheck", "-XX:+UnlockExperimentalVMOptions", "-XX:PerMethodSpecTrapLimit=0", "-XX:PerMethodTrapLimit=0");


### PR DESCRIPTION
C1 and C2 miss some klass initialization checks for defaultvalue.

Long term, we should add support for patching defaultvalue in C1 (tracked by [JDK-8265067](https://bugs.openjdk.java.net/browse/JDK-8265067)).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280270](https://bugs.openjdk.java.net/browse/JDK-8280270): [lworld] JITs miss some klass initialization checks for defaultvalue


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer) ⚠️ Review applies to 8d7b2c2e802c1d3cdfb872e5c404e805fa6b63f2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/611/head:pull/611` \
`$ git checkout pull/611`

Update a local copy of the PR: \
`$ git checkout pull/611` \
`$ git pull https://git.openjdk.java.net/valhalla pull/611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 611`

View PR using the GUI difftool: \
`$ git pr show -t 611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/611.diff">https://git.openjdk.java.net/valhalla/pull/611.diff</a>

</details>
