### PR TITLE
8280704: [lworld] Rename defaultvalue to aconst_init in tests

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -536,7 +536,7 @@ public class TestBasicFunctionality {
         Asserts.assertEQ(result, val5.hash() + val5.v3.hash());
     }
 
-    // Test defaultvalue
+    // Test aconst_init
     @Test
     @IR(failOn = {ALLOC, LOAD, STORE, LOOP, TRAP})
     public long test23() {
@@ -550,7 +550,7 @@ public class TestBasicFunctionality {
         Asserts.assertEQ(result, MyValue2.createDefaultInline().hash());
     }
 
-    // Test defaultvalue
+    // Test aconst_init
     @Test
     @IR(failOn = {ALLOC, STORE, LOOP, TRAP})
     public long test24() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -721,7 +721,7 @@ public class TestUnloadedInlineTypeField {
     }
 
     // Test case 16:
-    // Defaultvalue with type which is not an inline type
+    // aconst_init with type which is not an inline type
     static final class MyValue16 {
         final int foo;
 
@@ -757,7 +757,7 @@ public class TestUnloadedInlineTypeField {
     }
 
     // Test case 17:
-    // Same as test16 but with unloaded type at defaultvalue
+    // Same as test16 but with unloaded type at aconst_init
     static final class MyValue17 {
         final int foo;
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedDefault.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedDefault.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8247309
- * @summary Test correct handling of defaultvalue bytecode with unresolved inline class.
+ * @summary Test correct handling of aconst_init bytecode with unresolved inline class.
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestUnresolvedDefault::test TestUnresolvedDefault
  */
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/CreationErrorTest.java
@@ -91,20 +91,20 @@ public class CreationErrorTest {
 
     }
 
-    // Note: this test might become obsolete if defaultvalue is extended to accept identity classes
+    // Note: this test might become obsolete if aconst_init is extended to accept identity classes
     static void testErroneousValueCreation() {
-        MethodHandle testDefaultvalueOnIdentityClass = InstructionHelper.loadCode(
+        MethodHandle testAconstInitOnIdentityClass = InstructionHelper.loadCode(
                 LOOKUP,
-                "testDefaultValueOnIdentityClass",
+                "testAconstInitOnIdentityClass",
                 MethodType.methodType(boolean.class),
                 CODE -> {
-                    CODE.defaultvalue(IdentityClass.class)
+                    CODE.aconst_init(IdentityClass.class)
                         .iconst_1()
                         .return_(TypeTag.Z);
                 });
         Throwable error = null;
         try {
-            boolean result = (boolean) testDefaultvalueOnIdentityClass.invokeExact();
+            boolean result = (boolean) testAconstInitOnIdentityClass.invokeExact();
         } catch (Throwable t) {
             error = t;
         }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -279,7 +279,7 @@ public class InlineOops {
     }
 
     /**
-     * Just some check sanity checks with defaultvalue, withfield, astore and aload
+     * Just some check sanity checks with aconst_init, withfield, astore and aload
      *
      * Changes to javac slot usage may well break this test
      */
@@ -585,7 +585,7 @@ public class InlineOops {
                         LOOKUP, "exerciseVBytecodeExprStackWithDefault", mt,
                         CODE->{
                             CODE
-                            .defaultvalue(FooValue.class.asValueType())
+                            .aconst_init(FooValue.class.asValueType())
                             .aload(oopMapsSlot)
                             .iconst_0()  // Test-D0 Slots=R Stack=Q(RRR)RV
                             .invokestatic(InlineOops.class, GET_OOP_MAP_NAME, GET_OOP_MAP_DESC, false)
@@ -595,7 +595,7 @@ public class InlineOops {
                             .iconst_1()  // Test-D1 Slots=R Stack=RV
                             .invokestatic(InlineOops.class, GET_OOP_MAP_NAME, GET_OOP_MAP_DESC, false)
                             .aastore()
-                            .defaultvalue(FooValue.class.asValueType())
+                            .aconst_init(FooValue.class.asValueType())
                             .astore(vtSlot)
                             .aload(oopMapsSlot)
                             .iconst_2()  // Test-D2 Slots=RQ(RRR) Stack=RV

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
@@ -246,7 +246,7 @@ public class InlineTypesTest {
                     .iinc(3, 1)
                     .aload_2()
                     .iload_3()
-                    .defaultvalue(inlineClass)
+                    .aconst_init(inlineClass)
                     .aastore()
                     .iinc(3, 1)
                     .goto_("loop1")

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestBytecodeLib.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestBytecodeLib.java
@@ -93,7 +93,7 @@ public class TestBytecodeLib {
         byte[] codeBytes = InstructionHelper.buildCode(LOOKUP, methodName, methodType,
             CODE -> {
                 CODE
-                .defaultvalue(Point.class)
+                .aconst_init(Point.class)
                 .checkcast(lClass) // expect no descriptor here
                 .checkcast(qClass) // expect Q-type descriptor here
                 .pop()

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java
@@ -63,14 +63,14 @@ public class VerifierInlineTypes {
 
     public static void main(String[] args) throws Exception {
 
-        // Test that a defaultvalue opcode with an out of bounds cp index causes a VerifyError.
+        // Test that a aconst_init opcode with an out of bounds cp index causes a VerifyError.
         runTestVerifyError("defValBadCP", "Illegal constant pool index");
 
         // Test that ClassFormatError is thrown for a class file, with major version 54, that
-        // contains a defaultvalue opcode.
+        // contains a aconst_init opcode.
         runTestFormatError("defValBadMajorVersion", "aconst_init not supported by this class file version");
 
-        // Test VerifyError is thrown if a defaultvalue's cp entry is not a class.
+        // Test VerifyError is thrown if a aconst_init's cp entry is not a class.
         runTestVerifyError("defValWrongCPType", "Illegal type at constant pool entry");
 
         // Test that a withfield opcode with an out of bounds cp index causes a VerifyError.
@@ -90,7 +90,7 @@ public class VerifierInlineTypes {
         // Test VerifyError is thrown if a withfields's cp entry is not a field.
         runTestVerifyError("wthFldWrongCPType", "Illegal type at constant pool entry");
 
-        // Test VerifyError is thrown if a defaultvalue's cp entry is not an inline type.
+        // Test VerifyError is thrown if a aconst_init's cp entry is not an inline type.
         runTestVerifyError("defValueObj", "Illegal type at constant pool entry 4");
 
         // Test that the verifier doesn't require that a withfield bytecode has a Q type operand.

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/verifierTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/verifierTests.jcod
@@ -43,7 +43,7 @@
 //  static Value makeValue(int); descriptor: (I)LValue; flags: (0x0008) ACC_STATIC
 //    Code:
 //      stack=2, locals=2, args_size=1
-//         0: defaultvalue  #3                  // class Value
+//         0: aconst_init   #3                  // class Value
 //         3: astore_1
 //         4: aload_1
 //         5: iload_0
@@ -53,7 +53,7 @@
 //        11: areturn
 
 
-// The constant pool index of the defaultvalue opcode (0xCB) in the Code
+// The constant pool index of the aconst_init opcode (0xCB) in the Code
 // attribute was changed to 0x93.  Since this index is outside the range of
 // the constant pool, a VerifyError exception should get thrown.
 //
@@ -126,7 +126,7 @@ class defValBadCP {
           2; // max_stack
           2; // max_locals
           Bytes[12]{
-            0xCB00934C2B1ACC00; // Changed CP index from 3 to 0x93 for opcode 0xCB (defaultvalue)
+            0xCB00934C2B1ACC00; // Changed CP index from 3 to 0x93 for opcode 0xCB (aconst_init)
             0x024C2BB0;         // so that the index is outside of the range of the constant pool.
           };
           [0] { // Traps
@@ -155,7 +155,7 @@ class defValBadCP {
 ///////////////////////////////////////////////////////////
 
 // The class's major version was changed to 54.  Since this class has a
-// defaultvalue opcode (0xCB), this should cause a ClassFormatError
+// aconst_init opcode (0xCB), this should cause a ClassFormatError
 // exception to get thrown.
 //
 class defValBadMajorVersion {
@@ -328,7 +328,7 @@ class defValWrongCPType {
           2; // max_stack
           2; // max_locals
           Bytes[12]{
-            0xCB00024C2B1ACC00; // Changed CP index from 3 to 2 for opcode 0xCB (defaultvalue)
+            0xCB00024C2B1ACC00; // Changed CP index from 3 to 2 for opcode 0xCB (aconst_init)
             0x024C2BB0;         // so that the cp index no longer points to a cp Class entry.
           };
           [0] { // Traps
@@ -819,9 +819,9 @@ class wthFldWrongCPType {
 
 ///////////////////////////////////////////////////////////
 
-// The cp entry for the defaultvalue opcode was changed to a reference that
+// The cp entry for the aconst_init opcode was changed to a reference that
 // is not an inline type.
-// This should cause a VerifyError because the cp entry for opcode defaultvalue
+// This should cause a VerifyError because the cp entry for opcode aconst_init
 // must be an inline type.
 //
 class defValueObj {
@@ -904,7 +904,7 @@ class defValueObj {
           2; // max_stack
           2; // max_locals
           Bytes[13]{
-            0xCB00044C1A2B5FCC; // Changed defaultvalue's cp index at byte 3 from 3 to 4.
+            0xCB00044C1A2B5FCC; // Changed aconst_init's cp index at byte 3 from 3 to 4.
             0x00024C2BB0;
           };
           [0] { // Traps

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/CodeBuilder.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/CodeBuilder.java
@@ -155,8 +155,8 @@ public class CodeBuilder<S, T, E, C extends CodeBuilder<S, T, E, C>> extends Att
         return thisBuilder();
     }
 
-    public C defaultvalue(S clazz) {
-        emitOp(Opcode.DEFAULTVALUE, clazz);
+    public C aconst_init(S clazz) {
+        emitOp(Opcode.ACONST_INIT, clazz);
         code.writeChar(poolHelper.putClass(clazz));
         return thisBuilder();
     }

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/Opcode.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/Opcode.java
@@ -229,7 +229,7 @@ public enum Opcode {
     IF_NONNULL(199),
     GOTO_W(200),
     JSR_W(201),
-    DEFAULTVALUE(203),
+    ACONST_INIT(203),
     WITHFIELD(204);
 
 

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/TypedCodeBuilder.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/TypedCodeBuilder.java
@@ -731,7 +731,7 @@ public class TypedCodeBuilder<S, T, E, C extends TypedCodeBuilder<S, T, E, C>> e
                 state.pop();
                 break;
             case NEW:
-            case DEFAULTVALUE:
+            case ACONST_INIT:
                 state.push(typeHelper.type((S) optValue));
                 break;
             case NEWARRAY:


### PR DESCRIPTION
Renamed defaultvalue to aconst_init

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280704](https://bugs.openjdk.java.net/browse/JDK-8280704): [lworld] Rename defaultvalue to aconst_init in tests


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/618/head:pull/618` \
`$ git checkout pull/618`

Update a local copy of the PR: \
`$ git checkout pull/618` \
`$ git pull https://git.openjdk.java.net/valhalla pull/618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 618`

View PR using the GUI difftool: \
`$ git pr show -t 618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/618.diff">https://git.openjdk.java.net/valhalla/pull/618.diff</a>

</details>
