### PR TITLE
Fixed typo

### DIFF
--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -316,7 +316,7 @@ public final class Unsafe {
      * Returns the header size of the given primitive class.
      *
      * @param pc primitive class
-     * @param <V> value clas
+     * @param <V> value class
      * @return the header size of the primitive class
      */
     public native <V> long valueHeaderSize(Class<V> pc);


### PR DESCRIPTION
Simple typo fix. "clas" changed to "class".

Sincerely, Vladimir.