### PR TITLE
8280524: [lworld] Interpreter incorrectly handles uninitialized static inline type field

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3008,9 +3008,10 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
             __ andl(flags2, ConstantPoolCacheEntry::field_index_mask);
   #ifdef _LP64
             Label slow_case, finish;
-            __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
+            __ movptr(rbx, Address(obj, java_lang_Class::klass_offset()));
+            __ cmpb(Address(rbx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
             __ jcc(Assembler::notEqual, slow_case);
-          __ get_default_value_oop(rcx, off, rax);
+          __ get_default_value_oop(rbx, rscratch1, rax);
           __ jmp(finish);
           __ bind(slow_case);
   #endif // LP64

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -392,7 +392,7 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_inline_type_field(JavaT
   //       another class which accesses this field in its static initializer, in this case the
   //       access must succeed to allow circularity
   // The code below tries to load and initialize the field's class again before returning the default value.
-  // If the field was not initialized because of an error, a exception should be thrown.
+  // If the field was not initialized because of an error, an exception should be thrown.
   // If the class is being initialized, the default value is returned.
   instanceHandle mirror_h(THREAD, (instanceOop)mirror);
   InstanceKlass* klass = InstanceKlass::cast(java_lang_Class::as_Klass(mirror));
@@ -410,10 +410,10 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_inline_type_field(JavaT
     }
     field_k->initialize(CHECK);
     oop defaultvalue = InlineKlass::cast(field_k)->default_value();
-    // It is safe to initialized the static field because 1) the current thread is the initializing thread
+    // It is safe to initialize the static field because 1) the current thread is the initializing thread
     // and is the only one that can access it, and 2) the field is actually not initialized (i.e. null)
     // otherwise the JVM should not be executing this code.
-    mirror->obj_field_put(offset, defaultvalue);
+    mirror_h()->obj_field_put(offset, defaultvalue);
     current->set_vm_result(defaultvalue);
   } else {
     assert(klass->is_in_error_state(), "If not initializing, initialization must have failed to get there");


### PR DESCRIPTION
Code in the interpreter that's supposed to check if the type of a static, null-free inline type field is initialized assumes that `rcx` contains the `InlineKlass*`. However, `rcx` is only initialized for non-static fields:
https://github.com/openjdk/valhalla/blob/ba87b167f2fe2327508a06ec8652c6ddaa9402c1/src/hotspot/cpu/x86/templateTable_x86.cpp#L2939-L2943

As a result, the check spuriously fails, leading to an "impossible" NPE because the null value is not replaced by the default value. This patch also fixes an unrelated issue where an `instanceHandle` should be used instead of an `instanceOop`.

I found this with compiler stress testing and initially assumed that it is a compiler bug. The patch was contributed by @fparain.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280524](https://bugs.openjdk.java.net/browse/JDK-8280524): [lworld] Interpreter incorrectly handles uninitialized static inline type field


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Contributors
 * Frederic Parain `<fparain@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/617/head:pull/617` \
`$ git checkout pull/617`

Update a local copy of the PR: \
`$ git checkout pull/617` \
`$ git pull https://git.openjdk.java.net/valhalla pull/617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 617`

View PR using the GUI difftool: \
`$ git pr show -t 617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/617.diff">https://git.openjdk.java.net/valhalla/pull/617.diff</a>

</details>
