### PR TITLE
8281380: [lworld] Rename T_INLINE_TYPE to T_PRIMITIVE_OBJECT

### DIFF
--- a/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/abstractInterpreter_aarch64.cpp
@@ -48,7 +48,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 8; break;
     case T_OBJECT : i = 9; break;
     case T_ARRAY  : i = 9; break;
-    case T_INLINE_TYPE : i = 10; break;
+    case T_PRIMITIVE_OBJECT : i = 10; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers,

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -585,7 +585,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       break;
     }
 
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_OBJECT: {
         if (patch_code != lir_patch_none) {
           jobject2reg_with_patching(dest->as_register(), info);
@@ -632,7 +632,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
 void LIR_Assembler::const2stack(LIR_Opr src, LIR_Opr dest) {
   LIR_Const* c = src->as_constant_ptr();
   switch (c->type()) {
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
     {
       if (! c->as_jobject())
@@ -699,7 +699,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
     assert(c->as_jint() == 0, "should be");
     insn = &Assembler::strw;
     break;
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
   case T_ARRAY:
     // Non-null case is not handled on aarch64 but handled on x86
@@ -742,7 +742,7 @@ void LIR_Assembler::reg2reg(LIR_Opr src, LIR_Opr dest) {
       return;
     }
     assert(src->is_single_cpu(), "must match");
-    if (src->type() == T_OBJECT || src->type() == T_INLINE_TYPE) {
+    if (src->type() == T_OBJECT || src->type() == T_PRIMITIVE_OBJECT) {
       __ verify_oop(src->as_register());
     }
     move_regs(src->as_register(), dest->as_register());
@@ -842,7 +842,7 @@ void LIR_Assembler::reg2mem(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -972,7 +972,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
   LIR_Address* addr = src->as_address_ptr();
   LIR_Address* from_addr = src->as_address_ptr();
 
-  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_INLINE_TYPE) {
+  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_PRIMITIVE_OBJECT) {
     __ verify_oop(addr->base()->as_pointer_register());
   }
 
@@ -996,7 +996,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -1261,7 +1261,7 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   Register len =  op->len()->as_register();
   __ uxtw(len, len);
 
-  if (UseSlowPath || op->type() == T_INLINE_TYPE ||
+  if (UseSlowPath || op->type() == T_PRIMITIVE_OBJECT ||
       (!UseFastNewObjectArray && is_reference_type(op->type())) ||
       (!UseFastNewTypeArray   && !is_reference_type(op->type()))) {
     __ b(*op->stub()->entry());
@@ -2141,7 +2141,7 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
       case T_METADATA:
         imm = (intptr_t)(opr2->as_constant_ptr()->as_metadata());
         break;
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_OBJECT:
       case T_ARRAY:
         jobject2reg(opr2->as_constant_ptr()->as_jobject(), rscratch1);
@@ -2308,7 +2308,7 @@ void LIR_Assembler::shift_op(LIR_Code code, LIR_Opr left, LIR_Opr count, LIR_Opr
       }
       break;
     case T_LONG:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_ADDRESS:
     case T_OBJECT:
       switch (code) {
@@ -2345,7 +2345,7 @@ void LIR_Assembler::shift_op(LIR_Code code, LIR_Opr left, jint count, LIR_Opr de
       break;
     case T_LONG:
     case T_ADDRESS:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_OBJECT:
       switch (code) {
       case lir_shl:  __ lsl (dreg, lreg, count); break;
@@ -3378,7 +3378,7 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
     xchg = &MacroAssembler::atomic_xchgal;
     add = &MacroAssembler::atomic_addal;
     break;
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
   case T_ARRAY:
     if (UseCompressedOops) {

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1209,7 +1209,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
 
   klass2reg_with_patching(klass_reg, obj, patching_info);
   if (x->is_null_free()) {
-    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
+    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_PRIMITIVE_OBJECT, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
   }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -650,7 +650,7 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
   }
 
   switch (type) {
-    case T_INLINE_TYPE :
+    case T_PRIMITIVE_OBJECT :
     case T_OBJECT  :
     case T_ARRAY   : {
       oop obj;

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -48,7 +48,7 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
 
-  assert(type != T_INLINE_TYPE, "Not supported yet");
+  assert(type != T_PRIMITIVE_OBJECT, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {
@@ -88,7 +88,7 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
   bool in_native = (decorators & IN_NATIVE) != 0;
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
 
-  assert(type != T_INLINE_TYPE, "Not supported yet");
+  assert(type != T_PRIMITIVE_OBJECT, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -779,7 +779,7 @@ void InterpreterMacroAssembler::remove_activation(
     ldr(rscratch1, Address(rfp, frame::interpreter_frame_method_offset * wordSize));
     ldr(rscratch1, Address(rscratch1, Method::const_offset()));
     ldrb(rscratch1, Address(rscratch1, ConstMethod::result_type_offset()));
-    cmpw(rscratch1, (u1) T_INLINE_TYPE);
+    cmpw(rscratch1, (u1) T_PRIMITIVE_OBJECT);
     br(Assembler::NE, skip);
 
     // We are returning an inline type, load its fields into registers

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4290,7 +4290,7 @@ void MacroAssembler::data_for_value_array_index(Register array, Register array_k
   lslv(index, index, rscratch1);
 
   add(data, array, index);
-  add(data, data, arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE));
+  add(data, data, arrayOopDesc::base_offset_in_bytes(T_PRIMITIVE_OBJECT));
 }
 
 void MacroAssembler::load_heap_oop(Register dst, Address src, Register tmp1,
@@ -5846,7 +5846,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
 bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                                         VMRegPair* from, int from_count, int& from_index, VMReg to,
                                         RegState reg_state[], Register val_array) {
-  assert(sig->at(sig_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
+  assert(sig->at(sig_index)._bt == T_PRIMITIVE_OBJECT, "should be at end delimiter");
   assert(to->is_valid(), "destination must be valid");
 
   if (reg_state[to->value()] == reg_written) {
@@ -5875,7 +5875,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
     val_obj = val_obj_tmp;
   }
 
-  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_INLINE_TYPE);
+  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_PRIMITIVE_OBJECT);
   load_heap_oop(val_obj, Address(val_array, index));
 
   ScalarizedInlineArgsStream stream(sig, sig_index, from, from_count, from_index);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -358,7 +358,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       if (int_args < Argument::n_int_register_parameters_j) {
         regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
       } else {
@@ -438,7 +438,7 @@ int SharedRuntime::java_return_convention(const BasicType *sig_bt, VMRegPair *re
     case T_ADDRESS:
       // Should T_METADATA be added to java_calling_convention as well ?
     case T_METADATA:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       if (int_args < SharedRuntime::java_return_convention_max_int) {
         regs[i].set2(INT_ArgReg[int_args]->as_VMReg());
         int_args ++;
@@ -514,23 +514,23 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
   if (InlineTypePassFieldsAsArgs) {
      for (int i = 0; i < sig_extended->length(); i++) {
        BasicType bt = sig_extended->at(i)._bt;
-       if (bt == T_INLINE_TYPE) {
+       if (bt == T_PRIMITIVE_OBJECT) {
          // In sig_extended, an inline type argument starts with:
-         // T_INLINE_TYPE, followed by the types of the fields of the
+         // T_PRIMITIVE_OBJECT, followed by the types of the fields of the
          // inline type and T_VOID to mark the end of the value
          // type. Inline types are flattened so, for instance, in the
          // case of an inline type with an int field and an inline type
          // field that itself has 2 fields, an int and a long:
-         // T_INLINE_TYPE T_INT T_INLINE_TYPE T_INT T_LONG T_VOID (second
-         // slot for the T_LONG) T_VOID (inner T_INLINE_TYPE) T_VOID
-         // (outer T_INLINE_TYPE)
+         // T_PRIMITIVE_OBJECT T_INT T_PRIMITIVE_OBJECT T_INT T_LONG T_VOID (second
+         // slot for the T_LONG) T_VOID (inner T_PRIMITIVE_OBJECT) T_VOID
+         // (outer T_PRIMITIVE_OBJECT)
          total_args_passed++;
          int vt = 1;
          do {
            i++;
            BasicType bt = sig_extended->at(i)._bt;
            BasicType prev_bt = sig_extended->at(i-1)._bt;
-           if (bt == T_INLINE_TYPE) {
+           if (bt == T_PRIMITIVE_OBJECT) {
              vt++;
            } else if (bt == T_VOID &&
                       prev_bt != T_LONG &&
@@ -561,7 +561,7 @@ static void gen_c2i_adapter_helper(MacroAssembler* masm,
                                    Register tmp3,
                                    int extraspace,
                                    bool is_oop) {
-  assert(bt != T_INLINE_TYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
+  assert(bt != T_PRIMITIVE_OBJECT || !InlineTypePassFieldsAsArgs, "no inline type here");
   if (bt == T_VOID) {
     assert(prev_bt == T_LONG || prev_bt == T_DOUBLE, "missing half");
     return;
@@ -647,7 +647,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // Is there an inline type argument?
     bool has_inline_argument = false;
     for (int i = 0; i < sig_extended->length() && !has_inline_argument; i++) {
-      has_inline_argument = (sig_extended->at(i)._bt == T_INLINE_TYPE);
+      has_inline_argument = (sig_extended->at(i)._bt == T_PRIMITIVE_OBJECT);
     }
     if (has_inline_argument) {
       // There is at least an inline type argument: we're coming from
@@ -709,10 +709,10 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   // next_arg_comp is the next argument from the compiler point of
   // view (inline type fields are passed in registers/on the stack). In
-  // sig_extended, an inline type argument starts with: T_INLINE_TYPE,
+  // sig_extended, an inline type argument starts with: T_PRIMITIVE_OBJECT,
   // followed by the types of the fields of the inline type and T_VOID
   // to mark the end of the inline type. ignored counts the number of
-  // T_INLINE_TYPE/T_VOID. next_vt_arg is the next inline type argument:
+  // T_PRIMITIVE_OBJECT/T_VOID. next_vt_arg is the next inline type argument:
   // used to get the buffer for that argument from the pool of buffers
   // we allocated above and want to pass to the
   // interpreter. next_arg_int is the next argument from the
@@ -723,7 +723,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     assert(next_arg_int <= total_args_passed, "more arguments for the interpreter than expected?");
     BasicType bt = sig_extended->at(next_arg_comp)._bt;
     int st_off = (total_args_passed - next_arg_int - 1) * Interpreter::stackElementSize;
-    if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_PRIMITIVE_OBJECT) {
       int next_off = st_off - Interpreter::stackElementSize;
       const int offset = (bt == T_LONG || bt == T_DOUBLE) ? next_off : st_off;
       const VMRegPair reg_pair = regs[next_arg_comp-ignored];
@@ -741,7 +741,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     } else {
       ignored++;
       // get the buffer from the just allocated pool of buffers
-      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_INLINE_TYPE);
+      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_PRIMITIVE_OBJECT);
       __ load_heap_oop(buf_oop, Address(buf_array, index));
       next_vt_arg++; next_arg_int++;
       int vt = 1;
@@ -755,7 +755,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         next_arg_comp++;
         BasicType bt = sig_extended->at(next_arg_comp)._bt;
         BasicType prev_bt = sig_extended->at(next_arg_comp - 1)._bt;
-        if (bt == T_INLINE_TYPE) {
+        if (bt == T_PRIMITIVE_OBJECT) {
           vt++;
           ignored++;
         } else if (bt == T_VOID && prev_bt != T_LONG && prev_bt != T_DOUBLE) {
@@ -871,7 +871,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm, int comp_args_on_stack
   for (int i = 0; i < total_args_passed; i++) {
     BasicType bt = sig->at(i)._bt;
 
-    assert(bt != T_INLINE_TYPE, "i2c adapter doesn't unpack inline typ args");
+    assert(bt != T_PRIMITIVE_OBJECT, "i2c adapter doesn't unpack inline typ args");
     if (bt == T_VOID) {
       assert(i > 0 && (sig->at(i - 1)._bt == T_LONG || sig->at(i - 1)._bt == T_DOUBLE), "missing half");
       continue;
@@ -1126,7 +1126,7 @@ static int c_calling_convention_priv(const BasicType *sig_bt,
         // fall through
       case T_OBJECT:
       case T_ARRAY:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_ADDRESS:
       case T_METADATA:
         if (int_args < Argument::n_int_register_parameters_c) {
@@ -1801,7 +1801,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 #endif /* ASSERT */
     switch (in_sig_bt[i]) {
       case T_ARRAY:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_OBJECT:
         object_move(masm, map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
                     ((i == 0) && (!is_static)),
@@ -1986,7 +1986,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in v0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_INLINE_TYPE:           // Really a handle
+  case T_PRIMITIVE_OBJECT:           // Really a handle
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;
@@ -3246,7 +3246,7 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {
@@ -3293,7 +3293,7 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
   j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -309,7 +309,7 @@ class StubGenerator: public StubCodeGenerator {
     return_address = __ pc();
 
     // store result depending on type (everything that is not
-    // T_OBJECT, T_INLINE_TYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
+    // T_OBJECT, T_PRIMITIVE_OBJECT, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     // n.b. this assumes Java returns an integral result in r0
     // and a floating result in j_farg0
     // All of j_rargN may be used to return inline type fields so be careful
@@ -322,7 +322,7 @@ class StubGenerator: public StubCodeGenerator {
     __ ldr(Rresult_type, result_type);
     __ cmp(Rresult_type, (u1)T_OBJECT);
     __ br(Assembler::EQ, is_long);
-    __ cmp(Rresult_type, (u1)T_INLINE_TYPE);
+    __ cmp(Rresult_type, (u1)T_PRIMITIVE_OBJECT);
     __ br(Assembler::EQ, is_value);
     __ cmp(Rresult_type, (u1)T_LONG);
     __ br(Assembler::EQ, is_long);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -562,7 +562,7 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
   case T_VOID   : /* nothing to do */        break;
   case T_FLOAT  : /* nothing to do */        break;
   case T_DOUBLE : /* nothing to do */        break;
-  case T_INLINE_TYPE: // fall through (value types are handled with oops)
+  case T_PRIMITIVE_OBJECT: // fall through (value types are handled with oops)
   case T_OBJECT :
     // retrieve result from frame
     __ ldr(r0, Address(rfp, frame::interpreter_frame_oop_temp_offset*wordSize));

--- a/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
+++ b/src/hotspot/cpu/x86/abstractInterpreter_x86.cpp
@@ -133,7 +133,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 6; break;
     case T_OBJECT : // fall through
     case T_ARRAY  : i = 7; break;
-    case T_INLINE_TYPE : i = 8; break;
+    case T_PRIMITIVE_OBJECT : i = 8; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers, "index out of bounds");
@@ -154,7 +154,7 @@ int AbstractInterpreter::BasicType_as_index(BasicType type) {
     case T_DOUBLE : i = 8; break;
     case T_OBJECT : i = 9; break;
     case T_ARRAY  : i = 9; break;
-    case T_INLINE_TYPE : i = 10; break;
+    case T_PRIMITIVE_OBJECT : i = 10; break;
     default       : ShouldNotReachHere();
   }
   assert(0 <= i && i < AbstractInterpreter::number_of_result_handlers,

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -197,7 +197,7 @@ void LIR_Assembler::push(LIR_Opr opr) {
     __ push_addr(frame_map()->address_for_slot(opr->single_stack_ix()));
   } else if (opr->is_constant()) {
     LIR_Const* const_opr = opr->as_constant_ptr();
-    if (const_opr->type() == T_OBJECT || const_opr->type() == T_INLINE_TYPE) {
+    if (const_opr->type() == T_OBJECT || const_opr->type() == T_PRIMITIVE_OBJECT) {
       __ push_oop(const_opr->as_jobject());
     } else if (const_opr->type() == T_INT) {
       __ push_jint(const_opr->as_jint());
@@ -636,7 +636,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       break;
     }
 
-    case T_INLINE_TYPE: // Fall through
+    case T_PRIMITIVE_OBJECT: // Fall through
     case T_OBJECT: {
       if (patch_code != lir_patch_none) {
         jobject2reg_with_patching(dest->as_register(), info);
@@ -727,7 +727,7 @@ void LIR_Assembler::const2stack(LIR_Opr src, LIR_Opr dest) {
       __ movptr(frame_map()->address_for_slot(dest->single_stack_ix()), c->as_jint_bits());
       break;
 
-    case T_INLINE_TYPE: // Fall through
+    case T_PRIMITIVE_OBJECT: // Fall through
     case T_OBJECT:
       __ movoop(frame_map()->address_for_slot(dest->single_stack_ix()), c->as_jobject());
       break;
@@ -767,7 +767,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
       __ movptr(as_Address(addr), c->as_jint_bits());
       break;
 
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY:
       if (c->as_jobject() == NULL) {
@@ -856,7 +856,7 @@ void LIR_Assembler::reg2reg(LIR_Opr src, LIR_Opr dest) {
     }
 #endif
     assert(src->is_single_cpu(), "must match");
-    if (src->type() == T_OBJECT || src->type() == T_INLINE_TYPE) {
+    if (src->type() == T_OBJECT || src->type() == T_PRIMITIVE_OBJECT) {
       __ verify_oop(src->as_register());
     }
     move_regs(src->as_register(), dest->as_register());
@@ -1042,7 +1042,7 @@ void LIR_Assembler::reg2mem(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_ARRAY:   // fall through
     case T_OBJECT:  // fall through
       if (UseCompressedOops && !wide) {
@@ -1215,7 +1215,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
   LIR_Address* addr = src->as_address_ptr();
   Address from_addr = as_Address(addr);
 
-  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_INLINE_TYPE) {
+  if (addr->base()->type() == T_OBJECT || addr->base()->type() == T_PRIMITIVE_OBJECT) {
     __ verify_oop(addr->base()->as_pointer_register());
   }
 
@@ -1276,7 +1276,7 @@ void LIR_Assembler::mem2reg(LIR_Opr src, LIR_Opr dest, BasicType type, LIR_Patch
       break;
     }
 
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY:   // fall through
       if (UseCompressedOops && !wide) {
@@ -1653,7 +1653,7 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
   Register len =  op->len()->as_register();
   LP64_ONLY( __ movslq(len, len); )
 
-  if (UseSlowPath || op->type() == T_INLINE_TYPE ||
+  if (UseSlowPath || op->type() == T_PRIMITIVE_OBJECT ||
       (!UseFastNewObjectArray && is_reference_type(op->type())) ||
       (!UseFastNewTypeArray   && !is_reference_type(op->type()))) {
     __ jmp(*op->stub()->entry());

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1393,7 +1393,7 @@ void LIRGenerator::do_NewObjectArray(NewObjectArray* x) {
   }
   klass2reg_with_patching(klass_reg, obj, patching_info);
   if (x->is_null_free()) {
-    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_INLINE_TYPE, klass_reg, slow_path);
+    __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_PRIMITIVE_OBJECT, klass_reg, slow_path);
   } else {
     __ allocate_array(reg, len, tmp1, tmp2, tmp3, tmp4, T_OBJECT, klass_reg, slow_path);
   }

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -658,7 +658,7 @@ BasicType frame::interpreter_frame_result(oop* oop_result, jvalue* value_result)
 
   switch (type) {
     case T_OBJECT  :
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_ARRAY   : {
       oop obj;
       if (method->is_native()) {

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -46,7 +46,7 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
   bool atomic = (decorators & MO_RELAXED) != 0;
 
-  assert(type != T_INLINE_TYPE, "Not supported yet");
+  assert(type != T_PRIMITIVE_OBJECT, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {
@@ -112,7 +112,7 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
   bool is_not_null = (decorators & IS_NOT_NULL) != 0;
   bool atomic = (decorators & MO_RELAXED) != 0;
 
-  assert(type != T_INLINE_TYPE, "Not supported yet");
+  assert(type != T_PRIMITIVE_OBJECT, "Not supported yet");
   switch (type) {
   case T_OBJECT:
   case T_ARRAY: {

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -197,7 +197,7 @@ void ZBarrierSetAssembler::store_at(MacroAssembler* masm,
                                     Register tmp3) {
   BLOCK_COMMENT("ZBarrierSetAssembler::store_at {");
 
-  assert(type != T_INLINE_TYPE, "Not supported yet");
+  assert(type != T_PRIMITIVE_OBJECT, "Not supported yet");
   // Verify oop store
   if (is_reference_type(type)) {
     // Note that src could be noreg, which means we

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1181,7 +1181,7 @@ void InterpreterMacroAssembler::remove_activation(
     movptr(rdi, Address(rbp, frame::interpreter_frame_method_offset * wordSize));
     movptr(rdi, Address(rdi, Method::const_offset()));
     load_unsigned_byte(rdi, Address(rdi, ConstMethod::result_type_offset()));
-    cmpl(rdi, T_INLINE_TYPE);
+    cmpl(rdi, T_PRIMITIVE_OBJECT);
     jcc(Assembler::notEqual, skip);
 
     // We are returning an inline type, load its fields into registers

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4993,7 +4993,7 @@ void MacroAssembler::data_for_value_array_index(Register array, Register array_k
   andl(rcx, Klass::_lh_log2_element_size_mask);
   shlptr(index); // index << rcx
 
-  lea(data, Address(array, index, Address::times_1, arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE)));
+  lea(data, Address(array, index, Address::times_1, arrayOopDesc::base_offset_in_bytes(T_PRIMITIVE_OBJECT)));
 }
 
 void MacroAssembler::load_heap_oop(Register dst, Address src, Register tmp1,
@@ -5737,7 +5737,7 @@ bool MacroAssembler::unpack_inline_helper(const GrowableArray<SigEntry>* sig, in
 bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int& sig_index, int vtarg_index,
                                         VMRegPair* from, int from_count, int& from_index, VMReg to,
                                         RegState reg_state[], Register val_array) {
-  assert(sig->at(sig_index)._bt == T_INLINE_TYPE, "should be at end delimiter");
+  assert(sig->at(sig_index)._bt == T_PRIMITIVE_OBJECT, "should be at end delimiter");
   assert(to->is_valid(), "destination must be valid");
 
   if (reg_state[to->value()] == reg_written) {
@@ -5762,7 +5762,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
     val_obj = val_obj_tmp;
   }
 
-  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_INLINE_TYPE);
+  int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + vtarg_index * type2aelembytes(T_PRIMITIVE_OBJECT);
   load_heap_oop(val_obj, Address(val_array, index));
 
   ScalarizedInlineArgsStream stream(sig, sig_index, from, from_count, from_index);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -482,7 +482,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_INT:
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_ADDRESS:
       if( reg_arg0 == 9999 )  {
         reg_arg0 = i;
@@ -1038,7 +1038,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
     case T_SHORT:
     case T_INT:
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
     case T_METADATA:
@@ -1622,7 +1622,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   for (int i = 0; i < total_in_args ; i++, c_arg++ ) {
     switch (in_sig_bt[i]) {
       case T_ARRAY:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_OBJECT:
         object_move(masm, map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
                     ((i == 0) && (!is_static)),
@@ -1794,7 +1794,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in st0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_INLINE_TYPE:           // Really a handle
+  case T_PRIMITIVE_OBJECT:           // Really a handle
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -529,7 +529,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       if (int_args < Argument::n_int_register_parameters_j) {
         regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
       } else {
@@ -608,7 +608,7 @@ int SharedRuntime::java_return_convention(const BasicType *sig_bt,
       assert(sig_bt[i + 1] == T_VOID, "expecting half");
       // fall through
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_ARRAY:
     case T_ADDRESS:
     case T_METADATA:
@@ -696,23 +696,23 @@ static int compute_total_args_passed_int(const GrowableArray<SigEntry>* sig_exte
   if (InlineTypePassFieldsAsArgs) {
     for (int i = 0; i < sig_extended->length(); i++) {
       BasicType bt = sig_extended->at(i)._bt;
-      if (bt == T_INLINE_TYPE) {
+      if (bt == T_PRIMITIVE_OBJECT) {
         // In sig_extended, an inline type argument starts with:
-        // T_INLINE_TYPE, followed by the types of the fields of the
+        // T_PRIMITIVE_OBJECT, followed by the types of the fields of the
         // inline type and T_VOID to mark the end of the value
         // type. Inline types are flattened so, for instance, in the
         // case of an inline type with an int field and an inline type
         // field that itself has 2 fields, an int and a long:
-        // T_INLINE_TYPE T_INT T_INLINE_TYPE T_INT T_LONG T_VOID (second
-        // slot for the T_LONG) T_VOID (inner T_INLINE_TYPE) T_VOID
-        // (outer T_INLINE_TYPE)
+        // T_PRIMITIVE_OBJECT T_INT T_PRIMITIVE_OBJECT T_INT T_LONG T_VOID (second
+        // slot for the T_LONG) T_VOID (inner T_PRIMITIVE_OBJECT) T_VOID
+        // (outer T_PRIMITIVE_OBJECT)
         total_args_passed++;
         int vt = 1;
         do {
           i++;
           BasicType bt = sig_extended->at(i)._bt;
           BasicType prev_bt = sig_extended->at(i-1)._bt;
-          if (bt == T_INLINE_TYPE) {
+          if (bt == T_PRIMITIVE_OBJECT) {
             vt++;
           } else if (bt == T_VOID &&
                      prev_bt != T_LONG &&
@@ -739,7 +739,7 @@ static void gen_c2i_adapter_helper(MacroAssembler* masm,
                                    const Address& to,
                                    int extraspace,
                                    bool is_oop) {
-  assert(bt != T_INLINE_TYPE || !InlineTypePassFieldsAsArgs, "no inline type here");
+  assert(bt != T_PRIMITIVE_OBJECT || !InlineTypePassFieldsAsArgs, "no inline type here");
   if (bt == T_VOID) {
     assert(prev_bt == T_LONG || prev_bt == T_DOUBLE, "missing half");
     return;
@@ -816,7 +816,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // Is there an inline type argument?
     bool has_inline_argument = false;
     for (int i = 0; i < sig_extended->length() && !has_inline_argument; i++) {
-      has_inline_argument = (sig_extended->at(i)._bt == T_INLINE_TYPE);
+      has_inline_argument = (sig_extended->at(i)._bt == T_PRIMITIVE_OBJECT);
     }
     if (has_inline_argument) {
       // There is at least an inline type argument: we're coming from
@@ -879,10 +879,10 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
   // next_arg_comp is the next argument from the compiler point of
   // view (inline type fields are passed in registers/on the stack). In
-  // sig_extended, an inline type argument starts with: T_INLINE_TYPE,
+  // sig_extended, an inline type argument starts with: T_PRIMITIVE_OBJECT,
   // followed by the types of the fields of the inline type and T_VOID
   // to mark the end of the inline type. ignored counts the number of
-  // T_INLINE_TYPE/T_VOID. next_vt_arg is the next inline type argument:
+  // T_PRIMITIVE_OBJECT/T_VOID. next_vt_arg is the next inline type argument:
   // used to get the buffer for that argument from the pool of buffers
   // we allocated above and want to pass to the
   // interpreter. next_arg_int is the next argument from the
@@ -893,7 +893,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     assert(next_arg_int <= total_args_passed, "more arguments for the interpreter than expected?");
     BasicType bt = sig_extended->at(next_arg_comp)._bt;
     int st_off = (total_args_passed - next_arg_int) * Interpreter::stackElementSize;
-    if (!InlineTypePassFieldsAsArgs || bt != T_INLINE_TYPE) {
+    if (!InlineTypePassFieldsAsArgs || bt != T_PRIMITIVE_OBJECT) {
       int next_off = st_off - Interpreter::stackElementSize;
       const int offset = (bt == T_LONG || bt == T_DOUBLE) ? next_off : st_off;
       const VMRegPair reg_pair = regs[next_arg_comp-ignored];
@@ -911,7 +911,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     } else {
       ignored++;
       // get the buffer from the just allocated pool of buffers
-      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_INLINE_TYPE);
+      int index = arrayOopDesc::base_offset_in_bytes(T_OBJECT) + next_vt_arg * type2aelembytes(T_PRIMITIVE_OBJECT);
       __ load_heap_oop(r14, Address(rscratch2, index));
       next_vt_arg++; next_arg_int++;
       int vt = 1;
@@ -925,7 +925,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         next_arg_comp++;
         BasicType bt = sig_extended->at(next_arg_comp)._bt;
         BasicType prev_bt = sig_extended->at(next_arg_comp-1)._bt;
-        if (bt == T_INLINE_TYPE) {
+        if (bt == T_PRIMITIVE_OBJECT) {
           vt++;
           ignored++;
         } else if (bt == T_VOID &&
@@ -1079,7 +1079,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   // rest through the floating point stack top.
   for (int i = 0; i < total_args_passed; i++) {
     BasicType bt = sig->at(i)._bt;
-    assert(bt != T_INLINE_TYPE, "i2c adapter doesn't unpack inline type args");
+    assert(bt != T_PRIMITIVE_OBJECT, "i2c adapter doesn't unpack inline type args");
     if (bt == T_VOID) {
       // Longs and doubles are passed in native word order, but misaligned
       // in the 32-bit build.
@@ -1351,7 +1351,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
         // fall through
       case T_OBJECT:
       case T_ARRAY:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_ADDRESS:
       case T_METADATA:
         if (int_args < Argument::n_int_register_parameters_c) {
@@ -2059,7 +2059,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 #endif /* ASSERT */
     switch (in_sig_bt[i]) {
       case T_ARRAY:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_OBJECT:
         __ object_move(map, oop_handle_offset, stack_slots, in_regs[i], out_regs[c_arg],
                     ((i == 0) && (!is_static)),
@@ -2247,7 +2247,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Result is in xmm0 we'll save as needed
     break;
   case T_ARRAY:                 // Really a handle
-  case T_INLINE_TYPE:           // Really a handle
+  case T_PRIMITIVE_OBJECT:           // Really a handle
   case T_OBJECT:                // Really a handle
       break; // can't de-handlize until after safepoint check
   case T_VOID: break;
@@ -4019,7 +4019,7 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {
@@ -4059,7 +4059,7 @@ BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(con
   j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -342,13 +342,13 @@ class StubGenerator: public StubCodeGenerator {
     return_address = __ pc();
 
     // store result depending on type (everything that is not
-    // T_OBJECT, T_INLINE_TYPE, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
+    // T_OBJECT, T_PRIMITIVE_OBJECT, T_LONG, T_FLOAT or T_DOUBLE is treated as T_INT)
     __ movptr(r13, result);
     Label is_long, is_float, is_double, is_value, exit;
     __ movl(rbx, result_type);
     __ cmpl(rbx, T_OBJECT);
     __ jcc(Assembler::equal, is_long);
-    __ cmpl(rbx, T_INLINE_TYPE);
+    __ cmpl(rbx, T_PRIMITIVE_OBJECT);
     __ jcc(Assembler::equal, is_value);
     __ cmpl(rbx, T_LONG);
     __ jcc(Assembler::equal, is_long);

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -354,7 +354,7 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
   case T_DOUBLE : /* nothing to do */        break;
 #endif // _LP64
 
-  case T_INLINE_TYPE: // fall through (inline types are handled with oops)
+  case T_PRIMITIVE_OBJECT: // fall through (inline types are handled with oops)
   case T_OBJECT :
     // retrieve result from frame
     __ movptr(rax, Address(rbp, frame::interpreter_frame_oop_temp_offset*wordSize));

--- a/src/hotspot/share/c1/c1_FrameMap.cpp
+++ b/src/hotspot/share/c1/c1_FrameMap.cpp
@@ -41,7 +41,7 @@ BasicTypeArray* FrameMap::signature_type_array_for(const ciMethod* method) {
   for (int i = 0; i < sig->count(); i++) {
     ciType* type = sig->type_at(i);
     BasicType t = type->basic_type();
-    if (t == T_ARRAY || t == T_INLINE_TYPE) {
+    if (t == T_ARRAY || t == T_PRIMITIVE_OBJECT) {
       t = T_OBJECT;
     }
     sta->append(t);

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -97,7 +97,7 @@ LIR_Address::Scale LIR_Address::scale(BasicType type) {
 char LIR_Opr::type_char(BasicType t) {
   switch (t) {
     case T_ARRAY:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       t = T_OBJECT;
     case T_BOOLEAN:
     case T_CHAR:
@@ -154,7 +154,7 @@ void LIR_Opr::validate_type() const {
     case T_OBJECT:
     case T_METADATA:
     case T_ARRAY:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       assert((kindfield == cpu_register || kindfield == stack_value) &&
              size_field() == single_size, "must match");
       break;

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -336,7 +336,7 @@ class LIR_Opr {
       case T_INT:
       case T_ADDRESS:
       case T_OBJECT:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_ARRAY:
       case T_METADATA:
         return single_size;
@@ -486,7 +486,7 @@ inline LIR_Opr::OprType as_OprType(BasicType type) {
   case T_FLOAT:    return LIR_Opr::float_type;
   case T_DOUBLE:   return LIR_Opr::double_type;
   case T_OBJECT:
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_ARRAY:    return LIR_Opr::object_type;
   case T_ADDRESS:  return LIR_Opr::address_type;
   case T_METADATA: return LIR_Opr::metadata_type;
@@ -678,7 +678,7 @@ class LIR_OprFact: public AllStatic {
     LIR_Opr res;
     switch (type) {
       case T_OBJECT: // fall through
-      case T_INLINE_TYPE: // fall through
+      case T_PRIMITIVE_OBJECT: // fall through
       case T_ARRAY:
         res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift)  |
                                             LIR_Opr::object_type  |
@@ -784,7 +784,7 @@ class LIR_OprFact: public AllStatic {
   static LIR_Opr stack(int index, BasicType type) {
     LIR_Opr res;
     switch (type) {
-      case T_INLINE_TYPE: // fall through
+      case T_PRIMITIVE_OBJECT: // fall through
       case T_OBJECT: // fall through
       case T_ARRAY:
         res = (LIR_Opr)(intptr_t)((index << LIR_Opr::data_shift) |

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -3141,7 +3141,7 @@ void LIRGenerator::invoke_load_one_argument(LIRItem* param, LIR_Opr loc) {
   } else {
     LIR_Address* addr = loc->as_address_ptr();
     param->load_for_store(addr->type());
-    assert(addr->type() != T_INLINE_TYPE, "not supported yet");
+    assert(addr->type() != T_PRIMITIVE_OBJECT, "not supported yet");
     if (addr->type() == T_OBJECT) {
       __ move_wide(param->result(), addr);
     } else {

--- a/src/hotspot/share/c1/c1_ValueType.cpp
+++ b/src/hotspot/share/c1/c1_ValueType.cpp
@@ -129,7 +129,7 @@ ValueType* as_ValueType(BasicType type) {
     case T_DOUBLE : return doubleType;
     case T_ARRAY  : return arrayType;
     case T_OBJECT : return objectType;
-    case T_INLINE_TYPE: return objectType;
+    case T_PRIMITIVE_OBJECT: return objectType;
     case T_ADDRESS: return addressType;
     case T_ILLEGAL: return illegalType;
     default       : ShouldNotReachHere();
@@ -149,7 +149,7 @@ ValueType* as_ValueType(ciConstant value) {
     case T_FLOAT  : return new FloatConstant (value.as_float ());
     case T_DOUBLE : return new DoubleConstant(value.as_double());
     case T_ARRAY  : // fall through (ciConstant doesn't have an array accessor)
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_OBJECT : {
       // TODO: Common the code with GraphBuilder::load_constant?
       ciObject* obj = value.as_object();

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -533,7 +533,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
   if (Signature::is_array(sym) &&
       (sym->char_at(1) == JVM_SIGNATURE_ARRAY ||
        sym->char_at(1) == JVM_SIGNATURE_CLASS ||
-       sym->char_at(1) == JVM_SIGNATURE_INLINE_TYPE )) {
+       sym->char_at(1) == JVM_SIGNATURE_PRIMITIVE_OBJECT )) {
     // We have an unloaded array.
     // Build it on the fly if the element class exists.
     SignatureStream ss(sym, false);
@@ -546,7 +546,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
                              require_local);
     if (elem_klass != NULL && elem_klass->is_loaded()) {
       // Now make an array for it
-      bool null_free_array = sym->is_Q_array_signature() && sym->char_at(1) == JVM_SIGNATURE_INLINE_TYPE;
+      bool null_free_array = sym->is_Q_array_signature() && sym->char_at(1) == JVM_SIGNATURE_PRIMITIVE_OBJECT;
       return ciArrayKlass::make(elem_klass, null_free_array);
     }
   }
@@ -577,7 +577,7 @@ ciKlass* ciEnv::get_klass_by_name_impl(ciKlass* accessing_klass,
   while (sym->char_at(i) == JVM_SIGNATURE_ARRAY) {
     i++;
   }
-  if (i > 0 && sym->char_at(i) == JVM_SIGNATURE_INLINE_TYPE) {
+  if (i > 0 && sym->char_at(i) == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
     // An unloaded array class of inline types is an ObjArrayKlass, an
     // unloaded inline type class is an InstanceKlass. For consistency,
     // make the signature of the unloaded array of inline type use L

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -52,7 +52,7 @@ protected:
   };
 
   ciInlineKlass(ciSymbol* name, jobject loader, jobject protection_domain) :
-    ciInstanceKlass(name, loader, protection_domain, T_INLINE_TYPE) {}
+    ciInstanceKlass(name, loader, protection_domain, T_PRIMITIVE_OBJECT) {}
 
   int compute_nonstatic_fields();
   const char* type_string() { return "ciInlineKlass"; }

--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -73,7 +73,7 @@ ciConstant ciInstance::field_value_impl(BasicType field_btype, int offset) {
     case T_FLOAT:   return ciConstant(obj->float_field(offset));
     case T_DOUBLE:  return ciConstant(obj->double_field(offset));
     case T_LONG:    return ciConstant(obj->long_field(offset));
-    case T_INLINE_TYPE:  // fall through
+    case T_PRIMITIVE_OBJECT:  // fall through
     case T_OBJECT:  // fall through
     case T_ARRAY: {
       oop o = obj->obj_field(offset);

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -813,7 +813,7 @@ void StaticFieldPrinter::do_field_helper(fieldDescriptor* fd, oop mirror, bool f
       }
       break;
     }
-    case T_INLINE_TYPE: {
+    case T_PRIMITIVE_OBJECT: {
       ResetNoHandleMark rnhm;
       Thread* THREAD = Thread::current();
       SignatureStream ss(fd->signature(), false);

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1445,7 +1445,7 @@ void ciMethod::print_impl(outputStream* st) {
 static BasicType erase_to_word_type(BasicType bt) {
   if (is_subword_type(bt))   return T_INT;
   if (is_reference_type(bt)) return T_OBJECT;
-  if (bt == T_INLINE_TYPE)   return T_OBJECT;
+  if (bt == T_PRIMITIVE_OBJECT)   return T_OBJECT;
   return bt;
 }
 

--- a/src/hotspot/share/ci/ciObjArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.cpp
@@ -54,7 +54,7 @@ ciObjArrayKlass::ciObjArrayKlass(Klass* k) : ciArrayKlass(k) {
   if (!ciObjectFactory::is_initialized()) {
     assert(_element_klass->is_java_lang_Object(), "only arrays of object are shared");
   }
-  _null_free = k->name()->is_Q_array_signature() && k->name()->char_at(1) == JVM_SIGNATURE_INLINE_TYPE;
+  _null_free = k->name()->is_Q_array_signature() && k->name()->char_at(1) == JVM_SIGNATURE_PRIMITIVE_OBJECT;
 }
 
 // ------------------------------------------------------------------
@@ -75,7 +75,7 @@ ciObjArrayKlass::ciObjArrayKlass(ciSymbol* array_name,
   } else {
     _element_klass = NULL;
   }
-  _null_free = array_name->is_Q_array_signature() && array_name->char_at(1) == JVM_SIGNATURE_INLINE_TYPE;
+  _null_free = array_name->is_Q_array_signature() && array_name->char_at(1) == JVM_SIGNATURE_PRIMITIVE_OBJECT;
 }
 
 // ------------------------------------------------------------------
@@ -120,7 +120,7 @@ ciSymbol* ciObjArrayKlass::construct_array_name(ciSymbol* element_name,
     name[pos] = JVM_SIGNATURE_ARRAY;
   }
   Symbol* base_name_sym = element_name->get_symbol();
-  assert(base_name_sym->char_at(0) != JVM_SIGNATURE_INLINE_TYPE, "unloaded array klass element should not have Q-type");
+  assert(base_name_sym->char_at(0) != JVM_SIGNATURE_PRIMITIVE_OBJECT, "unloaded array klass element should not have Q-type");
   if (Signature::is_array(base_name_sym) ||
       Signature::has_envelope(base_name_sym)) {
     strncpy(&name[pos], (char*)element_name->base(), element_len);

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -499,7 +499,7 @@ ciKlass* ciObjectFactory::get_unloaded_klass(ciKlass* accessing_klass,
     BasicType element_type = ss.type();
     assert(element_type != T_ARRAY, "unsuccessful decomposition");
     ciKlass* element_klass = NULL;
-    if (element_type == T_OBJECT || element_type == T_INLINE_TYPE) {
+    if (element_type == T_OBJECT || element_type == T_PRIMITIVE_OBJECT) {
       ciEnv *env = CURRENT_THREAD_ENV;
       ciSymbol* ci_name = env->get_symbol(ss.as_symbol());
       element_klass =

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1036,7 +1036,7 @@ class CompileReplay : public StackObj {
 
     void do_field(fieldDescriptor* fd) {
       BasicType bt = fd->field_type();
-      const char* string_value = bt != T_INLINE_TYPE ? _replay->parse_escaped_string() : NULL;
+      const char* string_value = bt != T_PRIMITIVE_OBJECT ? _replay->parse_escaped_string() : NULL;
       switch (bt) {
       case T_BYTE: {
         int value = atoi(string_value);
@@ -1089,7 +1089,7 @@ class CompileReplay : public StackObj {
         assert(res, "should succeed for arrays & objects");
         break;
       }
-      case T_INLINE_TYPE: {
+      case T_PRIMITIVE_OBJECT: {
         InlineKlass* vk = InlineKlass::cast(fd->field_holder()->get_inline_type_field_klass(fd->index()));
         if (fd->is_inlined()) {
           int field_offset = fd->offset() - vk->first_field_offset();
@@ -1150,7 +1150,7 @@ class CompileReplay : public StackObj {
           Klass* kelem = resolve_klass(field_signature + 1, CHECK_(true));
           value = oopFactory::new_objArray(kelem, length, CHECK_(true));
         } else if (field_signature[0] == JVM_SIGNATURE_ARRAY &&
-                   field_signature[1] == JVM_SIGNATURE_INLINE_TYPE) {
+                   field_signature[1] == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
           Klass* kelem = resolve_klass(field_signature + 1, CHECK_(true));
           value = oopFactory::new_valueArray(kelem, length, CHECK_(true));
         } else {
@@ -1238,7 +1238,7 @@ class CompileReplay : public StackObj {
       const char* string_value = parse_escaped_string();
       double value = atof(string_value);
       java_mirror->double_field_put(fd.offset(), value);
-    } else if (field_signature[0] == JVM_SIGNATURE_INLINE_TYPE) {
+    } else if (field_signature[0] == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
       Klass* kelem = resolve_klass(field_signature, CHECK);
       InlineKlass* vk = InlineKlass::cast(kelem);
       oop value = vk->allocate_instance(CHECK);

--- a/src/hotspot/share/ci/ciType.cpp
+++ b/src/hotspot/share/ci/ciType.cpp
@@ -45,7 +45,7 @@ ciType::ciType(BasicType basic_type) : ciMetadata() {
 }
 
 ciType::ciType(Klass* k) : ciMetadata(k) {
-  _basic_type = k->is_array_klass() ? T_ARRAY : (k->is_inline_klass() ? T_INLINE_TYPE : T_OBJECT);
+  _basic_type = k->is_array_klass() ? T_ARRAY : (k->is_inline_klass() ? T_PRIMITIVE_OBJECT : T_OBJECT);
 }
 
 

--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -186,7 +186,7 @@ void BytecodeAssembler::load(BasicType bt, u4 index) {
     case T_FLOAT:   fload(index); break;
     case T_DOUBLE:  dload(index); break;
     case T_LONG:    lload(index); break;
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     default:
       if (is_reference_type(bt)) {
                     aload(index);
@@ -256,7 +256,7 @@ void BytecodeAssembler::_return(BasicType bt) {
     case T_FLOAT:   freturn(); break;
     case T_DOUBLE:  dreturn(); break;
     case T_LONG:    lreturn(); break;
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_VOID:    _return(); break;
     default:
       if (is_reference_type(bt)) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1457,7 +1457,7 @@ static FieldAllocationType _basic_type_to_atype[2 * (T_CONFLICT + 1)] = {
   NONSTATIC_DOUBLE,    // T_LONG        = 11,
   NONSTATIC_OOP,       // T_OBJECT      = 12,
   NONSTATIC_OOP,       // T_ARRAY       = 13,
-  NONSTATIC_OOP,       // T_INLINE_TYPE = 14,
+  NONSTATIC_OOP,       // T_PRIMITIVE_OBJECT = 14,
   BAD_ALLOCATION_TYPE, // T_VOID        = 15,
   BAD_ALLOCATION_TYPE, // T_ADDRESS     = 16,
   BAD_ALLOCATION_TYPE, // T_NARROWOOP   = 17,
@@ -1478,7 +1478,7 @@ static FieldAllocationType _basic_type_to_atype[2 * (T_CONFLICT + 1)] = {
   STATIC_DOUBLE,       // T_LONG        = 11,
   STATIC_OOP,          // T_OBJECT      = 12,
   STATIC_OOP,          // T_ARRAY       = 13,
-  STATIC_OOP,          // T_INLINE_TYPE = 14,
+  STATIC_OOP,          // T_PRIMITIVE_OBJECT = 14,
   BAD_ALLOCATION_TYPE, // T_VOID        = 15,
   BAD_ALLOCATION_TYPE, // T_ADDRESS     = 16,
   BAD_ALLOCATION_TYPE, // T_NARROWOOP   = 17,
@@ -1663,7 +1663,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     const BasicType type = cp->basic_type_for_signature_at(signature_index);
 
     // Update FieldAllocationCount for this kind of field
-    fac->update(is_static, type, type == T_INLINE_TYPE);
+    fac->update(is_static, type, type == T_PRIMITIVE_OBJECT);
 
     // After field is initialized with type, we can augment it with aux info
     if (parsed_annotations.has_any_annotations()) {
@@ -5185,7 +5185,7 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
     case JVM_SIGNATURE_LONG:
     case JVM_SIGNATURE_DOUBLE:
       return signature + 1;
-    case JVM_SIGNATURE_INLINE_TYPE:
+    case JVM_SIGNATURE_PRIMITIVE_OBJECT:
       // Can't enable this check until JDK upgrades the bytecode generators
       // if (_major_version < CONSTANT_CLASS_DESCRIPTORS ) {
       //   classfile_parse_error("Class name contains illegal Q-signature "
@@ -6547,7 +6547,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
                                                    NULL,
                                                    CHECK);
     for (AllFieldStream fs(_fields, cp); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE && !fs.access_flags().is_static()) {
+      if (Signature::basic_type(fs.signature()) == T_PRIMITIVE_OBJECT && !fs.access_flags().is_static()) {
         // Pre-load inline class
         Klass* klass = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
             Handle(THREAD, _loader_data->class_loader()),

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -203,7 +203,7 @@ Symbol* ClassLoader::package_from_class_name(const Symbol* name, bool* bad_class
     // Set bad_class_name to true to indicate that the package name
     // could not be obtained due to an error condition.
     // In this situation, is_same_class_package returns false.
-    if (*start == JVM_SIGNATURE_CLASS || *start == JVM_SIGNATURE_INLINE_TYPE) {
+    if (*start == JVM_SIGNATURE_CLASS || *start == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
       if (bad_class_name != NULL) {
         *bad_class_name = true;
       }

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -338,7 +338,7 @@ bool FieldLayout::reconstruct_layout(const InstanceKlass* ik) {
       if (fs.access_flags().is_static()) continue;
       has_instance_fields = true;
       LayoutRawBlock* block;
-      if (type == T_INLINE_TYPE) {
+      if (type == T_PRIMITIVE_OBJECT) {
         InlineKlass* vk = InlineKlass::cast(ik->get_inline_type_field_klass(fs.index()));
         block = new LayoutRawBlock(fs.index(), LayoutRawBlock::INHERITED, vk->get_exact_size_in_bytes(),
                                    vk->get_alignment(), false);
@@ -631,7 +631,7 @@ void FieldLayoutBuilder::regular_field_sorting() {
       if (group != _static_fields) _nonstatic_oopmap_count++;
       group->add_oop_field(fs);
       break;
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       _has_inline_type_fields = true;
       if (group == _static_fields) {
         // static fields are never inlined
@@ -729,7 +729,7 @@ void FieldLayoutBuilder::inline_class_field_sorting(TRAPS) {
       }
       group->add_oop_field(fs);
       break;
-    case T_INLINE_TYPE: {
+    case T_PRIMITIVE_OBJECT: {
 //      fs.set_inline(true);
       _has_inline_type_fields = true;
       if (group == _static_fields) {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1153,7 +1153,7 @@ class ResetMirrorField: public FieldClosure {
       case T_BOOLEAN:
         _m()->bool_field_put(fd->offset(), false);
         break;
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_ARRAY:
       case T_OBJECT: {
         // It might be useful to cache the String field, but

--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -83,7 +83,7 @@ SeenThread* PlaceholderEntry::actionToQueue(PlaceholderTable::classloadAction ac
     case PlaceholderTable::DEFINE_CLASS:
        queuehead = _defineThreadQ;
        break;
-    case PlaceholderTable::INLINE_TYPE_FIELD:
+    case PlaceholderTable::PRIMITIVE_OBJECT_FIELD:
        queuehead = _inlineTypeFieldQ;
        break;
     default: Unimplemented();
@@ -102,7 +102,7 @@ void PlaceholderEntry::set_threadQ(SeenThread* seenthread, PlaceholderTable::cla
     case PlaceholderTable::DEFINE_CLASS:
        _defineThreadQ = seenthread;
        break;
-    case PlaceholderTable::INLINE_TYPE_FIELD:
+    case PlaceholderTable::PRIMITIVE_OBJECT_FIELD:
        _inlineTypeFieldQ = seenthread;
        break;
     default: Unimplemented();
@@ -273,7 +273,7 @@ static const char* action_to_string(PlaceholderTable::classloadAction action) {
   case PlaceholderTable::LOAD_INSTANCE: return "LOAD_INSTANCE";
   case PlaceholderTable::LOAD_SUPER:    return "LOAD_SUPER";
   case PlaceholderTable::DEFINE_CLASS:  return "DEFINE_CLASS";
-  case PlaceholderTable::INLINE_TYPE_FIELD: return "INLINE_TYPE_FIELD";
+  case PlaceholderTable::PRIMITIVE_OBJECT_FIELD: return "PRIMITIVE_OBJECT_FIELD";
  }
  return "";
 }

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -73,12 +73,12 @@ public:
 // on a class/classloader basis
 // so the head of that queue owns the token
 // and the rest of the threads return the result the first thread gets
-// INLINE_TYPE_FIELD: needed to check for inline type fields circularity
+// PRIMITIVE_OBJECT_FIELD: needed to check for inline type fields circularity
  enum classloadAction {
     LOAD_INSTANCE = 1,             // calling load_instance_class
     LOAD_SUPER = 2,                // loading superclass for this class
     DEFINE_CLASS = 3,              // find_or_define class
-    INLINE_TYPE_FIELD = 4          // inline type fields
+    PRIMITIVE_OBJECT_FIELD = 4     // primitive object fields
  };
 
   // find_and_add returns probe pointer - old or new

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -101,7 +101,7 @@ VerificationType StackMapFrame::set_locals_from_arg(
   switch (ss.type()) {
     case T_OBJECT:
     case T_ARRAY:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     {
       Symbol* sig = ss.as_symbol();
       if (!sig->is_permanent()) {
@@ -112,7 +112,7 @@ VerificationType StackMapFrame::set_locals_from_arg(
         assert(sig_copy == sig, "symbols don't match");
         sig = sig_copy;
       }
-      if (ss.type() == T_INLINE_TYPE) {
+      if (ss.type() == T_PRIMITIVE_OBJECT) {
         return VerificationType::inline_type(sig);
       }
       return VerificationType::reference_type(sig);

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -470,12 +470,12 @@ Klass* SystemDictionary::resolve_inline_type_field_or_fail(AllFieldStream* fs,
     MutexLocker mu(THREAD, SystemDictionary_lock);
     oldprobe = placeholders()->get_entry(p_hash, class_name, loader_data);
     if (oldprobe != NULL &&
-      oldprobe->check_seen_thread(THREAD, PlaceholderTable::INLINE_TYPE_FIELD)) {
+      oldprobe->check_seen_thread(THREAD, PlaceholderTable::PRIMITIVE_OBJECT_FIELD)) {
       throw_circularity_error = true;
 
     } else {
       placeholders()->find_and_add(p_hash, class_name, loader_data,
-                                   PlaceholderTable::INLINE_TYPE_FIELD, NULL, THREAD);
+                                   PlaceholderTable::PRIMITIVE_OBJECT_FIELD, NULL, THREAD);
     }
   }
 
@@ -491,7 +491,7 @@ Klass* SystemDictionary::resolve_inline_type_field_or_fail(AllFieldStream* fs,
   {
     MutexLocker mu(THREAD, SystemDictionary_lock);
     placeholders()->find_and_remove(p_hash, class_name, loader_data,
-                                    PlaceholderTable::INLINE_TYPE_FIELD, THREAD);
+                                    PlaceholderTable::PRIMITIVE_OBJECT_FIELD, THREAD);
   }
 
   class_name->decrement_refcount();
@@ -855,7 +855,7 @@ Klass* SystemDictionary::find_instance_or_array_klass(Symbol* class_name,
     SignatureStream ss(class_name, false);
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
-    if (t != T_OBJECT && t != T_INLINE_TYPE) {
+    if (t != T_OBJECT && t != T_PRIMITIVE_OBJECT) {
       k = Universe::typeArrayKlassObj(t);
     } else {
       k = SystemDictionary::find_instance_klass(ss.as_symbol(), class_loader, protection_domain);
@@ -1210,7 +1210,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
 
   if (ik->has_inline_type_fields()) {
     for (AllFieldStream fs(ik->fields(), ik->constants()); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
+      if (Signature::basic_type(fs.signature()) == T_PRIMITIVE_OBJECT) {
         if (!fs.access_flags().is_static()) {
           // Pre-load inline class
           Klass* real_k = SystemDictionary::resolve_inline_type_field_or_fail(&fs,
@@ -1848,7 +1848,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     SignatureStream ss(class_name, false);
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
-    if (t != T_OBJECT && t != T_INLINE_TYPE) {
+    if (t != T_OBJECT && t != T_PRIMITIVE_OBJECT) {
       klass = Universe::typeArrayKlassObj(t);
     } else {
       MutexLocker mu(current, SystemDictionary_lock);

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -218,13 +218,13 @@ VerificationType VerificationType::get_component(ClassVerifier *context) const {
     case T_DOUBLE:  return VerificationType(Double);
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE: {
+    case T_PRIMITIVE_OBJECT: {
       guarantee(ss.is_reference(), "unchecked verifier input?");
       Symbol* component = ss.as_symbol();
       // Create another symbol to save as signature stream unreferences this symbol.
       Symbol* component_copy = context->create_temporary_symbol(component);
       assert(component_copy == component, "symbols don't match");
-      return (ss.type() == T_INLINE_TYPE) ?
+      return (ss.type() == T_PRIMITIVE_OBJECT) ?
         VerificationType::inline_type(component_copy) :
         VerificationType::reference_type(component_copy);
    }

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -241,7 +241,7 @@ class VerificationType {
   bool is_double_array() const { return is_x_array(JVM_SIGNATURE_DOUBLE); }
   bool is_object_array() const { return is_x_array(JVM_SIGNATURE_CLASS); }
   bool is_array_array() const { return is_x_array(JVM_SIGNATURE_ARRAY); }
-  bool is_inline_type_array() const { return is_x_array(JVM_SIGNATURE_INLINE_TYPE); }
+  bool is_inline_type_array() const { return is_x_array(JVM_SIGNATURE_PRIMITIVE_OBJECT); }
   bool is_reference_array() const
     { return is_object_array() || is_array_array(); }
   bool is_nonscalar_array() const

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -3107,7 +3107,7 @@ void ClassVerifier::verify_anewarray(
     assert(n == length, "Unexpected number of characters in string");
   } else {         // it's an object or interface
     const char* component_name = component_type.name()->as_utf8();
-    char Q_or_L = component_type.is_inline_type() ? JVM_SIGNATURE_INLINE_TYPE : JVM_SIGNATURE_CLASS;
+    char Q_or_L = component_type.is_inline_type() ? JVM_SIGNATURE_PRIMITIVE_OBJECT : JVM_SIGNATURE_CLASS;
     // add one dimension to component with 'L' or 'Q' prepended and ';' appended.
     length = (int)strlen(component_name) + 3;
     arr_sig_str = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, length + 1);

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -501,7 +501,7 @@ inline int ClassVerifier::change_sig_to_verificationType(
         *inference_type = VerificationType::reference_type(name_copy);
         return 1;
       }
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       {
         Symbol* vname = sig_type->as_symbol();
         // Create another symbol to save as signature stream unreferences this symbol.

--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -208,7 +208,7 @@ void G1BarrierSetC2::pre_barrier(GraphKit* kit,
     if (pre_val->bottom_type() == TypePtr::NULL_PTR) return;
     assert(pre_val->bottom_type()->basic_type() == T_OBJECT, "or we shouldn't be here");
   }
-  assert(bt == T_OBJECT || bt == T_INLINE_TYPE, "or we shouldn't be here");
+  assert(bt == T_OBJECT || bt == T_PRIMITIVE_OBJECT, "or we shouldn't be here");
 
   IdealKit ideal(kit, true);
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1459,7 +1459,7 @@ JRT_ENTRY(void, InterpreterRuntime::post_field_modification(JavaThread* current,
 
   // Both Q-signatures and L-signatures are mapped to atos
   if (cp_entry->flag_state() == atos && ik->field_signature(index)->is_Q_signature()) {
-    sig_type = JVM_SIGNATURE_INLINE_TYPE;
+    sig_type = JVM_SIGNATURE_PRIMITIVE_OBJECT;
   }
 
   bool is_static = (obj == NULL);

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -51,7 +51,7 @@ static const BasicType types[Interpreter::number_of_result_handlers] = {
   T_FLOAT  ,
   T_DOUBLE ,
   T_OBJECT ,
-  T_INLINE_TYPE
+  T_PRIMITIVE_OBJECT
 };
 
 void TemplateInterpreterGenerator::generate_all() {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -154,7 +154,7 @@ class JavaArgumentUnboxer : public SignatureIterator {
   friend class SignatureIterator;  // so do_parameters_on can call do_type
   void do_type(BasicType type) {
     if (is_reference_type(type)) {
-      (type == T_INLINE_TYPE) ? _jca->push_oop(next_arg(T_INLINE_TYPE)) : _jca->push_oop(next_arg(T_OBJECT));
+      (type == T_PRIMITIVE_OBJECT) ? _jca->push_oop(next_arg(T_PRIMITIVE_OBJECT)) : _jca->push_oop(next_arg(T_OBJECT));
       return;
     }
     Handle arg = next_arg(type);

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -559,7 +559,7 @@ private:
   const int index() { return _index; }
   const InstanceKlass* holder() { return _holder; }
   const AccessFlags& access_flags() { return _access_flags; }
-  const bool is_inline_type() { return Signature::basic_type(_signature) == T_INLINE_TYPE; }
+  const bool is_inline_type() { return Signature::basic_type(_signature) == T_PRIMITIVE_OBJECT; }
 };
 
 static int compare_offset(FieldDesc* f1, FieldDesc* f2) {

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -110,7 +110,7 @@ Symbol* ArrayKlass::create_element_klass_array_name(Klass* element_klass, bool q
   new_str[idx++] = JVM_SIGNATURE_ARRAY;
   if (element_klass->is_instance_klass()) { // it could be an array or simple type
     if (qdesc) {
-      new_str[idx++] = JVM_SIGNATURE_INLINE_TYPE;
+      new_str[idx++] = JVM_SIGNATURE_PRIMITIVE_OBJECT;
     } else {
       new_str[idx++] = JVM_SIGNATURE_CLASS;
     }

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -71,7 +71,7 @@ protected:
   // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
   // strongly.
   static bool element_type_should_be_aligned(BasicType type) {
-    return type == T_DOUBLE || type == T_LONG || type == T_INLINE_TYPE;
+    return type == T_DOUBLE || type == T_LONG || type == T_PRIMITIVE_OBJECT;
   }
 
  public:

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -174,7 +174,7 @@ oop FlatArrayKlass::multi_allocate(int rank, jint* last_size, TRAPS) {
 }
 
 jint FlatArrayKlass::array_layout_helper(InlineKlass* vk) {
-  BasicType etype = T_INLINE_TYPE;
+  BasicType etype = T_PRIMITIVE_OBJECT;
   int esize = log2i_exact(round_up_power_of_2(vk->get_exact_size_in_bytes()));
   int hsize = arrayOopDesc::base_offset_in_bytes(etype);
 
@@ -206,7 +206,7 @@ size_t FlatArrayKlass::oop_size(oop obj) const {
 jint FlatArrayKlass::max_elements() const {
   // Check the max number of heap words limit first (because of int32_t in oopDesc_oop_size() etc)
   size_t max_size = max_jint;
-  max_size -= arrayOopDesc::header_size(T_INLINE_TYPE);
+  max_size -= arrayOopDesc::header_size(T_PRIMITIVE_OBJECT);
   max_size = align_down(max_size, MinObjAlignment);
   max_size <<= LogHeapWordSize;                                  // convert to max payload size in bytes
   max_size >>= layout_helper_log2_element_size(_layout_helper);  // divide by element size (in bytes) = max elements

--- a/src/hotspot/share/oops/flatArrayOop.inline.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.inline.hpp
@@ -31,7 +31,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/globals.hpp"
 
-inline void* flatArrayOopDesc::base() const { return arrayOopDesc::base(T_INLINE_TYPE); }
+inline void* flatArrayOopDesc::base() const { return arrayOopDesc::base(T_PRIMITIVE_OBJECT); }
 
 inline void* flatArrayOopDesc::value_at_addr(int index, jint lh) const {
   assert(is_within_bounds(index), "index out of bounds");

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -221,20 +221,20 @@ Klass* InlineKlass::value_array_klass_or_null() {
 // sorted in order of increasing offsets: the adapters and the
 // compiled code need to agree upon the order of fields.
 //
-// The list of basic types that is returned starts with a T_INLINE_TYPE
-// and ends with an extra T_VOID. T_INLINE_TYPE/T_VOID pairs are used as
+// The list of basic types that is returned starts with a T_PRIMITIVE_OBJECT
+// and ends with an extra T_VOID. T_PRIMITIVE_OBJECT/T_VOID pairs are used as
 // delimiters. Every entry between the two is a field of the inline
 // type. If there's an embedded inline type in the list, it also starts
-// with a T_INLINE_TYPE and ends with a T_VOID. This is so we can
+// with a T_PRIMITIVE_OBJECT and ends with a T_VOID. This is so we can
 // generate a unique fingerprint for the method's adapters and we can
 // generate the list of basic types from the interpreter point of view
 // (inline types passed as reference: iterate on the list until a
-// T_INLINE_TYPE, drop everything until and including the closing
+// T_PRIMITIVE_OBJECT, drop everything until and including the closing
 // T_VOID) or the compiler point of view (each field of the inline
-// types is an argument: drop all T_INLINE_TYPE/T_VOID from the list).
+// types is an argument: drop all T_PRIMITIVE_OBJECT/T_VOID from the list).
 int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
   int count = 0;
-  SigEntry::add_entry(sig, T_INLINE_TYPE, name(), base_off);
+  SigEntry::add_entry(sig, T_PRIMITIVE_OBJECT, name(), base_off);
   for (JavaFieldStream fs(this); !fs.done(); fs.next()) {
     if (fs.access_flags().is_static()) continue;
     int offset = base_off + fs.offset() - (base_off > 0 ? first_field_offset() : 0);
@@ -244,7 +244,7 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
       count += InlineKlass::cast(vk)->collect_fields(sig, offset);
     } else {
       BasicType bt = Signature::basic_type(fs.signature());
-      if (bt == T_INLINE_TYPE) {
+      if (bt == T_PRIMITIVE_OBJECT) {
         bt = T_OBJECT;
       }
       SigEntry::add_entry(sig, bt, fs.signature(), offset);
@@ -256,7 +256,7 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
   if (base_off == 0) {
     sig->sort(SigEntry::compare);
   }
-  assert(sig->at(0)._bt == T_INLINE_TYPE && sig->at(sig->length()-1)._bt == T_VOID, "broken structure");
+  assert(sig->at(0)._bt == T_PRIMITIVE_OBJECT && sig->at(sig->length()-1)._bt == T_VOID, "broken structure");
   return count;
 }
 
@@ -356,7 +356,7 @@ void InlineKlass::save_oop_fields(const RegisterMap& reg_map, GrowableArray<Hand
       assert(Universe::heap()->is_in_or_null(v), "must be heap pointer");
       handles.push(Handle(thread, v));
     }
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID &&
@@ -384,7 +384,7 @@ void InlineKlass::restore_oop_results(RegisterMap& reg_map, GrowableArray<Handle
       address loc = reg_map.location(pair.first());
       *(oop*)loc = handles.at(k++)();
     }
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID &&
@@ -408,7 +408,7 @@ oop InlineKlass::realloc_result(const RegisterMap& reg_map, const GrowableArray<
   int k = 0;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -152,7 +152,7 @@ class InlineKlass: public InstanceKlass {
     return InstanceKlass::signature_name_of_carrier(JVM_SIGNATURE_CLASS);
   }
   const char* val_signature_name() const {
-    return InstanceKlass::signature_name_of_carrier(JVM_SIGNATURE_INLINE_TYPE);
+    return InstanceKlass::signature_name_of_carrier(JVM_SIGNATURE_PRIMITIVE_OBJECT);
   }
 
   // Casting from Klass*

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -163,7 +163,7 @@ static inline bool is_class_loader(const Symbol* class_name,
   return false;
 }
 
-bool InstanceKlass::field_is_null_free_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_INLINE_TYPE; }
+bool InstanceKlass::field_is_null_free_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_PRIMITIVE_OBJECT; }
 
 // private: called to verify that k is a static member of this nest.
 // We know that k is an instance class in the same package and hence the
@@ -967,7 +967,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
           if (ss.is_array()) {
             continue;
           }
-          if (ss.type() == T_INLINE_TYPE) {
+          if (ss.type() == T_PRIMITIVE_OBJECT) {
             Symbol* symb = ss.as_symbol();
             if (symb == name()) continue;
             oop loader = class_loader();
@@ -1318,7 +1318,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
   // Initialize classes of inline fields
   if (EnableValhalla) {
     for (AllFieldStream fs(this); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
+      if (Signature::basic_type(fs.signature()) == T_PRIMITIVE_OBJECT) {
         Klass* klass = get_inline_type_field_klass_or_null(fs.index());
         if (fs.access_flags().is_static() && klass == NULL) {
           klass = SystemDictionary::resolve_or_fail(field_signature(fs.index())->fundamental_name(THREAD),
@@ -2694,7 +2694,7 @@ void InstanceKlass::remove_unshareable_info() {
 
   if (has_inline_type_fields()) {
     for (AllFieldStream fs(fields(), constants()); !fs.done(); fs.next()) {
-      if (Signature::basic_type(fs.signature()) == T_INLINE_TYPE) {
+      if (Signature::basic_type(fs.signature()) == T_PRIMITIVE_OBJECT) {
         reset_inline_type_field_klass(fs.index());
       }
     }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -428,7 +428,7 @@ protected:
   static BasicType layout_helper_element_type(jint lh) {
     assert(lh < (jint)_lh_neutral_value, "must be array");
     int btvalue = (lh >> _lh_element_type_shift) & _lh_element_type_mask;
-    assert((btvalue >= T_BOOLEAN && btvalue <= T_OBJECT) || btvalue == T_INLINE_TYPE, "sanity");
+    assert((btvalue >= T_BOOLEAN && btvalue <= T_OBJECT) || btvalue == T_PRIMITIVE_OBJECT, "sanity");
     return (BasicType) btvalue;
   }
 
@@ -449,7 +449,7 @@ protected:
   static int layout_helper_log2_element_size(jint lh) {
     assert(lh < (jint)_lh_neutral_value, "must be array");
     int l2esz = (lh >> _lh_log2_element_size_shift) & _lh_log2_element_size_mask;
-    assert(layout_helper_element_type(lh) == T_INLINE_TYPE || l2esz <= LogBytesPerLong,
+    assert(layout_helper_element_type(lh) == T_PRIMITIVE_OBJECT || l2esz <= LogBytesPerLong,
            "sanity. l2esz: 0x%x for lh: 0x%x", (uint)l2esz, (uint)lh);
     return l2esz;
   }

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -879,7 +879,7 @@ bool Method::is_getter() const {
     default:
       return false;
   }
-  if (InlineTypeReturnedAsFields && result_type() == T_INLINE_TYPE) {
+  if (InlineTypeReturnedAsFields && result_type() == T_PRIMITIVE_OBJECT) {
     // Don't treat this as (trivial) getter method because the
     // inline type should be returned in a scalarized form.
     return false;

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -116,7 +116,7 @@ void Symbol::set_permanent() {
 
 bool Symbol::is_Q_signature() const {
   int len = utf8_length();
-  return len > 2 && char_at(0) == JVM_SIGNATURE_INLINE_TYPE && char_at(len - 1) == JVM_SIGNATURE_ENDCLASS;
+  return len > 2 && char_at(0) == JVM_SIGNATURE_PRIMITIVE_OBJECT && char_at(len - 1) == JVM_SIGNATURE_ENDCLASS;
 }
 
 bool Symbol::is_Q_array_signature() const {
@@ -126,7 +126,7 @@ bool Symbol::is_Q_array_signature() const {
   }
   for (int i = 1; i < (l - 2); i++) {
     char c = char_at(i);
-    if (c == JVM_SIGNATURE_INLINE_TYPE) {
+    if (c == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
       return true;
     }
     if (c != JVM_SIGNATURE_ARRAY) {
@@ -141,7 +141,7 @@ bool Symbol::is_Q_method_signature() const {
   int len = utf8_length();
   if (len > 4 && char_at(0) == JVM_SIGNATURE_FUNC) {
     for (int i=1; i<len-3; i++) { // Must end with ")Qx;", where x is at least one character or more.
-      if (char_at(i) == JVM_SIGNATURE_ENDFUNC && char_at(i+1) == JVM_SIGNATURE_INLINE_TYPE) {
+      if (char_at(i) == JVM_SIGNATURE_ENDFUNC && char_at(i+1) == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
         return true;
       }
     }
@@ -150,7 +150,7 @@ bool Symbol::is_Q_method_signature() const {
 }
 
 Symbol* Symbol::fundamental_name(TRAPS) {
-  if ((char_at(0) == JVM_SIGNATURE_INLINE_TYPE || char_at(0) == JVM_SIGNATURE_CLASS) && ends_with(JVM_SIGNATURE_ENDCLASS)) {
+  if ((char_at(0) == JVM_SIGNATURE_PRIMITIVE_OBJECT || char_at(0) == JVM_SIGNATURE_CLASS) && ends_with(JVM_SIGNATURE_ENDCLASS)) {
     return SymbolTable::new_symbol(this, 1, utf8_length() - 1);
   } else {
     // reference count is incremented to be consistent with the behavior with
@@ -165,7 +165,7 @@ bool Symbol::is_same_fundamental_type(Symbol* s) const {
   if (utf8_length() < 3) return false;
   int offset1, offset2, len;
   if (ends_with(JVM_SIGNATURE_ENDCLASS)) {
-    if (char_at(0) != JVM_SIGNATURE_INLINE_TYPE && char_at(0) != JVM_SIGNATURE_CLASS) return false;
+    if (char_at(0) != JVM_SIGNATURE_PRIMITIVE_OBJECT && char_at(0) != JVM_SIGNATURE_CLASS) return false;
     offset1 = 1;
     len = utf8_length() - 2;
   } else {
@@ -173,7 +173,7 @@ bool Symbol::is_same_fundamental_type(Symbol* s) const {
     len = utf8_length();
   }
   if (ends_with(JVM_SIGNATURE_ENDCLASS)) {
-    if (s->char_at(0) != JVM_SIGNATURE_INLINE_TYPE && s->char_at(0) != JVM_SIGNATURE_CLASS) return false;
+    if (s->char_at(0) != JVM_SIGNATURE_PRIMITIVE_OBJECT && s->char_at(0) != JVM_SIGNATURE_CLASS) return false;
     offset2 = 1;
   } else {
     offset2 = 0;

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -776,10 +776,10 @@ void Parse::do_call() {
     if (is_reference_type(ct)) {
       record_profiled_return_for_speculation();
     }
-    if (rtype->basic_type() == T_INLINE_TYPE && !peek()->is_InlineTypeBase()) {
+    if (rtype->basic_type() == T_PRIMITIVE_OBJECT && !peek()->is_InlineTypeBase()) {
       Node* retnode = pop();
       retnode = InlineTypeNode::make_from_oop(this, retnode, rtype->as_inline_klass(), !gvn().type(retnode)->maybe_null());
-      push_node(T_INLINE_TYPE, retnode);
+      push_node(T_PRIMITIVE_OBJECT, retnode);
     }
   }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1278,7 +1278,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
   switch(type) {
     case T_LONG   : chk = new CmpLNode(value, _gvn.zerocon(T_LONG)); break;
     case T_INT    : chk = new CmpINode(value, _gvn.intcon(0)); break;
-    case T_INLINE_TYPE : // fall through
+    case T_PRIMITIVE_OBJECT : // fall through
     case T_ARRAY  : // fall through
       type = T_OBJECT;  // simplify further tests
     case T_OBJECT : {
@@ -1606,7 +1606,7 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
   }
   ld = _gvn.transform(ld);
 
-  if (((bt == T_OBJECT || bt == T_INLINE_TYPE) && C->do_escape_analysis()) || C->eliminate_boxing()) {
+  if (((bt == T_OBJECT || bt == T_PRIMITIVE_OBJECT) && C->do_escape_analysis()) || C->eliminate_boxing()) {
     // Improve graph before escape analysis and boxing elimination.
     record_for_igvn(ld);
   }
@@ -1832,7 +1832,7 @@ Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
 Node* GraphKit::load_array_element(Node* ary, Node* idx, const TypeAryPtr* arytype, bool set_ctrl) {
   const Type* elemtype = arytype->elem();
   BasicType elembt = elemtype->array_element_basic_type();
-  assert(elembt != T_INLINE_TYPE, "inline types are not supported by this method");
+  assert(elembt != T_PRIMITIVE_OBJECT, "inline types are not supported by this method");
   Node* adr = array_element_address(ary, idx, elembt, arytype->size());
   if (elembt == T_NARROWOOP) {
     elembt = T_OBJECT; // To satisfy switch in LoadNode::make()

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -610,7 +610,7 @@ Node* InlineTypeBaseNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
 InlineTypeNode* InlineTypeNode::make_uninitialized(PhaseGVN& gvn, ciInlineKlass* vk) {
   // Create a new InlineTypeNode with uninitialized values and NULL oop
-  Node* oop = (vk->is_empty() && vk->is_initialized()) ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
+  Node* oop = (vk->is_empty() && vk->is_initialized()) ? default_oop(gvn, vk) : gvn.zerocon(T_PRIMITIVE_OBJECT);
   InlineTypeNode* vt = new InlineTypeNode(vk, oop);
   vt->set_is_init(gvn);
   return vt;
@@ -623,7 +623,7 @@ Node* InlineTypeBaseNode::default_oop(PhaseGVN& gvn, ciInlineKlass* vk) {
 
 InlineTypeNode* InlineTypeNode::make_default(PhaseGVN& gvn, ciInlineKlass* vk) {
   // Create a new InlineTypeNode with default values
-  Node* oop = vk->is_initialized() ? default_oop(gvn, vk) : gvn.zerocon(T_INLINE_TYPE);
+  Node* oop = vk->is_initialized() ? default_oop(gvn, vk) : gvn.zerocon(T_PRIMITIVE_OBJECT);
   InlineTypeNode* vt = new InlineTypeNode(vk, oop);
   vt->set_is_init(gvn);
   for (uint i = 0; i < vt->field_count(); ++i) {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -778,7 +778,7 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       elem_type = klass->as_array_klass()->element_type();
       basic_elem_type = elem_type->basic_type();
       if (elem_type->is_inlinetype() && !klass->is_flat_array_klass()) {
-        assert(basic_elem_type == T_INLINE_TYPE, "unexpected element basic type");
+        assert(basic_elem_type == T_PRIMITIVE_OBJECT, "unexpected element basic type");
         basic_elem_type = T_OBJECT;
       }
       array_base = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
@@ -1034,11 +1034,11 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc, bool inline_
       } else if (use->is_InlineType()) {
         assert(use->isa_InlineType()->get_oop() == res, "unexpected inline type use");
         _igvn.rehash_node_delayed(use);
-        use->isa_InlineType()->set_oop(_igvn.zerocon(T_INLINE_TYPE));
+        use->isa_InlineType()->set_oop(_igvn.zerocon(T_PRIMITIVE_OBJECT));
       } else if (use->is_InlineTypePtr()) {
         assert(use->isa_InlineTypePtr()->get_oop() == res, "unexpected inline type ptr use");
         _igvn.rehash_node_delayed(use);
-        use->isa_InlineTypePtr()->set_oop(_igvn.zerocon(T_INLINE_TYPE));
+        use->isa_InlineTypePtr()->set_oop(_igvn.zerocon(T_PRIMITIVE_OBJECT));
         // Process users
         worklist.push(use);
       } else if (use->Opcode() == Op_StoreX && use->in(MemNode::Address) == res) {

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -891,7 +891,7 @@ Node *LoadNode::make(PhaseGVN& gvn, Node *ctl, Node *mem, Node *adr, const TypeP
   case T_FLOAT:   load = new LoadFNode (ctl, mem, adr, adr_type, rt,            mo, control_dependency); break;
   case T_DOUBLE:  load = new LoadDNode (ctl, mem, adr, adr_type, rt,            mo, control_dependency); break;
   case T_ADDRESS: load = new LoadPNode (ctl, mem, adr, adr_type, rt->is_ptr(),  mo, control_dependency); break;
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
 #ifdef _LP64
     if (adr->bottom_type()->is_ptr_to_narrowoop()) {
@@ -1164,7 +1164,7 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
       // (This is one of the few places where a generic PhaseTransform
       // can create new nodes.  Think of it as lazily manifesting
       // virtually pre-existing constants.)
-      assert(memory_type() != T_INLINE_TYPE, "should not be used for inline types");
+      assert(memory_type() != T_PRIMITIVE_OBJECT, "should not be used for inline types");
       Node* default_value = ld_alloc->in(AllocateNode::DefaultValue);
       if (default_value != NULL) {
         return default_value;
@@ -2696,7 +2696,7 @@ StoreNode* StoreNode::make(PhaseGVN& gvn, Node* ctl, Node* mem, Node* adr, const
   case T_DOUBLE:  return new StoreDNode(ctl, mem, adr, adr_type, val, mo);
   case T_METADATA:
   case T_ADDRESS:
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
 #ifdef _LP64
     if (adr->bottom_type()->is_ptr_to_narrowoop()) {

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -124,7 +124,7 @@ Node* Parse::fetch_interpreter_state(int index,
   case T_INT:     l = new LoadINode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeInt::INT,        MemNode::unordered); break;
   case T_FLOAT:   l = new LoadFNode(ctl, mem, adr, TypeRawPtr::BOTTOM, Type::FLOAT,         MemNode::unordered); break;
   case T_ADDRESS: l = new LoadPNode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeRawPtr::BOTTOM,  MemNode::unordered); break;
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:  l = new LoadPNode(ctl, mem, adr, TypeRawPtr::BOTTOM, TypeInstPtr::BOTTOM, MemNode::unordered); break;
   case T_LONG:
   case T_DOUBLE: {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -89,7 +89,7 @@ void Parse::array_load(BasicType bt) {
     return;
   } else if (ary_t->is_null_free()) {
     // Load from non-flattened inline type array (elements can never be null)
-    bt = T_INLINE_TYPE;
+    bt = T_PRIMITIVE_OBJECT;
   } else if (!ary_t->is_not_flat()) {
     // Cannot statically determine if array is flattened, emit runtime check
     assert(UseFlatArray && is_reference_type(bt) && elemptr->can_be_inline_type() && !ary_t->klass_is_exact() && !ary_t->is_not_null_free() &&
@@ -120,7 +120,7 @@ void Parse::array_load(BasicType bt) {
         ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
         const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
         Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, arytype));
-        Node* casted_adr = array_element_address(cast, idx, T_INLINE_TYPE, ary_t->size(), control());
+        Node* casted_adr = array_element_address(cast, idx, T_PRIMITIVE_OBJECT, ary_t->size(), control());
         // Re-execute flattened array load if buffering triggers deoptimization
         PreserveReexecuteState preexecs(this);
         jvms()->set_should_reexecute(true);

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -366,7 +366,7 @@ void Parse::do_withfield() {
 
   // Clone the inline type node and set the new field value
   InlineTypeNode* new_vt = holder->clone()->as_InlineType();
-  new_vt->set_oop(_gvn.zerocon(T_INLINE_TYPE));
+  new_vt->set_oop(_gvn.zerocon(T_PRIMITIVE_OBJECT));
   gvn().set_type(new_vt, new_vt->bottom_type());
   new_vt->set_field_value_by_offset(field->offset(), val);
 

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -136,7 +136,7 @@ const Type::TypeInfo Type::_type_info[Type::lastype] = {
   { Bad,             T_ILLEGAL,    "vectory:",      false, Op_VecY,              relocInfo::none          },  // VectorY
   { Bad,             T_ILLEGAL,    "vectorz:",      false, Op_VecZ,              relocInfo::none          },  // VectorZ
 #endif
-  { Bad,             T_INLINE_TYPE, "inline:",      false, Node::NotAMachineReg, relocInfo::none          },  // InlineType
+  { Bad,             T_PRIMITIVE_OBJECT, "inline:",      false, Node::NotAMachineReg, relocInfo::none          },  // InlineType
   { Bad,             T_ADDRESS,    "anyptr:",       false, Op_RegP,              relocInfo::none          },  // AnyPtr
   { Bad,             T_ADDRESS,    "rawptr:",       false, Op_RegP,              relocInfo::none          },  // RawPtr
   { Bad,             T_OBJECT,     "oop:",          true,  Op_RegP,              relocInfo::oop_type      },  // OopPtr
@@ -269,7 +269,7 @@ const Type* Type::get_typeflow_type(ciType* type) {
     assert(type->is_return_address(), "");
     return TypeRawPtr::make((address)(intptr_t)type->as_return_address()->bci());
 
-  case T_INLINE_TYPE: {
+  case T_PRIMITIVE_OBJECT: {
     bool is_null_free = type->is_null_free();
     ciInlineKlass* vk = type->unwrap()->as_inline_klass();
     if (is_null_free) {
@@ -307,7 +307,7 @@ const Type* Type::make_from_constant(ciConstant constant, bool require_constant,
     case T_FLOAT:    return TypeF::make(constant.as_float());
     case T_DOUBLE:   return TypeD::make(constant.as_double());
     case T_ARRAY:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
     case T_OBJECT: {
         const Type* con_type = NULL;
         ciObject* oop_constant = constant.as_object();
@@ -345,14 +345,14 @@ static ciConstant check_mismatched_access(ciConstant con, BasicType loadbt, bool
   switch (conbt) {
     case T_BOOLEAN: conbt = T_BYTE;   break;
     case T_ARRAY:   conbt = T_OBJECT; break;
-    case T_INLINE_TYPE: conbt = T_OBJECT; break;
+    case T_PRIMITIVE_OBJECT: conbt = T_OBJECT; break;
     default:                          break;
   }
   switch (loadbt) {
     case T_BOOLEAN:   loadbt = T_BYTE;   break;
     case T_NARROWOOP: loadbt = T_OBJECT; break;
     case T_ARRAY:     loadbt = T_OBJECT; break;
-    case T_INLINE_TYPE: loadbt = T_OBJECT; break;
+    case T_PRIMITIVE_OBJECT: loadbt = T_OBJECT; break;
     case T_ADDRESS:   loadbt = T_OBJECT; break;
     default:                             break;
   }
@@ -657,7 +657,7 @@ void Type::Initialize_shared(Compile* current) {
   // Nobody should ask _array_body_type[T_NARROWOOP]. Use NULL as assert.
   TypeAryPtr::_array_body_type[T_NARROWOOP] = NULL;
   TypeAryPtr::_array_body_type[T_OBJECT]  = TypeAryPtr::OOPS;
-  TypeAryPtr::_array_body_type[T_INLINE_TYPE] = TypeAryPtr::OOPS;
+  TypeAryPtr::_array_body_type[T_PRIMITIVE_OBJECT] = TypeAryPtr::OOPS;
   TypeAryPtr::_array_body_type[T_ARRAY]   = TypeAryPtr::OOPS; // arrays are stored in oop arrays
   TypeAryPtr::_array_body_type[T_BYTE]    = TypeAryPtr::BYTES;
   TypeAryPtr::_array_body_type[T_BOOLEAN] = TypeAryPtr::BYTES;  // boolean[] is a byte array
@@ -708,7 +708,7 @@ void Type::Initialize_shared(Compile* current) {
   _const_basic_type[T_DOUBLE]      = Type::DOUBLE;
   _const_basic_type[T_OBJECT]      = TypeInstPtr::BOTTOM;
   _const_basic_type[T_ARRAY]       = TypeInstPtr::BOTTOM; // there is no separate bottom for arrays
-  _const_basic_type[T_INLINE_TYPE] = TypeInstPtr::BOTTOM;
+  _const_basic_type[T_PRIMITIVE_OBJECT] = TypeInstPtr::BOTTOM;
   _const_basic_type[T_VOID]        = TypePtr::NULL_PTR;   // reflection represents void this way
   _const_basic_type[T_ADDRESS]     = TypeRawPtr::BOTTOM;  // both interpreter return addresses & random raw ptrs
   _const_basic_type[T_CONFLICT]    = Type::BOTTOM;        // why not?
@@ -725,7 +725,7 @@ void Type::Initialize_shared(Compile* current) {
   _zero_type[T_DOUBLE]      = TypeD::ZERO;
   _zero_type[T_OBJECT]      = TypePtr::NULL_PTR;
   _zero_type[T_ARRAY]       = TypePtr::NULL_PTR; // null array is null oop
-  _zero_type[T_INLINE_TYPE] = TypePtr::NULL_PTR;
+  _zero_type[T_PRIMITIVE_OBJECT] = TypePtr::NULL_PTR;
   _zero_type[T_ADDRESS]     = TypePtr::NULL_PTR; // raw pointers use the same null
   _zero_type[T_VOID]        = Type::TOP;         // the only void value is no value at all
 
@@ -2118,7 +2118,7 @@ const TypeTuple *TypeTuple::make_range(ciSignature* sig, bool ret_vt_fields) {
   case T_INT:
     field_array[TypeFunc::Parms] = get_const_type(return_type);
     break;
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
     if (ret_vt_fields) {
       uint pos = TypeFunc::Parms;
       field_array[pos++] = get_const_type(return_type); // Oop might be null when returning as fields
@@ -2183,7 +2183,7 @@ const TypeTuple *TypeTuple::make_domain(ciMethod* method, bool vt_fields_as_args
     case T_SHORT:
       field_array[pos++] = TypeInt::INT;
       break;
-    case T_INLINE_TYPE: {
+    case T_PRIMITIVE_OBJECT: {
       bool is_null_free = sig->is_null_free_at(i);
       if (vt_fields_as_args && type->as_inline_klass()->can_be_passed_as_fields() && is_null_free) {
         collect_inline_fields(type->as_inline_klass(), field_array, pos);
@@ -3440,7 +3440,7 @@ TypeOopPtr::TypeOopPtr(TYPES t, PTR ptr, ciKlass* k, bool xk, ciObject* o, Offse
             ciInstanceKlass* k = const_oop()->as_instance()->java_lang_Class_klass()->as_instance_klass();
             if (k->is_inlinetype() && this->offset() == k->as_inline_klass()->default_value_offset()) {
               // Special hidden field that contains the oop of the default inline type
-              // basic_elem_type = T_INLINE_TYPE;
+              // basic_elem_type = T_PRIMITIVE_OBJECT;
              _is_ptr_to_narrowoop = UseCompressedOops;
             } else {
               field = k->get_field_by_offset(this->offset(), true);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -814,7 +814,7 @@ class JNI_ArgumentPusherVaArg : public JNI_ArgumentPusher {
 
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE: push_object(va_arg(_ap, jobject)); break;
+    case T_PRIMITIVE_OBJECT: push_object(va_arg(_ap, jobject)); break;
     default:            ShouldNotReachHere();
     }
   }
@@ -855,7 +855,7 @@ class JNI_ArgumentPusherArray : public JNI_ArgumentPusher {
     case T_DOUBLE:      push_double((_ap++)->d); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE: push_object((_ap++)->l); break;
+    case T_PRIMITIVE_OBJECT: push_object((_ap++)->l); break;
     default:            ShouldNotReachHere();
     }
   }
@@ -1005,7 +1005,7 @@ JNI_ENTRY(jobject, jni_NewObjectA(JNIEnv *env, jclass clazz, jmethodID methodID,
     JNI_ArgumentPusherArray ap(methodID, args);
     jni_invoke_nonstatic(env, &jvalue, obj, JNI_NONVIRTUAL, methodID, &ap, CHECK_NULL);
   } else {
-    JavaValue jvalue(T_INLINE_TYPE);
+    JavaValue jvalue(T_PRIMITIVE_OBJECT);
     JNI_ArgumentPusherArray ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     obj = jvalue.get_jobject();
@@ -1037,7 +1037,7 @@ JNI_ENTRY(jobject, jni_NewObjectV(JNIEnv *env, jclass clazz, jmethodID methodID,
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_nonstatic(env, &jvalue, obj, JNI_NONVIRTUAL, methodID, &ap, CHECK_NULL);
   } else {
-    JavaValue jvalue(T_INLINE_TYPE);
+    JavaValue jvalue(T_PRIMITIVE_OBJECT);
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     obj = jvalue.get_jobject();
@@ -1074,7 +1074,7 @@ JNI_ENTRY(jobject, jni_NewObject(JNIEnv *env, jclass clazz, jmethodID methodID, 
   } else {
     va_list args;
     va_start(args, methodID);
-    JavaValue jvalue(T_INLINE_TYPE);
+    JavaValue jvalue(T_PRIMITIVE_OBJECT);
     JNI_ArgumentPusherVaArg ap(methodID, args);
     jni_invoke_static(env, &jvalue, NULL, JNI_STATIC, methodID, &ap, CHECK_NULL);
     va_end(args);

--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -282,7 +282,7 @@ checkStaticFieldID(JavaThread* thr, jfieldID fid, jclass cls, int ftype)
     ReportJNIFatalError(thr, fatal_static_field_not_found);
   if ((fd.field_type() != ftype) &&
       !(fd.field_type() == T_ARRAY && ftype == T_OBJECT) &&
-      !(fd.field_type() == T_INLINE_TYPE && ftype == T_OBJECT)) {
+      !(fd.field_type() == T_PRIMITIVE_OBJECT && ftype == T_OBJECT)) {
     ReportJNIFatalError(thr, fatal_static_field_mismatch);
   }
 }
@@ -320,7 +320,7 @@ checkInstanceFieldID(JavaThread* thr, jfieldID fid, jobject obj, int ftype)
 
   if ((fd.field_type() != ftype) &&
       !(fd.field_type() == T_ARRAY && ftype == T_OBJECT) &&
-      !(fd.field_type() == T_INLINE_TYPE && ftype == T_OBJECT)) {
+      !(fd.field_type() == T_PRIMITIVE_OBJECT && ftype == T_OBJECT)) {
     ReportJNIFatalError(thr, fatal_instance_field_mismatch);
   }
 }
@@ -493,7 +493,7 @@ void jniCheck::validate_class_descriptor(JavaThread* thr, const char* name) {
   size_t len = strlen(name);
 
   if (len >= 2 &&
-      (name[0] == JVM_SIGNATURE_CLASS || name[0] == JVM_SIGNATURE_INLINE_TYPE) && // 'L' or 'Q'
+      (name[0] == JVM_SIGNATURE_CLASS || name[0] == JVM_SIGNATURE_PRIMITIVE_OBJECT) && // 'L' or 'Q'
       name[len-1] == JVM_SIGNATURE_ENDCLASS ) {    // ';'
     char msg[JVM_MAXPATHLEN];
     jio_snprintf(msg, JVM_MAXPATHLEN, "%s%s%s",

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -2013,7 +2013,7 @@ void JvmtiExport::post_raw_field_modification(JavaThread *thread, Method* method
   bool handle_created = false;
 
   // convert oop to JNI handle.
-  if (sig_type == JVM_SIGNATURE_CLASS || sig_type == JVM_SIGNATURE_INLINE_TYPE) {
+  if (sig_type == JVM_SIGNATURE_CLASS || sig_type == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
     handle_created = true;
     value->l = (jobject)JNIHandles::make_local(thread, cast_to_oop(value->l));
   }

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -511,7 +511,7 @@ bool VM_GetOrSetLocal::is_assignable(const char* ty_sign, Klass* klass, Thread* 
 
   int len = (int) strlen(ty_sign);
   if ((ty_sign[0] == JVM_SIGNATURE_CLASS ||
-       ty_sign[0] == JVM_SIGNATURE_INLINE_TYPE) &&
+       ty_sign[0] == JVM_SIGNATURE_PRIMITIVE_OBJECT) &&
       ty_sign[len-1] == JVM_SIGNATURE_ENDCLASS) { // Need pure class/interface name
     ty_sign++;
     len -= 2;
@@ -579,7 +579,7 @@ bool VM_GetOrSetLocal::check_slot_type_lvt(javaVFrame* jvf) {
     slot_type = T_INT;
     break;
   case T_ARRAY:
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
     slot_type = T_OBJECT;
     break;
   default:
@@ -705,7 +705,7 @@ void VM_GetOrSetLocal::doit() {
       // since the handle will be long gone by the time the deopt
       // happens. The oop stored in the deferred local will be
       // gc'd on its own.
-      if (_type == T_OBJECT || _type == T_INLINE_TYPE) {
+      if (_type == T_OBJECT || _type == T_PRIMITIVE_OBJECT) {
         _value.l = cast_from_oop<jobject>(JNIHandles::resolve_external_guard(_value.l));
       }
       // Re-read the vframe so we can see that it is deoptimized
@@ -724,7 +724,7 @@ void VM_GetOrSetLocal::doit() {
       case T_FLOAT:  locals->set_float_at (_index, _value.f); break;
       case T_DOUBLE: locals->set_double_at(_index, _value.d); break;
       case T_OBJECT:
-      case T_INLINE_TYPE: {
+      case T_PRIMITIVE_OBJECT: {
         Handle ob_h(current_thread, JNIHandles::resolve_external_guard(_value.l));
         locals->set_obj_at (_index, ob_h);
         break;
@@ -746,7 +746,7 @@ void VM_GetOrSetLocal::doit() {
         case T_FLOAT:  _value.f = locals->float_at (_index);   break;
         case T_DOUBLE: _value.d = locals->double_at(_index);   break;
         case T_OBJECT:
-        case T_INLINE_TYPE: {
+        case T_PRIMITIVE_OBJECT: {
           // Wrap the oop to be returned in a local JNI handle since
           // oops_do() no longer applies after doit() is finished.
           oop obj = locals->obj_at(_index)();

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1380,7 +1380,7 @@ static int reassign_fields_by_klass(InstanceKlass* klass, frame* fr, RegisterMap
     BasicType type = fields->at(i)._type;
     int offset = base_offset + fields->at(i)._offset;
     // Check for flattened inline type field before accessing the ScopeValue because it might not have any fields
-    if (type == T_INLINE_TYPE) {
+    if (type == T_PRIMITIVE_OBJECT) {
       // Recursively re-assign flattened inline type fields
       InstanceKlass* vk = fields->at(i)._klass;
       assert(vk != NULL, "must be resolved");
@@ -1478,7 +1478,7 @@ void Deoptimization::reassign_flat_array_elements(frame* fr, RegisterMap* reg_ma
   InlineKlass* vk = vak->element_klass();
   assert(vk->flatten_array(), "should only be used for flattened inline type arrays");
   // Adjust offset to omit oop header
-  int base_offset = arrayOopDesc::base_offset_in_bytes(T_INLINE_TYPE) - InlineKlass::cast(vk)->first_field_offset();
+  int base_offset = arrayOopDesc::base_offset_in_bytes(T_PRIMITIVE_OBJECT) - InlineKlass::cast(vk)->first_field_offset();
   // Initialize all elements of the flattened inline type array
   for (int i = 0; i < sv->field_size(); i++) {
     ScopeValue* val = sv->field_at(i);

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -157,7 +157,7 @@ void fieldDescriptor::print() const { print_on(tty); }
 
 void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
   BasicType ft = field_type();
-  if (ft != T_INLINE_TYPE) {
+  if (ft != T_PRIMITIVE_OBJECT) {
     print_on(st);
   }
   jint as_int = 0;
@@ -197,7 +197,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       as_int = obj->bool_field(offset());
       st->print(" %s", obj->bool_field(offset()) ? "true" : "false");
       break;
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       if (is_inlined()) {
         // Print fields of inlined fields (recursively)
         InlineKlass* vk = InlineKlass::cast(field_holder()->get_inline_type_field_klass(index()));

--- a/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
@@ -83,6 +83,6 @@ inline BasicType fieldDescriptor::field_type() const {
 }
 
 inline bool fieldDescriptor::is_inlined()  const  { return field()->is_inlined(); }
-inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_INLINE_TYPE; }
+inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_PRIMITIVE_OBJECT; }
 
 #endif // SHARE_RUNTIME_FIELDDESCRIPTOR_INLINE_HPP

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -155,7 +155,7 @@ static BasicType runtime_type_from(JavaValue* result) {
 #ifndef _LP64
     case T_OBJECT   : // fall through
     case T_ARRAY    : // fall through
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
 #endif
     case T_BYTE     : // fall through
     case T_VOID     : return T_INT;
@@ -165,7 +165,7 @@ static BasicType runtime_type_from(JavaValue* result) {
 #ifdef _LP64
     case T_ARRAY    : // fall through
     case T_OBJECT   : return T_OBJECT;
-    case T_INLINE_TYPE: return T_INLINE_TYPE;
+    case T_PRIMITIVE_OBJECT: return T_PRIMITIVE_OBJECT;
 #endif
     default:
       ShouldNotReachHere();
@@ -408,7 +408,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
   }
 
   jobject value_buffer = NULL;
-  if (InlineTypeReturnedAsFields && result->get_type() == T_INLINE_TYPE) {
+  if (InlineTypeReturnedAsFields && result->get_type() == T_PRIMITIVE_OBJECT) {
     // Pre allocate a buffered inline type in case the result is returned
     // flattened by compiled code
     InlineKlass* vk = method->returned_inline_type(thread);
@@ -606,7 +606,7 @@ class SignatureChekker : public SignatureIterator {
       check_double_word(); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       check_reference(); break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -1150,7 +1150,7 @@ oop Reflection::invoke_method(oop method_mirror, Handle receiver, objArrayHandle
   if (java_lang_Class::is_primitive(return_type_mirror)) {
     rtype = basic_type_mirror_to_basic_type(return_type_mirror);
   } else if (java_lang_Class::as_Klass(return_type_mirror)->is_inline_klass()) {
-    rtype = java_lang_Class::is_primary_mirror(return_type_mirror) ? T_OBJECT : T_INLINE_TYPE;
+    rtype = java_lang_Class::is_primary_mirror(return_type_mirror) ? T_OBJECT : T_PRIMITIVE_OBJECT;
   } else {
     rtype = T_OBJECT;
   }
@@ -1194,7 +1194,7 @@ oop Reflection::invoke_constructor(oop constructor_mirror, objArrayHandle args, 
     if (klass->is_hidden()) {
       rtype = T_OBJECT;
     } else {
-      rtype = T_INLINE_TYPE;
+      rtype = T_PRIMITIVE_OBJECT;
     }
     return invoke(klass, method, no_receiver, override, ptypes, rtype, args, false, CHECK_NULL);
   }

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -935,7 +935,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
 
     GrowableArray<Handle> return_values;
     InlineKlass* vk = NULL;
-    if (return_oop && InlineTypeReturnedAsFields && method->result_type() == T_INLINE_TYPE) {
+    if (return_oop && InlineTypeReturnedAsFields && method->result_type() == T_PRIMITIVE_OBJECT) {
       // Check if inline type is returned as fields
       vk = InlineKlass::returned_inline_klass(map);
       if (vk != NULL) {

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2466,7 +2466,7 @@ class AdapterFingerPrint : public CHeapObj<mtCode> {
         BasicType bt = T_ILLEGAL;
         if (sig_index < total_args_passed) {
           bt = sig->at(sig_index++)._bt;
-          if (bt == T_INLINE_TYPE) {
+          if (bt == T_PRIMITIVE_OBJECT) {
             // Found start of inline type in signature
             assert(InlineTypePassFieldsAsArgs, "unexpected start of inline type");
             if (sig_index == 1 && has_ro_adapter) {
@@ -2903,7 +2903,7 @@ int CompiledEntrySignature::compute_scalarized_cc(GrowableArray<SigEntry>*& sig_
     }
   }
   for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_INLINE_TYPE) {
+    if (ss.type() == T_PRIMITIVE_OBJECT) {
       InlineKlass* vk = ss.as_inline_klass(holder);
       if (vk->can_be_passed_as_fields()) {
         sig_cc->appendAll(vk->extended_sig());
@@ -2969,7 +2969,7 @@ void CompiledEntrySignature::compute_calling_conventions() {
     }
     for (SignatureStream ss(_method->signature()); !ss.at_return_type(); ss.next()) {
       BasicType bt = ss.type();
-      if (bt == T_INLINE_TYPE) {
+      if (bt == T_PRIMITIVE_OBJECT) {
         if (ss.as_inline_klass(_method->method_holder())->can_be_passed_as_fields()) {
           _num_inline_args++;
         }
@@ -3633,7 +3633,7 @@ oop SharedRuntime::allocate_inline_types_impl(JavaThread* current, methodHandle 
     nb_slots++;
   }
   for (SignatureStream ss(callee->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_INLINE_TYPE) {
+    if (ss.type() == T_PRIMITIVE_OBJECT) {
       nb_slots++;
     }
   }
@@ -3647,7 +3647,7 @@ oop SharedRuntime::allocate_inline_types_impl(JavaThread* current, methodHandle 
     i++;
   }
   for (SignatureStream ss(callee->signature()); !ss.at_return_type(); ss.next()) {
-    if (ss.type() == T_INLINE_TYPE) {
+    if (ss.type() == T_PRIMITIVE_OBJECT) {
       InlineKlass* vk = ss.as_inline_klass(holder);
       oop res = vk->allocate_instance(CHECK_NULL);
       array->obj_at_put(i, res);
@@ -3688,7 +3688,7 @@ JRT_LEAF(void, SharedRuntime::load_inline_type_fields_in_regs(JavaThread* curren
   int j = 1;
   for (int i = 0; i < sig_vk->length(); i++) {
     BasicType bt = sig_vk->at(i)._bt;
-    if (bt == T_INLINE_TYPE) {
+    if (bt == T_PRIMITIVE_OBJECT) {
       continue;
     }
     if (bt == T_VOID) {

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -226,7 +226,7 @@ inline int SignatureStream::scan_type(BasicType type) {
   const u1* tem;
   switch (type) {
   case T_OBJECT:
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
     tem = (const u1*) memchr(&base[end], JVM_SIGNATURE_ENDCLASS, limit - end);
     return (tem == NULL ? limit : tem + 1 - base);
 
@@ -306,7 +306,7 @@ bool Signature::is_valid_array_signature(const Symbol* sig) {
     // If it is an array, the type is the last character
     return (i + 1 == len);
   case JVM_SIGNATURE_CLASS:
-  case JVM_SIGNATURE_INLINE_TYPE:
+  case JVM_SIGNATURE_PRIMITIVE_OBJECT:
     // If it is an object, the last character must be a ';'
     return sig->char_at(len - 1) == JVM_SIGNATURE_ENDCLASS;
   }
@@ -564,7 +564,7 @@ ssize_t SignatureVerifier::is_valid_type(const char* type, ssize_t limit) {
     case JVM_SIGNATURE_BOOLEAN:
     case JVM_SIGNATURE_VOID:
       return index + 1;
-    case JVM_SIGNATURE_INLINE_TYPE: // fall through
+    case JVM_SIGNATURE_PRIMITIVE_OBJECT: // fall through
     case JVM_SIGNATURE_CLASS:
       for (index = index + 1; index < limit; ++index) {
         char c = type[index];
@@ -594,7 +594,7 @@ void SigEntry::add_entry(GrowableArray<SigEntry>* sig, BasicType bt, Symbol* sym
 
 // Returns true if the argument at index 'i' is not an inline type delimiter
 bool SigEntry::skip_value_delimiters(const GrowableArray<SigEntry>* sig, int i) {
-  return (sig->at(i)._bt != T_INLINE_TYPE &&
+  return (sig->at(i)._bt != T_PRIMITIVE_OBJECT &&
           (sig->at(i)._bt != T_VOID || sig->at(i-1)._bt == T_LONG || sig->at(i-1)._bt == T_DOUBLE));
 }
 
@@ -618,7 +618,7 @@ TempNewSymbol SigEntry::create_symbol(const GrowableArray<SigEntry>* sig) {
   sig_str[idx++] = '(';
   for (int i = 0; i < length; i++) {
     BasicType bt = sig->at(i)._bt;
-    if (bt == T_INLINE_TYPE || bt == T_VOID) {
+    if (bt == T_PRIMITIVE_OBJECT || bt == T_VOID) {
       // Ignore
     } else {
       if (bt == T_ARRAY) {

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -125,7 +125,7 @@ class Signature : AllStatic {
   // Determine if this signature char introduces an
   // envelope, which is a class name plus ';'.
   static bool has_envelope(char signature_char) {
-    return (signature_char == JVM_SIGNATURE_CLASS) || (signature_char == JVM_SIGNATURE_INLINE_TYPE);
+    return (signature_char == JVM_SIGNATURE_CLASS) || (signature_char == JVM_SIGNATURE_PRIMITIVE_OBJECT);
   }
 
   // Assuming has_envelope is true, return the symbol
@@ -271,7 +271,7 @@ class SignatureTypeNames : public SignatureIterator {
     case T_VOID:    type_name("void"    ); break;
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE:  type_name("jobject" ); break;
+    case T_PRIMITIVE_OBJECT:  type_name("jobject" ); break;
     default: ShouldNotReachHere();
     }
   }
@@ -409,7 +409,7 @@ class NativeSignatureIterator: public SignatureIterator {
     }
     case T_ARRAY:
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       pass_object(); _jni_offset++; _offset++;
       break;
     default:
@@ -524,7 +524,7 @@ class SignatureStream : public StackObj {
   }
 
   bool has_Q_descriptor() const {
-    return has_envelope() && (_signature->char_at(_begin) == JVM_SIGNATURE_INLINE_TYPE);
+    return has_envelope() && (_signature->char_at(_begin) == JVM_SIGNATURE_PRIMITIVE_OBJECT);
   }
 
   // return the symbol for chars in symbol_begin()..symbol_end()
@@ -599,16 +599,16 @@ class SigEntry {
     }
     assert((e1->_bt == T_LONG && (e2->_bt == T_LONG || e2->_bt == T_VOID)) ||
            (e1->_bt == T_DOUBLE && (e2->_bt == T_DOUBLE || e2->_bt == T_VOID)) ||
-           e1->_bt == T_INLINE_TYPE || e2->_bt == T_INLINE_TYPE || e1->_bt == T_VOID || e2->_bt == T_VOID, "bad bt");
+           e1->_bt == T_PRIMITIVE_OBJECT || e2->_bt == T_PRIMITIVE_OBJECT || e1->_bt == T_VOID || e2->_bt == T_VOID, "bad bt");
     if (e1->_bt == e2->_bt) {
-      assert(e1->_bt == T_INLINE_TYPE || e1->_bt == T_VOID, "only ones with duplicate offsets");
+      assert(e1->_bt == T_PRIMITIVE_OBJECT || e1->_bt == T_VOID, "only ones with duplicate offsets");
       return 0;
     }
     if (e1->_bt == T_VOID ||
-        e2->_bt == T_INLINE_TYPE) {
+        e2->_bt == T_PRIMITIVE_OBJECT) {
       return 1;
     }
-    if (e1->_bt == T_INLINE_TYPE ||
+    if (e1->_bt == T_PRIMITIVE_OBJECT ||
         e2->_bt == T_VOID) {
       return -1;
     }
@@ -623,7 +623,7 @@ class SigEntry {
 
 class SigEntryFilter {
 public:
-  bool operator()(const SigEntry& entry) { return entry._bt != T_INLINE_TYPE && entry._bt != T_VOID; }
+  bool operator()(const SigEntry& entry) { return entry._bt != T_PRIMITIVE_OBJECT && entry._bt != T_VOID; }
 };
 
 // Specialized SignatureStream: used for invoking SystemDictionary to either find

--- a/src/hotspot/share/runtime/signature_cc.hpp
+++ b/src/hotspot/share/runtime/signature_cc.hpp
@@ -41,7 +41,7 @@ class ScalarizedInlineArgsStream : public StackObj {
 public:
   ScalarizedInlineArgsStream(const GrowableArray<SigEntry>* sig, int sig_idx, VMRegPair* regs, int regs_count, int regs_idx, int step = 1)
     : _sig(sig), _sig_idx(sig_idx), _regs(regs), _regs_count(regs_count), _regs_idx(regs_idx), _step(step) {
-    assert(_sig->at(_sig_idx)._bt == (step > 0) ? T_INLINE_TYPE : T_VOID, "should be at inline type delimiter");
+    assert(_sig->at(_sig_idx)._bt == (step > 0) ? T_PRIMITIVE_OBJECT : T_VOID, "should be at inline type delimiter");
     _depth = 1;
     DEBUG_ONLY(_finished = false);
   }
@@ -51,7 +51,7 @@ public:
     do {
       _sig_idx += _step;
       bt = _sig->at(_sig_idx)._bt;
-      if (bt == T_INLINE_TYPE) {
+      if (bt == T_PRIMITIVE_OBJECT) {
         _depth += _step;
       } else if (bt == T_VOID &&
                  _sig->at(_sig_idx-1)._bt != T_LONG &&

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -482,7 +482,7 @@ address StubRoutines::select_fill_function(BasicType t, bool aligned, const char
   case T_DOUBLE:
   case T_LONG:
   case T_ARRAY:
-  case T_INLINE_TYPE:
+  case T_PRIMITIVE_OBJECT:
   case T_OBJECT:
   case T_NARROWOOP:
   case T_NARROWKLASS:

--- a/src/hotspot/share/runtime/vframe_hp.cpp
+++ b/src/hotspot/share/runtime/vframe_hp.cpp
@@ -457,7 +457,7 @@ void jvmtiDeferredLocalVariableSet::update_value(StackValueCollection* locals, B
       locals->set_long_at(index, value.j);
       break;
     case T_OBJECT:
-    case T_INLINE_TYPE:
+    case T_PRIMITIVE_OBJECT:
       {
         Handle obj(Thread::current(), cast_to_oop(value.l));
         locals->set_obj_at(index, obj);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -997,7 +997,7 @@ void DumperSupport:: write_header(AbstractDumpWriter* writer, hprofTag tag, u4 l
 hprofTag DumperSupport::sig2tag(Symbol* sig) {
   switch (sig->char_at(0)) {
     case JVM_SIGNATURE_CLASS    : return HPROF_NORMAL_OBJECT;
-    case JVM_SIGNATURE_INLINE_TYPE: return HPROF_NORMAL_OBJECT;
+    case JVM_SIGNATURE_PRIMITIVE_OBJECT: return HPROF_NORMAL_OBJECT;
     case JVM_SIGNATURE_ARRAY    : return HPROF_NORMAL_OBJECT;
     case JVM_SIGNATURE_BYTE     : return HPROF_BYTE;
     case JVM_SIGNATURE_CHAR     : return HPROF_CHAR;
@@ -1028,7 +1028,7 @@ hprofTag DumperSupport::type2tag(BasicType type) {
 u4 DumperSupport::sig2size(Symbol* sig) {
   switch (sig->char_at(0)) {
     case JVM_SIGNATURE_CLASS:
-    case JVM_SIGNATURE_INLINE_TYPE:
+    case JVM_SIGNATURE_PRIMITIVE_OBJECT:
     case JVM_SIGNATURE_ARRAY: return sizeof(address);
     case JVM_SIGNATURE_BOOLEAN:
     case JVM_SIGNATURE_BYTE: return 1;
@@ -1073,7 +1073,7 @@ void DumperSupport::dump_field_value(AbstractDumpWriter* writer, const FieldStre
   char type = fld.signature()->char_at(0);
   offset += fld.offset();
   switch (type) {
-    case JVM_SIGNATURE_INLINE_TYPE: {
+    case JVM_SIGNATURE_PRIMITIVE_OBJECT: {
       if (fld.field_descriptor().is_inlined()) {
         writer->write_inlinedObjectID(writer->inlined_object_support());
         break;
@@ -1481,12 +1481,12 @@ void DumperSupport::dump_basic_type_array_class(AbstractDumpWriter* writer, Klas
 // which means we need to truncate arrays that are too long.
 int DumperSupport::calculate_array_max_length(AbstractDumpWriter* writer, arrayOop array, short header_size) {
   BasicType type = ArrayKlass::cast(array->klass())->element_type();
-  assert((type >= T_BOOLEAN && type <= T_OBJECT) || type == T_INLINE_TYPE, "invalid array element type");
+  assert((type >= T_BOOLEAN && type <= T_OBJECT) || type == T_PRIMITIVE_OBJECT, "invalid array element type");
 
   int length = array->length();
 
   int type_size;
-  if (type == T_OBJECT || type == T_INLINE_TYPE) {
+  if (type == T_OBJECT || type == T_PRIMITIVE_OBJECT) {
     type_size = sizeof(address);
   } else {
     type_size = type2aelembytes(type);

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -136,7 +136,7 @@ void basic_types_init() {
       case T_DOUBLE:
       case T_LONG:
       case T_OBJECT:
-      case T_INLINE_TYPE:
+      case T_PRIMITIVE_OBJECT:
       case T_ADDRESS:     // random raw pointer
       case T_METADATA:    // metadata pointer
       case T_NARROWOOP:   // compressed pointer
@@ -202,7 +202,7 @@ void basic_types_init() {
   }
   _type2aelembytes[T_OBJECT] = heapOopSize;
   _type2aelembytes[T_ARRAY]  = heapOopSize;
-  _type2aelembytes[T_INLINE_TYPE]  = heapOopSize;
+  _type2aelembytes[T_PRIMITIVE_OBJECT]  = heapOopSize;
 }
 
 
@@ -214,7 +214,7 @@ char type2char_tab[T_CONFLICT+1] = {
   JVM_SIGNATURE_BYTE,    JVM_SIGNATURE_SHORT,
   JVM_SIGNATURE_INT,     JVM_SIGNATURE_LONG,
   JVM_SIGNATURE_CLASS,   JVM_SIGNATURE_ARRAY,
-  JVM_SIGNATURE_INLINE_TYPE, JVM_SIGNATURE_VOID,
+  JVM_SIGNATURE_PRIMITIVE_OBJECT, JVM_SIGNATURE_VOID,
   0, 0, 0, 0, 0
 };
 
@@ -268,7 +268,7 @@ BasicType type2field[T_CONFLICT+1] = {
   T_LONG,                  // T_LONG     = 11,
   T_OBJECT,                // T_OBJECT   = 12,
   T_OBJECT,                // T_ARRAY    = 13,
-  T_INLINE_TYPE,           // T_INLINE_TYPE = 14,
+  T_PRIMITIVE_OBJECT,      // T_PRIMITIVE_OBJECT = 14,
   T_VOID,                  // T_VOID     = 15,
   T_ADDRESS,               // T_ADDRESS  = 16,
   T_NARROWOOP,             // T_NARROWOOP= 17,
@@ -293,7 +293,7 @@ BasicType type2wfield[T_CONFLICT+1] = {
   T_LONG,    // T_LONG     = 11,
   T_OBJECT,  // T_OBJECT   = 12,
   T_OBJECT,  // T_ARRAY    = 13,
-  T_OBJECT,  // T_INLINE_TYPE = 14,
+  T_OBJECT,  // T_PRIMITIVE_OBJECT = 14,
   T_VOID,    // T_VOID     = 15,
   T_ADDRESS, // T_ADDRESS  = 16,
   T_NARROWOOP, // T_NARROWOOP  = 17,
@@ -318,7 +318,7 @@ int _type2aelembytes[T_CONFLICT+1] = {
   T_LONG_aelem_bytes,        // T_LONG     = 11,
   T_OBJECT_aelem_bytes,      // T_OBJECT   = 12,
   T_ARRAY_aelem_bytes,       // T_ARRAY    = 13,
-  T_INLINE_TYPE_aelem_bytes,   // T_INLINE_TYPE = 14,
+  T_PRIMITIVE_OBJECT_aelem_bytes, // T_PRIMITIVE_OBJECT = 14,
   0,                         // T_VOID     = 15,
   T_OBJECT_aelem_bytes,      // T_ADDRESS  = 16,
   T_NARROWOOP_aelem_bytes,   // T_NARROWOOP= 17,

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -678,7 +678,7 @@ enum BasicType {
   // types in their own right.
   T_OBJECT      = 12,
   T_ARRAY       = 13,
-  T_INLINE_TYPE = 14,
+  T_PRIMITIVE_OBJECT = 14,
   T_VOID        = 15,
   T_ADDRESS     = 16,
   T_NARROWOOP   = 17,
@@ -699,7 +699,7 @@ enum BasicType {
     F(JVM_SIGNATURE_LONG,    T_LONG,    N)      \
     F(JVM_SIGNATURE_CLASS,   T_OBJECT,  N)      \
     F(JVM_SIGNATURE_ARRAY,   T_ARRAY,   N)      \
-    F(JVM_SIGNATURE_INLINE_TYPE, T_INLINE_TYPE, N) \
+    F(JVM_SIGNATURE_PRIMITIVE_OBJECT, T_PRIMITIVE_OBJECT, N) \
     F(JVM_SIGNATURE_VOID,    T_VOID,    N)      \
     /*end*/
 
@@ -725,7 +725,7 @@ inline bool is_double_word_type(BasicType t) {
 }
 
 inline bool is_reference_type(BasicType t) {
-  return (t == T_OBJECT || t == T_ARRAY || t == T_INLINE_TYPE);
+  return (t == T_OBJECT || t == T_ARRAY || t == T_PRIMITIVE_OBJECT);
 }
 
 inline bool is_integral_type(BasicType t) {
@@ -779,7 +779,7 @@ enum BasicTypeSize {
   T_NARROWOOP_size   = 1,
   T_NARROWKLASS_size = 1,
   T_VOID_size        = 0,
-  T_INLINE_TYPE_size = 1
+  T_PRIMITIVE_OBJECT_size = 1
 };
 
 // this works on valid parameter types but not T_VOID, T_CONFLICT, etc.
@@ -809,11 +809,11 @@ enum ArrayElementSize {
 #ifdef _LP64
   T_OBJECT_aelem_bytes      = 8,
   T_ARRAY_aelem_bytes       = 8,
-  T_INLINE_TYPE_aelem_bytes = 8,
+  T_PRIMITIVE_OBJECT_aelem_bytes = 8,
 #else
   T_OBJECT_aelem_bytes      = 4,
   T_ARRAY_aelem_bytes       = 4,
-  T_INLINE_TYPE_aelem_bytes = 4,
+  T_PRIMITIVE_OBJECT_aelem_bytes = 4,
 #endif
   T_NARROWOOP_aelem_bytes   = 4,
   T_NARROWKLASS_aelem_bytes = 4,
@@ -920,7 +920,7 @@ inline TosState as_TosState(BasicType type) {
     case T_FLOAT  : return ftos;
     case T_DOUBLE : return dtos;
     case T_VOID   : return vtos;
-    case T_INLINE_TYPE: // fall through
+    case T_PRIMITIVE_OBJECT: // fall through
     case T_ARRAY  :   // fall through
     case T_OBJECT : return atos;
     default       : return ilgl;

--- a/src/java.base/share/native/include/classfile_constants.h.template
+++ b/src/java.base/share/native/include/classfile_constants.h.template
@@ -154,7 +154,7 @@ enum {
     JVM_SIGNATURE_BYTE          = 'B',
     JVM_SIGNATURE_CHAR          = 'C',
     JVM_SIGNATURE_CLASS         = 'L',
-    JVM_SIGNATURE_INLINE_TYPE   = 'Q',
+    JVM_SIGNATURE_PRIMITIVE_OBJECT = 'Q',
     JVM_SIGNATURE_ENDCLASS      = ';',
     JVM_SIGNATURE_ENUM          = 'E',
     JVM_SIGNATURE_FLOAT         = 'F',

--- a/src/java.base/share/native/libjava/check_classname.c
+++ b/src/java.base/share/native/libjava/check_classname.c
@@ -195,7 +195,7 @@ skip_over_field_signature(char *name, jboolean void_okay,
                 return name + 1;
 
             case JVM_SIGNATURE_CLASS:
-            case JVM_SIGNATURE_INLINE_TYPE: {
+            case JVM_SIGNATURE_PRIMITIVE_OBJECT: {
                 /* Skip over the classname, if one is there. */
                 char *p =
                     skip_over_fieldname(name + 1, JNI_TRUE, --length);

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3724,13 +3724,13 @@ static const char* get_result_signature(const char* signature) {
           case JVM_SIGNATURE_FUNC:  /* ignore initial (, if given */
             break;
           case JVM_SIGNATURE_CLASS:
-          case JVM_SIGNATURE_INLINE_TYPE:
+          case JVM_SIGNATURE_PRIMITIVE_OBJECT:
             while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             break;
           case JVM_SIGNATURE_ARRAY:
             while (*p == JVM_SIGNATURE_ARRAY) p++;
             /* If an array of classes, skip over class name, too. */
-            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_INLINE_TYPE) {
+            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
                 while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             }
             break;
@@ -3810,7 +3810,7 @@ signature_to_fieldtype(context_type *context,
                 continue;       /* only time we ever do the loop > 1 */
 
             case JVM_SIGNATURE_CLASS:
-            case JVM_SIGNATURE_INLINE_TYPE: {
+            case JVM_SIGNATURE_PRIMITIVE_OBJECT: {
                 char buffer_space[256];
                 char *buffer = buffer_space;
                 char *finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
@@ -4193,7 +4193,7 @@ static int signature_to_args_size(const char *method_signature)
             args_size += 1;
             break;
           case JVM_SIGNATURE_CLASS:
-          case JVM_SIGNATURE_INLINE_TYPE:
+          case JVM_SIGNATURE_PRIMITIVE_OBJECT:
             args_size += 1;
             while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             break;
@@ -4201,7 +4201,7 @@ static int signature_to_args_size(const char *method_signature)
             args_size += 1;
             while ((*p == JVM_SIGNATURE_ARRAY)) p++;
             /* If an array of classes, skip over class name, too. */
-            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_INLINE_TYPE) {
+            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
                 while (*p != JVM_SIGNATURE_ENDCLASS)
                   p++;
             }


### PR DESCRIPTION
Please review this renaming patch, changing T_INLINE_TYPE to T_PRIMITIVE_OBJECT in order to prevent the confusion between the InlineKlass concept, which is used to represent both value classes and primitive classes, and the BasicType that represents only primitive classes.

Remaining occurrences of the "INLINE_TYPE" string are located in a JDI test, which could be fixed later, and in the verifier code, which might need to be revisited to check the way value classes/primitive classes are handled.

Tested with Mach5, tier1 to ensure build is working on all platforms.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281380](https://bugs.openjdk.java.net/browse/JDK-8281380): [lworld] Rename T_INLINE_TYPE to T_PRIMITIVE_OBJECT


### Reviewers
 * [Harold Seigel](https://openjdk.java.net/census#hseigel) (@hseigel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/638/head:pull/638` \
`$ git checkout pull/638`

Update a local copy of the PR: \
`$ git checkout pull/638` \
`$ git pull https://git.openjdk.java.net/valhalla pull/638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 638`

View PR using the GUI difftool: \
`$ git pr show -t 638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/638.diff">https://git.openjdk.java.net/valhalla/pull/638.diff</a>

</details>
