### PR TITLE
8282108: [lworld] Enhance CreateSymbols to read Preload attribute

### DIFF
--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -2252,6 +2252,7 @@ public class CreateSymbols {
                 }
                 ((FieldDescription) feature).constantValue = value;
                 break;
+            case "Preload":
             case "SourceFile":
                 //ignore, not needed
                 break;


### PR DESCRIPTION
Arrange to skip Preload attribute as it is not relevant to compilation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282108](https://bugs.openjdk.java.net/browse/JDK-8282108): [lworld] Enhance CreateSymbols to read Preload attribute


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/657/head:pull/657` \
`$ git checkout pull/657`

Update a local copy of the PR: \
`$ git checkout pull/657` \
`$ git pull https://git.openjdk.java.net/valhalla pull/657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 657`

View PR using the GUI difftool: \
`$ git pr show -t 657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/657.diff">https://git.openjdk.java.net/valhalla/pull/657.diff</a>

</details>
