### PR TITLE
8281026: Allow for compiler.note.cant.instantiate.object.directly to be suppressed via an option

### DIFF
--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -267,7 +267,7 @@ define SetupJavaCompilationBody
   JAVA_WARNINGS_ARE_ERRORS ?= -Werror
 
   # Tell javac to do exactly as told and no more
-  PARANOIA_FLAGS := -implicit:none -Xprefer:source -XDignore.symbol.file=true -encoding ascii
+  PARANOIA_FLAGS := -implicit:none -Xprefer:source -XDignore.symbol.file=true -XDtolerateObjectInstantiation -encoding ascii
 
   $1_FLAGS += -g -Xlint:all $$($1_TARGET_RELEASE) $$(PARANOIA_FLAGS) $$(JAVA_WARNINGS_ARE_ERRORS)
   $1_FLAGS += $$($1_JAVAC_FLAGS)

--- a/make/langtools/build.properties
+++ b/make/langtools/build.properties
@@ -24,10 +24,10 @@
 #
 
 #javac configuration for "normal build" (these will be passed to the bootstrap compiler):
-javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports -Werror -g:source,lines,vars
+javac.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-exports -XDtolerateObjectInstantiation -Werror -g:source,lines,vars
 
 #version used to compile build tools
-javac.build.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-options -Werror -g:source,lines,vars
+javac.build.opts = -XDignore.symbol.file=true -Xlint:all,-deprecation,-options -XDtolerateObjectInstantiation -Werror -g:source,lines,vars
 javac.build.source = 8
 javac.build.target = 8
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -178,7 +178,7 @@ public class Attr extends JCTree.Visitor {
                              Feature.PATTERN_SWITCH.allowedInSource(source);
         sourceName = source.name;
         useBeforeDeclarationWarning = options.isSet("useBeforeDeclarationWarning");
-
+        tolerateObjectInstantiation = options.isSet("tolerateObjectInstantiation");
         statInfo = new ResultInfo(KindSelector.NIL, Type.noType);
         varAssignmentInfo = new ResultInfo(KindSelector.ASG, Type.noType);
         unknownExprInfo = new ResultInfo(KindSelector.VAL, Type.noType);
@@ -229,6 +229,12 @@ public class Attr extends JCTree.Visitor {
      * RFE: 6425594
      */
     boolean useBeforeDeclarationWarning;
+
+    /**
+     * Switch: warn about use of new Object() ? By default, Yes;
+     * but not if -XDtolerateObjectInstantiation is in effect
+     */
+    boolean tolerateObjectInstantiation;
 
     /**
      * Switch: name of source level; used for error reporting.
@@ -2824,7 +2830,7 @@ public class Attr extends JCTree.Visitor {
             clazztype = TreeInfo.isEnumInit(env.tree) ?
                 attribIdentAsEnumType(env, (JCIdent)clazz) :
                 attribType(clazz, env);
-            if (clazztype.tsym == syms.objectType.tsym && cdef == null && !tree.classDeclRemoved()) {
+            if (!tolerateObjectInstantiation && clazztype.tsym == syms.objectType.tsym && cdef == null && !tree.classDeclRemoved()) {
                 log.note(tree.pos(), Notes.CantInstantiateObjectDirectly);
             }
         } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -108,6 +108,13 @@ public class Check {
     private final Preview preview;
     private final boolean warnOnAnyAccessToMembers;
 
+    /**
+     * Switch: warn about use of new Object() ? By default, Yes;
+     * but not if -XDtolerateObjectInstantiation is in effect
+     */
+    boolean tolerateObjectInstantiation;
+
+
     // The set of lint options currently in effect. It is initialized
     // from the context, and then is set/reset as needed by Attr as it
     // visits all the various parts of the trees during attribution.
@@ -144,6 +151,7 @@ public class Check {
         source = Source.instance(context);
         target = Target.instance(context);
         warnOnAnyAccessToMembers = options.isSet("warnOnAccessToMembers");
+        tolerateObjectInstantiation = options.isSet("tolerateObjectInstantiation");
         Target target = Target.instance(context);
         syntheticNameChar = target.syntheticNameChar();
 
@@ -805,7 +813,7 @@ public class Check {
             /* Tolerate an encounter with abstract Object, we will mutate the constructor reference
                to an invocation of java.util.Objects.newIdentity downstream.
             */
-            if (t.tsym == syms.objectType.tsym)
+            if (!tolerateObjectInstantiation && t.tsym == syms.objectType.tsym)
                 log.note(expr.pos(), Notes.CantInstantiateObjectDirectly);
             if ((t.tsym.flags() & (ABSTRACT | INTERFACE)) != 0 && t.tsym != syms.objectType.tsym) {
                 log.error(expr, Errors.AbstractCantBeInstantiated(t.tsym));


### PR DESCRIPTION
Introduce the javac option -XDtolerateObjectInstantiation to suppress the warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281026](https://bugs.openjdk.java.net/browse/JDK-8281026): Allow for compiler.note.cant.instantiate.object.directly to be suppressed via an option


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/636/head:pull/636` \
`$ git checkout pull/636`

Update a local copy of the PR: \
`$ git checkout pull/636` \
`$ git pull https://git.openjdk.java.net/valhalla pull/636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 636`

View PR using the GUI difftool: \
`$ git pr show -t 636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/636.diff">https://git.openjdk.java.net/valhalla/pull/636.diff</a>

</details>
