### PR TITLE
8279839 [lworld] Javac has started incorrectly accepting native as a modifer for classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -422,7 +422,7 @@ public class Flags {
      */
     public static final int
         AccessFlags                       = PUBLIC | PROTECTED | PRIVATE,
-        LocalClassFlags                   = FINAL | ABSTRACT | ENUM | SYNTHETIC  | ACC_PRIMITIVE | ACC_VALUE | ACC_PERMITS_VALUE,
+        LocalClassFlags                   = FINAL | ABSTRACT | STRICTFP | ENUM | SYNTHETIC | ACC_PERMITS_VALUE,
         StaticLocalClassFlags             = LocalClassFlags | STATIC | INTERFACE,
         MemberClassFlags                  = LocalClassFlags | INTERFACE | AccessFlags,
         MemberStaticClassFlags            = MemberClassFlags | STATIC,
@@ -435,7 +435,8 @@ public class Flags {
         MethodFlags                       = AccessFlags | ABSTRACT | STATIC | NATIVE |
                                             SYNCHRONIZED | FINAL | STRICTFP,
         RecordMethodFlags                 = AccessFlags | ABSTRACT | STATIC |
-                                            SYNCHRONIZED | FINAL | STRICTFP;
+                                            SYNCHRONIZED | FINAL | STRICTFP,
+        AdjustedClassFlags                = ClassFlags | ACC_PRIMITIVE | ACC_VALUE;
     public static final long
         ExtendedStandardFlags             = (long)StandardFlags | DEFAULT | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,
         ExtendedMemberClassFlags          = (long)MemberClassFlags | SEALED | NON_SEALED | PRIMITIVE_CLASS | VALUE_CLASS,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2238,7 +2238,7 @@ public class Lower extends TreeTranslator {
 
         // Convert a protected modifier to public, mask static modifier.
         if ((tree.mods.flags & PROTECTED) != 0) tree.mods.flags |= PUBLIC;
-        tree.mods.flags &= ClassFlags;
+        tree.mods.flags &= AdjustedClassFlags;
 
         // Convert name to flat representation, replacing '.' by '$'.
         tree.name = Convert.shortName(currentClass.flatName());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1564,7 +1564,7 @@ public class ClassWriter extends ClassFile {
         } else {
             flags = adjustFlags(c.flags() & ~(DEFAULT | STRICTFP));
             if ((flags & PROTECTED) != 0) flags |= PUBLIC;
-            flags = flags & ClassFlags;
+            flags = flags & AdjustedClassFlags;
             if ((flags & INTERFACE) == 0) flags |= ACC_SUPER;
         }
 

--- a/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.java
@@ -8,6 +8,6 @@
 public native class NativeModifierTest {
 
     public native class NativeClassIsNotAThing {
-    } 
+    }
 
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.java
@@ -1,0 +1,13 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8279839
+ * @summary [lworld] Javac has started incorrectly accepting native as a modifer for classes
+ * @compile/fail/ref=NativeModifierTest.out -XDrawDiagnostics -XDdev NativeModifierTest.java
+ */
+
+public native class NativeModifierTest {
+
+    public native class NativeClassIsNotAThing {
+    } 
+
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/NativeModifierTest.out
@@ -1,0 +1,3 @@
+NativeModifierTest.java:8:15: compiler.err.mod.not.allowed.here: native
+NativeModifierTest.java:10:19: compiler.err.mod.not.allowed.here: native
+2 errors


### PR DESCRIPTION
Confusion between the ACC_VALUE and ACC_NATIVE resolved
by making explicit class flags masks for the adjusted flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8279839](https://bugs.openjdk.java.net/browse/JDK-8279839): [lworld] Javac has started incorrectly accepting native as a modifer for classes


### Reviewers
 * [Srikanth Adayapalam](https://openjdk.java.net/census#sadayapalam) (@sadayapalam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/627/head:pull/627` \
`$ git checkout pull/627`

Update a local copy of the PR: \
`$ git checkout pull/627` \
`$ git pull https://git.openjdk.java.net/valhalla pull/627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 627`

View PR using the GUI difftool: \
`$ git pr show -t 627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/627.diff">https://git.openjdk.java.net/valhalla/pull/627.diff</a>

</details>
