### PR TITLE
8280980: [lworld] MethodHandle and VarHandle support for value classes

### DIFF
--- a/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/ArrayElementVarHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,110 +67,71 @@ public class ArrayElementVarHandleTest {
             NonFlattenValue.make(100, 200)
     };
 
-    /*
-     * VarHandle of Object[].class
-     */
-    @Test
-    public void testObjectArrayVarHandle() throws Throwable {
-        // Point[] <: Point.ref[] <: Object
-        Object[] array1 = newArray(Object[].class, POINTS.length);
-        setElements(array1, POINTS);
-        setElements(array1, NULL_POINTS);
-        setElements(array1, new Object[] { "abc", Point.makePoint(1, 2) });
+    private static final ValueOptional[] VALUES = new ValueOptional[]{
+            new ValueOptional(null),
+            new ValueOptional(P),
+            null
+    };
 
-        Point.ref[] array2 = new Point.ref[NULL_POINTS.length];
-        setElements(array2, POINTS);
-        setElements(array2, NULL_POINTS);
+    @DataProvider(name="data")
+    static Object[][] data() throws Throwable {
+        int plen = POINTS.length;
+        int llen = LINES.length;
+        int vlen = VALUES.length;
+        return new Object[][]{
+                // Point[] <: Point.ref[] <: Object[]
+                new Object[] { newArray(Object[].class, plen),    POINTS },
+                new Object[] { newArray(Object[].class, plen),    NULL_POINTS },
+                new Object[] { newArray(Object[].class, plen),    new Object[] { "abc", Point.makePoint(1, 2) } },
+                new Object[] { newArray(Point.ref[].class, plen), NULL_POINTS },
+                new Object[] { newArray(Point[].class, plen),     POINTS },
+                new Object[] { new Point.ref[plen],               POINTS },
+                new Object[] { new Point.ref[plen],               NULL_POINTS },
+                new Object[] { new Point[plen],                   POINTS },
 
-        Point[] array3 = new Point[POINTS.length];
-        setElements(array3, POINTS);
+                // Line[] <: Line.ref[]
+                new Object[] { newArray(Object[].class, llen),    LINES },
+                new Object[] { newArray(Object[].class, llen),    NULL_LINES },
+                new Object[] { newArray(Object[].class, llen),    LINES },
+                new Object[] { newArray(Line.ref[].class, llen),  NULL_LINES },
+                new Object[] { newArray(Line[].class, llen),      LINES },
+                new Object[] { new Line.ref[llen],                LINES },
+                new Object[] { new Line.ref[llen],                NULL_LINES },
+                new Object[] { new Line[llen],                    LINES },
+
+                // value class
+                new Object[] { newArray(Object[].class, vlen),        VALUES },
+                new Object[] { newArray(ValueOptional[].class, vlen), VALUES },
+                new Object[] { new ValueOptional[vlen],               VALUES },
+
+                // non flattened values
+                new Object[] { newArray(NonFlattenValue[].class, NFV_ARRAY.length), NFV_ARRAY },
+                new Object[] { new NonFlattenValue[NFV_ARRAY.length], NFV_ARRAY }
+        };
     }
 
     /*
-     * VarHandle of Point.ref[].class
+     * Test VarHandle to set elements of the given array with
+     * various access mode.
      */
-    @Test
-    public void testPointRefVarHandle() throws Throwable {
-        // Point[] <: Point.ref[] <: Object
-        Point.ref[] array1 = (Point.ref[])newArray(Point.ref[].class, POINTS.length);
-        assertTrue(array1.getClass().componentType() == Point.ref.class);
-
-        setElements(array1, POINTS);
-        setElements(array1, NULL_POINTS);
-
-        Point.ref[] array2 = new Point.ref[NULL_POINTS.length];
-        setElements(array2, POINTS);
-        setElements(array2, NULL_POINTS);
-
-        Point[] array3 = new Point[POINTS.length];
-        setElements(array3, POINTS);
+    @Test(dataProvider = "data")
+    public void testSetArrayElements(Object[] array, Object[] data) throws Throwable {
+        setElements(array, data);
     }
 
     /*
-     * VarHandle of Point[].class
+     * Constructs a new array of the specified type and size using
+     * MethodHandle.
      */
-    @Test
-    public void testPointArrayVarHandle()  throws Throwable {
-        // Point[] <: Point.ref[] <: Object
-        Point[] array1 = (Point[]) newArray(Point[].class, POINTS.length);
-        assertTrue(array1.getClass().componentType() == Point.class.asValueType());
-        setElements(array1, POINTS);
-
-        Point[] array3 = new Point[POINTS.length];
-        setElements(array3, POINTS);
-    }
-
-    /*
-     * VarHandle of Line.ref[].class
-     */
-    @Test
-    public void testLineRefVarHandle() throws Throwable {
-        // Line[] <: Line.ref[]
-        Line.ref[] array1 = (Line.ref[])newArray(Line.ref[].class, LINES.length);
-        assertTrue(array1.getClass().componentType() == Line.ref.class);
-
-        setElements(array1, LINES);
-        setElements(array1, NULL_LINES);
-
-        Line.ref[] array2 = new Line.ref[LINES.length];
-        setElements(array2, LINES);
-        setElements(array2, NULL_LINES);
-
-        Line[] array3 = new Line[LINES.length];
-        setElements(array3, LINES);
-    }
-
-    /*
-     * VarHandle of Line[].class
-     */
-    @Test
-    public void testLineVarHandle() throws Throwable {
-        Line[] array1 = (Line[])newArray(Line[].class, LINES.length);
-        assertTrue(array1.getClass().componentType() == Line.class.asValueType());
-        setElements(array1, LINES);
-
-        Line[] array3 = new Line[LINES.length];
-        setElements(array3, LINES);
-    }
-
-    /*
-     * VarHandle of NonFlattenValue[].class
-     */
-    @Test
-    public void testNonFlattenedValueVarHandle() throws Throwable {
-        NonFlattenValue[] array1 = (NonFlattenValue[])newArray(NonFlattenValue[].class, NFV_ARRAY.length);
-        assertTrue(array1.getClass().componentType() == NonFlattenValue.class.asValueType());
-        setElements(array1, NFV_ARRAY);
-
-        NonFlattenValue[] array3 = new NonFlattenValue[POINTS.length];
-        setElements(array3, NFV_ARRAY);
-    }
-
-    Object[] newArray(Class<?> arrayType, int size) throws Throwable {
+    static Object[] newArray(Class<?> arrayType, int size) throws Throwable {
         MethodHandle ctor = MethodHandles.arrayConstructor(arrayType);
         return (Object[]) ctor.invoke(size);
     }
 
+    /*
+     * Sets the given array with the given elements.
+     * This tests several VarHandle access mode.
+     */
     void setElements(Object[] array, Object[] elements) {
         Class<?> arrayType = array.getClass();
         assertTrue(array.length >= elements.length);
@@ -267,6 +228,4 @@ public class ArrayElementVarHandleTest {
             assertEquals(vh.compareAndExchange(array, i, elements[i], v), elements[i]);
         }
     }
-
-
 }

--- a/test/jdk/valhalla/valuetypes/MixedValues.java
+++ b/test/jdk/valhalla/valuetypes/MixedValues.java
@@ -26,11 +26,13 @@ import java.util.List;
 public class MixedValues {
     static Point staticPoint = Point.makePoint(10, 10);
     static Line.ref staticLine;   // null static field of non-flattened type
+    static ValueOptional staticValue;
     Point p;
     Line l;
     MutablePath mutablePath;
     List<String> list;
     Point.ref nfp;
+    ValueOptional voptional;
 
     public MixedValues(Point p, Line l, MutablePath path, String... names) {
         this.p = p;
@@ -38,5 +40,6 @@ public class MixedValues {
         this.mutablePath = path;
         this.list = List.of(names);
         this.nfp = p;
+        this.voptional = new ValueOptional(p);
     }
 }

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -100,6 +100,9 @@ public class ObjectMethods {
             { new ReferenceType0(30), new ValueType1(30), true},
             { new ReferenceType0(30), new ValueType2(30), true},
             { new PrimitiveRecord(40, "forty"), new PrimitiveRecord(40, "forty"), true},
+            { new ValueRecord(50, "fifty"), new ValueRecord(50, "fifty"), true},
+            { new ValueOptional(LINE1), new ValueOptional(LINE1), true},
+            { new ValueOptional(List.of(P1)), new ValueOptional(List.of(P1)), false},
         };
     }
 
@@ -143,6 +146,8 @@ public class ObjectMethods {
             { MyValue1.default },
             { new MyValue1(0,0, null) },
             { new MyValue1(0,0, P1) },
+            { ValueOptional.default },
+            { new ValueOptional(P1) },
         };
     }
 
@@ -170,6 +175,7 @@ public class ObjectMethods {
             { Point.default,        hash(Point.class.asValueType(), 0, 0) },
             { MyValue1.default,     hash(MyValue1.class.asValueType(), Point.default, null) },
             { new MyValue1(0, 0, null), hash(MyValue1.class.asValueType(), Point.makePoint(0,0), null) },
+            { new ValueOptional(P1), hash(ValueOptional.class, P1) },
         };
     }
 
