### PR TITLE
8280519: Revert fix for JDK-8212175 as it is not relevant anymore

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2344,8 +2344,7 @@ public class Check {
         // or by virtue of being a member of a diamond inferred anonymous class. Latter case is to
         // be treated "as if as they were annotated" with @Override.
         boolean mustOverride = explicitOverride ||
-                (env.info.isAnonymousDiamond && !m.isConstructor() && !m.isPrivate() &&
-                        (!m.owner.isPrimitiveClass() || (tree.body.flags & SYNTHETIC) == 0));
+                (env.info.isAnonymousDiamond && !m.isConstructor() && !m.isPrivate());
         if (mustOverride && !isOverrider(m)) {
             DiagnosticPosition pos = tree.pos();
             for (JCAnnotation a : tree.getModifiers().annotations) {


### PR DESCRIPTION
Revert fix for JDK-8212175 as it is not relevant anymore

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280519](https://bugs.openjdk.java.net/browse/JDK-8280519): Revert fix for JDK-8212175 as it is not relevant anymore


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/615/head:pull/615` \
`$ git checkout pull/615`

Update a local copy of the PR: \
`$ git checkout pull/615` \
`$ git pull https://git.openjdk.java.net/valhalla pull/615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 615`

View PR using the GUI difftool: \
`$ git pr show -t 615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/615.diff">https://git.openjdk.java.net/valhalla/pull/615.diff</a>

</details>
