### PR TITLE
8281336: [lworld] Remove workaround in LambdaToMethod to circumvent BootstrapMethodError

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -268,10 +268,10 @@ import static sun.invoke.util.Wrapper.isWrapperType;
             }
 
             // check receiver type
-            if (!implClass.isAssignableFrom(receiverClass)) {
+            if (!implClass.asPrimaryType().isAssignableFrom(receiverClass.asPrimaryType())) {
                 throw new LambdaConversionException(
                         String.format("Invalid receiver type %s; not a subtype of implementation type %s",
-                                      receiverClass, implClass));
+                                      receiverClass.descriptorString(), implClass.descriptorString()));
             }
         } else {
             // no receiver
@@ -321,7 +321,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
         for (int i = 0; i < dynamicMethodType.parameterCount(); i++) {
             Class<?> dynamicParamType = dynamicMethodType.parameterType(i);
             Class<?> descriptorParamType = descriptor.parameterType(i);
-            if (!descriptorParamType.isAssignableFrom(dynamicParamType)) {
+            if (!descriptorParamType.asPrimaryType().isAssignableFrom(dynamicParamType.asPrimaryType())) {
                 String msg = String.format("Type mismatch for dynamic parameter %d: %s is not a subtype of %s",
                                            i, dynamicParamType, descriptorParamType);
                 throw new LambdaConversionException(msg);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -2283,14 +2283,6 @@ public class LambdaToMethod extends TreeTranslator {
                 return tree.ownerAccessible;
             }
 
-            /* Workaround to BootstrapMethodError. This workaround should not be required in the unified
-               class generation model, but seems to be required ...
-               Todo: Investigate to see if a defect should be reported against runtime lambda machinery
-            */
-            boolean receiverIsReferenceProjection() {
-                return tree.getQualifierExpression().type.isReferenceProjection();
-            }
-
             /**
              * This method should be called only when target release <= 14
              * where LambdaMetaFactory does not spin nestmate classes.
@@ -2343,7 +2335,6 @@ public class LambdaToMethod extends TreeTranslator {
                         (!nestmateLambdas && isPrivateInOtherClass()) ||
                         isProtectedInSuperClassOfEnclosingClassInOtherPackage(tree.sym, owner) ||
                         !receiverAccessible() ||
-                        receiverIsReferenceProjection() ||
                         (tree.getMode() == ReferenceMode.NEW &&
                           tree.kind != ReferenceKind.ARRAY_CTOR &&
                           (tree.sym.owner.isDirectlyOrIndirectlyLocal() || tree.sym.owner.isInner() || tree.sym.owner.isValueClass()));


### PR DESCRIPTION
Remove the workaround in Javac and include the fix from Mandy for runtime in lieu.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8281336](https://bugs.openjdk.java.net/browse/JDK-8281336): [lworld] Remove workaround in LambdaToMethod to circumvent BootstrapMethodError
 * [JDK-8274399](https://bugs.openjdk.java.net/browse/JDK-8274399): [lworld] LambdaConversionException thrown when the receiver type is a primitive reference type and the implementation type is the primitive value type of the same class


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)


### Contributors
 * Mandy Chung `<mchung@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/631/head:pull/631` \
`$ git checkout pull/631`

Update a local copy of the PR: \
`$ git checkout pull/631` \
`$ git pull https://git.openjdk.java.net/valhalla pull/631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 631`

View PR using the GUI difftool: \
`$ git pr show -t 631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/631.diff">https://git.openjdk.java.net/valhalla/pull/631.diff</a>

</details>
