### PR TITLE
8279655: [lworld] Bogus error: incompatible types: Object cannot be converted to Foo

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1737,7 +1737,7 @@ public class Types {
     }
     // where
         private boolean areDisjoint(ClassSymbol ts, ClassSymbol ss) {
-            if (isSubtype(erasure(ts.type), erasure(ss.type))) {
+            if (isSubtype(erasure(ts.type.referenceProjectionOrSelf()), erasure(ss.type))) {
                 return false;
             }
             // if both are classes or both are interfaces, shortcut

--- a/test/langtools/tools/javac/valhalla/lworld-values/T8279655.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/T8279655.java
@@ -1,0 +1,18 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279655
+ * @summary Bogus error: incompatible types: Object cannot be converted to Foo
+ * @compile T8279655.java
+ */
+
+public class T8279655 {
+
+    sealed interface Foo permits Bar { }
+    primitive class Bar implements Foo { }
+
+    class Test {
+        void test(Object o) {
+            Foo foo = (Foo)o;
+        }
+    }
+}


### PR DESCRIPTION
Use of `referenceProjectionOrSelf` in the subtype check of the `areDisjoint` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279655](https://bugs.openjdk.java.net/browse/JDK-8279655): [lworld] Bogus error: incompatible types: Object cannot be converted to Foo


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/612/head:pull/612` \
`$ git checkout pull/612`

Update a local copy of the PR: \
`$ git checkout pull/612` \
`$ git pull https://git.openjdk.java.net/valhalla pull/612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 612`

View PR using the GUI difftool: \
`$ git pr show -t 612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/612.diff">https://git.openjdk.java.net/valhalla/pull/612.diff</a>

</details>
