### PR TITLE
8282512: Remove usages of __WithField in compiler tests

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestC1.java
@@ -38,7 +38,6 @@ import static compiler.valhalla.inlinetypes.InlineTypes.rL;
  * @summary Various tests that are specific for C1.
  * @library /test/lib /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @compile -XDallowWithFieldOperator TestC1.java
  * @run driver/timeout=300 compiler.valhalla.inlinetypes.TestC1
  */
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
@@ -34,6 +34,8 @@ import sun.hotspot.WhiteBox;
  * @test TestDeoptimizationWhenBuffering
  * @summary Test correct execution after deoptimizing from inline type specific runtime calls.
  * @library /testlibrary /test/lib /compiler/whitebox /
+ * @build org.openjdk.asmtools.* org.openjdk.asmtools.jasm.*
+ * @run driver org.openjdk.asmtools.JtregDriver jasm -strict TestDeoptimizationWhenBufferingClasses.jasm
  * @compile -XDallowWithFieldOperator TestDeoptimizationWhenBuffering.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
@@ -73,35 +75,6 @@ import sun.hotspot.WhiteBox;
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.*::test*
  *                   compiler.valhalla.inlinetypes.TestDeoptimizationWhenBuffering
  */
-
-final primitive class MyValue1 {
-    static int cnt = 0;
-    final int x;
-    final MyValue2 vtField1;
-    final MyValue2.ref vtField2;
-
-    public MyValue1() {
-        this.x = ++cnt;
-        this.vtField1 = new MyValue2();
-        this.vtField2 = new MyValue2();
-    }
-
-    public int hash() {
-        return x + vtField1.x + vtField2.x;
-    }
-
-    public MyValue1 testWithField(int x) {
-        return __WithField(this.x, x);
-    }
-}
-
-final primitive class MyValue2 {
-    static int cnt = 0;
-    final int x;
-    public MyValue2() {
-        this.x = ++cnt;
-    }
-}
 
 public class TestDeoptimizationWhenBuffering {
     static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java
@@ -35,8 +35,8 @@ import sun.hotspot.WhiteBox;
  * @summary Test correct execution after deoptimizing from inline type specific runtime calls.
  * @library /testlibrary /test/lib /compiler/whitebox /
  * @build org.openjdk.asmtools.* org.openjdk.asmtools.jasm.*
+ * @build sun.hotspot.WhiteBox
  * @run driver org.openjdk.asmtools.JtregDriver jasm -strict TestDeoptimizationWhenBufferingClasses.jasm
- * @compile -XDallowWithFieldOperator TestDeoptimizationWhenBuffering.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:+DeoptimizeALot -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.*::test*

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBufferingClasses.jasm
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptimizationWhenBufferingClasses.jasm
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+public final primitive value class compiler/valhalla/inlinetypes/MyValue1
+    version 63:0
+{
+    static Field cnt:I;
+    final Field x:I;
+    final Field vtField1:"Qcompiler/valhalla/inlinetypes/MyValue2;";
+    final Field vtField2:"Lcompiler/valhalla/inlinetypes/MyValue2;";
+    
+    public static Method <init>:"()Qcompiler/valhalla/inlinetypes/MyValue1;" stack 2 {
+        getstatic cnt:I;
+        iconst_1;
+        iadd;
+        putstatic cnt:I;
+        
+        aconst_init compiler/valhalla/inlinetypes/MyValue1;
+        
+        getstatic cnt:I;
+        withfield x:I;
+        
+        invokestatic compiler/valhalla/inlinetypes/MyValue2.<init>:"()Qcompiler/valhalla/inlinetypes/MyValue2;";
+        withfield vtField1:"Qcompiler/valhalla/inlinetypes/MyValue2;";
+        
+        invokestatic compiler/valhalla/inlinetypes/MyValue2.<init>:"()Qcompiler/valhalla/inlinetypes/MyValue2;";
+        withfield vtField2:"Lcompiler/valhalla/inlinetypes/MyValue2;";
+        
+        areturn;
+    }
+
+    public Method hash:"()I" stack 2 {
+        aload_0;
+        getfield x:I;
+        
+        aload_0;
+        getfield vtField1:"Qcompiler/valhalla/inlinetypes/MyValue2;";
+        getfield compiler/valhalla/inlinetypes/MyValue2.x:I;
+        iadd;
+        
+        aload_0;
+        getfield vtField2:"Lcompiler/valhalla/inlinetypes/MyValue2;";
+        getfield compiler/valhalla/inlinetypes/MyValue2.x:I;
+        iadd;
+        
+        ireturn;
+    }
+
+    public Method testWithField:"(I)Qcompiler/valhalla/inlinetypes/MyValue1;" stack 2 {
+        aload_0;
+        iload_1;
+        withfield x:I;
+        areturn;
+    }
+
+}
+
+public final primitive value class compiler/valhalla/inlinetypes/MyValue2
+    version 63:0
+{
+    static Field cnt:I;
+    final Field x:I;
+    
+    public static Method <init>:"()Qcompiler/valhalla/inlinetypes/MyValue2;" stack 2 {
+        getstatic cnt:I;
+        iconst_1;
+        iadd;
+        putstatic cnt:I;
+        
+        aconst_init compiler/valhalla/inlinetypes/MyValue2;
+        
+        getstatic cnt:I;
+        withfield x:I;
+        
+        areturn;
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,8 @@ import compiler.lib.ir_framework.*;
  * @summary Verify that C1 performs escape analysis before optimizing withfield bytecode to putfield.
  * @library /test/lib /
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @compile -XDallowWithFieldOperator TestWithfieldC1.java
+ * @build org.openjdk.asmtools.* org.openjdk.asmtools.jasm.*
+ * @run driver org.openjdk.asmtools.JtregDriver jasm -strict TestWithfieldC1Classes.jasm
  * @run driver/timeout=300 compiler.valhalla.inlinetypes.TestWithfieldC1
  */
 
@@ -75,114 +76,6 @@ public class TestWithfieldC1 {
         }
     }
 
-    static primitive class FooValue {
-        public int x = 0, y = 0;
-
-        @ForceInline
-        static FooValue test1() {
-            FooValue v = FooValue.default;
-
-            v = __WithField(v.x, 1);
-            v = __WithField(v.y, 1);
-            foo_static = v;
-
-            v = __WithField(v.x, 2);
-            v = __WithField(v.y, 2);
-            return v;
-        }
-
-        @ForceInline
-        static FooValue test3() {
-            FooValue v = FooValue.default;
-
-            v = __WithField(v.x, 1);
-            v = __WithField(v.y, 1);
-            set_foo_static_if_null(v);
-
-            v = __WithField(v.x, 2);
-            v = __WithField(v.y, 2);
-            return v;
-        }
-
-        @ForceInline
-        static FooValue test4() {
-            FooValue v = FooValue.default;
-            for (int i=1; i<=2; i++) {
-                v = __WithField(v.x, i);
-                v = __WithField(v.y, i);
-                set_foo_static_if_null(v);
-            }
-
-            return v;
-        }
-
-        @ForceInline
-        static FooValue test5() {
-            FooValue v1 = FooValue.default;
-            FooValue v2 = FooValue.default;
-            v2 = v1;
-
-            v1 = __WithField(v1.x, 1);
-            v1 = __WithField(v1.y, 1);
-            set_foo_static_if_null(v1);
-
-            v2 = __WithField(v2.x, 2);
-            v2 = __WithField(v2.y, 2);
-
-            return v2;
-        }
-
-        @ForceInline
-        static FooValue test6() {
-            FooValue v = FooValue.default;
-
-            v = __WithField(v.x, 1);
-            v = __WithField(v.y, 1);
-            foo_static_arr[0] = v;
-
-            v = __WithField(v.x, 2);
-            v = __WithField(v.y, 2);
-            return v;
-        }
-
-
-        @ForceInline
-        static FooValue test7() {
-            FooValue v1 = FooValue.default;
-            FooValue v2 = FooValue.default;
-            v2 = v1;
-
-            v1 = __WithField(v1.x, 1);
-            v1 = __WithField(v1.y, 1);
-
-            v2 = __WithField(v2.x, 2);
-            v2 = __WithField(v2.y, 2);
-
-            return v1;
-        }
-
-        @ForceInline
-        static FooValue test8() {
-            FooValue v1 = FooValue.default;
-
-            v1 = __WithField(v1.x, 1);
-            v1 = __WithField(v1.y, 1);
-
-            v1.non_static_method();
-
-            v1 = __WithField(v1.x, 2);
-            v1 = __WithField(v1.y, 2);
-
-            return v1;
-        }
-
-
-        @DontInline
-        private void non_static_method() {
-            set_foo_static_if_null(this);
-        }
-    }
-
     static void validate_foo_static_and(FooValue v) {
         Asserts.assertEQ(foo_static.x, 1);
         Asserts.assertEQ(foo_static.y, 1);
@@ -205,15 +98,7 @@ public class TestWithfieldC1 {
     // escape with putfield
     @Test(compLevel = CompLevel.C1_SIMPLE)
     public FooValue test2() {
-        FooValue v = FooValue.default;
-
-        v = __WithField(v.x, 1);
-        v = __WithField(v.y, 1);
-        foo_instance = v;
-
-        v = __WithField(v.x, 2);
-        v = __WithField(v.y, 2);
-        return v;
+        return FooValue.test2(this);
     }
 
     @Run(test = "test2")
@@ -310,21 +195,7 @@ public class TestWithfieldC1 {
     // duplicate reference with local variables
     @Test(compLevel = CompLevel.C1_SIMPLE)
     public FooValue test9() {
-        FooValue v = FooValue.default;
-
-        v = __WithField(v.x, 1);
-        v = __WithField(v.y, 1);
-
-        FooValue v2 = v;
-
-        v = __WithField(v.x, 2);
-        v = __WithField(v.y, 2);
-
-        v2 = __WithField(v2.x, 3);
-        v2 = __WithField(v2.y, 3);
-
-        foo_instance = v2;
-        return v;
+        return FooValue.test9(this);
     }
 
     @Run(test = "test9")

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1Classes.jasm
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestWithfieldC1Classes.jasm
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package compiler/valhalla/inlinetypes;
+
+public final primitive value class FooValue
+    version 63:0
+{
+    public final Field x:I;
+    public final Field y:I;
+
+    // escape with putstatic
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test1:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 1 {
+        aconst_init FooValue; astore_0;
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        aload_0; putstatic TestWithfieldC1.foo_static:"Lcompiler/valhalla/inlinetypes/FooValue;";
+        
+        aload_0; iconst_2; withfield x:I; astore_0;
+        aload_0; iconst_2; withfield y:I; astore_0;
+        
+        aload_0; areturn;
+    }
+
+    // escape with putfield
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test2:"(Lcompiler/valhalla/inlinetypes/TestWithfieldC1;)Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 2 {
+        aconst_init FooValue; astore_1;
+        aload_1; iconst_1; withfield FooValue.x:I; astore_1;
+        aload_1; iconst_1; withfield FooValue.y:I; astore_1;
+        
+        aload_0; aload_1; putfield TestWithfieldC1.foo_instance:"Lcompiler/valhalla/inlinetypes/FooValue;";
+        
+        aload_1; iconst_2; withfield x:I; astore_1;
+        aload_1; iconst_2; withfield y:I; astore_1;
+        
+        aload_1; areturn;
+    }
+
+    // escape with function call
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test3:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 1 {
+        aconst_init FooValue; astore_0;
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        aload_0; invokestatic TestWithfieldC1.set_foo_static_if_null:"(Qcompiler/valhalla/inlinetypes/FooValue;)V";
+        
+        aload_0; iconst_2; withfield x:I; astore_0;
+        aload_0; iconst_2; withfield y:I; astore_0;
+        
+        aload_0; areturn;
+    }
+
+    // escape and then branch backwards
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test4:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 2 {
+        aconst_init FooValue; astore_0;
+        iconst_1; istore_1;
+        
+        loop: stack_frame_type append; locals_map class "Qcompiler/valhalla/inlinetypes/FooValue;", int;
+            // iterate two times
+            iload_1; iconst_2; if_icmpgt end;
+            
+            aload_0; iload_1; withfield x:I; astore_0;
+            aload_0; iload_1; withfield y:I; astore_0;
+            
+            aload_0; invokestatic TestWithfieldC1.set_foo_static_if_null:"(Qcompiler/valhalla/inlinetypes/FooValue;)V";
+            
+            iinc 1,1; goto loop;
+        
+        end: stack_frame_type same;
+            aload_0; areturn;
+    }
+
+    // escape using a different local variable
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test5:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 2 {
+        aconst_init FooValue; astore_0;
+        aconst_init FooValue; astore_1;
+        aload_0; astore_1;
+        
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        aload_0; invokestatic TestWithfieldC1.set_foo_static_if_null:"(Qcompiler/valhalla/inlinetypes/FooValue;)V";
+        
+        aload_1; iconst_2; withfield x:I; astore_1;
+        aload_1; iconst_2; withfield y:I; astore_1;
+        
+        aload_1; areturn;
+    }
+    
+    // escape using aastore
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test6:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 3 locals 1 {
+        aconst_init FooValue; astore_0;
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        getstatic TestWithfieldC1.foo_static_arr:"[Lcompiler/valhalla/inlinetypes/FooValue;";
+        iconst_0; aload_0; aastore;
+        
+        aload_0; iconst_2; withfield x:I; astore_0;
+        aload_0; iconst_2; withfield y:I; astore_0;
+        
+        aload_0; areturn;
+    }
+
+    // Copying a value into different local slots -- disable withfield optimization
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test7:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 2 {
+        aconst_init FooValue; astore_0;
+        aconst_init FooValue; astore_1;
+        aload_0; astore_1;
+        
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        aload_1; iconst_2; withfield x:I; astore_1;
+        aload_1; iconst_2; withfield y:I; astore_1;
+        
+        aload_0; areturn;
+    }
+
+    // escape by invoking non-static method
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test8:"()Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 1 {
+        aconst_init FooValue; astore_0;
+        aload_0; iconst_1; withfield x:I; astore_0;
+        aload_0; iconst_1; withfield y:I; astore_0;
+        
+        aload_0; invokevirtual non_static_method:"()V";
+        
+        aload_0; iconst_2; withfield x:I; astore_0;
+        aload_0; iconst_2; withfield y:I; astore_0;
+        
+        aload_0; areturn;
+    }
+    
+    @+compiler/lib/ir_framework/DontInline{}
+    private Method non_static_method:"()V" stack 1 {
+        aload_0;
+        invokestatic TestWithfieldC1.set_foo_static_if_null:"(Qcompiler/valhalla/inlinetypes/FooValue;)V";
+        return;
+    }
+    
+    // duplicate reference with local variables
+    @+compiler/lib/ir_framework/ForceInline{}
+    static Method test9:"(Lcompiler/valhalla/inlinetypes/TestWithfieldC1;)Qcompiler/valhalla/inlinetypes/FooValue;" stack 2 locals 3 {
+        aconst_init FooValue; astore_1;
+        aload_1; iconst_1; withfield x:I; astore_1;
+        aload_1; iconst_1; withfield y:I; astore_1;
+        
+        aload_1; astore_2;
+        
+        aload_1; iconst_2; withfield x:I; astore_1;
+        aload_1; iconst_2; withfield y:I; astore_1;
+        
+        aload_2; iconst_3; withfield x:I; astore_2;
+        aload_2; iconst_3; withfield y:I; astore_2;
+        
+        aload_0; aload_2; putfield TestWithfieldC1.foo_instance:"Lcompiler/valhalla/inlinetypes/FooValue;";
+
+        aload_1; areturn;
+    }
+
+}


### PR DESCRIPTION
Rewrote 2 compiler tests to perform 'withfield' operations in jasm code rather than using the '__WithField' javac hack.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282512](https://bugs.openjdk.java.net/browse/JDK-8282512): Remove usages of __WithField in compiler tests


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/664/head:pull/664` \
`$ git checkout pull/664`

Update a local copy of the PR: \
`$ git checkout pull/664` \
`$ git pull https://git.openjdk.java.net/valhalla pull/664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 664`

View PR using the GUI difftool: \
`$ git pr show -t 664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/664.diff">https://git.openjdk.java.net/valhalla/pull/664.diff</a>

</details>
