### PR TITLE
8281378: [lworld] Crash in LateInlineMHCallGenerator::do_late_inline_check

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -452,9 +452,10 @@ bool LateInlineMHCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms)
   if (cg != NULL) {
     // AlwaysIncrementalInline causes for_method_handle_inline() to
     // return a LateInlineCallGenerator. Extract the
-    // InlineCallGenerato from it.
-    if (AlwaysIncrementalInline && cg->is_late_inline()) {
+    // InlineCallGenerator from it.
+    if (AlwaysIncrementalInline && cg->is_late_inline() && !cg->is_virtual_late_inline()) {
       cg = cg->inline_cg();
+      assert(cg != NULL, "inline call generator expected");
     }
 
     assert(!cg->is_late_inline() || cg->is_mh_late_inline() || AlwaysIncrementalInline, "we're doing late inlining");


### PR DESCRIPTION
I think this is caused by the support that was added recently for
virtual call late inlining and I propose tweaking the
AlwaysIncrementalInline logic for that case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281378](https://bugs.openjdk.java.net/browse/JDK-8281378): [lworld] Crash in LateInlineMHCallGenerator::do_late_inline_check


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/637/head:pull/637` \
`$ git checkout pull/637`

Update a local copy of the PR: \
`$ git checkout pull/637` \
`$ git pull https://git.openjdk.java.net/valhalla pull/637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 637`

View PR using the GUI difftool: \
`$ git pr show -t 637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/637.diff">https://git.openjdk.java.net/valhalla/pull/637.diff</a>

</details>
