### PR TITLE
8281116: [lworld] Adding Preload attribute support

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4134,10 +4134,6 @@ void ClassFileParser::apply_parsed_class_attributes(InstanceKlass* k) {
   if (_sde_buffer != NULL) {
     k->set_source_debug_extension(_sde_buffer, _sde_length);
   }
-  if (_preload_classes != NULL) {
-    k->set_has_preload_attribute();
-    k->set_preload_classes(_preload_classes);
-  }
 }
 
 // Create the Annotations object that will
@@ -4182,6 +4178,7 @@ void ClassFileParser::apply_parsed_class_metadata(
   this_klass->set_inner_classes(_inner_classes);
   this_klass->set_nest_members(_nest_members);
   this_klass->set_nest_host_index(_nest_host);
+  this_klass->set_preload_classes(_preload_classes);
   this_klass->set_annotations(_combined_annotations);
   this_klass->set_permitted_subclasses(_permitted_subclasses);
   this_klass->set_record_components(_record_components);
@@ -5675,6 +5672,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   assert(NULL == _methods, "invariant");
   assert(NULL == _inner_classes, "invariant");
   assert(NULL == _nest_members, "invariant");
+  assert(NULL == _preload_classes, "invariant");
   assert(NULL == _combined_annotations, "invariant");
   assert(NULL == _record_components, "invariant");
   assert(NULL == _permitted_subclasses, "invariant");
@@ -6048,6 +6046,7 @@ void ClassFileParser::clear_class_metadata() {
   _inner_classes = NULL;
   _nest_members = NULL;
   _permitted_subclasses = NULL;
+  _preload_classes = NULL;
   _combined_annotations = NULL;
   _class_annotations = _class_type_annotations = NULL;
   _fields_annotations = _fields_type_annotations = NULL;
@@ -6089,6 +6088,10 @@ ClassFileParser::~ClassFileParser() {
 
   if (_permitted_subclasses != NULL && _permitted_subclasses != Universe::the_empty_short_array()) {
     MetadataFactory::free_array<u2>(_loader_data, _permitted_subclasses);
+  }
+
+  if (_preload_classes != NULL) {
+    MetadataFactory::free_array<u2>(_loader_data, _preload_classes);
   }
 
   // Free interfaces

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -130,6 +130,7 @@ class ClassFileParser {
   Array<u2>* _nest_members;
   u2 _nest_host;
   Array<u2>* _permitted_subclasses;
+  Array<u2>* _preload_classes;
   Array<RecordComponent*>* _record_components;
   GrowableArray<InstanceKlass*>* _temp_local_interfaces;
   Array<InstanceKlass*>* _local_interfaces;
@@ -350,6 +351,10 @@ class ClassFileParser {
 
   u2 parse_classfile_permitted_subclasses_attribute(const ClassFileStream* const cfs,
                                                     const u1* const permitted_subclasses_attribute_start,
+                                                    TRAPS);
+
+  u2 parse_classfile_preload_attribute(const ClassFileStream* const cfs,
+                                                    const u1* const preload_attribute_start,
                                                     TRAPS);
 
   u2 parse_classfile_record_attribute(const ClassFileStream* const cfs,

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -170,6 +170,7 @@
   template(tag_inner_classes,                         "InnerClasses")                             \
   template(tag_nest_members,                          "NestMembers")                              \
   template(tag_nest_host,                             "NestHost")                                 \
+  template(tag_preload,                               "Preload")                                  \
   template(tag_constant_value,                        "ConstantValue")                            \
   template(tag_code,                                  "Code")                                     \
   template(tag_exceptions,                            "Exceptions")                               \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -140,6 +140,7 @@
   LOG_TAG(phases) \
   LOG_TAG(plab) \
   LOG_TAG(placeholders) \
+  LOG_TAG(preload)   /* Trace successfull class preloading */ \
   LOG_TAG(preorder)  /* Trace all classes loaded in order referenced (not loaded) */ \
   LOG_TAG(preview)   /* Trace loading of preview feature types */ \
   LOG_TAG(promotion) \

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -285,8 +285,7 @@ class InstanceKlass: public Klass {
     _misc_invalid_inline_super                = 1 << 19, // invalid super type for an inline type
     _misc_invalid_identity_super              = 1 << 20, // invalid super type for an identity type
     _misc_has_injected_identityObject         = 1 << 21, // IdentityObject has been injected by the JVM
-    _misc_has_injected_primitiveObject        = 1 << 22, // PrimitiveObject has been injected by the JVM
-    _misc_has_preload_attribute               = 1 << 23  // class has a Preload attribute
+    _misc_has_injected_primitiveObject        = 1 << 22  // PrimitiveObject has been injected by the JVM
   };
 
   // (*) An inline type is considered empty if it contains no non-static fields or
@@ -490,11 +489,7 @@ class InstanceKlass: public Klass {
   }
 
   bool has_preload_attribute() const {
-    return (_misc_flags & _misc_has_preload_attribute) != 0;
-  }
-
-  void set_has_preload_attribute() {
-    _misc_flags |= _misc_has_preload_attribute;
+    return _preload_classes != NULL;
   }
 
   // field sizes

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -285,7 +285,8 @@ class InstanceKlass: public Klass {
     _misc_invalid_inline_super                = 1 << 19, // invalid super type for an inline type
     _misc_invalid_identity_super              = 1 << 20, // invalid super type for an identity type
     _misc_has_injected_identityObject         = 1 << 21, // IdentityObject has been injected by the JVM
-    _misc_has_injected_primitiveObject        = 1 << 22  // PrimitiveObject has been injected by the JVM
+    _misc_has_injected_primitiveObject        = 1 << 22, // PrimitiveObject has been injected by the JVM
+    _misc_has_preload_attribute               = 1 << 23  // class has a Preload attribute
   };
 
   // (*) An inline type is considered empty if it contains no non-static fields or
@@ -349,7 +350,7 @@ class InstanceKlass: public Klass {
   //     ...
   Array<u2>*      _fields;
   const Klass**   _inline_type_field_klasses; // For "inline class" fields, NULL if none present
-
+  const Array<u2>* _preload_classes;
   const InlineKlassFixedBlock* _adr_inlineklass_fixed_block;
 
   // embedded Java vtable follows here
@@ -473,7 +474,7 @@ class InstanceKlass: public Klass {
   }
 
   bool has_injected_identityObject() const {
-    return (_misc_flags & _misc_has_injected_identityObject);
+    return (_misc_flags & _misc_has_injected_identityObject) != 0;
   }
 
   void set_has_injected_identityObject() {
@@ -481,11 +482,19 @@ class InstanceKlass: public Klass {
   }
 
   bool has_injected_valueObject() const {
-    return (_misc_flags & _misc_has_injected_primitiveObject);
+    return (_misc_flags & _misc_has_injected_primitiveObject) != 0;
   }
 
   void set_has_injected_primitiveObject() {
     _misc_flags |= _misc_has_injected_primitiveObject;
+  }
+
+  bool has_preload_attribute() const {
+    return (_misc_flags & _misc_has_preload_attribute) != 0;
+  }
+
+  void set_has_preload_attribute() {
+    _misc_flags |= _misc_has_preload_attribute;
   }
 
   // field sizes
@@ -561,6 +570,9 @@ class InstanceKlass: public Klass {
     _fields = f;
     _java_fields_count = java_fields_count;
   }
+
+  const Array<u2>* preload_classes() const { return _preload_classes; }
+  void set_preload_classes(Array<u2>* c) { _preload_classes = c; }
 
   // inner classes
   Array<u2>* inner_classes() const       { return _inner_classes; }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadValue0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadValue0.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class PreloadValue0 {
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadValue0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadValue0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,4 @@
  * questions.
  */
 
-public value class PreloadValue0 {
-
-}
+public value class PreloadValue0 { }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
@@ -25,6 +25,6 @@ public class ValuePreloadClient0 {
     PreloadValue0 value;
 
     public static void main(String[] args) {
-	System.out.print("Success");
+        System.out.print("Success");
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient0.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class ValuePreloadClient0 {
+    PreloadValue0 value;
+
+    public static void main(String[] args) {
+	System.out.print("Success");
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// The test class is based in the Java source code below, but the constant
+// pool entry #33 (used by the Preload attribute) has been modified to
+// contain the name of a non-existing class.
+//
+// public class ValuePreloadClient1 {
+//     PreloadValue0 value;
+//
+//     public static void main(String[] args) {
+//         System.out.print("Success");
+//     }
+// }
+
+ class ValuePreloadClient1 {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "java/lang/Object"; // #4
+    Utf8 "<init>"; // #5
+    Utf8 "()V"; // #6
+    Field #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "java/lang/System"; // #10
+    Utf8 "out"; // #11
+    Utf8 "Ljava/io/PrintStream;"; // #12
+    String #14; // #13
+    Utf8 "Success"; // #14
+    Method #16 #17; // #15
+    class #18; // #16
+    NameAndType #19 #20; // #17
+    Utf8 "java/io/PrintStream"; // #18
+    Utf8 "print"; // #19
+    Utf8 "(Ljava/lang/String;)V"; // #20
+    class #22; // #21
+    Utf8 "ValuePreloadClient1"; // #22
+    Utf8 "value"; // #23
+    Utf8 "LPreloadValue0;"; // #24
+    Utf8 "Code"; // #25
+    Utf8 "LineNumberTable"; // #26
+    Utf8 "main"; // #27
+    Utf8 "([Ljava/lang/String;)V"; // #28
+    Utf8 "SourceFile"; // #29
+    Utf8 "ValuePreloadClient1.java"; // #30
+    Utf8 "Preload"; // #31
+    class #33; // #32
+    Utf8 "PreloadValue1"; // #33
+  } // Constant Pool
+
+  0x0021; // access
+  #21;// this_cpx
+  #2;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0000; // access
+      #23; // name_index
+      #24; // descriptor_index
+      [] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#25) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2AB70001B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#26) { // LineNumberTable
+              [] { // line_number_table
+                0  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0009; // access
+      #27; // name_index
+      #28; // descriptor_index
+      [] { // Attributes
+        Attr(#25) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#26) { // LineNumberTable
+              [] { // line_number_table
+                0  5;
+                8  6;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#29) { // SourceFile
+      #30;
+    } // end SourceFile
+    ;
+    Attr(#31) { // Preload
+      0x00010020;
+    } // end Preload
+  } // Attributes
+} // end class ValuePreloadClient1

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -52,8 +52,8 @@ public class ValuePreloadTest {
     }
 
     public static void main(String[] args) throws Exception {
-	    ProcessBuilder pb = exec("-Xlog:class+preload","ValuePreloadClient0");
-	    checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during linking of class ValuePreloadClient0 because of its Preload attribute");
+        ProcessBuilder pb = exec("-Xlog:class+preload","ValuePreloadClient0");
+        checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during linking of class ValuePreloadClient0 because of its Preload attribute");
 
         pb = exec("-Xlog:class+preload","ValuePreloadClient1");
         checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (Preload attribute) failed");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test ValuePreloadTest
+ * @library /test/lib
+ * @compile ValuePreloadClient0.java PreloadValue0.java ValuePreloadClient1.jcod
+ * @run driver ValuePreloadTest
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ValuePreloadTest {
+
+    static ProcessBuilder exec(String... args) throws Exception {
+        List<String> argsList = new ArrayList<>();
+        Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
+        Collections.addAll(argsList, args);
+        return ProcessTools.createJavaProcessBuilder(argsList);
+    }
+
+    static void checkFor(ProcessBuilder pb, String... outputStrings) throws Exception {
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        for (String s: outputStrings) {
+            out.shouldContain(s);
+        }
+        out.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+	    ProcessBuilder pb = exec("-Xlog:class+preload","ValuePreloadClient0");
+	    checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during linking of class ValuePreloadClient0 because of its Preload attribute");
+
+        pb = exec("-Xlog:class+preload","ValuePreloadClient1");
+        checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (Preload attribute) failed");
+    }
+}


### PR DESCRIPTION
Please review this changeset adding support for the Preload attribute.
It includes a logging feature to track and diagnose those optimistic class loading.

Tested with Mach5 tier1.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281116](https://bugs.openjdk.java.net/browse/JDK-8281116): [lworld] Adding Preload attribute support


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/623/head:pull/623` \
`$ git checkout pull/623`

Update a local copy of the PR: \
`$ git checkout pull/623` \
`$ git pull https://git.openjdk.java.net/valhalla pull/623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 623`

View PR using the GUI difftool: \
`$ git pr show -t 623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/623.diff">https://git.openjdk.java.net/valhalla/pull/623.diff</a>

</details>
