### PR TITLE
8280456: [lworld] javac should allow compilation with abstract java.lang.Object class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2887,7 +2887,7 @@ public class Attr extends JCTree.Visitor {
             }
             // Check that class is not abstract
             if (cdef == null && !isSpeculativeDiamondInferenceRound && // class body may be nulled out in speculative tree copy
-                (clazztype.tsym.flags() & (ABSTRACT | INTERFACE)) != 0) {
+                (clazztype.tsym.flags() & (ABSTRACT | INTERFACE)) != 0 && clazztype.tsym != syms.objectType.tsym) { // tolerate abstract Object
                 log.error(tree.pos(),
                           Errors.AbstractCantBeInstantiated(clazztype.tsym));
                 skipNonDiamondPath = true;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -516,6 +516,11 @@ public class LambdaToMethod extends TreeTranslator {
         List<JCExpression> indy_args = init==null? List.nil() : translate(List.of(init), localContext.prev);
 
 
+        if (refSym.isConstructor() && tree.expr.type.tsym == syms.objectType.tsym) {
+            if (tree.mode == ReferenceMode.NEW && tree.kind == ReferenceKind.TOPLEVEL) {
+                refSym = rs.resolveInternalMethod(tree, attrEnv, syms.objectsType, names.newIdentity, List.nil(), List.nil());
+            }
+        }
         //build a sam instance using an indy call to the meta-factory
         result = makeMetafactoryIndyCall(localContext, refSym.asHandle(), indy_args);
     }

--- a/test/langtools/tools/javac/valhalla/value-objects/ObjectInstantiationTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ObjectInstantiationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8280456
+ * @summary javac should allow compilation with abstract java.lang.Object class
+ * @compile/ref=ObjectInstantiationTest.out -XDrawDiagnostics ObjectInstantiationTest.java
+ * @run main ObjectInstantiationTest
+ */
+
+public class ObjectInstantiationTest {
+
+    interface I {
+        Object getObject();
+    }
+
+    public static void main(String [] args) {
+
+        Object o1 = java.util.Objects.newIdentity();
+        Object o2 = new Object();
+        Object o3 = foo(Object::new);
+
+        if (o1.getClass() != o2.getClass())
+            throw new AssertionError("Unexpected class identity");
+        if (o2.getClass() != o3.getClass())
+            throw new AssertionError("Unexpected class identity");
+    }
+
+    static Object foo(I i) {
+        return i.getObject();
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/ObjectInstantiationTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/ObjectInstantiationTest.out
@@ -1,0 +1,2 @@
+ObjectInstantiationTest.java:41:21: compiler.note.cant.instantiate.object.directly
+ObjectInstantiationTest.java:42:25: compiler.note.cant.instantiate.object.directly


### PR DESCRIPTION
- Warn on attempt to instantiate Object
    - If j.l.O is seen as abstract, don't complain about abstract class instantiation
    - Reroute instantiation to calls of java.util.Objects.newIdentity
    - Extend treatment to both constructor invocations and constructor references.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280456](https://bugs.openjdk.java.net/browse/JDK-8280456): [lworld] javac should allow compilation with abstract java.lang.Object class


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/616/head:pull/616` \
`$ git checkout pull/616`

Update a local copy of the PR: \
`$ git checkout pull/616` \
`$ git pull https://git.openjdk.java.net/valhalla pull/616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 616`

View PR using the GUI difftool: \
`$ git pr show -t 616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/616.diff">https://git.openjdk.java.net/valhalla/pull/616.diff</a>

</details>
