### PR TITLE
fail during inference if primitive classes are bounds during the first overload resolution phase

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -248,8 +248,6 @@ public class Infer {
 
             // return instantiated version of method type
             return mt;
-        } catch (Throwable t) {
-            throw t;
         } finally {
             if (resultInfo != null || !allowGraphInference) {
                 inferenceContext.notifyChange();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -213,6 +213,17 @@ public class Infer {
 
             deferredAttrContext.complete();
 
+            /* if boxing is not allowed then, no undetVar should have a bound that is a primitive class, unless the bound
+             * was originally declared as an upper bound in the corresponding inference variable.
+             * InferenceContext::boundedVars returns those variables with bounds that were not originally declared as
+             * upper bounds of the inference variable
+             */
+            if (!allowBoxing && inferenceContext.asUndetVars(inferenceContext.boundedVars())
+                    .stream().map(t -> ((UndetVar)t).getBounds(InferenceBound.EQ, InferenceBound.LOWER, InferenceBound.UPPER))
+                    .flatMap(Collection::stream).anyMatch(Type::isPrimitiveClass)) {
+                throw error(null);
+            }
+
             // minimize as yet undetermined type variables
             if (allowGraphInference) {
                 inferenceContext.solve(warn);
@@ -237,6 +248,8 @@ public class Infer {
 
             // return instantiated version of method type
             return mt;
+        } catch (Throwable t) {
+            throw t;
         } finally {
             if (resultInfo != null || !allowGraphInference) {
                 inferenceContext.notifyChange();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1052,11 +1052,8 @@ public class Resolve {
 
         public boolean compatible(Type found, Type req, Warner warn) {
             InferenceContext inferenceContext = deferredAttrContext.inferenceContext;
-            boolean anyIsUndetVar = inferenceContext.asUndetVar(found).hasTag(UNDETVAR) || inferenceContext.asUndetVar(req).hasTag(UNDETVAR);
-            boolean anyIsPrimitiveClass = found.isPrimitiveClass() || req.isPrimitiveClass();
             return strict ?
-                    (anyIsUndetVar && anyIsPrimitiveClass ? false :
-                    types.isSubtypeUnchecked(inferenceContext.asUndetVar(found), inferenceContext.asUndetVar(req), warn)) :
+                    types.isSubtypeUnchecked(inferenceContext.asUndetVar(found), inferenceContext.asUndetVar(req), warn) :
                     types.isConvertible(inferenceContext.asUndetVar(found), inferenceContext.asUndetVar(req), warn);
         }
 


### PR DESCRIPTION
Fail during inference if any bound is a primitive class during the first phase

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/651/head:pull/651` \
`$ git checkout pull/651`

Update a local copy of the PR: \
`$ git checkout pull/651` \
`$ git pull https://git.openjdk.java.net/valhalla pull/651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 651`

View PR using the GUI difftool: \
`$ git pr show -t 651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/651.diff">https://git.openjdk.java.net/valhalla/pull/651.diff</a>

</details>
