### PR TITLE
addressing a NPE in the compiler due to empty warnStack

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2029,12 +2029,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isValueProjection() {
             return isUniversal() && !isReferenceProjection();
         }
-
-        public Type withTypeVar(Type t) {
-            return t.hasTag(TYPEVAR) && t.isReferenceProjection() && t == projection ?
-                    referenceProjection() :
-                    this;
-        }
     }
 
     /** A captured type variable comes from wildcards which can have
@@ -2100,10 +2094,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             sb.append(" of ");
             sb.append(wildcard);
             return sb.toString();
-        }
-
-        public Type withTypeVar(Type t) {
-            return this;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2029,6 +2029,12 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isValueProjection() {
             return isUniversal() && !isReferenceProjection();
         }
+
+        public Type withTypeVar(Type t) {
+            return t.hasTag(TYPEVAR) && t.isReferenceProjection() && t == projection ?
+                    referenceProjection() :
+                    this;
+        }
     }
 
     /** A captured type variable comes from wildcards which can have
@@ -2094,6 +2100,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             sb.append(" of ");
             sb.append(wildcard);
             return sb.toString();
+        }
+
+        public Type withTypeVar(Type t) {
+            return this;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1685,18 +1685,8 @@ public class Types {
             public Boolean visitType(Type t, Type s) {
                 if (s.isPartial())
                     return containedBy(s, t);
-                else {
-                    boolean result = isSameType(t, s);
-                    // warnStack.head is != null if we are checking for an assignment, in other cases we should be strict
-                    // the order in the condition below matters
-                    if (warnStack.head != null && allowUniversalTVars && !result) {
-                        result = isSameType(t.referenceProjectionOrSelf(), s.referenceProjectionOrSelf());
-                        if (result) {
-                            warnStack.head.warn(LintCategory.UNCHECKED);
-                        }
-                    }
-                    return result;
-                }
+                else
+                    return isSameType(t, s);
             }
 
 //            void debugContainsType(WildcardType t, Type s) {
@@ -1750,12 +1740,8 @@ public class Types {
             public Boolean visitTypeVar(TypeVar t, Type s) {
                 if (s.hasTag(TYPEVAR)) {
                     TypeVar other = (TypeVar)s;
-                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym) {
-                        if (warnStack.head != null) {
-                            warnStack.head.warn(LintCategory.UNCHECKED);
-                        }
+                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym)
                         return true;
-                    }
                 }
                 return isSameType(t, s);
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1750,8 +1750,12 @@ public class Types {
             public Boolean visitTypeVar(TypeVar t, Type s) {
                 if (s.hasTag(TYPEVAR)) {
                     TypeVar other = (TypeVar)s;
-                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym)
+                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym) {
+                        if (warnStack.head != null) {
+                            warnStack.head.warn(LintCategory.UNCHECKED);
+                        }
                         return true;
+                    }
                 }
                 return isSameType(t, s);
             }

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -123,7 +123,6 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
                     """
                     class Foo<__universal X> {
-                        void m() {}
                         void m2(X x) {}
                         void test() {
                             m2(null);

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -83,53 +83,53 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
         String warning1 = "compiler.warn.universal.variable.cannot.be.assigned.null";
         for (DiagAndCode diagAndCode : java.util.List.of(
                 new DiagAndCode(warning1,
-                    """
-                    class Box<__universal T> {
-                        T t;
-                        void m() { t = null; }
-                    }
-                    """),
+                """
+                class Box<__universal T> {
+                    T t;
+                    void m() { t = null; }
+                }
+                """),
                 new DiagAndCode(warning1,
-                    """
-                    class Box<__universal T> {
-                        T m() { return null; }
-                    }
-                    """),
+                """
+                class Box<__universal T> {
+                    T m() { return null; }
+                }
+                """),
                 new DiagAndCode(warning1,
-                    """
-                    class Box<__universal T> {
-                        T t;
-                        Box(T t) {
-                            this.t = t;
-                        }
-                        void m() { t = null; }
+                """
+                class Box<__universal T> {
+                    T t;
+                    Box(T t) {
+                        this.t = t;
                     }
-                    """),
+                    void m() { t = null; }
+                }
+                """),
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null.2",
-                    """
-                    import java.util.function.*;
+                """
+                import java.util.function.*;
 
-                    class MyMap<__universal K, __universal V> {
-                        K getKey(K k) { return k; }
-                        V getValue(V v) { return v; }
+                class MyMap<__universal K, __universal V> {
+                    K getKey(K k) { return k; }
+                    V getValue(V v) { return v; }
 
-                        void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
-                            K k = getKey(k1);
-                            V v = getValue(v1);
-                            v = f.apply(k, v);
-                        }
+                    void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
+                        K k = getKey(k1);
+                        V v = getValue(v1);
+                        v = f.apply(k, v);
                     }
-                    """),
-                    new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
-                    """
-                    class Foo<__universal X> {
-                        void m() {}
-                        void m2(X x) {}
-                        void test() {
-                            m2(null);
-                        }
+                }
+                """),
+                new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
+                """
+                class Foo<__universal X> {
+                    void m() {}
+                    void m2(X x) {}
+                    void test() {
+                        m2(null);
                     }
-                    """),
+                }
+                """),
                 new DiagAndCode("compiler.warn.prob.found.req",
                 """
                 class Foo<__universal X> { }
@@ -173,6 +173,16 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                     void m() {
                         Foo<Atom.ref> ref = null;
                         bar(ref);
+                    }
+                }
+                """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                """
+                class Wrapper<__universal T> {}
+                class Test<__universal T> {
+                    Wrapper<T.ref> newWrapper() { return null; }
+                    void m() {
+                        Wrapper<T> w = newWrapper();
                     }
                 }
                 """)

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -48,7 +48,7 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
     private static String[] EMPTY_OPTIONS = {};
 
     private static String[] LINT_OPTIONS = {
-        "-Xlint:all"
+        "-Xlint:universal"
     };
 
     public UniversalTVarsCompilationTests() {
@@ -78,115 +78,59 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
         }
     }
 
-    public void testWarnings() {
+    public void testWarningNullAssigment() {
         record DiagAndCode(String diag, String code){}
         String warning1 = "compiler.warn.universal.variable.cannot.be.assigned.null";
         for (DiagAndCode diagAndCode : java.util.List.of(
                 new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T t;
-                    void m() { t = null; }
-                }
-                """),
-                new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T m() { return null; }
-                }
-                """),
-                new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T t;
-                    Box(T t) {
-                        this.t = t;
+                    """
+                    class Box<__universal T> {
+                        T t;
+                        void m() { t = null; }
                     }
-                    void m() { t = null; }
-                }
-                """),
+                    """),
+                new DiagAndCode(warning1,
+                    """
+                    class Box<__universal T> {
+                        T m() { return null; }
+                    }
+                    """),
+                new DiagAndCode(warning1,
+                    """
+                    class Box<__universal T> {
+                        T t;
+                        Box(T t) {
+                            this.t = t;
+                        }
+                        void m() { t = null; }
+                    }
+                    """),
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null.2",
-                """
-                import java.util.function.*;
+                    """
+                    import java.util.function.*;
 
-                class MyMap<__universal K, __universal V> {
-                    K getKey(K k) { return k; }
-                    V getValue(V v) { return v; }
+                    class MyMap<__universal K, __universal V> {
+                        K getKey(K k) { return k; }
+                        V getValue(V v) { return v; }
 
-                    void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
-                        K k = getKey(k1);
-                        V v = getValue(v1);
-                        v = f.apply(k, v);
+                        void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
+                            K k = getKey(k1);
+                            V v = getValue(v1);
+                            v = f.apply(k, v);
+                        }
                     }
-                }
-                """),
+                    """),
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
-                """
-                class Foo<__universal X> {
-                    void m() {}
-                    void m2(X x) {}
-                    void test() {
-                        m2(null);
+                    """
+                    class Foo<__universal X> {
+                        void m() {}
+                        void m2(X x) {}
+                        void test() {
+                            m2(null);
+                        }
                     }
-                }
-                """),
-                new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Foo<__universal X> { }
-
-                primitive class Atom { }
-
-                class Test {
-                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
-                        val = ref;
-                    }
-                }
-                """),
-                new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom { }
-                class Test {
-                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
-                        ref = val;
-                    }
-                }
-                """),
-                new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom {}
-                class Test {
-                    void bar(Foo<Atom.ref> f) {}
-                    void m() {
-                        Foo<Atom> val = null;
-                        bar(val);
-                    }
-                }
-                """),
-                new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom {}
-                class Test {
-                    void bar(Foo<Atom> f) {}
-                    void m() {
-                        Foo<Atom.ref> ref = null;
-                        bar(ref);
-                    }
-                }
-                """),
-                new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Wrapper<__universal T> {}
-                class Test<__universal T> {
-                    Wrapper<T.ref> newWrapper() { return null; }
-                    void m() {
-                        Wrapper<T> w = newWrapper();
-                    }
-                }
-                """)
-                )) {
+                    """)
+                    )) {
             testHelper(LINT_OPTIONS, diagAndCode.diag, TestResult.COMPILE_WITH_WARNING, diagAndCode.code);
             testHelper(EMPTY_OPTIONS, diagAndCode.code);
         }
@@ -231,13 +175,6 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                 """
                 import java.io.*;
                 class C<__universal T extends Reader> { T.ref x = null; }
-                """,
-                """
-                primitive class Atom {}
-                class Test {
-                    void bar(Atom f) {}
-                    void bar(Atom.ref f) {}
-                }
                 """
                 )) {
             testHelper(LINT_OPTIONS, code);

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -48,7 +48,7 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
     private static String[] EMPTY_OPTIONS = {};
 
     private static String[] LINT_OPTIONS = {
-        "-Xlint:universal"
+        "-Xlint:all"
     };
 
     public UniversalTVarsCompilationTests() {
@@ -78,7 +78,7 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
         }
     }
 
-    public void testWarningNullAssigment() {
+    public void testWarnings() {
         record DiagAndCode(String diag, String code){}
         String warning1 = "compiler.warn.universal.variable.cannot.be.assigned.null";
         for (DiagAndCode diagAndCode : java.util.List.of(
@@ -119,7 +119,64 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                             v = f.apply(k, v);
                         }
                     }
-                    """) )) {
+                    """),
+                    new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
+                    """
+                    class Foo<__universal X> {
+                        void m() {}
+                        void m2(X x) {}
+                        void test() {
+                            m2(null);
+                        }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                """
+                class Foo<__universal X> { }
+
+                primitive class Atom { }
+
+                class Test {
+                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
+                        val = ref;
+                    }
+                }
+                """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                """
+                class Foo<__universal X> { }
+                primitive class Atom { }
+                class Test {
+                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
+                        ref = val;
+                    }
+                }
+                """),
+                new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
+                """
+                class Foo<__universal X> { }
+                primitive class Atom {}
+                class Test {
+                    void bar(Foo<Atom.ref> f) {}
+                    void m() {
+                        Foo<Atom> val = null;
+                        bar(val);
+                    }
+                }
+                """),
+                new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
+                """
+                class Foo<__universal X> { }
+                primitive class Atom {}
+                class Test {
+                    void bar(Foo<Atom> f) {}
+                    void m() {
+                        Foo<Atom.ref> ref = null;
+                        bar(ref);
+                    }
+                }
+                """)
+                )) {
             testHelper(LINT_OPTIONS, diagAndCode.diag, TestResult.COMPILE_WITH_WARNING, diagAndCode.code);
             testHelper(EMPTY_OPTIONS, diagAndCode.code);
         }
@@ -164,6 +221,13 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                 """
                 import java.io.*;
                 class C<__universal T extends Reader> { T.ref x = null; }
+                """,
+                """
+                primitive class Atom {}
+                class Test {
+                    void bar(Atom f) {}
+                    void bar(Atom.ref f) {}
+                }
                 """
                 )) {
             testHelper(LINT_OPTIONS, code);


### PR DESCRIPTION
Fixing a compiler crash plus other review comments from Maurizio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/663/head:pull/663` \
`$ git checkout pull/663`

Update a local copy of the PR: \
`$ git checkout pull/663` \
`$ git pull https://git.openjdk.java.net/valhalla pull/663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 663`

View PR using the GUI difftool: \
`$ git pr show -t 663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/663.diff">https://git.openjdk.java.net/valhalla/pull/663.diff</a>

</details>
