### PR TITLE
8281325: [lworld] Unused code emitted for unpacking arguments leads to code buffer overflow

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5770,16 +5770,13 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
                                           RegState reg_state[]) {
   assert(sig->at(sig_index)._bt == T_VOID, "should be at end delimiter");
   assert(from->is_valid(), "source must be valid");
-  Register tmp1 = r10, tmp2 = r11;
-  Register fromReg;
-  if (from->is_reg()) {
-    fromReg = from->as_Register();
-  } else {
-    int st_off = from->reg2stack() * VMRegImpl::stack_slot_size;
-    ldr(tmp1, Address(sp, st_off));
-    fromReg = tmp1;
-  }
+#ifdef ASSERT
+  bool progress = false;
+  const int start_offset = offset();
+#endif
 
+  Register tmp1 = r10, tmp2 = r11;
+  Register fromReg = noreg;
   ScalarizedInlineArgsStream stream(sig, sig_index, to, to_count, to_index, -1);
   bool done = true;
   bool mark_done = true;
@@ -5789,7 +5786,6 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     assert(toReg->is_valid(), "destination must be valid");
     int off = sig->at(stream.sig_index())._offset;
     assert(off > 0, "offset in object should be positive");
-    Address fromAddr = Address(fromReg, off);
 
     int idx = (int)toReg->value();
     if (reg_state[idx] == reg_readonly) {
@@ -5800,11 +5796,21 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
       continue;
     } else if (reg_state[idx] == reg_written) {
       continue;
-    } else {
-      assert(reg_state[idx] == reg_writable, "must be writable");
-      reg_state[idx] = reg_written;
     }
+    assert(reg_state[idx] == reg_writable, "must be writable");
+    reg_state[idx] = reg_written;
+    DEBUG_ONLY(progress = true);
 
+    if (fromReg = noreg) {
+      if (from->is_reg()) {
+        fromReg = from->as_Register();
+      } else {
+        int st_off = from->reg2stack() * VMRegImpl::stack_slot_size;
+        ldr(tmp1, Address(sp, st_off));
+        fromReg = tmp1;
+      }
+    }
+    Address fromAddr = Address(fromReg, off);
     if (!toReg->is_FloatRegister()) {
       Register dst = toReg->is_stack() ? tmp2 : toReg->as_Register();
       if (is_reference_type(bt)) {
@@ -5832,6 +5838,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     reg_state[from->value()] = reg_writable;
   }
   from_index--;
+  assert(progress || (start_offset == offset()), "should not emit code");
   return done;
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5801,7 +5801,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     reg_state[idx] = reg_written;
     DEBUG_ONLY(progress = true);
 
-    if (fromReg = noreg) {
+    if (fromReg == noreg) {
       if (from->is_reg()) {
         fromReg = from->as_Register();
       } else {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5693,7 +5693,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
     reg_state[idx] = reg_written;
     DEBUG_ONLY(progress = true);
 
-    if (fromReg = noreg) {
+    if (fromReg == noreg) {
       if (from->is_reg()) {
         fromReg = from->as_Register();
       } else {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -74,9 +74,6 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-generic
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
-# Valhalla
-compiler/valhalla/inlinetypes/TestCallingConvention.java 8281325 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
An unrelated change to javac that came in with the mainline merge triggered this:
When emitting code to scalarize a buffered inline type argument in the method entries, there is sometimes an overlap with registers/stack slots occupied by another argument that needs to be resolved before we can make progress. We should not emit any code in such a case and proceed with the next argument (we will revisit this argument later, once the conflict has been resolved).

Some of that code will be refactored by [JDK-8278390](https://bugs.openjdk.java.net/browse/JDK-8278390) anyway.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281325](https://bugs.openjdk.java.net/browse/JDK-8281325): [lworld] Unused code emitted for unpacking arguments leads to code buffer overflow


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/633/head:pull/633` \
`$ git checkout pull/633`

Update a local copy of the PR: \
`$ git checkout pull/633` \
`$ git pull https://git.openjdk.java.net/valhalla pull/633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 633`

View PR using the GUI difftool: \
`$ git pr show -t 633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/633.diff">https://git.openjdk.java.net/valhalla/pull/633.diff</a>

</details>
