### PR TITLE
8281463: [lworld] VALUE / PRIMITIVE modifiers should be supported by reflection

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -202,9 +202,6 @@ public final class Class<T> implements java.io.Serializable,
     private static final int ANNOTATION = 0x00002000;
     private static final int ENUM       = 0x00004000;
     private static final int SYNTHETIC  = 0x00001000;
-    private static final int VALUE_CLASS     = 0x00000100;
-    private static final int PERMITS_VALUE   = 0x00000040;
-    private static final int PRIMITIVE_CLASS = 0x00000800;
 
     private static native void registerNatives();
     static {
@@ -625,7 +622,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isPrimitiveClass() {
-        return (this.getModifiers() & PRIMITIVE_CLASS) != 0;
+        return (this.getModifiers() & Modifier.PRIMITIVE) != 0;
     }
 
     /**
@@ -636,7 +633,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isValue() {
-        return (this.getModifiers() & VALUE_CLASS) != 0;
+        return (this.getModifiers() & Modifier.VALUE) != 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -30,7 +30,7 @@ import java.util.StringJoiner;
 /**
  * The Modifier class provides {@code static} methods and
  * constants to decode class and member access modifiers.  The sets of
- * modifiers are represented as integers with distinct bit positions
+ * modifiers are represented as integers with bit positions
  * representing different modifiers.  The values for the constants
  * representing the modifiers are taken from the tables in sections
  * {@jvms 4.1}, {@jvms 4.4}, {@jvms 4.5}, and {@jvms 4.7} of
@@ -161,6 +161,7 @@ public class Modifier {
     /**
      * Return {@code true} if the integer argument includes the
      * {@code native} modifier, {@code false} otherwise.
+     * The {@code native} modifier only applies to modifiers of methods.
      *
      * @param   mod a set of modifiers
      * @return {@code true} if {@code mod} includes the
@@ -197,6 +198,7 @@ public class Modifier {
     /**
      * Return {@code true} if the integer argument includes the
      * {@code strictfp} modifier, {@code false} otherwise.
+     * The {@code strictfp} modifier only applies to modifiers of methods.
      *
      * @param   mod a set of modifiers
      * @return {@code true} if {@code mod} includes the
@@ -251,8 +253,13 @@ public class Modifier {
         if ((mod & TRANSIENT) != 0)     sj.add("transient");
         if ((mod & VOLATILE) != 0)      sj.add("volatile");
         if ((mod & SYNCHRONIZED) != 0)  sj.add("synchronized");
-        if ((mod & NATIVE) != 0)        sj.add("native");
-        if ((mod & STRICT) != 0)        sj.add("strictfp");
+        if ((mod & NATIVE) != 0)        sj.add("native");   // ambiguous with value
+        if ((mod & VALUE) == 0) {
+            if ((mod & STRICT) != 0)    sj.add("strictfp");
+        } else {
+            if ((mod & PRIMITIVE) != 0) sj.add("primitive");
+            else sj.add("value");
+        }
         if ((mod & INTERFACE) != 0)     sj.add("interface");
 
         return sj.toString();
@@ -319,9 +326,15 @@ public class Modifier {
 
     /**
      * The {@code int} value representing the {@code native}
-     * modifier.
+     * modifier when applied to the modifiers of a method.
      */
     public static final int NATIVE           = 0x00000100;
+
+    /**
+     * The {@code int} value representing the {@code value}
+     * modifier when applied to the modifiers of a class.
+     */
+    public static final int VALUE            = 0x00000100;
 
     /**
      * The {@code int} value representing the {@code interface}
@@ -337,9 +350,15 @@ public class Modifier {
 
     /**
      * The {@code int} value representing the {@code strictfp}
-     * modifier.
+     * modifier when applied to the modifiers of a method.
      */
     public static final int STRICT           = 0x00000800;
+
+    /**
+     * The {@code int} value representing the {@code primitive}
+     * modifier when applied to the modifiers of a class.
+     */
+    public static final int PRIMITIVE        = 0x00000800;
 
     // Bits not (yet) exposed in the public API either because they
     // have different meanings for fields and methods and there is no
@@ -374,9 +393,10 @@ public class Modifier {
      * @jls 8.1.1 Class Modifiers
      */
     private static final int CLASS_MODIFIERS =
-        Modifier.PUBLIC         | Modifier.PROTECTED    | Modifier.PRIVATE |
-        Modifier.ABSTRACT       | Modifier.STATIC       | Modifier.FINAL   |
-        Modifier.STRICT         | Modifier.PERMITS_VALUE;
+        Modifier.PUBLIC         | Modifier.PROTECTED     | Modifier.PRIVATE |
+        Modifier.ABSTRACT       | Modifier.STATIC        | Modifier.FINAL   |
+        // Modifier.STRICT is obsolete as a class modifier
+        Modifier.VALUE          | Modifier.PERMITS_VALUE | Modifier.PRIMITIVE;
 
     /**
      * The Java source modifiers that can be applied to an interface.
@@ -384,7 +404,8 @@ public class Modifier {
      */
     private static final int INTERFACE_MODIFIERS =
         Modifier.PUBLIC         | Modifier.PROTECTED    | Modifier.PRIVATE |
-        Modifier.ABSTRACT       | Modifier.STATIC       | Modifier.STRICT;
+        // Modifier.STRICT is obsolete as a class modifier
+        Modifier.ABSTRACT       | Modifier.STATIC;
 
 
     /**

--- a/test/jdk/java/lang/reflect/Modifier/toStringTest.java
+++ b/test/jdk/java/lang/reflect/Modifier/toStringTest.java
@@ -23,36 +23,54 @@
 
 /**
  * @test
- * @bug 4394937 8051382
+ * @bug 4394937 8051382 8281463
  * @summary tests the toString method of reflect.Modifier
+ * @run testng toStringTest
  */
 
 import java.lang.reflect.Modifier;
 
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
 public class toStringTest {
 
-    static void testString(int test, String expected) {
-        if(!Modifier.toString(test).equals(expected))
-            throw new RuntimeException(test +
-                                          " yields incorrect toString result");
-    }
-
-    public static void main(String [] argv) {
-        int allMods = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE |
+    static final int allMods = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE |
             Modifier.ABSTRACT | Modifier.STATIC | Modifier.FINAL |
             Modifier.TRANSIENT | Modifier.VOLATILE | Modifier.SYNCHRONIZED |
-            Modifier.NATIVE | Modifier.STRICT | Modifier.INTERFACE;
+            Modifier.NATIVE | Modifier.VALUE  | Modifier.PERMITS_VALUE | Modifier.PRIMITIVE | Modifier.INTERFACE;
+    String allModsString = "public protected private abstract static " +
+            "final transient volatile synchronized native primitive interface";
 
-        String allModsString = "public protected private abstract static " +
-            "final transient volatile synchronized native strictfp interface";
+    static final int  primitiveMods = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE |
+            Modifier.ABSTRACT | Modifier.STATIC | Modifier.FINAL |
+            Modifier.TRANSIENT | Modifier.VOLATILE | Modifier.SYNCHRONIZED |
+            Modifier.NATIVE | Modifier.VALUE  | Modifier.PERMITS_VALUE | Modifier.PRIMITIVE | Modifier.INTERFACE;
+    String primitiveModsString = "public protected private abstract static " +
+            "final transient volatile synchronized native primitive interface";
 
-        /* zero should have an empty string */
-        testString(0, "");
+    static final int  valueMods = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE |
+            Modifier.ABSTRACT | Modifier.STATIC | Modifier.FINAL |
+            Modifier.TRANSIENT | Modifier.VOLATILE | Modifier.SYNCHRONIZED |
+            Modifier.NATIVE | Modifier.VALUE  | Modifier.PERMITS_VALUE | Modifier.INTERFACE;
+    String valueModsString = "public protected private abstract static " +
+            "final transient volatile synchronized native value interface";
 
-        /* test to make sure all modifiers print out in the proper order */
-        testString(allMods, allModsString);
+    @DataProvider(name="Modifiers")
+    Object[][] modifiers() {
+        return new Object[][] {
+                {0, ""},
+                {~0, allModsString},
+                {allMods, allModsString},
+                {primitiveMods, primitiveModsString},
+                {valueMods, valueModsString},
+        };
+    }
 
-        /* verify no extraneous modifiers are printed */
-        testString(~0, allModsString);
+    @Test(dataProvider = "Modifiers")
+    void testString(int test, String expected) {
+        String actual = Modifier.toString(test);
+        Assert.assertEquals(actual, expected, "incorrect toString");
     }
 }


### PR DESCRIPTION
Update java.lang.reflection.Modifier to reflect the JVMS specified bits in the modifier.

The re-use of bits between method and class modifiers poses a problem for this API.
Previously, all bits were distinct and the modifiers do not include any indication of whether
the modifier bits are from a class, field, or method. As a result there is ambiguity as two which
of two meanings a bit takes on.  NATIVE vs VALUE and STRICT vs PRIMITIVE.

Please review for discussion purposes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281463](https://bugs.openjdk.java.net/browse/JDK-8281463): [lworld] VALUE / PRIMITIVE modifiers should be supported by reflection


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/640/head:pull/640` \
`$ git checkout pull/640`

Update a local copy of the PR: \
`$ git checkout pull/640` \
`$ git pull https://git.openjdk.java.net/valhalla pull/640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 640`

View PR using the GUI difftool: \
`$ git pr show -t 640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/640.diff">https://git.openjdk.java.net/valhalla/pull/640.diff</a>

</details>
