### PR TITLE
8281454: [lworld] Assert in EA due to oop access to flat array

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3744,12 +3744,12 @@ Node* GraphKit::array_lh_test(Node* klass, jint mask, jint val, bool eq) {
   return _gvn.transform(new BoolNode(cmp, eq ? BoolTest::eq : BoolTest::ne));
 }
 
-Node* GraphKit::flat_array_test(Node* ary, bool flat) {
+Node* GraphKit::flat_array_test(Node* array_or_klass, bool flat) {
   // We can't use immutable memory here because the mark word is mutable.
   // PhaseIdealLoop::move_flat_array_check_out_of_loop will make sure the
   // check is moved out of loops (mainly to enable loop unswitching).
   Node* mem = UseArrayMarkWordCheck ? memory(Compile::AliasIdxRaw) : immutable_memory();
-  Node* cmp = _gvn.transform(new FlatArrayCheckNode(C, mem, ary));
+  Node* cmp = _gvn.transform(new FlatArrayCheckNode(C, mem, array_or_klass));
   record_for_igvn(cmp); // Give it a chance to be optimized out by IGVN
   return _gvn.transform(new BoolNode(cmp, flat ? BoolTest::eq : BoolTest::ne));
 }

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -875,7 +875,7 @@ class GraphKit : public Phase {
   Node* inline_type_test(Node* obj, bool is_inline = true);
   Node* is_val_mirror(Node* mirror);
   Node* array_lh_test(Node* kls, jint mask, jint val, bool eq = true);
-  Node* flat_array_test(Node* ary, bool flat = true);
+  Node* flat_array_test(Node* array_or_klass, bool flat = true);
   Node* null_free_array_test(Node* klass, bool null_free = true);
   Node* inline_array_null_guard(Node* ary, Node* val, int nargs, bool safe_for_replace = false);
 

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1239,7 +1239,7 @@ bool IfNode::is_flat_array_check(PhaseTransform* phase, Node** array) {
   Node* cmp = bol->in(1);
   if (cmp->isa_FlatArrayCheck()) {
     if (array != NULL) {
-      *array = cmp->in(FlatArrayCheckNode::Array);
+      *array = cmp->in(FlatArrayCheckNode::ArrayOrKlass);
     }
     return true;
   }

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -171,9 +171,7 @@ class LibraryCallKit : public GraphKit {
     NonArray,
     ObjectArray,
     NonObjectArray,
-    TypeArray,
-    FlatArray,
-    NonFlatArray
+    TypeArray
   };
 
   Node* generate_hidden_class_guard(Node* kls, RegionNode* region);
@@ -192,14 +190,6 @@ class LibraryCallKit : public GraphKit {
   }
   Node* generate_typeArray_guard(Node* kls, RegionNode* region) {
     return generate_array_guard_common(kls, region, TypeArray);
-  }
-  Node* generate_flatArray_guard(Node* kls, RegionNode* region) {
-    assert(UseFlatArray, "can never be flattened");
-    return generate_array_guard_common(kls, region, FlatArray);
-  }
-  Node* generate_non_flatArray_guard(Node* kls, RegionNode* region) {
-    assert(UseFlatArray, "can never be flattened");
-    return generate_array_guard_common(kls, region, NonFlatArray);
   }
   Node* generate_array_guard_common(Node* kls, RegionNode* region, ArrayKind kind);
   Node* generate_virtual_guard(Node* obj_klass, RegionNode* slow_region);

--- a/src/hotspot/share/opto/loopUnswitch.cpp
+++ b/src/hotspot/share/opto/loopUnswitch.cpp
@@ -323,8 +323,8 @@ IfNode* PhaseIdealLoop::create_slow_version_of_loop(IdealLoopTree *loop,
     assert(cmp->req() == 3, "unexpected number of inputs for FlatArrayCheck");
     cmp->add_req_batch(C->top(), unswitch_iffs.size() - 1);
     for (uint i = 0; i < unswitch_iffs.size(); i++) {
-      Node* array = unswitch_iffs.at(i)->in(1)->in(1)->in(FlatArrayCheckNode::Array);
-      cmp->set_req(FlatArrayCheckNode::Array + i, array);
+      Node* array = unswitch_iffs.at(i)->in(1)->in(1)->in(FlatArrayCheckNode::ArrayOrKlass);
+      cmp->set_req(FlatArrayCheckNode::ArrayOrKlass + i, array);
     }
   }
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1012,7 +1012,7 @@ void PhaseIdealLoop::move_flat_array_check_out_of_loop(Node* n) {
     return;
   }
   Node* mem = n->in(FlatArrayCheckNode::Memory);
-  Node* array = n->in(FlatArrayCheckNode::Array)->uncast();
+  Node* array = n->in(FlatArrayCheckNode::ArrayOrKlass)->uncast();
   IdealLoopTree* check_loop = get_loop(get_ctrl(n));
   IdealLoopTree* ary_loop = get_loop(get_ctrl(array));
 

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -282,15 +282,16 @@ public:
 };
 
 //--------------------------FlatArrayCheckNode---------------------------------
-// Returns true if one of the input arrays (there can be multiple) is flat.
+// Returns true if one of the input array objects or array klass ptrs (there
+// can be multiple) is flat.
 class FlatArrayCheckNode : public CmpNode {
 public:
   enum {
     Control,
     Memory,
-    Array
+    ArrayOrKlass
   };
-  FlatArrayCheckNode(Compile* C, Node* mem, Node* array) : CmpNode(mem, array) {
+  FlatArrayCheckNode(Compile* C, Node* mem, Node* array_or_klass) : CmpNode(mem, array_or_klass) {
     init_class_id(Class_FlatArrayCheck);
     init_flags(Flag_is_macro);
     C->add_macro_node(this);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5907,7 +5907,7 @@ const Type    *TypeInstKlassPtr::xmeet( const Type *t ) const {
       // below the centerline when the superclass is exact. We need to
       // do the same here.
       if (klass()->equals(ciEnv::current()->Object_klass()) && !klass_is_exact()) {
-        return TypeAryKlassPtr::make(ptr, tp->elem(), tp->klass(), offset, tp->is_not_flat(), tp->is_not_null_free(), tp->null_free());
+        return TypeAryKlassPtr::make(ptr, tp->elem(), tp->klass(), offset, tp->is_not_flat(), tp->is_not_null_free(), tp->is_null_free());
       } else {
         // cannot subclass, so the meet has to fall badly below the centerline
         ptr = NotNull;
@@ -5926,7 +5926,7 @@ const Type    *TypeInstKlassPtr::xmeet( const Type *t ) const {
         if (klass()->equals(ciEnv::current()->Object_klass())) {
           // that is, tp's array type is a subtype of my klass
           return TypeAryKlassPtr::make(ptr,
-                                       tp->elem(), tp->klass(), offset, tp->is_not_flat(), tp->is_not_null_free(), tp->null_free());
+                                       tp->elem(), tp->klass(), offset, tp->is_not_flat(), tp->is_not_null_free(), tp->is_null_free());
         }
       }
       // The other case cannot happen, since I cannot be a subtype of an array.

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1085,9 +1085,11 @@ public:
   virtual bool maybe_null() const { return meet_ptr(Null) == ptr(); }
 
   virtual bool can_be_inline_type() const { return false; }
-  virtual bool flatten_array() const { return false; }
-  virtual bool is_not_flat() const { return false; }
-  virtual bool is_not_null_free() const { return false; }
+  virtual bool flatten_array()      const { return false; }
+  virtual bool is_flat()            const { return false; }
+  virtual bool is_not_flat()        const { return false; }
+  virtual bool is_null_free()       const { return false; }
+  virtual bool is_not_null_free()   const { return false; }
 
   // Tests for relation to centerline of type lattice:
   static bool above_centerline(PTR ptr) { return (ptr <= AnyNull); }
@@ -1389,10 +1391,10 @@ public:
   bool      is_stable() const { return _ary->_stable; }
 
   // Inline type array properties
-  bool is_flat()          const { return _ary->_elem->isa_inlinetype() != NULL; }
-  bool is_not_flat()      const { return _ary->_not_flat; }
-  bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && !_ary->_elem->make_ptr()->maybe_null()); }
-  bool is_not_null_free() const { return _ary->_not_null_free; }
+  bool is_flat()          const override { return _ary->_elem->isa_inlinetype() != NULL; }
+  bool is_not_flat()      const override { return _ary->_not_flat; }
+  bool is_null_free()     const override { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && !_ary->_elem->make_ptr()->maybe_null()); }
+  bool is_not_null_free() const override { return _ary->_not_null_free; }
 
   bool is_autobox_cache() const { return _is_autobox_cache; }
 
@@ -1664,9 +1666,10 @@ public:
     return TypeKlassPtr::empty() || _elem->empty();
   }
 
-  virtual bool is_not_flat() const { return _not_flat; }
-  virtual bool is_not_null_free() const { return _not_null_free; }
-  bool null_free() const { return _null_free; }
+  bool is_flat()          const override { return klass()->is_flat_array_klass(); }
+  bool is_not_flat()      const override { return _not_flat; }
+  bool is_null_free()     const override { return _null_free; }
+  bool is_not_null_free() const override { return _not_null_free; }
 
 #ifndef PRODUCT
   virtual void dump2( Dict &d, uint depth, outputStream *st ) const; // Specialized per-Type dumping

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1391,10 +1391,10 @@ public:
   bool      is_stable() const { return _ary->_stable; }
 
   // Inline type array properties
-  bool is_flat()          const override { return _ary->_elem->isa_inlinetype() != NULL; }
-  bool is_not_flat()      const override { return _ary->_not_flat; }
-  bool is_null_free()     const override { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && !_ary->_elem->make_ptr()->maybe_null()); }
-  bool is_not_null_free() const override { return _ary->_not_null_free; }
+  bool is_flat()          const { return _ary->_elem->isa_inlinetype() != NULL; }
+  bool is_not_flat()      const { return _ary->_not_flat; }
+  bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && !_ary->_elem->make_ptr()->maybe_null()); }
+  bool is_not_null_free() const { return _ary->_not_null_free; }
 
   bool is_autobox_cache() const { return _is_autobox_cache; }
 
