### PR TITLE
8280707: [lworld] More issues with C2's arraycopy intrinsic

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5188,10 +5188,7 @@ const TypePtr* TypeAryPtr::add_field_offset_and_offset(intptr_t offset) const {
         int mask = (1 << shift) - 1;
         intptr_t field_offset = ((offset - header) & mask);
         ciField* field = vk->get_field_by_offset(field_offset + vk->first_field_offset(), false);
-        if (field == NULL) {
-          // This may happen with nested AddP(base, AddP(base, base, offset), longcon(16))
-          return add_offset(offset);
-        } else {
+        if (field != NULL) {
           return with_field_offset(field_offset)->add_offset(offset - field_offset - adj);
         }
       }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1433,7 +1433,7 @@ public class TestIntrinsics {
     }
 
     @Run(test = "test71")
-    public void test71_verifier(RunInfo info) {
+    public void test71_verifier() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         Asserts.assertEQ(test71(true, v, v), v.v1);
         Asserts.assertEQ(test71(false, v, v), v.v1);
@@ -1457,7 +1457,7 @@ public class TestIntrinsics {
     }
 
     @Run(test = "test72")
-    public void test72_verifier(RunInfo info) {
+    public void test72_verifier() {
         MyValue1 v = MyValue1.createWithFieldsInline(rI, rL);
         Asserts.assertEQ(test72(true, v, v, V1_OFFSET), v.v1);
         Asserts.assertEQ(test72(false, v, v, V1_OFFSET), v.v1);
@@ -1484,8 +1484,74 @@ public class TestIntrinsics {
     }
 
     @Run(test = "test73")
-    public void test73_verifier(RunInfo info) {
+    public void test73_verifier() {
         Asserts.assertEQ(test73(true, V1_OFFSET), test73_value1.v1);
         Asserts.assertEQ(test73(false, V1_OFFSET), test73_value2.v1);
+    }
+
+    static primitive class EmptyInline {
+
+    }
+
+    static primitive class ByteInline {
+        byte x = 0;
+    }
+
+    @Test
+    public void test74(EmptyInline[] emptyArray) {
+        System.arraycopy(emptyArray, 0, emptyArray, 10, 10);
+        System.arraycopy(emptyArray, 0, emptyArray, 20, 10);
+    }
+
+    @Run(test = "test74")
+    public void test74_verifier() {
+        EmptyInline[] emptyArray = new EmptyInline[100];
+        test74(emptyArray);
+        for (EmptyInline empty : emptyArray) {
+            Asserts.assertEQ(empty, EmptyInline.default);
+        }
+    }
+
+    @Test
+    public void test75(EmptyInline[] emptyArray) {
+        System.arraycopy(emptyArray, 0, emptyArray, 10, 10);
+    }
+
+    @Run(test = "test75")
+    public void test75_verifier() {
+        EmptyInline[] emptyArray = new EmptyInline[100];
+        test75(emptyArray);
+        for (EmptyInline empty : emptyArray) {
+            Asserts.assertEQ(empty, EmptyInline.default);
+        }
+    }
+
+    @Test
+    public void test76(ByteInline[] byteArray) {
+        System.arraycopy(byteArray, 0, byteArray, 10, 10);
+        System.arraycopy(byteArray, 0, byteArray, 20, 10);
+    }
+
+    @Run(test = "test76")
+    public void test76_verifier() {
+        ByteInline[] byteArray = new ByteInline[100];
+        test76(byteArray);
+        for (ByteInline b : byteArray) {
+            Asserts.assertEQ(b, ByteInline.default);
+        }
+    }
+
+    @Test
+    public void test77(ByteInline[] byteArray) {
+        System.arraycopy(byteArray, 0, byteArray, 10, 10);
+    }
+
+    @Run(test = "test77")
+    public void test77_verifier() {
+        ByteInline[] byteArray = new ByteInline[100];
+        test77(byteArray);
+        for (ByteInline b : byteArray) {
+            Asserts.assertEQ(b, ByteInline.default);
+        }
     }
 }


### PR DESCRIPTION
The memory output of the `MemBarCPUOrder` node added to prevent writes into the source from floating below the arraycopy is not correctly wired. As a result, we hit an "dependence cycle found" assert in GCM. I also removed a comment in that code that was already removed from mainline.

In `TypeAryPtr::add_field_offset_and_offset` we set the wrong offset if the field is not found in a flat array (for example, because the inline type has no fields). This leads to an assert in the matcher due to an unexpected address type change.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280707](https://bugs.openjdk.java.net/browse/JDK-8280707): [lworld] More issues with C2's arraycopy intrinsic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/620/head:pull/620` \
`$ git checkout pull/620`

Update a local copy of the PR: \
`$ git checkout pull/620` \
`$ git pull https://git.openjdk.java.net/valhalla pull/620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 620`

View PR using the GUI difftool: \
`$ git pr show -t 620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/620.diff">https://git.openjdk.java.net/valhalla/pull/620.diff</a>

</details>
