### PR TITLE
8281279: [lworld] Add JVM support for ACC_PERMITS_VALUE

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,6 +282,7 @@ class ClassFileParser {
   void parse_fields(const ClassFileStream* const cfs,
                     bool is_interface,
                     bool is_inline_type,
+                    bool is_permits_value_class,
                     FieldAllocationCount* const fac,
                     ConstantPool* cp,
                     const int cp_size,
@@ -292,6 +293,7 @@ class ClassFileParser {
   Method* parse_method(const ClassFileStream* const cfs,
                        bool is_interface,
                        bool is_inline_type,
+                       bool is_permits_value_class,
                        const ConstantPool* cp,
                        AccessFlags* const promoted_flags,
                        TRAPS);
@@ -299,6 +301,7 @@ class ClassFileParser {
   void parse_methods(const ClassFileStream* const cfs,
                      bool is_interface,
                      bool is_inline_type,
+                     bool is_permits_value_class,
                      AccessFlags* const promoted_flags,
                      bool* const has_final_method,
                      bool* const declares_nonstatic_concrete_methods,
@@ -506,10 +509,12 @@ class ClassFileParser {
   void verify_legal_field_modifiers(jint flags,
                                     bool is_interface,
                                     bool is_inline_type,
+                                    bool is_permits_value_class,
                                     TRAPS) const;
   void verify_legal_method_modifiers(jint flags,
                                      bool is_interface,
                                      bool is_inline_type,
+                                     bool is_permits_value_class,
                                      const Symbol* name,
                                      TRAPS) const;
 
@@ -598,6 +603,7 @@ class ClassFileParser {
   bool is_hidden() const { return _is_hidden; }
   bool is_interface() const { return _access_flags.is_interface(); }
   bool is_inline_type() const { return _access_flags.is_value_class(); }
+  bool is_permits_value_class() const { return _access_flags.is_permits_value_class(); }
   bool is_value_capable_class() const;
   bool has_inline_fields() const { return _has_inline_type_fields; }
   bool invalid_inline_super() const { return _invalid_inline_super; }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -649,6 +649,7 @@ protected:
   bool is_abstract() const              { return _access_flags.is_abstract(); }
   bool is_super() const                 { return _access_flags.is_super(); }
   bool is_synthetic() const             { return _access_flags.is_synthetic(); }
+  bool is_permits_value_class() const   { return _access_flags.is_permits_value_class(); }
   void set_is_synthetic()               { _access_flags.set_is_synthetic(); }
   bool has_finalizer() const            { return _access_flags.has_finalizer(); }
   bool has_final_method() const         { return _access_flags.has_final_method(); }

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -883,8 +883,7 @@ void JvmtiClassFileReconstituter::write_class_file_format() {
   copy_cpool_bytes(writeable_address(cpool_size()));
 
   // JVMSpec|           u2 access_flags;
-  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_PRIMITIVE | JVM_ACC_VALUE));
-
+  write_u2(ik()->access_flags().get_flags() & (JVM_RECOGNIZED_CLASS_MODIFIERS | JVM_ACC_PRIMITIVE | JVM_ACC_VALUE | JVM_ACC_PERMITS_VALUE));
   // JVMSpec|           u2 this_class;
   // JVMSpec|           u2 super_class;
   write_u2(class_symbol_to_cpool_index(ik()->name()));

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,7 @@ class AccessFlags {
   bool is_abstract    () const         { return (_flags & JVM_ACC_ABSTRACT    ) != 0; }
   bool is_value_class () const         { return (_flags & JVM_ACC_VALUE       ) != 0; }
   bool is_primitive_class () const     { return (_flags & JVM_ACC_PRIMITIVE   ) != 0; }
+  bool is_permits_value_class () const { return (_flags & JVM_ACC_PERMITS_VALUE   ) != 0; }
 
   // Attribute flags
   bool is_synthetic   () const         { return (_flags & JVM_ACC_SYNTHETIC   ) != 0; }

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,18 @@ public class Modifier {
      */
     public static boolean isSynchronized(int mod) {
         return (mod & SYNCHRONIZED) != 0;
+    }
+
+    /**
+     * Return {@code true} if the integer argument includes the
+     * {@code permitsValue} modifier, {@code false} otherwise.
+     *
+     * @param   mod a set of modifiers
+     * @return {@code true} if {@code mod} includes the
+     * {@code permitsValue} modifier; {@code false} otherwise.
+     */
+    public static boolean isPermitsValue(int mod) {
+        return (mod & PERMITS_VALUE) != 0;
     }
 
     /**
@@ -288,6 +300,12 @@ public class Modifier {
     public static final int SYNCHRONIZED     = 0x00000020;
 
     /**
+     * The {@code int} value representing the {@code permits_value}
+     * modifier.
+     */
+    public static final int PERMITS_VALUE    = 0x00000040;
+
+    /**
      * The {@code int} value representing the {@code volatile}
      * modifier.
      */
@@ -358,7 +376,7 @@ public class Modifier {
     private static final int CLASS_MODIFIERS =
         Modifier.PUBLIC         | Modifier.PROTECTED    | Modifier.PRIVATE |
         Modifier.ABSTRACT       | Modifier.STATIC       | Modifier.FINAL   |
-        Modifier.STRICT;
+        Modifier.STRICT         | Modifier.PERMITS_VALUE;
 
     /**
      * The Java source modifiers that can be applied to an interface.

--- a/src/java.base/share/native/include/classfile_constants.h.template
+++ b/src/java.base/share/native/include/classfile_constants.h.template
@@ -46,6 +46,7 @@ enum {
     JVM_ACC_SUPER         = 0x0020,
     JVM_ACC_VOLATILE      = 0x0040,
     JVM_ACC_BRIDGE        = 0x0040,
+    JVM_ACC_PERMITS_VALUE = 0x0040,
     JVM_ACC_TRANSIENT     = 0x0080,
     JVM_ACC_VARARGS       = 0x0080,
     JVM_ACC_NATIVE        = 0x0100,
@@ -69,6 +70,7 @@ enum {
 #define JVM_ACC_SUPER_BIT         5
 #define JVM_ACC_VOLATILE_BIT      6
 #define JVM_ACC_BRIDGE_BIT        6
+#define JVM_ACC_PERMITS_VALUE_BIT 6
 #define JVM_ACC_TRANSIENT_BIT     7
 #define JVM_ACC_VARARGS_BIT       7
 #define JVM_ACC_NATIVE_BIT        8

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GetfieldChains.jcod
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/GetfieldChains.jcod
@@ -318,54 +318,6 @@ class compiler/valhalla/inlinetypes/NamedRectangleP {
   } // Attributes
 } // end class compiler/valhalla/inlinetypes/NamedRectangleP
 
-class compiler/valhalla/inlinetypes/PointN$ref {
-  0xCAFEBABE;
-  0; // minor version
-  62; // version
-  [] { // Constant Pool
-    ; // first element is empty
-    class #2; // #1
-    Utf8 "compiler/valhalla/inlinetypes/PointN$ref"; // #2
-    class #4; // #3
-    Utf8 "java/lang/Object"; // #4
-    Utf8 "SourceFile"; // #5
-    Utf8 "PointN.java"; // #6
-    Utf8 "NestMembers"; // #7
-    class #9; // #8
-    Utf8 "compiler/valhalla/inlinetypes/PointN"; // #9
-    Utf8 "PermittedSubclasses"; // #10
-  } // Constant Pool
-
-  0x0421; // access
-  #1;// this_cpx
-  #3;// super_cpx
-
-  [] { // Interfaces
-  } // Interfaces
-
-  [] { // Fields
-  } // Fields
-
-  [] { // Methods
-  } // Methods
-
-  [] { // Attributes
-    Attr(#5) { // SourceFile
-      #6;
-    } // end SourceFile
-    ;
-    Attr(#7) { // NestMembers
-      [] { // classes
-        #8;
-      }
-    } // end NestMembers
-    ;
-    Attr(#10) { // PermittedSubclasses
-      0x00010008;
-    } // end PermittedSubclasses
-  } // Attributes
-} // end class compiler/valhalla/inlinetypes/PointN$ref
-
 class compiler/valhalla/inlinetypes/PointN {
   0xCAFEBABE;
   0; // minor version
@@ -386,7 +338,7 @@ class compiler/valhalla/inlinetypes/PointN {
     Utf8 "toString"; // #12
     Utf8 "(Qcompiler/valhalla/inlinetypes/PointN;)Ljava/lang/String;"; // #13
     class #15; // #14
-    Utf8 "compiler/valhalla/inlinetypes/PointN$ref"; // #15
+    Utf8 "java/lang/Object"; // #15
     Utf8 "()Ljava/lang/String;"; // #16
     Utf8 "Code"; // #17
     Utf8 "LineNumberTable"; // #18
@@ -517,54 +469,6 @@ class compiler/valhalla/inlinetypes/PointN {
   } // Attributes
 } // end class compiler/valhalla/inlinetypes/PointN
 
-class compiler/valhalla/inlinetypes/RectangleN$ref {
-  0xCAFEBABE;
-  0; // minor version
-  62; // version
-  [] { // Constant Pool
-    ; // first element is empty
-    class #2; // #1
-    Utf8 "compiler/valhalla/inlinetypes/RectangleN$ref"; // #2
-    class #4; // #3
-    Utf8 "java/lang/Object"; // #4
-    Utf8 "SourceFile"; // #5
-    Utf8 "RectangleN.java"; // #6
-    Utf8 "NestMembers"; // #7
-    class #9; // #8
-    Utf8 "compiler/valhalla/inlinetypes/RectangleN"; // #9
-    Utf8 "PermittedSubclasses"; // #10
-  } // Constant Pool
-
-  0x0421; // access
-  #1;// this_cpx
-  #3;// super_cpx
-
-  [] { // Interfaces
-  } // Interfaces
-
-  [] { // Fields
-  } // Fields
-
-  [] { // Methods
-  } // Methods
-
-  [] { // Attributes
-    Attr(#5) { // SourceFile
-      #6;
-    } // end SourceFile
-    ;
-    Attr(#7) { // NestMembers
-      [] { // classes
-        #8;
-      }
-    } // end NestMembers
-    ;
-    Attr(#10) { // PermittedSubclasses
-      0x00010008;
-    } // end PermittedSubclasses
-  } // Attributes
-} // end class compiler/valhalla/inlinetypes/RectangleN$ref
-
 class compiler/valhalla/inlinetypes/RectangleN {
   0xCAFEBABE;
   0; // minor version
@@ -591,7 +495,7 @@ class compiler/valhalla/inlinetypes/RectangleN {
     Utf8 "toString"; // #18
     Utf8 "(Qcompiler/valhalla/inlinetypes/RectangleN;)Ljava/lang/String;"; // #19
     class #21; // #20
-    Utf8 "compiler/valhalla/inlinetypes/RectangleN$ref"; // #21
+    Utf8 "java/lang/Object"; // #21
     Utf8 "()Ljava/lang/String;"; // #22
     Utf8 "Code"; // #23
     Utf8 "LineNumberTable"; // #24
@@ -721,54 +625,6 @@ class compiler/valhalla/inlinetypes/RectangleN {
   } // Attributes
 } // end class compiler/valhalla/inlinetypes/RectangleN
 
-class compiler/valhalla/inlinetypes/RectangleP$ref {
-  0xCAFEBABE;
-  0; // minor version
-  62; // version
-  [] { // Constant Pool
-    ; // first element is empty
-    class #2; // #1
-    Utf8 "compiler/valhalla/inlinetypes/RectangleP$ref"; // #2
-    class #4; // #3
-    Utf8 "java/lang/Object"; // #4
-    Utf8 "SourceFile"; // #5
-    Utf8 "Rectangle.java"; // #6
-    Utf8 "NestMembers"; // #7
-    class #9; // #8
-    Utf8 "compiler/valhalla/inlinetypes/RectangleP"; // #9
-    Utf8 "PermittedSubclasses"; // #10
-  } // Constant Pool
-
-  0x0421; // access
-  #1;// this_cpx
-  #3;// super_cpx
-
-  [] { // Interfaces
-  } // Interfaces
-
-  [] { // Fields
-  } // Fields
-
-  [] { // Methods
-  } // Methods
-
-  [] { // Attributes
-    Attr(#5) { // SourceFile
-      #6;
-    } // end SourceFile
-    ;
-    Attr(#7) { // NestMembers
-      [] { // classes
-        #8;
-      }
-    } // end NestMembers
-    ;
-    Attr(#10) { // PermittedSubclasses
-      0x00010008;
-    } // end PermittedSubclasses
-  } // Attributes
-} // end class compiler/valhalla/inlinetypes/RectangleP$ref
-
 class compiler/valhalla/inlinetypes/RectangleP {
   0xCAFEBABE;
   0; // minor version
@@ -795,7 +651,7 @@ class compiler/valhalla/inlinetypes/RectangleP {
     Utf8 "toString"; // #18
     Utf8 "(Qcompiler/valhalla/inlinetypes/RectangleP;)Ljava/lang/String;"; // #19
     class #21; // #20
-    Utf8 "compiler/valhalla/inlinetypes/RectangleP$ref"; // #21
+    Utf8 "java/lang/Object"; // #21
     Utf8 "()Ljava/lang/String;"; // #22
     Utf8 "Code"; // #23
     Utf8 "LineNumberTable"; // #24

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HiddenPoint.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/HiddenPoint.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,45 +38,11 @@
 //      }
 //  }
 
-class HiddenPoint$ref {
-  0xCAFEBABE;
-  0; // minor version
-  62; // version
-  [7] { // Constant Pool
-    ; // first element is empty
-    class #2; // #1     at 0x0A
-    Utf8 "HiddenPoint$ref"; // #2     at 0x0D
-    class #4; // #3     at 0x1F
-    Utf8 "java/lang/Object"; // #4     at 0x22
-    Utf8 "SourceFile"; // #5     at 0x35
-    Utf8 "HiddenPoint.java"; // #6     at 0x42
-  } // Constant Pool
-
-  0x0420; // access [ ACC_SUPER ACC_ABSTRACT ]
-  #1;// this_cpx
-  #3;// super_cpx
-
-  [0] { // Interfaces
-  } // Interfaces
-
-  [0] { // fields
-  } // fields
-
-  [0] { // methods
-  } // methods
-
-  [1] { // Attributes
-    Attr(#5, 2) { // SourceFile at 0x63
-      #6;
-    } // end SourceFile
-  } // Attributes
-} // end class HiddenPoint$ref
-
 class HiddenPoint {
   0xCAFEBABE;
   0; // minor version
   62; // version
-  [60] { // Constant Pool
+  [40] { // Constant Pool
     ; // first element is empty
     class #2; // #1     at 0x0A
     Utf8 "HiddenPoint"; // #2     at 0x0D
@@ -91,86 +57,66 @@ class HiddenPoint {
     NameAndType #12 #13; // #11     at 0x40
     Utf8 "makeConcatWithConstants"; // #12     at 0x45
     Utf8 "(II)Ljava/lang/String;"; // #13     at 0x5F
-    InvokeDynamic 1s #15; // #14     at 0x78
-    NameAndType #16 #17; // #15     at 0x7D
-    Utf8 "hashCode"; // #16     at 0x82
-    Utf8 "(QHiddenPoint;)I"; // #17     at 0x8D
-    InvokeDynamic 1s #19; // #18     at 0xA0
-    NameAndType #20 #21; // #19     at 0xA5
-    Utf8 "equals"; // #20     at 0xAA
-    Utf8 "(QHiddenPoint;Ljava/lang/Object;)Z"; // #21     at 0xB3
-    InvokeDynamic 1s #23; // #22     at 0xD8
-    NameAndType #24 #25; // #23     at 0xDD
-    Utf8 "toString"; // #24     at 0xE2
-    Utf8 "(QHiddenPoint;)Ljava/lang/String;"; // #25     at 0xED
-    class #27; // #26     at 0x0111
-    Utf8 "HiddenPoint$ref"; // #27     at 0x0114
-    Utf8 "getValue"; // #28     at 0x0126
-    Utf8 "()Ljava/lang/String;"; // #29     at 0x0131
-    Utf8 "Code"; // #30     at 0x0148
-    Utf8 "LineNumberTable"; // #31     at 0x014F
-    Utf8 "()I"; // #32     at 0x0161
-    Utf8 "(Ljava/lang/Object;)Z"; // #33     at 0x0167
-    Utf8 "<init>"; // #34     at 0x017F
-    Utf8 "()Ljava/lang/Object;"; // #35     at 0x0188
-    Utf8 "SourceFile"; // #36     at 0x019A
-    Utf8 "HiddenPoint.java"; // #37     at 0x01A7
-    Utf8 "BootstrapMethods"; // #38     at 0x01BA
-    MethodHandle 6b #40; // #39     at 0x01CD
-    Method #41 #42; // #40     at 0x01D1
-    class #43; // #41     at 0x01D6
-    NameAndType #12 #44; // #42     at 0x01D9
-    Utf8 "java/lang/invoke/StringConcatFactory"; // #43     at 0x01DE
-    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;"; // #44     at 0x0205
-    String #46; // #45     at 0x02A0
-    Utf8 "x: , y: "; // #46     at 0x02A3
-    MethodHandle 6b #48; // #47     at 0x02B0
-    Method #49 #50; // #48     at 0x02B4
-    class #51; // #49     at 0x02B9
-    NameAndType #52 #53; // #50     at 0x02BC
-    Utf8 "java/lang/invoke/ValueBootstrapMethods"; // #51     at 0x02C1
-    Utf8 "makeBootstrapMethod"; // #52     at 0x02EA
-    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"; // #53     at 0x0300
-    Utf8 "InnerClasses"; // #54     at 0x0376
-    class #56; // #55     at 0x0385
-    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #56     at 0x0388
-    class #58; // #57     at 0x03B0
-    Utf8 "java/lang/invoke/MethodHandles"; // #58     at 0x03B3
-    Utf8 "Lookup"; // #59     at 0x03D4
+    class #15; // #14     at 0x78
+    Utf8 "java/lang/Object"; // #15     at 0x7B
+    Utf8 "getValue"; // #16     at 0x8E
+    Utf8 "()Ljava/lang/String;"; // #17     at 0x99
+    Utf8 "Code"; // #18     at 0xB0
+    Utf8 "LineNumberTable"; // #19     at 0xB7
+    Utf8 "<init>"; // #20     at 0xC9
+    Utf8 "()Ljava/lang/Object;"; // #21     at 0xD2
+    Utf8 "SourceFile"; // #22     at 0xE4
+    Utf8 "HiddenPoint.java"; // #23     at 0xF1
+    Utf8 "BootstrapMethods"; // #24     at 0x0104
+    MethodHandle 6b #26; // #25     at 0x0117
+    Method #27 #28; // #26     at 0x011B
+    class #29; // #27     at 0x0120
+    NameAndType #12 #30; // #28     at 0x0123
+    Utf8 "java/lang/invoke/StringConcatFactory"; // #29     at 0x0128
+    Utf8 "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;"; // #30     at 0x014F
+    String #32; // #31     at 0x01EA
+    Utf8 "x: , y: "; // #32     at 0x01ED
+    Utf8 "InnerClasses"; // #33     at 0x01FA
+    class #35; // #34     at 0x0209
+    Utf8 "java/lang/invoke/MethodHandles$Lookup"; // #35     at 0x020C
+    class #37; // #36     at 0x0234
+    Utf8 "java/lang/invoke/MethodHandles"; // #37     at 0x0237
+    Utf8 "Lookup"; // #38     at 0x0258
+    Utf8 "Preload"; // #39     at 0x0261
   } // Constant Pool
 
-  0x0930; // access [ ACC_SUPER ACC_PRIMITIVE ACC_SUPER ACC_FINAL ]
+  0x0130; // access [ ACC_SUPER ACC_FINAL ]
   #1;// this_cpx
-  #26;// super_cpx
+  #14;// super_cpx
 
   [0] { // Interfaces
   } // Interfaces
 
-  [2] { // fields
-    { // Member at 0x03E7
+  [2] { // Fields
+    {  // field at 0x0275
       0x0010; // access
-      #5; // name_cpx
-      #6; // sig_cpx
+      #5; // name_index       : x
+      #6; // descriptor_index : I
       [0] { // Attributes
       } // Attributes
-    } // Member
+    }
     ;
-    { // Member at 0x03EF
+    {  // field at 0x027D
       0x0010; // access
-      #9; // name_cpx
-      #6; // sig_cpx
+      #9; // name_index       : y
+      #6; // descriptor_index : I
       [0] { // Attributes
       } // Attributes
-    } // Member
-  } // fields
+    }
+  } // Fields
 
-  [2] { // methods
-    { // Member at 0x03F9
+  [2] { // Methods
+    {  // method at 0x0287
       0x0001; // access
-      #28; // name_cpx
-      #29; // sig_cpx
+      #16; // name_index       : getValue
+      #17; // descriptor_index : ()Ljava/lang/String;
       [1] { // Attributes
-        Attr(#30, 38) { // Code at 0x0401
+        Attr(#18, 38) { // Code at 0x028F
           2; // max_stack
           1; // max_locals
           Bytes[14]{
@@ -180,22 +126,22 @@ class HiddenPoint {
           [0] { // Traps
           } // end Traps
           [1] { // Attributes
-            Attr(#31, 6) { // LineNumberTable at 0x0421
-              [1] { // LineNumberTable
-                0  9; //  at 0x042D
+            Attr(#19, 6) { // LineNumberTable at 0x02AF
+              [1] { // line_number_table
+                0  10; //  at 0x02BB
               }
             } // end LineNumberTable
           } // Attributes
         } // end Code
       } // Attributes
-    } // Member
+    }
     ;
-    { // Member at 0x04B5
+    {  // method at 0x02BB
       0x0008; // access
-      #34; // name_cpx
-      #35; // sig_cpx
+      #20; // name_index       : <init>
+      #21; // descriptor_index : ()LHiddenPoint;
       [1] { // Attributes
-        Attr(#30, 56) { // Code at 0x04BD
+        Attr(#18, 56) { // Code at 0x02C3
           2; // max_stack
           1; // max_locals
           Bytes[20]{
@@ -206,46 +152,44 @@ class HiddenPoint {
           [0] { // Traps
           } // end Traps
           [1] { // Attributes
-            Attr(#31, 18) { // LineNumberTable at 0x04E3
-              [4] { // LineNumberTable
-                0  4; //  at 0x04EF
-                4  5; //  at 0x04F3
-                11  6; //  at 0x04F7
-                18  7; //  at 0x04FB
+            Attr(#19, 18) { // LineNumberTable at 0x02E9
+              [4] { // line_number_table
+                0  5; //  at 0x02F5
+                4  6; //  at 0x02F9
+                11  7; //  at 0x02FD
+                18  8; //  at 0x0301
               }
             } // end LineNumberTable
           } // Attributes
         } // end Code
       } // Attributes
-    } // Member
-  } // methods
+    }
+  } // Methods
 
-  [3] { // Attributes
-    Attr(#36, 2) { // SourceFile at 0x04FD
-      #37;
+  [4] { // Attributes
+    Attr(#22, 2) { // SourceFile at 0x0303
+      #23;
     } // end SourceFile
     ;
-    Attr(#38, 12) { // BootstrapMethods at 0x0505
-      [2] { // bootstrap_methods
+    Attr(#24, 8) { // BootstrapMethods at 0x030B
+      [1] { // bootstrap_methods
         {  //  bootstrap_method
-          #39; // bootstrap_method_ref
+          #25; // bootstrap_method_ref
           [1] { // bootstrap_arguments
-            #45; //  at 0x0513
-          }  //  bootstrap_arguments
-        }  //  bootstrap_method
-        ;
-        {  //  bootstrap_method
-          #47; // bootstrap_method_ref
-          [0] { // bootstrap_arguments
+            #31; //  at 0x0319
           }  //  bootstrap_arguments
         }  //  bootstrap_method
       }
     } // end BootstrapMethods
     ;
-    Attr(#54, 10) { // InnerClasses at 0x0517
-      [1] { // InnerClasses
-        #55 #57 #59 25; //  at 0x0527
+    Attr(#33, 10) { // InnerClasses at 0x0319
+      [1] { // classes
+        #34 #36 #38 25; //  at 0x0329
       }
     } // end InnerClasses
+    ;
+    Attr(#39, 4) { // Preload at 0x0329
+      0x00010001;
+    } // end Preload
   } // Attributes
 } // end class HiddenPoint

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCCFETests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCCFETests.jcod
@@ -1,0 +1,888 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// These tests are based on this .java file.  Each test case changed an access
+// flag to cause a ClassFormatError exception when loading the class.
+/*
+public abstract class AbstractPV {
+
+    static int x = 3;
+
+    public static synchronized void meth() {
+        System.out.println("hi");
+    }
+}
+*/
+
+
+// Added ACC_VALUE to class access flags.
+class AbstractPV_ACC_VALUE {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "AbstractPV_ACC_VALUE"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "AbstractPV_ACC_VALUE.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0561; // access [ ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0029; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class AbstractPV_ACC_VALUE
+
+
+// Removed ACC_STATIC from field access flags.
+class AbstractPVField {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "AbstractPVField"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "AbstractPVField.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0461; // access [ ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0000; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0029; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class AbstractPVField
+
+
+// Added ACC_FINAL to class access flags.
+class AbstractPVFinal {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "AbstractPVFinal"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "AbstractPVFinal.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0471; // access [ ACC_FINAL ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0029; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class AbstractPVFinal
+
+
+// Added ACC_INTERFACE to class access flags
+class AbstractPVintf {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "AbstractPVintf"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "AbstractPVintf.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0661; // access [ ACC_INTERFACE ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0029; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class AbstractPVintf
+
+
+// Changed the access flags for synchronized method meth() to not be static.
+class AbstractPVMethod {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "AbstractPVMethod"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "AbstractPVMethod.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0461; // access [ ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0021; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class AbstractPVMethod
+
+
+// Removed ACC_ABSTRACT from class access flags.
+class NoAbstract {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "NoAbstract"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "NoAbstract.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0061; // access [ ACC_PUBLIC ACC_SUPER ACC_PERMITS_VALUE ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0029; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class NoAbstract

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCICCETests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCICCETests.jcod
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// This is an abstract class that cannot be a super class for value classes
+// because ACC_PERMITS_VALUE was removed from its class access flags.
+// It's based on the following source:
+/*
+public abstract class NonPVSuper {
+
+    static int x = 3;
+
+    public static void meth() {
+        System.out.println("hi");
+    }
+}
+*/
+class NonPVSuper {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [33] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "hi"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x7F
+    class #18; // #16     at 0x84
+    NameAndType #19 #20; // #17     at 0x87
+    Utf8 "java/io/PrintStream"; // #18     at 0x8C
+    Utf8 "println"; // #19     at 0xA2
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xAC
+    Field #22 #23; // #21     at 0xC4
+    class #24; // #22     at 0xC9
+    NameAndType #25 #26; // #23     at 0xCC
+    Utf8 "NonPVSuper"; // #24     at 0xD1
+    Utf8 "x"; // #25     at 0xDE
+    Utf8 "I"; // #26     at 0xE2
+    Utf8 "Code"; // #27     at 0xE6
+    Utf8 "LineNumberTable"; // #28     at 0xED
+    Utf8 "meth"; // #29     at 0xFF
+    Utf8 "<clinit>"; // #30     at 0x0106
+    Utf8 "SourceFile"; // #31     at 0x0111
+    Utf8 "NonPVSuper.java"; // #32     at 0x011E
+  } // Constant Pool
+
+  0x0421; // access [ ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ]
+  #22;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x013A
+      0x0008; // access
+      #25; // name_index       : x
+      #26; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [3] { // Methods
+    {  // method at 0x0144
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x014C
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x0163
+              [1] { // line_number_table
+                0  2; //  at 0x016F
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016F
+      0x0009; // access
+      #29; // name_index       : meth
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 37) { // Code at 0x0177
+          2; // max_stack
+          0; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 10) { // LineNumberTable at 0x0192
+              [2] { // line_number_table
+                0  7; //  at 0x019E
+                8  8; //  at 0x01A2
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x01A2
+      0x0008; // access
+      #30; // name_index       : <clinit>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#27, 29) { // Code at 0x01AA
+          1; // max_stack
+          0; // max_locals
+          Bytes[5]{
+            0x06B30015B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#28, 6) { // LineNumberTable at 0x01C1
+              [1] { // line_number_table
+                0  4; //  at 0x01CD
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#31, 2) { // SourceFile at 0x01CF
+      #32;
+    } // end SourceFile
+  } // Attributes
+} // end class NonPVSuper
+
+
+// Dot is a value class that tries to inherit from a super class (NonPVSuper)
+// that does not have access flag ACC_PERMIT_VALUES set.
+// Dot is based on the following source:
+/*
+public value final class Dot extends NonPVSuper {
+    int x = 3;
+
+    public int getX() {
+        return x;
+    }
+}
+*/
+class Dot {
+  0xCAFEBABE;
+  0; // minor version
+  62; // version
+  [18] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "Dot"; // #2     at 0x0D
+    Field #1 #4; // #3     at 0x13
+    NameAndType #5 #6; // #4     at 0x18
+    Utf8 "x"; // #5     at 0x1D
+    Utf8 "I"; // #6     at 0x21
+    class #8; // #7     at 0x25
+    Utf8 "NonPVSuper"; // #8     at 0x28
+    Utf8 "getX"; // #9     at 0x35
+    Utf8 "()I"; // #10     at 0x3C
+    Utf8 "Code"; // #11     at 0x42
+    Utf8 "LineNumberTable"; // #12     at 0x49
+    Utf8 "<init>"; // #13     at 0x5B
+    Utf8 "()LDot;"; // #14     at 0x64
+    Utf8 "SourceFile"; // #15     at 0x6E
+    Utf8 "Dot.java"; // #16     at 0x7B
+    Utf8 "Preload"; // #17     at 0x86
+  } // Constant Pool
+
+  0x0131; // access [ ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  #1;// this_cpx
+  #7;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0x9A
+      0x0010; // access
+      #5; // name_index       : x
+      #6; // descriptor_index : I
+      [0] { // Attributes
+      } // Attributes
+    }
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xA4
+      0x0001; // access
+      #9; // name_index       : getX
+      #10; // descriptor_index : ()I
+      [1] { // Attributes
+        Attr(#11, 29) { // Code at 0xAC
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB40003AC;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 6) { // LineNumberTable at 0xC3
+              [1] { // line_number_table
+                0  5; //  at 0xCF
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0xCF
+      0x0009; // access
+      #13; // name_index       : <init>
+      #14; // descriptor_index : ()LDot;
+      [1] { // Attributes
+        Attr(#11, 41) { // Code at 0xD7
+          2; // max_stack
+          1; // max_locals
+          Bytes[13]{
+            0xCB00014B062A5FCC;
+            0x00034B2AB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#12, 10) { // LineNumberTable at 0xF6
+              [2] { // line_number_table
+                0  1; //  at 0x0102
+                4  2; //  at 0x0106
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [2] { // Attributes
+    Attr(#15, 2) { // SourceFile at 0x0108
+      #16;
+    } // end SourceFile
+    ;
+    Attr(#17, 4) { // Preload at 0x0110
+      0x00010001;
+    } // end Preload
+  } // Attributes
+} // end class Dot

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_CFETest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_CFETest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test ACC_CFETest
+ * @bug 8281279
+ * @summary test class access rules for classes that have ACC_PERMITS_VALUE set.
+ * @compile ACCCFETests.jcod
+ * @run main/othervm -XX:+EnableValhalla -Xverify:remote ACC_CFETest
+ */
+
+public class ACC_CFETest {
+
+    public static void runTest(String test_name, String message) throws Exception {
+        System.out.println("Testing: " + test_name);
+        try {
+            Class newClass = Class.forName(test_name);
+        } catch (java.lang.ClassFormatError e) {
+            if (!e.getMessage().contains(message)) {
+                throw new RuntimeException( "Wrong ClassFormatError: " + e.getMessage());
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // Test illegal class that has both ACC_VALUE and ACC_PERMITS_VALUE set.
+        runTest("AbstractPV_ACC_VALUE",
+                "Illegal class modifiers in class AbstractPV_ACC_VALUE (a permits_value class)");
+
+        // Test illegal class that has ACC_PERMITS_VALUE set and a non-static field..
+        runTest("AbstractPVField", "Illegal field modifiers in class AbstractPVField");
+
+        // Test illegal class that has both ACC_FINAL and ACC_PERMITS_VALUE set.
+        runTest("AbstractPVFinal",
+                "Illegal class modifiers in class AbstractPVFinal (a permits_value class)");
+
+        // Test illegal class that has both ACC_INTERFACE and ACC_PERMITS_VALUE set.
+        runTest("AbstractPVintf",
+                "Illegal class modifiers in class AbstractPVintf (a permits_value class)");
+
+        // Test illegal class that has ACC_PERMITS_VALUE set and a non-static synchronized method.
+        runTest("AbstractPVMethod",
+                "Method meth in class AbstractPVMethod (an inline class) has illegal modifiers");
+
+        // Test illegal class that has ACC_PERMITS_VALUE set, but not ACC_ABSTRACT.
+        runTest("NoAbstract", "Illegal class modifiers in class NoAbstract (a permits_value class)");
+    }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_ICCETest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_ICCETest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test ACC_ICCETest
+ * @bug 8281279
+ * @summary test that ACC_PERMITS_VALUE must be set for the super class of
+ *          a value class (unless the super is java.lang.Object);
+ * @compile ACCICCETests.jcod
+ * @run main/othervm -XX:+EnableValhalla ACC_ICCETest
+ */
+
+public class ACC_ICCETest {
+
+    public static void runTest(String test_name, String message) throws Exception {
+        System.out.println("Testing: " + test_name);
+        try {
+            Class newClass = Class.forName(test_name);
+        } catch (java.lang.IncompatibleClassChangeError e) {
+            if (!e.getMessage().contains(message)) {
+                throw new RuntimeException( "Wrong IncompatibleClassChangeError: " + e.getMessage());
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // Test illegal class that has both ACC_VALUE and ACC_PERMITS_VALUE set.
+        runTest("Dot", "value class Dot cannot inherit from class NonPVSuper");
+    }
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class getclmdf006 {
     public static int run(String args[], PrintStream out) {
         check(getclmdf006a.class, 0);
         check(getclmdf006b.class, Modifier.FINAL);
-        check(getclmdf006c.class, Modifier.ABSTRACT);
+        check(getclmdf006c.class, Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
         check(getclmdf006d.class, Modifier.INTERFACE | Modifier.ABSTRACT);
         check(getclmdf006e.class, Modifier.PUBLIC | Modifier.INTERFACE |
                                   Modifier.ABSTRACT);
@@ -69,22 +69,23 @@ public class getclmdf006 {
         check(Inner09.class, Modifier.PROTECTED | Modifier.ABSTRACT);
         check(Inner10.class, Modifier.STATIC);
         check(Inner11.class, Modifier.STATIC | Modifier.FINAL);
-        check(Inner12.class, Modifier.STATIC | Modifier.ABSTRACT);
+        check(Inner12.class, Modifier.STATIC | Modifier.ABSTRACT |
+                             Modifier.PERMITS_VALUE);
         check(Inner13.class, Modifier.PUBLIC | Modifier.STATIC);
         check(Inner14.class, Modifier.PUBLIC | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner15.class, Modifier.PUBLIC | Modifier.STATIC |
-                             Modifier.ABSTRACT);
+                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
         check(Inner16.class, Modifier.PRIVATE | Modifier.STATIC);
         check(Inner17.class, Modifier.PRIVATE | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner18.class, Modifier.PRIVATE | Modifier.STATIC |
-                             Modifier.ABSTRACT);
+                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
         check(Inner19.class, Modifier.PROTECTED | Modifier.STATIC);
         check(Inner20.class, Modifier.PROTECTED | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner21.class, Modifier.PROTECTED | Modifier.STATIC |
-                             Modifier.ABSTRACT);
+                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
         check(Inner22.class, Modifier.STATIC | Modifier.INTERFACE |
                              Modifier.ABSTRACT);
         check(Inner23.class, Modifier.PUBLIC | Modifier.STATIC |

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006/getclmdf006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006/getclmdf006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ extern "C" {
 #define ACC_STATIC      0x0008
 #define ACC_FINAL       0x0010
 #define ACC_SUPER       0x0020
+#define ACC_PERMITS_VALUE    0x0040
 #define ACC_INTERFACE   0x0200
 #define ACC_ABSTRACT    0x0400
 
@@ -82,6 +83,7 @@ void printModifiers(jint mod) {
     if (mod & ACC_SUPER) printf(" SUPER");
     if (mod & ACC_INTERFACE) printf(" INTERFACE");
     if (mod & ACC_ABSTRACT) printf(" ABSTRACT");
+    if (mod & ACC_PERMITS_VALUE) printf(" PERMITS_VALUE");
     printf(" (0x%0x)\n", mod);
 }
 


### PR DESCRIPTION
Please review this fix to add JVM support for ACC_PERMITS_VALUE.  This change throws an ICCE exception when loading a value class whose super class is not java.lang.Object or does not have ACC_PERMITS_VALUE set.  The fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold