### PR TITLE
8279840 [lworld] Inconsistent treatment of repeated modifiers.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4531,8 +4531,9 @@ public class JavacParser implements Parser {
                 case CLASS: case INTERFACE: case ENUM:
                     isPrimitiveModifier = true;
                     break;
-                case IDENTIFIER: // primitive record R || new primitive Comparable() {}
-                    if (next.name() == names.record || (mode & EXPR) != 0)
+                case IDENTIFIER: // primitive record R || primitive primitive || primitive value || new primitive Comparable() {}
+                    if (next.name() == names.record || next.name() == names.primitive
+                            || next.name() == names.value || (mode & EXPR) != 0)
                         isPrimitiveModifier = true;
                     break;
             }
@@ -4556,8 +4557,9 @@ public class JavacParser implements Parser {
                 case CLASS: case INTERFACE: case ENUM:
                     isValueModifier = true;
                     break;
-                case IDENTIFIER: // value record R || new value Comparable() {} ??
-                    if (next.name() == names.record || (mode & EXPR) != 0)
+                case IDENTIFIER: // value record R || value value || value primitive || new value Comparable() {} ??
+                    if (next.name() == names.record || next.name() == names.value
+                            || next.name() == names.primitive || (mode & EXPR) != 0)
                         isValueModifier = true;
                     break;
             }

--- a/test/langtools/tools/javac/valhalla/value-objects/ModifiersTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ModifiersTest.java
@@ -1,0 +1,22 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279840
+ * @summary [lworld] Inconsistent treatment of repeated modifiers.
+ * @compile/fail/ref=ModifiersTest.out -XDrawDiagnostics -XDdev ModifiersTest.java
+ */
+
+public class ModifiersTest {
+
+    static static class StaticTest {
+    }
+
+    native native class NativeTest {
+    }
+
+    value value primitive class ValueTest {
+    }
+
+    primitive primitive value class PrimitiveTest {
+    }
+
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/ModifiersTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/ModifiersTest.out
@@ -1,0 +1,5 @@
+ModifiersTest.java:10:12: compiler.err.repeated.modifier
+ModifiersTest.java:13:12: compiler.err.repeated.modifier
+ModifiersTest.java:16:11: compiler.err.repeated.modifier
+ModifiersTest.java:19:15: compiler.err.repeated.modifier
+4 errors


### PR DESCRIPTION
Make context-dependent keywords value and primitive act more like ordinary modifiers (for consistent error reporting.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279840](https://bugs.openjdk.java.net/browse/JDK-8279840): [lworld] Inconsistent treatment of repeated modifiers.


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.java.net/valhalla pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/625.diff">https://git.openjdk.java.net/valhalla/pull/625.diff</a>

</details>
