### PR TITLE
8282292: [lworld] runtime/valhalla/inlinetypes/WithFieldAccessorTest.java Xcomp C1 asserts

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2107,7 +2107,7 @@ void GraphBuilder::withfield(int field_index) {
   Value val = pop(type);
   Value obj = apop();
 
-  if (!holder->is_loaded() || !holder->is_inlinetype()) {
+  if (!holder->is_loaded() || !holder->is_inlinetype() || !will_link) {
     apush(append_split(new Deoptimize(holder, state_before)));
     return;
   }


### PR DESCRIPTION
Please review this small patch fixing handling of illegal accesses in C1's implementation of withfield.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282292](https://bugs.openjdk.java.net/browse/JDK-8282292): [lworld] runtime/valhalla/inlinetypes/WithFieldAccessorTest.java Xcomp C1 asserts


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/659/head:pull/659` \
`$ git checkout pull/659`

Update a local copy of the PR: \
`$ git checkout pull/659` \
`$ git pull https://git.openjdk.java.net/valhalla pull/659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 659`

View PR using the GUI difftool: \
`$ git pr show -t 659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/659.diff">https://git.openjdk.java.net/valhalla/pull/659.diff</a>

</details>
