### PR TITLE
8282107: Valhalla: javac does not correctly recognize value class factory <init>

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1007,7 +1007,8 @@ public class ClassReader {
                         //- System.err.println(" # " + sym.type);
                         if (sym.kind == MTH && sym.type.getThrownTypes().isEmpty())
                             sym.type.asMethodType().thrown = thrown;
-                        if (sym.kind == MTH  && sym.name == names.init && sym.owner.isValueClass()) {
+                        // Map value class factory methods back to constructors for the benefit of earlier pipeline stages
+                        if (sym.kind == MTH  && sym.name == names.init && !sym.type.getReturnType().hasTag(TypeTag.VOID)) {
                             sym.type = new MethodType(sym.type.getParameterTypes(),
                                     syms.voidType,
                                     sym.type.getThrownTypes(),

--- a/test/langtools/tools/javac/valhalla/value-objects/ConsumeValueClassAtLowerLevel.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ConsumeValueClassAtLowerLevel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282107
+ * @summary Check that javac can compile against value classes at lower source levels
+ * @compile GenericPoint.java
+ * @compile --source 16 ConsumeValueClassAtLowerLevel.java
+ * @run main ConsumeValueClassAtLowerLevel
+ */
+
+public class ConsumeValueClassAtLowerLevel {
+    public static void main(String [] args) {
+
+        /* Attempting to instantiate a value/primitive class in earlier source level should
+         * result in an InstantiationError since javac's class reader downgrades
+         * the value class to an identity class if current source level does not
+         * support value/primitive class. And so rather than invoke the factory method,
+         * the source code of earlier vintage would attempt to invoke the constructor
+         * and so should crash and burn with an InstantiationError.
+         *
+         * This behavior is subject to change - see JDK-8282525
+         */
+        boolean gotIE = false;
+        try {
+            GenericPoint<Integer> gl = new GenericPoint<>(0, 0);
+        } catch (java.lang.InstantiationError ie) {
+            gotIE = true;
+        }
+        if (!gotIE) {
+            throw new AssertionError("Did not see instantiation error!");
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/GenericPoint.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/GenericPoint.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class GenericPoint<T> {
+
+    T x, y;
+
+    GenericPoint(T x, T y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
Cope with the ill effects of javac downgrading the value class file at lower source levels leaving fuller treatment to JDK-8282525

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282107](https://bugs.openjdk.java.net/browse/JDK-8282107): Valhalla: javac does not correctly recognize value class factory <init>


### Reviewers
 * @biboudis (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/661/head:pull/661` \
`$ git checkout pull/661`

Update a local copy of the PR: \
`$ git checkout pull/661` \
`$ git pull https://git.openjdk.java.net/valhalla pull/661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 661`

View PR using the GUI difftool: \
`$ git pr show -t 661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/661.diff">https://git.openjdk.java.net/valhalla/pull/661.diff</a>

</details>
