### PR TITLE
fixing bugs in inference and type system more regression tests

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4390,9 +4390,9 @@ public class Types {
             return t;
         else if (t.isPrimitive() || s.isPrimitive())
             return syms.errType;
-        else if (isSubtypeNoCapture(t, s))
+        else if (isBoundedBy(t, s, (t1, s1, w) -> isSubtypeNoCapture(t1, s1)))
             return t;
-        else if (isSubtypeNoCapture(s, t))
+        else if (isBoundedBy(s, t, (s1, t1, w) -> isSubtypeNoCapture(s1, t1)))
             return s;
 
         List<Type> closure = union(closure(t), closure(s));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -218,7 +218,9 @@ public class Infer {
              * InferenceContext::boundedVars returns those variables with bounds that were not originally declared as
              * upper bounds of the inference variable
              */
-            if (!allowBoxing && inferenceContext.asUndetVars(inferenceContext.boundedVars())
+            if (!allowBoxing &&
+                    resultInfo == null &&
+                    inferenceContext.asUndetVars(inferenceContext.boundedVars())
                     .stream().map(t -> ((UndetVar)t).getBounds(InferenceBound.EQ, InferenceBound.LOWER, InferenceBound.UPPER))
                     .flatMap(Collection::stream).anyMatch(Type::isPrimitiveClass)) {
                 throw error(null);

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -486,8 +486,7 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                 """
         );
 
-        // primitive classes don't have subtypes
-        assertFail("compiler.err.not.within.bounds",
+        assertOK(
                 """
                 primitive class Point {}
 
@@ -497,6 +496,35 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                     void m() {
                         MyList<? extends Point> ls = null;
                     }
+                }
+                """
+        );
+    }
+
+    public void testInferenceAndTypeSystem() {
+        assertOK(
+                """
+                primitive class MyValue {
+                    MyValue m(U u) {
+                        return u.getValue(MyValue.class.asValueType());
+                    }
+                }
+
+                class U {
+                    <V> V getValue(Class<?> pc) { return null; }
+                }
+                """
+        );
+        assertOK(
+                """
+                primitive class MyValue {
+                    void m(U u) {
+                        MyValue vt = u.makePrivateBuffer(this);
+                    }
+                }
+
+                class U {
+                    <V> V makePrivateBuffer(V value) { return null; }
                 }
                 """
         );

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTvarsTypeSystemTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTvarsTypeSystemTest.java
@@ -78,14 +78,19 @@ public class UniversalTvarsTypeSystemTest extends TypeHarness {
                 interface I {}
                 static abstract class A {}
                 primitive class Point extends A implements I {}
+                primitive class Circle extends A implements I {}
                 """,
-                "Point", "Point.ref", "A", "I");
+                "Point", "Point.ref", "Circle", "Circle.ref", "A", "I");
         Assert.check(types.lub(typeMap.get("Point"), typeMap.get("Point.ref")).tsym == typeMap.get("Point.ref").tsym);
         Assert.check(types.lub(typeMap.get("Point"), typeMap.get("A")).tsym == typeMap.get("A").tsym);
         Assert.check(types.lub(typeMap.get("Point"), typeMap.get("I")).tsym == typeMap.get("I").tsym);
+        Assert.check(types.lub(typeMap.get("Circle"), typeMap.get("I")).tsym == typeMap.get("I").tsym);
 
-        // this is currently failing we need to update the implementation of Types::glb
-        //Assert.check(types.glb(primitiveType, primitiveRefType).tsym == primitiveType.tsym);
+        Assert.check(types.glb(typeMap.get("Point"), typeMap.get("Point.ref")).tsym == typeMap.get("Point").tsym);
+        Assert.check(types.glb(typeMap.get("Point"), typeMap.get("I")).tsym == typeMap.get("Point").tsym);
+        Assert.check(types.glb(typeMap.get("Point.ref"), typeMap.get("I")).tsym == typeMap.get("Point.ref").tsym);
+        Assert.check(types.glb(typeMap.get("Circle"), typeMap.get("I")).tsym == typeMap.get("Circle").tsym);
+        Assert.check(types.glb(typeMap.get("Circle.ref"), typeMap.get("I")).tsym == typeMap.get("Circle.ref").tsym);
     }
 
     void test_isBoundedBy() {


### PR DESCRIPTION
this PR is adapting Types::glb so that it can deal with primitive classes. It also fixes a bug in inference, basically we are now failing during overload resolution if any undetVar has a bound that is a primitive class. But a bug was making inference fail after overload resolution in some cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/654/head:pull/654` \
`$ git checkout pull/654`

Update a local copy of the PR: \
`$ git checkout pull/654` \
`$ git pull https://git.openjdk.java.net/valhalla pull/654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 654`

View PR using the GUI difftool: \
`$ git pr show -t 654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/654.diff">https://git.openjdk.java.net/valhalla/pull/654.diff</a>

</details>
