### PR TITLE
8281537: [lworld] runtime/cds/appcds/TestDumpClassListSource.java fails with Exception: java.lang.RuntimeException: Class Hello should be printed in classlist

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -189,7 +189,7 @@ public class TestDumpClassListSource {
 
         checkFileExistence("ClassList", fileList);
 
-        checkMatch(listFileName, "Hello id: [0-9]+ super: [0-9]+ source: .*/test-hello.jar", EXPECT_MATCH,
+        checkMatch(listFileName, "Hello id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/test-hello.jar", EXPECT_MATCH,
                    "Class Hello should be printed in classlist");
         //      2.3.2 dump shared archive based on listFileName
         String archive = "test-hello.jsa";


### PR DESCRIPTION
Small test fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281537](https://bugs.openjdk.java.net/browse/JDK-8281537): [lworld] runtime/cds/appcds/TestDumpClassListSource.java fails with Exception: java.lang.RuntimeException: Class Hello should be printed in classlist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/643/head:pull/643` \
`$ git checkout pull/643`

Update a local copy of the PR: \
`$ git checkout pull/643` \
`$ git pull https://git.openjdk.java.net/valhalla pull/643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 643`

View PR using the GUI difftool: \
`$ git pr show -t 643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/643.diff">https://git.openjdk.java.net/valhalla/pull/643.diff</a>

</details>
