### PR TITLE
8281166: [lworld] javac should generate BSM to invoke the static factory for value class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2341,7 +2341,7 @@ public class LambdaToMethod extends TreeTranslator {
                         receiverIsReferenceProjection() ||
                         (tree.getMode() == ReferenceMode.NEW &&
                           tree.kind != ReferenceKind.ARRAY_CTOR &&
-                          (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner() || tree.sym.owner.isPrimitiveClass()));
+                          (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner() || tree.sym.owner.isValueClass()));
             }
 
             Type generatedRefSig() {

--- a/test/langtools/tools/javac/valhalla/value-objects/ConstructorRefTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ConstructorRefTest.java
@@ -56,7 +56,7 @@ public class ConstructorRefTest {
         }
     }
 
-    public static void main(String [] args) {   
+    public static void main(String [] args) {
 
         Supplier<P.ref> sxp = P::new;
         P p = (P) sxp.get();

--- a/test/langtools/tools/javac/valhalla/value-objects/ConstructorRefTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ConstructorRefTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8281166
+ * @summary javac should generate BSM to invoke the static factory for value class
+ * @run main ConstructorRefTest
+ */
+
+import java.util.function.Supplier;
+
+public class ConstructorRefTest {
+
+    public static value class V {
+
+        final int x;
+        final int y;
+
+        V() {
+            x = 1234;
+            y = 5678;
+        }
+    }
+
+    public static primitive class P {
+
+        final int x;
+        final int y;
+
+        P() {
+            x = 1234;
+            y = 5678;
+        }
+    }
+
+    public static void main(String [] args) {   
+
+        Supplier<P.ref> sxp = P::new;
+        P p = (P) sxp.get();
+        if (p.x != 1234 || p.y != 5678)
+            throw new AssertionError(p);
+
+        Supplier<V> sxv = V::new;
+        V v = (V) sxv.get();
+        if (v.x != 1234 || v.y != 5678)
+            throw new AssertionError(v);
+    }
+}


### PR DESCRIPTION
When constructor reference expressions invole value classes, ensure that TransValues will see the constructor call in order for that call to be transformed into factory method invocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281166](https://bugs.openjdk.java.net/browse/JDK-8281166): [lworld] javac should generate BSM to invoke the static factory for value class


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/629/head:pull/629` \
`$ git checkout pull/629`

Update a local copy of the PR: \
`$ git checkout pull/629` \
`$ git pull https://git.openjdk.java.net/valhalla pull/629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 629`

View PR using the GUI difftool: \
`$ git pr show -t 629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/629.diff">https://git.openjdk.java.net/valhalla/pull/629.diff</a>

</details>