@@ -265,4 +271,6 @@ public class ObjectMethods {
     }
 
     static primitive record PrimitiveRecord(int i, String name) {}
+    static value record ValueRecord(int i, String name) {}
+
 }

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -82,6 +82,28 @@ public class Reflection {
         checkInstanceMethod(NonFlattenValue.class.asValueType(), "has", boolean.class, Point.class.asValueType(), Point.ref.class);
     }
 
+    @Test
+    public static void testValueOptionalClass() throws Exception  {
+        Point point = Point.makePoint(10,20);
+        Constructor<ValueOptional> ctor = ValueOptional.class.getDeclaredConstructor(Object.class);
+        ValueOptional o = ctor.newInstance(point);
+        assertEquals(o.getClass(), ValueOptional.class);
+
+        Field field = ValueOptional.class.getDeclaredField("o");
+        // accessible but no write access
+        field.trySetAccessible();
+        assertTrue(field.isAccessible());
+
+        if (field.get(o) != point) {
+            fail("Unexpected ValueOptional.o value: " +  field.get(o));
+        }
+        try {
+            field.set(o, point);
+            fail("IllegalAccessException not thrown");
+        } catch (IllegalAccessException e) {}
+
+        checkToString(field);
+    }
 
     static void checkInstanceField(Class<?> declaringClass, String name, Class<?> type) throws Exception {
         Field f = declaringClass.getDeclaredField(name);
@@ -100,6 +122,9 @@ public class Reflection {
         int mods = f.getModifiers();
         if (Modifier.isPublic(mods)) {
             sb.append("public").append(" ");
+        }
+        if (Modifier.isPrivate(mods)) {
+            sb.append("private").append(" ");
         }
         if (Modifier.isStatic(mods)) {
             sb.append("static").append(" ");

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -27,7 +27,6 @@
  * @bug 8273360
  * @summary Test reflection of constructors for value classes
  * @run testng/othervm StaticFactoryTest
- * @run testng/othervm -Dsun.reflect.noInflation=true -Djdk.reflection.useDirectMethodHandle=false StaticFactoryTest
  */
 
 import java.lang.reflect.Constructor;

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -25,9 +25,9 @@
 /*
  * @test
  * @bug 8273360
- * @summary Test reflection of constructors for primitive classes
+ * @summary Test reflection of constructors for value classes
  * @run testng/othervm StaticFactoryTest
- * @run testng/othervm -Dsun.reflect.noInflation=true StaticFactoryTest
+ * @run testng/othervm -Dsun.reflect.noInflation=true -Djdk.reflection.useDirectMethodHandle=false StaticFactoryTest
  */
 
 import java.lang.reflect.Constructor;
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
@@ -55,77 +56,95 @@ public class StaticFactoryTest {
         }
     }
 
-    static final Class<?> PRIMITIVE_TYPE = SimplePrimitive.class.asValueType();
+    static value class SimpleValue {
+        private final SimplePrimitive v;
 
-    @Test
-    public static void testPrimitiveClassConstructor() throws Exception {
-        String cn = PRIMITIVE_TYPE.getName();
-        Class<?> c = Class.forName(cn).asValueType();
+        SimpleValue() {
+            this.v = SimplePrimitive.default;
+        }
 
-        assertTrue(c.isPrimitiveClass());
-        assertTrue(c == PRIMITIVE_TYPE);
+        public SimpleValue(SimplePrimitive v) {
+            this.v = v;
+        }
     }
 
-    @Test
-    public static void constructor() throws Exception {
-        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
+    @DataProvider
+    static Object[][] classes() {
+        return new Object[][]{
+                new Object[] { SimplePrimitive.class, true },
+                new Object[] { SimpleValue.class, false },
+        };
+    }
+
+    @Test(dataProvider = "classes")
+    public void testConstructor(Class<?> c, boolean isPrimitiveClass) throws ReflectiveOperationException {
+        String cn = c.getName();
+        Class<?> clz = Class.forName(cn);
+
+        assertTrue(clz.isValue());
+        assertTrue(clz.isPrimitiveClass() == isPrimitiveClass);
+
+        Constructor<?> ctor = clz.getDeclaredConstructor();
         Object o = ctor.newInstance();
-        assertTrue(o.getClass() == PRIMITIVE_TYPE.asPrimaryType());
+        assertTrue(o.getClass() == c);
+
+        // Verify that the constructor and field can be set accessible
+        ctor.setAccessible(true);
+        assertTrue(ctor.trySetAccessible());
+
+        // Check that getDeclaredMethods does not include the static factory method
+        Method[] methods = clz.getDeclaredMethods();
+        for (Method m : methods) {
+            if (Modifier.isStatic(m.getModifiers())) {
+                assertFalse(m.getName().equals("<init>"));
+            }
+        }
+    }
+
+    @DataProvider
+    static Object[][] ctors() {
+        return new Object[][]{
+                new Object[] { SimplePrimitive.class, Set.of("public StaticFactoryTest$SimplePrimitive(int)",
+                                                             "StaticFactoryTest$SimplePrimitive()")},
+                new Object[] { SimpleValue.class, Set.of("public StaticFactoryTest$SimpleValue(StaticFactoryTest$SimplePrimitive)",
+                                                         "StaticFactoryTest$SimpleValue()") },
+        };
     }
 
     // Check that the class has the expected Constructors
-    @Test
-    public static void constructors() throws Exception {
-        Set<String> expectedSig = Set.of("public StaticFactoryTest$SimplePrimitive(int)",
-                                         "StaticFactoryTest$SimplePrimitive()");
-        Constructor<? extends Object>[] cons = PRIMITIVE_TYPE.getDeclaredConstructors();
+    @Test(dataProvider = "ctors")
+    public static void constructors(Class<?> c, Set<String> signatures) throws ReflectiveOperationException {
+        Constructor<?>[] cons = c.getDeclaredConstructors();
         Set<String> actualSig = Arrays.stream(cons).map(Constructor::toString)
                                       .collect(Collectors.toSet());
-        boolean ok = expectedSig.equals(actualSig);
+        boolean ok = signatures.equals(actualSig);
         if (!ok) {
-            System.out.printf("expected: %s%n", expectedSig);
+            System.out.printf("expected: %s%n", signatures);
             System.out.printf("declared: %s%n", actualSig);
             assertTrue(ok);
         }
     }
 
-    // Check that the constructor and field can be set accessible
-    @Test
-    public static void setAccessible() throws Exception {
-        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
-        ctor.setAccessible(true);
-
-        Field field = PRIMITIVE_TYPE.getField("x");
-        field.setAccessible(true);
-    }
-
-    // Check that the constructor and field can be set accessible
-    @Test
-    public static void trySetAccessible() throws Exception {
-        Constructor<?> ctor = PRIMITIVE_TYPE.getDeclaredConstructor();
-        assertTrue(ctor.trySetAccessible());
-
-        Field field = PRIMITIVE_TYPE.getField("x");
-        assertTrue(field.trySetAccessible());
+    @DataProvider
+    static Object[][] fields() throws ReflectiveOperationException {
+        return new Object[][]{
+                new Object[] { SimplePrimitive.class.getDeclaredField("x"), new SimplePrimitive(), 200},
+                new Object[] { SimpleValue.class.getDeclaredField("v"), new SimpleValue(), new SimplePrimitive(10) },
+        };
     }
 
     // Check that the final field cannot be modified
-    @Test(expectedExceptions = IllegalAccessException.class)
-    public static void setFinalField() throws Exception {
-        Field field = PRIMITIVE_TYPE.getField("x");
+    @Test(dataProvider = "fields", expectedExceptions = IllegalAccessException.class)
+    public static void readOnlyFields(Field field, Object obj, Object newValue) throws ReflectiveOperationException {
+        // succeeds to set accessible flag
         field.setAccessible(true);
-        field.setInt(new SimplePrimitive(100), 200);
-    }
+        assertTrue(field.trySetAccessible());
 
-
-    // Check that the class does not have a static method with the name <init>
-    @Test
-    public static void initFactoryNotMethods() {
-        Method[] methods = PRIMITIVE_TYPE.getDeclaredMethods();
-        for (Method m : methods) {
-            if (Modifier.isStatic(m.getModifiers())) {
-                assertFalse(m.getName().equals("<init>"));
-            }
+        // value class' final fields cannot be modified
+        if (field.getType() == int.class) {
+            field.setInt(obj, ((Integer) newValue).intValue());
+        } else {
+            field.set(obj, newValue);
         }
     }
 }

--- a/test/jdk/valhalla/valuetypes/StreamTest.java
+++ b/test/jdk/valhalla/valuetypes/StreamTest.java
@@ -31,6 +31,7 @@
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.testng.Assert.*;
@@ -40,7 +41,8 @@ public class StreamTest {
     private Value[] init() {
         Value[] values = new Value[10];
         for (int i = 0; i < 10; i++) {
-            values[i] = new Value(i, new Point(i,i*2), (i%2) == 0 ? null : new Point(i*10, i*20));
+            values[i] = new Value(i, new Point(i,i*2), (i%2) == 0 ? null : new Point(i*10, i*20),
+                                  List.of(new X(i), new X(i*10)));
         }
         return values;
     }
@@ -73,14 +75,27 @@ public class StreamTest {
         stream.forEach(p -> assertTrue((p.x % 2) == 0));
     }
 
+    @Test
+    public void testValue() {
+        long count = Arrays.stream(values)
+                           .map(Value.ref::list)
+                           .flatMap(List::stream)
+                           .map(X::x)
+                           .filter(x -> x >= 10)
+                           .count();
+        assertEquals(count, values.length-1);
+    }
+
     static primitive class Value {
         int i;
         Point p;
         Point.ref nullable;
-        Value(int i, Point p, Point.ref np) {
+        List<X> list;
+        Value(int i, Point p, Point.ref np, List<X> list) {
             this.i = i;
             this.p = p;
             this.nullable = np;
+            this.list = list;
         }
 
         Point point() {
@@ -92,5 +107,17 @@ public class StreamTest {
         }
 
         int getI() { return i; }
+
+        List<X> list() { return list; }
+    }
+
+    static value class X {
+        private int x;
+        X(int x) {
+            this.x = x;
+        }
+        int x() {
+            return x;
+        }
     }
 }

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -39,13 +39,18 @@ public class ValueArray {
     @DataProvider(name="elementTypes")
     static Object[][] elementTypes() {
         return new Object[][]{
-            new Object[] { Point.class.asValueType(), new Point(0,0) },
+            new Object[] { Point.class.asValueType(), Point.default },
             new Object[] { Point.ref.class, null },
+            new Object[] { ValueOptional.class, null },
         };
     }
+
+    /*
+     * Test an array created from the given element type via Array::newInstance
+     */
     @Test(dataProvider="elementTypes")
-    public void testPrimitiveElementType(Class<?> elementType, Object defaultValue) {
-        assertTrue(elementType.isPrimitiveClass());
+    public void testElementType(Class<?> elementType, Object defaultValue) {
+        assertTrue(elementType.isValue());
         assertTrue(elementType.isPrimaryType() || defaultValue != null);
 
         Object[] array = (Object[])Array.newInstance(elementType, 1);
@@ -88,9 +93,16 @@ public class ValueArray {
                                                    NonFlattenValue.make(100, 200)}},
             new Object[] { Point[].class,  new Point[0] },
             new Object[] { Point.ref[].class,  new Point.ref[0] },
+            new Object[] { ValueOptional[].class,  new ValueOptional[0] },
         };
     }
 
+    /*
+     * Test the following properties of an array of value class:
+     * - class name
+     * - array element can be null or not
+     * - array covariance if the element type is a primitive value type
+     */
     @Test(dataProvider="arrayTypes")
     public void testArrays(Class<?> arrayClass, Object[] array) {
         testClassName(arrayClass);
@@ -121,7 +133,7 @@ public class ValueArray {
 
     /**
      * Setting the elements of an array.
-     * NPE will be thrown if null is set on an element in an array of value type
+     * NPE will be thrown if null is set on an element in an array of primitive value type
      */
     static void testArrayElements(Class<?> arrayClass, Object[] array) {
         Class<?> componentType = arrayClass.getComponentType();
@@ -222,12 +234,14 @@ public class ValueArray {
     }
 
     @Test
-    static void testPointArray() {
+    static void testInstanceOf() {
         Point[] qArray = new Point[0];
         Point.ref[] lArray = new Point.ref[0];
+        ValueOptional[] vArray = new ValueOptional[0];
 
         // language instanceof
         assertTrue(qArray instanceof Point[]);
         assertTrue(lArray instanceof Point.ref[]);
+        assertTrue(vArray instanceof ValueOptional[]);
     }
 }

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -47,6 +47,9 @@ public class ValueConstantDesc {
             new Object[] { Point.ref.class, ClassDesc.ofDescriptor("L" + NAME + ";"), NAME},
             new Object[] { Point[].class,   ClassDesc.ofDescriptor("[Q" + NAME + ";"), NAME + "[]"},
             new Object[] { Point.ref[][].class, ClassDesc.ofDescriptor("[[L" + NAME + ";"), NAME + "[][]"},
+            new Object[] { ValueOptional.class, ClassDesc.ofDescriptor("LValueOptional;"), "ValueOptional"},
+            new Object[] { ValueOptional[].class, ClassDesc.ofDescriptor("[LValueOptional;"), "ValueOptional[]"},
+            new Object[] { ValueOptional[][].class, ClassDesc.ofDescriptor("[[LValueOptional;"), "ValueOptional[][]"},
         };
     }
 
@@ -69,7 +72,8 @@ public class ValueConstantDesc {
     static Object[][] componentTypes() {
         return new Object[][]{
             new Object[] { Point.class.asValueType() },
-            new Object[] { Point.ref.class }
+            new Object[] { Point.ref.class },
+            new Object[] { ValueOptional.class }
         };
     }
 
@@ -92,6 +96,8 @@ public class ValueConstantDesc {
                 new Object[] { Point.ref.class,     "L" + NAME + ";"},
                 new Object[] { Point[].class,       "[Q" + NAME + ";"},
                 new Object[] { Point.ref[][].class, "[[L" + NAME + ";"},
+                new Object[] { ValueOptional.class, "LValueOptional;"},
+                new Object[] { ValueOptional[].class, "[LValueOptional;"},
         };
     }
     @Test(dataProvider="valueDesc")


### PR DESCRIPTION
Add new test cases for value classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280980](https://bugs.openjdk.java.net/browse/JDK-8280980): [lworld] MethodHandle and VarHandle support for value classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/624/head:pull/624` \
`$ git checkout pull/624`

Update a local copy of the PR: \
`$ git checkout pull/624` \
`$ git pull https://git.openjdk.java.net/valhalla pull/624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 624`

View PR using the GUI difftool: \
`$ git pr show -t 624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/624.diff">https://git.openjdk.java.net/valhalla/pull/624.diff</a>

</details>
