### PR TITLE
8281471: [lworld] check_code.c should not accept Q-signatures as valid

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5210,12 +5210,14 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
     case JVM_SIGNATURE_DOUBLE:
       return signature + 1;
     case JVM_SIGNATURE_PRIMITIVE_OBJECT:
-      // Can't enable this check until JDK upgrades the bytecode generators
-      // if (_major_version < CONSTANT_CLASS_DESCRIPTORS ) {
-      //   classfile_parse_error("Class name contains illegal Q-signature "
-      //                                    "in descriptor in class file %s",
-      //                                    CHECK_0);
-      // }
+      // Can't enable this check fully until JDK upgrades the bytecode generators.
+      // For now, compare to class file version 51 so old verifier doesn't see Q signatures.
+      if (_major_version < 51 /* CONSTANT_CLASS_DESCRIPTORS */ ) {
+        classfile_parse_error("Class name contains illegal Q-signature "
+                              "in descriptor in class file %s",
+                              CHECK_0);
+        return NULL;
+      }
       // fall through
     case JVM_SIGNATURE_CLASS:
     {

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3724,13 +3724,12 @@ static const char* get_result_signature(const char* signature) {
           case JVM_SIGNATURE_FUNC:  /* ignore initial (, if given */
             break;
           case JVM_SIGNATURE_CLASS:
-          case JVM_SIGNATURE_PRIMITIVE_OBJECT:
             while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             break;
           case JVM_SIGNATURE_ARRAY:
             while (*p == JVM_SIGNATURE_ARRAY) p++;
             /* If an array of classes, skip over class name, too. */
-            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
+            if (*p == JVM_SIGNATURE_CLASS) {
                 while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             }
             break;
@@ -3809,8 +3808,7 @@ signature_to_fieldtype(context_type *context,
                 array_depth++;
                 continue;       /* only time we ever do the loop > 1 */
 
-            case JVM_SIGNATURE_CLASS:
-            case JVM_SIGNATURE_PRIMITIVE_OBJECT: {
+            case JVM_SIGNATURE_CLASS: {
                 char buffer_space[256];
                 char *buffer = buffer_space;
                 char *finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
@@ -4193,7 +4191,6 @@ static int signature_to_args_size(const char *method_signature)
             args_size += 1;
             break;
           case JVM_SIGNATURE_CLASS:
-          case JVM_SIGNATURE_PRIMITIVE_OBJECT:
             args_size += 1;
             while (*p != JVM_SIGNATURE_ENDCLASS) p++;
             break;
@@ -4201,7 +4198,7 @@ static int signature_to_args_size(const char *method_signature)
             args_size += 1;
             while ((*p == JVM_SIGNATURE_ARRAY)) p++;
             /* If an array of classes, skip over class name, too. */
-            if (*p == JVM_SIGNATURE_CLASS || *p == JVM_SIGNATURE_PRIMITIVE_OBJECT) {
+            if (*p == JVM_SIGNATURE_CLASS) {
                 while (*p != JVM_SIGNATURE_ENDCLASS)
                   p++;
             }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadInlineTypes.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/BadInlineTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,5 +90,8 @@ public class BadInlineTypes {
         runTest("ValueCloneable", "Inline Types do not support Cloneable");
 
         runTest("SuperIsZero", "Invalid superclass index 0 in class file SuperIsZero");
+
+        runTest("QInOldClass",
+                "Class name contains illegal Q-signature in descriptor in class file QInOldClass");
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/cfpTests.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 // This file contains multiple illegal inline type classes that should cause
 // ClassFormatError exceptions when attempted to be loaded.
 //
-// The .jcod classes were originally generated from this Java file and then
+// Many of these test were originally generated from this Java file and then
 // modified to cause ClassFormatError or ClassCircularityError exceptions.  The
 // '(bad)' comments in most of the tests show where the modifications were made.
 //
@@ -2568,3 +2568,129 @@ class SuperIsZero {
     } // end SourceFile
   } // Attributes
 } // end class SuperIsZero
+
+
+// This class file tests that a ClassFormatError exception is thrown for an old
+// class file (version 49) containing a Q signature.  This file is based on the
+// following Java code, except the signature for method callDot() was changed
+// to "(QDot;)V";.
+/*
+public class QInOldClass {
+
+    public static void callDot(Dot d) {
+        System.out.println("Hi Dot");
+    }
+
+}
+*/
+class QInOldClass {
+  0xCAFEBABE;
+  0; // minor version
+  49; // version
+  [32] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    Field #8 #9; // #7     at 0x39
+    class #10; // #8     at 0x3E
+    NameAndType #11 #12; // #9     at 0x41
+    Utf8 "java/lang/System"; // #10     at 0x46
+    Utf8 "out"; // #11     at 0x59
+    Utf8 "Ljava/io/PrintStream;"; // #12     at 0x5F
+    String #14; // #13     at 0x77
+    Utf8 "Hi Dot"; // #14     at 0x7A
+    Method #16 #17; // #15     at 0x83
+    class #18; // #16     at 0x88
+    NameAndType #19 #20; // #17     at 0x8B
+    Utf8 "java/io/PrintStream"; // #18     at 0x90
+    Utf8 "println"; // #19     at 0xA6
+    Utf8 "(Ljava/lang/String;)V"; // #20     at 0xB0
+    class #22; // #21     at 0xC8
+    Utf8 "QInOldClass"; // #22     at 0xCB
+    Utf8 "Code"; // #23     at 0xD6
+    Utf8 "LineNumberTable"; // #24     at 0xDD
+    Utf8 "callDot"; // #25     at 0xEF
+    Utf8 "(QDot;)V"; // #26     at 0xF9
+    Utf8 "SourceFile"; // #27     at 0x0104
+    Utf8 "QInOldClass.java"; // #28     at 0x0111
+    Utf8 "Preload"; // #29     at 0x0121
+    class #31; // #30     at 0x012B
+    Utf8 "Dot"; // #31     at 0x012E
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #21;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0x0140
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#23, 29) { // Code at 0x0148
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#24, 6) { // LineNumberTable at 0x015F
+              [1] { // line_number_table
+                0  2; //  at 0x016B
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x016B
+      0x0009; // access
+      #25; // name_index       : callDot
+      #26; // descriptor_index : (LDot;)V
+      [1] { // Attributes
+        Attr(#23, 37) { // Code at 0x0173
+          2; // max_stack
+          1; // max_locals
+          Bytes[9]{
+            0xB20007120DB6000F;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#24, 10) { // LineNumberTable at 0x018E
+              [2] { // line_number_table
+                0  5; //  at 0x019A
+                8  6; //  at 0x019E
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [2] { // Attributes
+    Attr(#27, 2) { // SourceFile at 0x01A0
+      #28;
+    } // end SourceFile
+    ;
+    Attr(#29, 4) { // Preload at 0x01A8
+      0x0001001E;
+    } // end Preload
+  } // Attributes
+} // end class QInOldClass


### PR DESCRIPTION
Please review this small change to not allow Q signatures in old class files that are verified using the old verifier.  The change removes checks for Q signatures from the old verifier.

The fix was tested with Mach5 tiers 1-2 on Linux, Mac OS, and Windows, and Mach5 tiers 3-5 on Linux x64.

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8281471](https://bugs.openjdk.java.net/browse/JDK-8281471): [lworld] check_code.c should not accept Q-signatures as valid


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/645/head:pull/645` \
`$ git checkout pull/645`

Update a local copy of the PR: \
`$ git checkout pull/645` \
`$ git pull https://git.openjdk.java.net/valhalla pull/645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 645`

View PR using the GUI difftool: \
`$ git pr show -t 645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/645.diff">https://git.openjdk.java.net/valhalla/pull/645.diff</a>

</details>
