### PR TITLE
8282079: [lworld] Generate Preload attribute in lambdas and proxies if value classes are referenced

### DIFF
--- a/test/jdk/valhalla/valuetypes/LambdaTest.java
+++ b/test/jdk/valhalla/valuetypes/LambdaTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test lambdas with parameter types or return type of value class
+ * @run testng/othervm LambdaTest
+ */
+
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class LambdaTest {
+    static value class V {
+        int v;
+        V(int v) {
+            this.v = v;
+        }
+
+        static V get(int v) {
+            return new V(v);
+        }
+    }
+
+    static primitive class P {
+        int p;
+        P(int p) {
+            this.p = p;
+        }
+
+        static P get(int p) {
+            return new P(p);
+        }
+    }
+
+    static int getV(V v) {
+        return v.v;
+    }
+
+    static int getP(P p) {
+        return p.p;
+    }
+
+    @Test
+    public void testValueParameterType() {
+        Function<P.ref, Integer> func1 = LambdaTest::getP;
+        assertTrue(func1.apply(new P(100)) == 100);
+
+        Function<V, Integer> func2 = LambdaTest::getV;
+        assertTrue(func2.apply(new V(200)) == 200);
+    }
+
+    @Test
+    public void testValueReturnType() {
+        IntFunction<P.ref> func1 = P::get;
+        assertEquals(func1.apply(10), new P(10));
+
+        IntFunction<V> func2 = V::get;
+        assertEquals(func2.apply(20), new V(20));
+    }
+}

--- a/test/jdk/valhalla/valuetypes/ProxyTest.java
+++ b/test/jdk/valhalla/valuetypes/ProxyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test dynamic proxies with parameter types or return type of value class
+ * @run testng/othervm ProxyTest
+ */
+
+import java.lang.reflect.*;
+import java.util.Arrays;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class ProxyTest {
+    static value class V {
+        int v;
+        V(int v) {
+            this.v = v;
+        }
+    }
+
+    static primitive class P {
+        int p;
+        P(int p) {
+            this.p = p;
+        }
+    }
+
+    interface I {
+        int getV(V v);
+        int getP(P p);
+    }
+
+    interface J {
+        int[] getV(V[] v);
+    }
+
+    @Test
+    public void testProxy() throws Exception {
+        InvocationHandler handler = new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                switch (method.getName()) {
+                    case "getV":
+                        V v = (V)args[0];
+                        return v.v;
+                    case "getP":
+                        P p = (P)args[0];
+                        return p.p;
+                    default:
+                        throw new UnsupportedOperationException(method.toString());
+                }
+            }
+        };
+
+        Class<?>[] intfs = new Class<?>[] { I.class };
+        I i = (I) Proxy.newProxyInstance(ProxyTest.class.getClassLoader(), intfs, handler);
+
+        assertTrue(i.getV(new V(100)) == 100);
+        assertTrue(i.getP(new P(200)) == 200);
+    }
+
+    @Test
+    public void testValueArrayType() {
+        InvocationHandler handler = new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                switch (method.getName()) {
+                    case "getV":
+                        V[] vs = (V[])args[0];
+                        return Arrays.stream(vs).mapToInt(v -> v.v).toArray();
+                    default:
+                        throw new UnsupportedOperationException(method.toString());
+                }
+            }
+        };
+
+        Class<?>[] intfs = new Class<?>[] { J.class };
+        J j = (J) Proxy.newProxyInstance(ProxyTest.class.getClassLoader(), intfs, handler);
+
+        V[] array = new V[] { new V(10), new V(20), new V(30)};
+        assertEquals(j.getV(array), new int[] { 10, 20, 30});
+    }
+}

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -104,25 +104,6 @@ public class QTypeDescriptorTest {
         assertEquals(test.points[1], P1);
     }
 
-    @Test
-    public void testProxy() throws Exception {
-        InvocationHandler handler = new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                if (method.getName().equals("toLine")) {
-                    return toLine((Point)args[0], (NonFlattenValue)args[1]);
-                }
-                throw new UnsupportedOperationException(method.toString());
-            }
-        };
-
-        Class<?>[] intfs = new Class<?>[] { I.class };
-        I intf = (I) Proxy.newProxyInstance(QTypeDescriptorTest.class.getClassLoader(), intfs, handler);
-        Line l = intf.toLine(P0, NFV);
-        assertEquals(l.p1, P0);
-        assertEquals(l.p2, NFV.pointValue());
-    }
-
     @DataProvider
     static Object[][] descriptors() {
         return new Object[][]{


### PR DESCRIPTION
This patch updates the lambda metafactory and dynamic proxy generator to generate `Preload` attribute to list the classes to be preloaded.   That includes value classes and primitive class if its primitive value type is referenced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282079](https://bugs.openjdk.java.net/browse/JDK-8282079): [lworld] Generate Preload attribute in lambdas and proxies if value classes are referenced


### Reviewers
 * [Roger Riggs](https://openjdk.java.net/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/662/head:pull/662` \
`$ git checkout pull/662`

Update a local copy of the PR: \
`$ git checkout pull/662` \
`$ git pull https://git.openjdk.java.net/valhalla pull/662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 662`

View PR using the GUI difftool: \
`$ git pr show -t 662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/662.diff">https://git.openjdk.java.net/valhalla/pull/662.diff</a>

</details>