@@ -1666,10 +1666,10 @@ public:
     return TypeKlassPtr::empty() || _elem->empty();
   }
 
-  bool is_flat()          const override { return klass()->is_flat_array_klass(); }
-  bool is_not_flat()      const override { return _not_flat; }
-  bool is_null_free()     const override { return _null_free; }
-  bool is_not_null_free() const override { return _not_null_free; }
+  bool is_flat()          const { return klass()->is_flat_array_klass(); }
+  bool is_not_flat()      const { return _not_flat; }
+  bool is_null_free()     const { return _null_free; }
+  bool is_not_null_free() const { return _not_null_free; }
 
 #ifndef PRODUCT
   virtual void dump2( Dict &d, uint depth, outputStream *st ) const; // Specialized per-Type dumping


### PR DESCRIPTION
Similar to [JDK-8250951](https://bugs.openjdk.java.net/browse/JDK-8250951), we hit an assert in EA because an oop load is used to access a flat array. The load is from an `Arrays.copyOf` and flat array checks in `LibraryCallKit::inline_array_copyOf` will prevent that load from ever being executed but the dead subgraph is not removed because we run with `-XX:+StressReflectiveCode`.

I fixed this by using the `FlatArrayCheckNode` for checks in the intrinsics as well. This ensures that the graph is folded even with  `-XX:+StressReflectiveCode` and enables more aggressive optimizations. The patch also includes some cleanups and removal of (now) dead code.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281454](https://bugs.openjdk.java.net/browse/JDK-8281454): [lworld] Assert in EA due to oop access to flat array


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/642/head:pull/642` \
`$ git checkout pull/642`

Update a local copy of the PR: \
`$ git checkout pull/642` \
`$ git pull https://git.openjdk.java.net/valhalla pull/642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 642`

View PR using the GUI difftool: \
`$ git pr show -t 642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/642.diff">https://git.openjdk.java.net/valhalla/pull/642.diff</a>

</details>
