### PR TITLE
8280746: [lworld] Initial core libraries support for value classes

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1190,7 +1190,7 @@ public class ObjectOutputStream
             // remaining cases
             if (obj instanceof String) {
                 writeString((String) obj, unshared);
-            } else if (cl.isValueClass()) {
+            } else if (cl.isValue()) {
                 throw new NotSerializableException(cl.getName());
             } else if (cl.isArray()) {
                 writeArray(obj, desc, unshared);

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1190,7 +1190,7 @@ public class ObjectOutputStream
             // remaining cases
             if (obj instanceof String) {
                 writeString((String) obj, unshared);
-            } else if (cl.isPrimitiveClass()) {
+            } else if (cl.isValueClass()) {
                 throw new NotSerializableException(cl.getName());
             } else if (cl.isArray()) {
                 writeArray(obj, desc, unshared);

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -504,7 +504,6 @@ public class ObjectStreamClass implements Serializable {
         name = cl.getName();
         isProxy = Proxy.isProxyClass(cl);
         isEnum = Enum.class.isAssignableFrom(cl);
-        boolean isPrimitiveClass = cl.isPrimitiveClass();
         isRecord = cl.isRecord();
         serializable = Serializable.class.isAssignableFrom(cl);
         externalizable = Externalizable.class.isAssignableFrom(cl);
@@ -576,8 +575,8 @@ public class ObjectStreamClass implements Serializable {
         if (deserializeEx == null) {
             if (isEnum) {
                 deserializeEx = new ExceptionInfo(name, "enum type");
-            } else if (isPrimitiveClass && writeReplaceMethod == null) {
-                deserializeEx = new ExceptionInfo(name, "primitive class");
+            } else if (cl.isValueClass() && writeReplaceMethod == null) {
+                deserializeEx = new ExceptionInfo(name, cl.isPrimitiveClass() ? "primitive class" : "value class");
             } else if (cons == null && !isRecord) {
                 deserializeEx = new ExceptionInfo(name, "no valid constructor");
             }

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -575,7 +575,7 @@ public class ObjectStreamClass implements Serializable {
         if (deserializeEx == null) {
             if (isEnum) {
                 deserializeEx = new ExceptionInfo(name, "enum type");
-            } else if (cl.isValueClass() && writeReplaceMethod == null) {
+            } else if (cl.isValue() && writeReplaceMethod == null) {
                 deserializeEx = new ExceptionInfo(name, cl.isPrimitiveClass() ? "primitive class" : "value class");
             } else if (cons == null && !isRecord) {
                 deserializeEx = new ExceptionInfo(name, "no valid constructor");

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -202,6 +202,8 @@ public final class Class<T> implements java.io.Serializable,
     private static final int ANNOTATION = 0x00002000;
     private static final int ENUM       = 0x00004000;
     private static final int SYNTHETIC  = 0x00001000;
+    private static final int VALUE_CLASS     = 0x00000100;
+    private static final int PERMITS_VALUE   = 0x00000040;
     private static final int PRIMITIVE_CLASS = 0x00000800;
 
     private static native void registerNatives();
@@ -237,6 +239,9 @@ public final class Class<T> implements java.io.Serializable,
         String s = isPrimitive() ? "" : "class ";
         if (isInterface()) {
             s = "interface ";
+        }
+        if (isValueClass()) {
+            s = "value ";
         }
         if (isPrimitiveClass()) {
             s = "primitive ";
@@ -307,8 +312,8 @@ public final class Class<T> implements java.io.Serializable,
                 if (isAnnotation()) {
                     sb.append('@');
                 }
-                if (isPrimitiveClass()) {
-                    sb.append("primitive ");
+                if (isValueClass()) {
+                    sb.append(isPrimitiveClass() ? "primitive" : "value");
                 }
                 if (isInterface()) { // Note: all annotation interfaces are interfaces
                     sb.append("interface");
@@ -605,19 +610,33 @@ public final class Class<T> implements java.io.Serializable,
      * <p>
      * Each primitive class has a {@linkplain #isPrimaryType() primary type}
      * representing the <em>primitive reference type</em> and a
-     * {@linkplain #isValueType() secondary type} representing
+     * {@linkplain #isPrimitiveValueType() secondary type} representing
      * the <em>primitive value type</em>.  The primitive reference type
      * and primitive value type can be obtained by calling the
      * {@link #asPrimaryType()} and {@link #asValueType} method
      * of a primitive class respectively.
+     * <p>
+     * A primitive class is a {@linkplain #isValueClass() value class}.
      *
      * @return {@code true} if this class is a primitive class, otherwise {@code false}
+     * @see #isValueClass()
      * @see #asPrimaryType()
      * @see #asValueType()
      * @since Valhalla
      */
     public boolean isPrimitiveClass() {
         return (this.getModifiers() & PRIMITIVE_CLASS) != 0;
+    }
+
+    /**
+     * Returns {@code true} if this class is a value class.
+     *
+     * @return {@code true} if this class is a value class;
+     * otherwise {@code false}
+     * @since Valhalla
+     */
+    public boolean isValueClass() {
+        return (this.getModifiers() & VALUE_CLASS) != 0;
     }
 
     /**
@@ -650,7 +669,7 @@ public final class Class<T> implements java.io.Serializable,
      * @apiNote Alternatively, this method returns null if this class is not
      *          a primitive class rather than throwing UOE.
      *
-     * @return the {@code Class} representing the {@linkplain #isValueType()
+     * @return the {@code Class} representing the {@linkplain #isPrimitiveValueType()
      * primitive value type} of this class if this class is a primitive class
      * @throws UnsupportedOperationException if this class or interface
      *         is not a primitive class
@@ -694,11 +713,11 @@ public final class Class<T> implements java.io.Serializable,
      * Returns {@code true} if this {@code Class} object represents
      * a {@linkplain #isPrimitiveClass() primitive} value type.
      *
-     * @return {@code true} if this {@code Class} object represents the
-     * value type of a primitive class
+     * @return {@code true} if this {@code Class} object represents
+     * the value type of a primitive class
      * @since Valhalla
      */
-    public boolean isValueType() {
+    public boolean isPrimitiveValueType() {
         return isPrimitiveClass() && this == secondaryType;
     }
 
@@ -4048,7 +4067,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @throws ClassCastException if the object is not
      * {@code null} and is not assignable to the type T.
-     * @throws NullPointerException if this class is an {@linkplain #isValueType()
+     * @throws NullPointerException if this class is an {@linkplain #isPrimitiveValueType()
      * primitive value type} and the object is {@code null}
      *
      * @since 1.5
@@ -4056,7 +4075,7 @@ public final class Class<T> implements java.io.Serializable,
     @SuppressWarnings("unchecked")
     @IntrinsicCandidate
     public T cast(Object obj) {
-        if (isValueType() && obj == null)
+        if (isPrimitiveValueType() && obj == null)
             throw new NullPointerException(getName() + " is a primitive value type");
 
         if (obj != null && !isInstance(obj))
@@ -4570,7 +4589,7 @@ public final class Class<T> implements java.io.Serializable,
         if (isArray()) {
             return "[" + componentType.descriptorString();
         }
-        char typeDesc = isValueType() ? 'Q' : 'L';
+        char typeDesc = isPrimitiveValueType() ? 'Q' : 'L';
         if (isHidden()) {
             String name = getName();
             int index = name.indexOf('/');

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -240,7 +240,7 @@ public final class Class<T> implements java.io.Serializable,
         if (isInterface()) {
             s = "interface ";
         }
-        if (isValueClass()) {
+        if (isValue()) {
             s = "value ";
         }
         if (isPrimitiveClass()) {
@@ -312,7 +312,7 @@ public final class Class<T> implements java.io.Serializable,
                 if (isAnnotation()) {
                     sb.append('@');
                 }
-                if (isValueClass()) {
+                if (isValue()) {
                     sb.append(isPrimitiveClass() ? "primitive" : "value");
                 }
                 if (isInterface()) { // Note: all annotation interfaces are interfaces
@@ -616,10 +616,10 @@ public final class Class<T> implements java.io.Serializable,
      * {@link #asPrimaryType()} and {@link #asValueType} method
      * of a primitive class respectively.
      * <p>
-     * A primitive class is a {@linkplain #isValueClass() value class}.
+     * A primitive class is a {@linkplain #isValue() value class}.
      *
      * @return {@code true} if this class is a primitive class, otherwise {@code false}
-     * @see #isValueClass()
+     * @see #isValue()
      * @see #asPrimaryType()
      * @see #asValueType()
      * @since Valhalla
@@ -635,7 +635,7 @@ public final class Class<T> implements java.io.Serializable,
      * otherwise {@code false}
      * @since Valhalla
      */
-    public boolean isValueClass() {
+    public boolean isValue() {
         return (this.getModifiers() & VALUE_CLASS) != 0;
     }
 

--- a/src/java.base/share/classes/java/lang/IdentityObject.java
+++ b/src/java.base/share/classes/java/lang/IdentityObject.java
@@ -27,7 +27,7 @@ package java.lang;
 
 /**
  * A restricted interface implemented by all identity objects.
-
+ *
  * IdentityObject: An object with identity.
  *
  * *Identity* is a property of certain objects, determined at instance creation
@@ -59,7 +59,7 @@ package java.lang;
  * Abstract classes and interfaces may implement or extend this interface if they
  * wish to guarantee that all instances of the class or interface have identity.
  *
- * @since 1.18
+ * @since Valhalla
  */
 public interface IdentityObject {
 }

--- a/src/java.base/share/classes/java/lang/ValueObject.java
+++ b/src/java.base/share/classes/java/lang/ValueObject.java
@@ -59,7 +59,7 @@ package java.lang;
  * wish to guarantee that all instances of the class or interface are value
  * objects.
  *
- * @since 1.18
+ * @since Valhalla
  */
 
 public interface ValueObject {

--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -260,12 +260,12 @@ public sealed interface ClassDesc
 
     /**
      * Returns whether this {@linkplain ClassDesc} describes a
-     * {@linkplain Class#isValueType() primitive value type}.
+     * {@linkplain Class#isPrimitiveValueType() primitive value type}.
      *
      * @return whether this {@linkplain ClassDesc} describes a primitive value type.
      * @since Valhalla
      */
-    default boolean isValueType() {
+    default boolean isPrimitiveValueType() {
         return descriptorString().startsWith("Q");
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -401,7 +401,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
             return true;
         }
 
-        if (fromType.isValueClass() && toType.isValueClass()) {
+        if (fromType.isValue() && toType.isValue()) {
             // val projection can be converted to ref projection; or vice verse
             return fromType.asPrimaryType() == toType.asPrimaryType();
         }

--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -401,7 +401,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
             return true;
         }
 
-        if (fromType.isPrimitiveClass() && toType.isPrimitiveClass()) {
+        if (fromType.isValueClass() && toType.isValueClass()) {
             // val projection can be converted to ref projection; or vice verse
             return fromType.asPrimaryType() == toType.asPrimaryType();
         }

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -134,7 +134,7 @@ class DirectMethodHandle extends MethodHandle {
         return make(member.getDeclaringClass(), member);
     }
     private static DirectMethodHandle makeAllocator(MemberName ctor) {
-        assert(ctor.isObjectConstructor() && !ctor.getDeclaringClass().isPrimitiveClass()) : ctor;
+        assert(ctor.isObjectConstructor() && !ctor.getDeclaringClass().isValueClass()) : ctor;
 
         Class<?> instanceClass = ctor.getDeclaringClass();
         ctor = ctor.asObjectConstructor();

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -134,7 +134,7 @@ class DirectMethodHandle extends MethodHandle {
         return make(member.getDeclaringClass(), member);
     }
     private static DirectMethodHandle makeAllocator(MemberName ctor) {
-        assert(ctor.isObjectConstructor() && !ctor.getDeclaringClass().isValueClass()) : ctor;
+        assert(ctor.isObjectConstructor() && !ctor.getDeclaringClass().isValue()) : ctor;
 
         Class<?> instanceClass = ctor.getDeclaringClass();
         ctor = ctor.asObjectConstructor();

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -431,7 +431,7 @@ final class MemberName implements Member, Cloneable {
     /** Utility method to query the modifier flags of this member. */
     public boolean isFinal() {
         // all fields declared in a value type are effectively final
-        assert(!clazz.isPrimitiveClass() || !isField() || Modifier.isFinal(flags));
+        assert(!clazz.isValueClass() || !isField() || Modifier.isFinal(flags));
         return Modifier.isFinal(flags);
     }
     /** Utility method to query whether this member or its defining class is final. */
@@ -479,7 +479,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isInlineableField()  {
         if (isField()) {
             Class<?> type = getFieldType();
-            return type.isValueType();
+            return type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
         }
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -431,7 +431,7 @@ final class MemberName implements Member, Cloneable {
     /** Utility method to query the modifier flags of this member. */
     public boolean isFinal() {
         // all fields declared in a value type are effectively final
-        assert(!clazz.isValueClass() || !isField() || Modifier.isFinal(flags));
+        assert(!clazz.isValue() || !isField() || Modifier.isFinal(flags));
         return Modifier.isFinal(flags);
     }
     /** Utility method to query whether this member or its defining class is final. */
@@ -479,7 +479,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isInlineableField()  {
         if (isField()) {
             Class<?> type = getFieldType();
-            return type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
+            return type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
         }
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5093,7 +5093,7 @@ assert((int)twice.invokeExact(21) == 42);
         Objects.requireNonNull(type);
         if (type.isPrimitive()) {
             return zero(Wrapper.forPrimitiveType(type), type);
-        } else if (type.isValueClass()) {
+        } else if (type.isValue()) {
             // TBD
             throw new UnsupportedOperationException();
         } else {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -48,7 +48,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.ReflectPermission;
 import java.nio.ByteOrder;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
@@ -4318,7 +4317,7 @@ return mh1;
      * <p> When the returned method handle is invoked,
      * the array reference and array index are checked.
      * A {@code NullPointerException} will be thrown if the array reference
-     * is {@code null} or if the array's element type is a {@link Class#isValueType()
+     * is {@code null} or if the array's element type is a {@link Class#isPrimitiveValueType()
      * a primitive value type} and attempts to set {@code null} in the
      * array element.  An {@code ArrayIndexOutOfBoundsException} will be
      * thrown if the index is negative or if it is greater than or equal to
@@ -5094,7 +5093,8 @@ assert((int)twice.invokeExact(21) == 42);
         Objects.requireNonNull(type);
         if (type.isPrimitive()) {
             return zero(Wrapper.forPrimitiveType(type), type);
-        } else if (type.isPrimitiveClass()) {
+        } else if (type.isValueClass()) {
+            // TBD
             throw new UnsupportedOperationException();
         } else {
             return zero(Wrapper.OBJECT, type);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -223,11 +223,10 @@ final class VarHandles {
         int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
 
         if (!componentType.isPrimitive()) {
-            // the redundant componentType.isValue() check is there to
-            // minimize the performance impact to non-value array.
+            // the redundant componentType.isPrimitiveValueType() check is
+            // there to minimize the performance impact to non-value array.
             // It should be removed when Unsafe::isFlattenedArray is intrinsified.
-
-            return maybeAdapt(componentType.isValueType() && UNSAFE.isFlattenedArray(arrayClass)
+            return maybeAdapt(componentType.isPrimitiveValueType() && UNSAFE.isFlattenedArray(arrayClass)
                 ? new VarHandleValues.Array(aoffset, ashift, arrayClass)
                 : new VarHandleReferences.Array(aoffset, ashift, arrayClass));
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -148,7 +148,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object checkCast(FieldInstanceReadWrite handle, $type$ value) {
-            if (handle.fieldType.isValueType())
+            if (handle.fieldType.isPrimitiveValueType())
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -501,7 +501,7 @@ final class VarHandle$Type$s {
 
 #if[Object]
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
-            if (handle.fieldType.isValueType())
+            if (handle.fieldType.isPrimitiveValueType())
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -744,7 +744,7 @@ final class VarHandle$Type$s {
 #if[Reference]
     static VarHandle makeVarHandleValuesArray(Class<?> arrayClass) {
         Class<?> componentType = arrayClass.getComponentType();
-        assert componentType.isValueType() && UNSAFE.isFlattenedArray(arrayClass);
+        assert componentType.isPrimitiveValueType() && UNSAFE.isFlattenedArray(arrayClass);
         // should cache these VarHandle for performance
         return VarHandles.makeArrayElementHandle(arrayClass);
     }
@@ -803,7 +803,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
-            if (handle.componentType.isValueType())
+            if (handle.componentType.isPrimitiveValueType())
                  Objects.requireNonNull(value);
 
             if (handle.arrayType == oarray.getClass()) {

--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -32,8 +32,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * determines that their referents may otherwise be reclaimed.  Phantom
  * references are most often used to schedule post-mortem cleanup actions.
  * <p>
- * The referent must not be an instance of a primitive class; such a value
- * can never have another reference to it and cannot be held in a reference type.
+ * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * value class}; such a value can never have another reference to it
+ * and cannot be held in a reference type.
  *
  * <p> Suppose the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">
@@ -90,7 +91,7 @@ public class PhantomReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of an
-     *         {@link Class#isPrimitiveClass() primitive class}
+     *         {@link Class#isValueClass() value class}
      */
     public PhantomReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -32,7 +32,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * determines that their referents may otherwise be reclaimed.  Phantom
  * references are most often used to schedule post-mortem cleanup actions.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * The referent must not be an instance of a {@linkplain Class#isValue()
  * value class}; such a value can never have another reference to it
  * and cannot be held in a reference type.
  *
@@ -91,7 +91,7 @@ public class PhantomReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of an
-     *         {@link Class#isValueClass() value class}
+     *         {@link Class#isValue() value class}
      */
     public PhantomReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -497,9 +497,11 @@ public abstract class Reference<T> {
     }
 
     Reference(T referent, ReferenceQueue<? super T> queue) {
-        if (referent != null && referent.getClass().isPrimitiveClass()) {
-            throw new IllegalArgumentException("cannot reference a primitive type: " +
-                    referent.getClass().getName());
+        if (referent != null && referent.getClass().isValueClass()) {
+            Class<?> c = referent.getClass();
+            throw new IllegalArgumentException("cannot reference a " +
+                    (c.isPrimitiveClass() ? "primitive class " : "value class ") +
+                    c.getName());
         }
         this.referent = referent;
         this.queue = (queue == null) ? ReferenceQueue.NULL : queue;

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -497,7 +497,7 @@ public abstract class Reference<T> {
     }
 
     Reference(T referent, ReferenceQueue<? super T> queue) {
-        if (referent != null && referent.getClass().isValueClass()) {
+        if (referent != null && referent.getClass().isValue()) {
             Class<?> c = referent.getClass();
             throw new IllegalArgumentException("cannot reference a " +
                     (c.isPrimitiveClass() ? "primitive class " : "value class ") +

--- a/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -31,7 +31,7 @@ package java.lang.ref;
  * collector in response to memory demand.  Soft references are most often used
  * to implement memory-sensitive caches.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * The referent must not be an instance of a {@linkplain Class#isValue()
  * value class}; such a value can never have another reference to it
  * and cannot be held in a reference type.
  *
@@ -85,7 +85,7 @@ public class SoftReference<T> extends Reference<T> {
      *
      * @param referent object the new soft reference will refer to
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isValueClass() value class}
+     *         {@link Class#isValue() value class}
      */
     public SoftReference(T referent) {
         super(referent);
@@ -100,7 +100,7 @@ public class SoftReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isValueClass() value class}
+     *         {@link Class#isValue() value class}
      */
     public SoftReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -31,8 +31,9 @@ package java.lang.ref;
  * collector in response to memory demand.  Soft references are most often used
  * to implement memory-sensitive caches.
  * <p>
- * The referent must not be an instance of a primitive class; such a value
- * can never have another reference to it and cannot be held in a reference type.
+ * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * value class}; such a value can never have another reference to it
+ * and cannot be held in a reference type.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">softly
@@ -84,7 +85,7 @@ public class SoftReference<T> extends Reference<T> {
      *
      * @param referent object the new soft reference will refer to
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isPrimitiveClass() primitive class}
+     *         {@link Class#isValueClass() value class}
      */
     public SoftReference(T referent) {
         super(referent);
@@ -99,7 +100,7 @@ public class SoftReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isPrimitiveClass() primitive class}
+     *         {@link Class#isValueClass() value class}
      */
     public SoftReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -31,7 +31,7 @@ package java.lang.ref;
  * made finalizable, finalized, and then reclaimed.  Weak references are most
  * often used to implement canonicalizing mappings.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * The referent must not be an instance of a {@linkplain Class#isValue()
  * value class}; such a value can never have another reference to it
  * and cannot be held in a reference type.
  *
@@ -57,7 +57,7 @@ public class WeakReference<T> extends Reference<T> {
      *
      * @param referent object the new weak reference will refer to
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isValueClass() value class}
+     *         {@link Class#isValue() value class}
      */
     public WeakReference(T referent) {
         super(referent);
@@ -71,7 +71,7 @@ public class WeakReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isValueClass() value class}
+     *         {@link Class#isValue() value class}
      */
     public WeakReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -31,8 +31,9 @@ package java.lang.ref;
  * made finalizable, finalized, and then reclaimed.  Weak references are most
  * often used to implement canonicalizing mappings.
  * <p>
- * The referent must not be an instance of a primitive class; such a value
- * can never have another reference to it and cannot be held in a reference type.
+ * The referent must not be an instance of a {@linkplain Class#isValueClass()
+ * value class}; such a value can never have another reference to it
+ * and cannot be held in a reference type.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">weakly
@@ -56,7 +57,7 @@ public class WeakReference<T> extends Reference<T> {
      *
      * @param referent object the new weak reference will refer to
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isPrimitiveClass() primitive class}
+     *         {@link Class#isValueClass() value class}
      */
     public WeakReference(T referent) {
         super(referent);
@@ -70,7 +71,7 @@ public class WeakReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IllegalArgumentException if the referent is an instance of a
-     *         {@link Class#isPrimitiveClass() primitive class}
+     *         {@link Class#isValueClass() value class}
      */
     public WeakReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -180,7 +180,7 @@ public class AccessibleObject implements AnnotatedElement {
      * <ul>
      * <li>static final fields declared in any class or interface</li>
      * <li>final fields declared in a {@linkplain Class#isHidden() hidden class}</li>
-     * <li>fields declared in a {@linkplain Class#isValueClass() value class}</li>
+     * <li>fields declared in a {@linkplain Class#isValue() value class}</li>
      * <li>final fields declared in a {@linkplain Class#isRecord() record}</li>
      * </ul>
      * <p> The {@code accessible} flag when {@code true} suppresses Java language access

--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -180,7 +180,7 @@ public class AccessibleObject implements AnnotatedElement {
      * <ul>
      * <li>static final fields declared in any class or interface</li>
      * <li>final fields declared in a {@linkplain Class#isHidden() hidden class}</li>
-     * <li>fields declared in a {@linkplain Class#isPrimitiveClass() primitive class}</li>
+     * <li>fields declared in a {@linkplain Class#isValueClass() value class}</li>
      * <li>final fields declared in a {@linkplain Class#isRecord() record}</li>
      * </ul>
      * <p> The {@code accessible} flag when {@code true} suppresses Java language access

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -767,7 +767,7 @@ class Field extends AccessibleObject implements Member {
      * <li>the field is non-static; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isHidden()
      *     hidden class};</li>
-     * <li>the field's declaring class is not a {@linkplain Class#isValueClass()
+     * <li>the field's declaring class is not a {@linkplain Class#isValue()
      *     value class}; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isRecord()
      *     record class}.</li>

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -767,8 +767,8 @@ class Field extends AccessibleObject implements Member {
      * <li>the field is non-static; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isHidden()
      *     hidden class};</li>
-     * <li>the field's declaring class is not a {@linkplain Class#isPrimitiveClass()
-     *     primitive class}; and</li>
+     * <li>the field's declaring class is not a {@linkplain Class#isValueClass()
+     *     value class}; and</li>
      * <li>the field's declaring class is not a {@linkplain Class#isRecord()
      *     record class}.</li>
      * </ul>

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -866,7 +866,7 @@ final class ProxyGenerator extends ClassWriter {
                 }
             } else {
                 String internalName = dotToSlash(type.getName());
-                if (type.isValueType()) {
+                if (type.isPrimitiveValueType()) {
                     internalName = 'Q' + internalName + ";";
                 }
                 mv.visitTypeInsn(CHECKCAST, internalName);
@@ -931,7 +931,7 @@ final class ProxyGenerator extends ClassWriter {
             mv.visitMethodInsn(INVOKESTATIC,
                     JL_CLASS,
                     "forName", "(Ljava/lang/String;)Ljava/lang/Class;", false);
-            if (cl.isValueType()) {
+            if (cl.isPrimitiveValueType()) {
               mv.visitMethodInsn(INVOKEVIRTUAL,
                                  JL_CLASS,
                                  "asValueType", "()Ljava/lang/Class;", false);

--- a/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
@@ -120,7 +120,7 @@ final class PrimitiveObjectMethods {
          * of the given primitive class are substitutable.
          */
         static MethodHandle primitiveTypeEquals(Class<?> type) {
-            assert type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
+            assert type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
             MethodType mt = methodType(boolean.class, type, type);
             MethodHandle[] getters = getters(type, TYPE_SORTER);
             MethodHandle instanceTrue = dropArguments(TRUE, 0, type, Object.class).asType(mt);
@@ -142,7 +142,7 @@ final class PrimitiveObjectMethods {
         }
 
         static MethodHandle primitiveTypeHashCode(Class<?> type) {
-            assert type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
+            assert type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
             MethodHandle target = dropArguments(constant(int.class, SALT), 0, type);
             MethodHandle cls = dropArguments(constant(Class.class, type),0, type);
             MethodHandle classHashCode = filterReturnValue(cls, hashCodeForType(Class.class));
@@ -177,7 +177,7 @@ final class PrimitiveObjectMethods {
             if (a == null && b == null) return true;
             if (a == null || b == null) return false;
             if (a.getClass() != b.getClass()) return false;
-            return a.getClass().isValueClass() ? valueEq(a, b) : (a == b);
+            return a.getClass().isValue() ? valueEq(a, b) : (a == b);
         }
 
         /*
@@ -215,7 +215,7 @@ final class PrimitiveObjectMethods {
         private static boolean isSameValueClass(Object a, Object b) {
             if (a == null || b == null) return false;
 
-            return a.getClass().isValueClass() && a.getClass() == b.getClass();
+            return a.getClass().isValue() && a.getClass() == b.getClass();
         }
 
         private static int hashCombiner(int accumulator, int value) {
@@ -416,7 +416,7 @@ final class PrimitiveObjectMethods {
         if (type.isPrimitive())
             return MethodHandleBuilder.primitiveEquals(type);
 
-        if (type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass())) {
+        if (type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass())) {
             return SUBST_TEST_METHOD_HANDLES.get(type);
         }
         return MethodHandleBuilder.referenceTypeEquals(type);
@@ -439,7 +439,7 @@ final class PrimitiveObjectMethods {
         try {
             // Note: javac disallows user to call super.hashCode if user implemented
             // risk for recursion for experts crafting byte-code
-            if (!c.isValueClass())
+            if (!c.isValue())
                 throw new InternalError("must be value or primitive class: " + c.getName());
             Class<?> type = c.isPrimitiveClass() ? c.asValueType() : c;
             return (int) HASHCODE_METHOD_HANDLES.get(type).invoke(o);

--- a/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
@@ -120,7 +120,7 @@ final class PrimitiveObjectMethods {
          * of the given primitive class are substitutable.
          */
         static MethodHandle primitiveTypeEquals(Class<?> type) {
-            assert type.isValueType();
+            assert type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
             MethodType mt = methodType(boolean.class, type, type);
             MethodHandle[] getters = getters(type, TYPE_SORTER);
             MethodHandle instanceTrue = dropArguments(TRUE, 0, type, Object.class).asType(mt);
@@ -136,13 +136,13 @@ final class PrimitiveObjectMethods {
             // otherwise return accumulator;
             return guardWithTest(IS_NULL.asType(mt),
                                  instanceTrue,
-                                 guardWithTest(IS_SAME_PRIMITIVE_CLASS.asType(mt),
+                                 guardWithTest(IS_SAME_VALUE_CLASS.asType(mt),
                                                accumulator,
                                                instanceFalse));
         }
 
         static MethodHandle primitiveTypeHashCode(Class<?> type) {
-            assert type.isValueType();
+            assert type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass());
             MethodHandle target = dropArguments(constant(int.class, SALT), 0, type);
             MethodHandle cls = dropArguments(constant(Class.class, type),0, type);
             MethodHandle classHashCode = filterReturnValue(cls, hashCodeForType(Class.class));
@@ -177,16 +177,19 @@ final class PrimitiveObjectMethods {
             if (a == null && b == null) return true;
             if (a == null || b == null) return false;
             if (a.getClass() != b.getClass()) return false;
-            return a.getClass().isPrimitiveClass() ? valueEq(a, b) : (a == b);
+            return a.getClass().isValueClass() ? valueEq(a, b) : (a == b);
         }
 
         /*
          * Returns true if two values are substitutable.
          */
         private static boolean valueEq(Object a, Object b) {
-            assert a != null && b != null && isSamePrimitiveClass(a, b);
+            assert a != null && b != null && isSameValueClass(a, b);
             try {
-                Class<?> type = a.getClass().asValueType();
+                Class<?> type = a.getClass();
+                if (type.isPrimitiveClass()) {
+                    type = type.asValueType();
+                }
                 return (boolean) substitutableInvoker(type).invoke(type.cast(a), type.cast(b));
             } catch (Error|RuntimeException e) {
                 throw e;
@@ -209,10 +212,10 @@ final class PrimitiveObjectMethods {
          * 1. a != null and b != null
          * 2. the declaring class of a and b is the same primitive class
          */
-        private static boolean isSamePrimitiveClass(Object a, Object b) {
+        private static boolean isSameValueClass(Object a, Object b) {
             if (a == null || b == null) return false;
 
-            return a.getClass().isPrimitiveClass() && a.getClass() == b.getClass();
+            return a.getClass().isValueClass() && a.getClass() == b.getClass();
         }
 
         private static int hashCombiner(int accumulator, int value) {
@@ -233,8 +236,8 @@ final class PrimitiveObjectMethods {
         private static final MethodHandle FALSE = constant(boolean.class, false);
         private static final MethodHandle TRUE = constant(boolean.class, true);
         private static final MethodHandle OBJECT_EQUALS = findStatic("eq", methodType(boolean.class, Object.class, Object.class));
-        private static final MethodHandle IS_SAME_PRIMITIVE_CLASS =
-            findStatic("isSamePrimitiveClass", methodType(boolean.class, Object.class, Object.class));
+        private static final MethodHandle IS_SAME_VALUE_CLASS =
+            findStatic("isSameValueClass", methodType(boolean.class, Object.class, Object.class));
         private static final MethodHandle IS_NULL =
             findStatic("isNull", methodType(boolean.class, Object.class, Object.class));
         private static final MethodHandle HASH_COMBINER =
@@ -413,16 +416,16 @@ final class PrimitiveObjectMethods {
         if (type.isPrimitive())
             return MethodHandleBuilder.primitiveEquals(type);
 
-        if (type.isValueType())
+        if (type.isPrimitiveValueType() || (type.isValueClass() && !type.isPrimitiveClass())) {
             return SUBST_TEST_METHOD_HANDLES.get(type);
-
+        }
         return MethodHandleBuilder.referenceTypeEquals(type);
     }
 
     // store the method handle for value types in ClassValue
     private static ClassValue<MethodHandle> SUBST_TEST_METHOD_HANDLES = new ClassValue<>() {
         @Override protected MethodHandle computeValue(Class<?> type) {
-            return MethodHandleBuilder.primitiveTypeEquals(type.asValueType());
+            return MethodHandleBuilder.primitiveTypeEquals(type);
         }
     };
 
@@ -432,12 +435,13 @@ final class PrimitiveObjectMethods {
      * @return the hash code of the given primitive class object.
      */
     private static int primitiveObjectHashCode(Object o) {
+        Class<?> c = o.getClass();
         try {
             // Note: javac disallows user to call super.hashCode if user implemented
             // risk for recursion for experts crafting byte-code
-            if (!o.getClass().isPrimitiveClass())
-                throw new InternalError("must be primitive type: " + o.getClass().getName());
-            Class<?> type = o.getClass().asValueType();
+            if (!c.isValueClass())
+                throw new InternalError("must be value or primitive class: " + c.getName());
+            Class<?> type = c.isPrimitiveClass() ? c.asValueType() : c;
             return (int) HASHCODE_METHOD_HANDLES.get(type).invoke(o);
         } catch (Error|RuntimeException e) {
             throw e;
@@ -449,7 +453,7 @@ final class PrimitiveObjectMethods {
 
     private static ClassValue<MethodHandle> HASHCODE_METHOD_HANDLES = new ClassValue<>() {
         @Override protected MethodHandle computeValue(Class<?> type) {
-            return MethodHandleBuilder.primitiveTypeHashCode(type.asValueType());
+            return MethodHandleBuilder.primitiveTypeHashCode(type);
         }
     };
 

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -269,7 +269,7 @@ public final class Unsafe {
      */
     public Object getReference(Object o, long offset, Class<?> pc) {
         Object ref = getReference(o, offset);
-        if (ref == null && pc.isValueType()) {
+        if (ref == null && pc.isPrimitiveValueType()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);
@@ -279,7 +279,7 @@ public final class Unsafe {
 
     public Object getReferenceVolatile(Object o, long offset, Class<?> pc) {
         Object ref = getReferenceVolatile(o, offset);
-        if (ref == null && pc.isValueType()) {
+        if (ref == null && pc.isPrimitiveValueType()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -91,7 +91,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                                    Class<?>[] checkedExceptions,
                                                    int modifiers)
     {
-        boolean isStaticFactory = declaringClass.isPrimitiveClass();
+        boolean isStaticFactory = declaringClass.isValueClass();
         return (ConstructorAccessor) generate(declaringClass,
                                               "<init>",
                                               parameterTypes,

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -91,7 +91,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
                                                    Class<?>[] checkedExceptions,
                                                    int modifiers)
     {
-        boolean isStaticFactory = declaringClass.isValueClass();
+        boolean isStaticFactory = declaringClass.isValue();
         return (ConstructorAccessor) generate(declaringClass,
                                               "<init>",
                                               parameterTypes,

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeArray.java
@@ -287,7 +287,7 @@ public class InlineTypeArray {
         assertTrue(myInts instanceof MyInt[]);
 
         Class<?> cls = MyInt.class.asValueType();
-        assertTrue(cls.isValueType());
+        assertTrue(cls.isPrimitiveValueType());
         Object arrObj = Array.newInstance(cls, 1);
         assertTrue(arrObj instanceof Object[], "Not Object array");
         assertTrue(arrObj instanceof Comparable[], "Not Comparable array");

--- a/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
+++ b/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
@@ -289,7 +289,7 @@ public class InstructionHelper {
             @Override
             public boolean isInlineClass(String desc) {
                 Class<?> aClass = symbol(desc);
-                return aClass != null && aClass.isValueType();
+                return aClass != null && aClass.isPrimitiveValueType();
             }
 
             @Override

--- a/test/jdk/valhalla/valuetypes/BasicTest.java
+++ b/test/jdk/valhalla/valuetypes/BasicTest.java
@@ -283,7 +283,7 @@ public class BasicTest {
     public void testGetInterfaces(Object o, Class<?>[] expectedInterfaces) {
         Class<?> type = o.getClass();
         assertEquals(type.getInterfaces(), expectedInterfaces);
-        if (type.isValueClass()) {
+        if (type.isValue()) {
             assertTrue(ValueObject.class.isAssignableFrom(type));
             assertTrue(o instanceof ValueObject);
         } else {

--- a/test/jdk/valhalla/valuetypes/BasicTest.java
+++ b/test/jdk/valhalla/valuetypes/BasicTest.java
@@ -71,12 +71,20 @@ public class BasicTest {
         }
     }
 
+    static value class Value {
+        int v;
+        Value(int v) {
+            this.v = v;
+        }
+    }
+
     @DataProvider(name="constants")
     static Object[][] constants() {
         return new Object[][]{
             new Object[] { Point.class, Point.class.asPrimaryType()},
             new Object[] { Point.val.class, Point.class.asValueType()},
             new Object[] { Point.ref.class, Point.class.asPrimaryType()},
+            new Object[] { Value.class, Value.class.asPrimaryType()},
         };
     }
 
@@ -95,6 +103,7 @@ public class BasicTest {
                 new Object[] { Point.val.class, false},
                 new Object[] { Point.class.asPrimaryType(), true},
                 new Object[] { Point.class.asValueType(), false},
+                new Object[] { Value.class, true},
         };
     }
     @Test(dataProvider="refTypes")
@@ -118,9 +127,9 @@ public class BasicTest {
         assertTrue(valType.isPrimitiveClass());
 
         assertTrue(refType.isPrimaryType());
-        assertFalse(refType.isValueType());
+        assertFalse(refType.isPrimitiveValueType());
 
-        assertTrue(valType.isValueType());
+        assertTrue(valType.isPrimitiveValueType());
         assertFalse(valType.isPrimaryType());
 
         assertEquals(refType.getName(), valType.getName());
@@ -169,6 +178,8 @@ public class BasicTest {
                 new Object[] { "BasicTest$Point", Point.class.asPrimaryType()},
                 new Object[] { "[QBasicTest$Point;", Point[].class},
                 new Object[] { "[[LBasicTest$Point;", Point.ref[][].class},
+                new Object[] { "BasicTest$Value", Value.class},
+                new Object[] { "[LBasicTest$Value;", Value[].class},
         };
     }
     @Test(dataProvider="names")
@@ -234,10 +245,19 @@ public class BasicTest {
         assertEquals(m.getParameterTypes(), paramTypes);
     }
 
-    @Test
-    public void testConstructor() throws ReflectiveOperationException {
-        Constructor<?> ctor = Point.class.getDeclaredConstructor(int.class, int.class);
-        assertTrue(ctor.getDeclaringClass() == Point.class.asPrimaryType());
+    @DataProvider(name="ctors")
+    static Object[][] ctors() {
+        return new Object[][]{
+                new Object[] { Point.class, new Class<?>[] { int.class, int.class}, new Object[] { 10, 10 }},
+                new Object[] { Value.class, new Class<?>[] { int.class }, new Object[] { 20 }},
+        };
+    }
+
+    @Test(dataProvider = "ctors")
+    public void testConstructor(Class<?> c, Class<?>[] paramTypes, Object[] params) throws ReflectiveOperationException {
+        Constructor<?> ctor = c.getDeclaredConstructor(paramTypes);
+        assertTrue(ctor.getDeclaringClass() == c.asPrimaryType());
+        Object o = ctor.newInstance(params);
     }
 
     class C implements IdentityObject { }
@@ -247,6 +267,7 @@ public class BasicTest {
     Object[][] intfs() {
         Point point = new Point(10, 20);
         Point[] array = new Point[] { point };
+        Value value = new Value(10);
         return new Object[][]{
                 new Object[]{ new BasicTest(), new Class<?>[] { IdentityObject.class }},
                 new Object[]{ point, new Class<?>[] { ValueObject.class }},
@@ -254,6 +275,7 @@ public class BasicTest {
                 new Object[]{ new C(), new Class<?>[] { IdentityObject.class }},
                 new Object[]{ Objects.newIdentity(), new Class<?>[] { IdentityObject.class }},
                 new Object[]{ array, new Class<?>[] { Cloneable.class, Serializable.class, IdentityObject.class }},
+                new Object[]{ value, new Class<?>[] { ValueObject.class }},
         };
     }
 
@@ -261,7 +283,7 @@ public class BasicTest {
     public void testGetInterfaces(Object o, Class<?>[] expectedInterfaces) {
         Class<?> type = o.getClass();
         assertEquals(type.getInterfaces(), expectedInterfaces);
-        if (type.isPrimitiveClass()) {
+        if (type.isValueClass()) {
             assertTrue(ValueObject.class.isAssignableFrom(type));
             assertTrue(o instanceof ValueObject);
         } else {
@@ -282,6 +304,7 @@ public class BasicTest {
         assertEquals(C.class.getNestMembers(), members);
         assertEquals(Arrays.stream(members).collect(Collectors.toSet()),
                      Set.of(BasicTest.class,
+                            Value.class,
                             Point.class.asPrimaryType(),
                             C.class.asPrimaryType(),
                             T.class.asPrimaryType()));

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -145,10 +145,10 @@ public class MethodHandleTest {
         // set an array element to null
         try {
             Object v = (Object)setter.invoke(array, 1, null);
-            assertFalse(elementType.isValueType(), "should fail to set a primitive class array element to null");
+            assertFalse(elementType.isPrimitiveValueType(), "should fail to set a primitive class array element to null");
             assertNull((Object)getter.invoke(array, 1));
         } catch (NullPointerException e) {
-            assertTrue(elementType.isValueType(), "should only fail to set a primitive class array element to null");
+            assertTrue(elementType.isPrimitiveValueType(), "should only fail to set a primitive class array element to null");
         }
     }
 
@@ -230,7 +230,7 @@ public class MethodHandleTest {
         Field f = c.getDeclaredField(name);
         boolean isStatic = Modifier.isStatic(f.getModifiers());
         assertTrue(f.getType().isPrimitiveClass());
-        assertTrue(f.getType().isValueType() == isValue);
+        assertTrue(f.getType().isPrimitiveValueType() == isValue);
         assertTrue((isStatic && obj == null) || (!isStatic && obj != null));
         Object v = f.get(obj);
 

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class SubstitutabilityTest {
+
     @DataProvider(name="substitutable")
     Object[][] substitutableCases() {
         Point p1 = Point.makePoint(10, 10);
@@ -70,6 +71,10 @@ public class SubstitutabilityTest {
                            valueBuilder().setNumber(Value.Number.intValue(100)).build() },
             new Object[] { valueBuilder().setReference(list).build(),
                            valueBuilder().setReference(list).build() },
+            new Object[] { new ValueOptional(p1), new ValueOptional(p1)},
+            new Object[] { new ValueOptional(p1), new ValueOptional(Point.makePoint(10, 10))},
+            new Object[] { new ValueOptional(list), new ValueOptional(list)},
+            new Object[] { new ValueOptional(null), new ValueOptional(null)},
         };
     }
 
@@ -103,6 +108,8 @@ public class SubstitutabilityTest {
                            valueBuilder().setNumber(new Value.IntNumber(99)).build() },
             new Object[] { valueBuilder().setReference(List.of("list")).build(),
                            valueBuilder().setReference(List.of("list")).build() },
+            new Object[] { new ValueOptional(point), new ValueOptional(mpath)},
+            new Object[] { new ValueOptional(Value.Number.intValue(1)), new ValueOptional(Value.Number.shortValue((short)1))},
         };
     }
     @Test(dataProvider="notSubstitutable")

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -115,7 +115,7 @@ public class ValueArray {
             sb.append("[");
             c = c.getComponentType();
         }
-        sb.append(c.isValueType() ? "Q" : "L").append(c.getName()).append(";");
+        sb.append(c.isPrimitiveValueType() ? "Q" : "L").append(c.getName()).append(";");
         assertEquals(sb.toString(), arrayClassName);
     }
 
@@ -142,7 +142,7 @@ public class ValueArray {
         Arrays.setAll(newArray, i -> array[i]);
 
         // test nullable
-        if (!componentType.isValueType()) {
+        if (!componentType.isPrimitiveValueType()) {
             for (int i = 0; i < newArray.length; i++) {
                 Array.set(newArray, i, null);
             }

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -102,7 +102,7 @@ public class ValueConstantDesc {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         Class<?> c = (Class<?>) cd.resolveConstantDesc(lookup);
         assertTrue(c == type);
-        assertTrue(cd.isValueType() == type.isValueType());
+        assertTrue(cd.isPrimitiveValueType() == type.isPrimitiveValueType());
     }
 
     @Test(expectedExceptions = {LinkageError.class})

--- a/test/jdk/valhalla/valuetypes/ValueOptional.java
+++ b/test/jdk/valhalla/valuetypes/ValueOptional.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class ValueOptional {
+    private Object o;
+    public ValueOptional(Object o) {
+        this.o = o;
+    }
+}


### PR DESCRIPTION
This is an initial core libraries patch to support value classes; in particular it will get the bootstrap methods for the substitutability test and the default implementation of hashCode to work so that it enables further testing and development to continue.   Only small number of new tests are added in this patch.  More update and new tests will continue via JDK-8280603.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280746](https://bugs.openjdk.java.net/browse/JDK-8280746): [lworld] Initial core libraries support for value classes


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/619/head:pull/619` \
`$ git checkout pull/619`

Update a local copy of the PR: \
`$ git checkout pull/619` \
`$ git pull https://git.openjdk.java.net/valhalla pull/619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 619`

View PR using the GUI difftool: \
`$ git pr show -t 619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/619.diff">https://git.openjdk.java.net/valhalla/pull/619.diff</a>

</details>
