### PR TITLE
addressing parameterized conversion warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2029,6 +2029,12 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isValueProjection() {
             return isUniversal() && !isReferenceProjection();
         }
+
+        public Type withTypeVar(Type t) {
+            return t.hasTag(TYPEVAR) && t.isReferenceProjection() && t == projection ?
+                    referenceProjection() :
+                    this;
+        }
     }
 
     /** A captured type variable comes from wildcards which can have
@@ -2094,6 +2100,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             sb.append(" of ");
             sb.append(wildcard);
             return sb.toString();
+        }
+
+        public Type withTypeVar(Type t) {
+            return this;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1672,8 +1672,18 @@ public class Types {
             public Boolean visitType(Type t, Type s) {
                 if (s.isPartial())
                     return containedBy(s, t);
-                else
-                    return isSameType(t, s);
+                else {
+                    boolean result = isSameType(t, s);
+                    // warnStack.head is != null if we are checking for an assignment, in other cases we should be strict
+                    // the order in the condition below matters
+                    if (warnStack.head != null && allowUniversalTVars && !result) {
+                        result = isSameType(t.referenceProjectionOrSelf(), s.referenceProjectionOrSelf());
+                        if (result) {
+                            warnStack.head.warn(LintCategory.UNCHECKED);
+                        }
+                    }
+                    return result;
+                }
             }
 
 //            void debugContainsType(WildcardType t, Type s) {
@@ -1727,8 +1737,12 @@ public class Types {
             public Boolean visitTypeVar(TypeVar t, Type s) {
                 if (s.hasTag(TYPEVAR)) {
                     TypeVar other = (TypeVar)s;
-                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym)
+                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym) {
+                        if (warnStack.head != null) {
+                            warnStack.head.warn(LintCategory.UNCHECKED);
+                        }
                         return true;
+                    }
                 }
                 return isSameType(t, s);
             }

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -83,40 +83,41 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
         String warning1 = "compiler.warn.universal.variable.cannot.be.assigned.null";
         for (DiagAndCode diagAndCode : java.util.List.of(
                 new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T t;
-                    void m() { t = null; }
-                }
-                """),
-                new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T m() { return null; }
-                }
-                """),
-                new DiagAndCode(warning1,
-                """
-                class Box<__universal T> {
-                    T t;
-                    Box(T t) {
-                        this.t = t;
+                    """
+                    class Box<__universal T> {
+                        T t;
+                        void m() { t = null; }
                     }
-                    void m() { t = null; }
-                }
-                """),
+                    """),
+                new DiagAndCode(warning1,
+                    """
+                    class Box<__universal T> {
+                        T m() { return null; }
+                    }
+                    """),
+                new DiagAndCode(warning1,
+                    """
+                    class Box<__universal T> {
+                        T t;
+                        Box(T t) {
+                            this.t = t;
+                        }
+                        void m() { t = null; }
+                    }
+                    """),
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null.2",
-                """
-                import java.util.function.*;
-
-                class MyMap<__universal K, __universal V> {
-                    K getKey(K k) { return k; }
-                    V getValue(V v) { return v; }
-
-                    void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
-                        K k = getKey(k1);
-                        V v = getValue(v1);
-                        v = f.apply(k, v);
+                    """
+                    import java.util.function.*;
+        
+                    class MyMap<__universal K, __universal V> {
+                        K getKey(K k) { return k; }
+                        V getValue(V v) { return v; }
+        
+                        void m(BiFunction<? super K, ? super V, ? extends V> f, K k1, V v1) {
+                            K k = getKey(k1);
+                            V v = getValue(v1);
+                            v = f.apply(k, v);
+                        }
                     }
                     """),
                 new DiagAndCode("compiler.warn.universal.variable.cannot.be.assigned.null",
@@ -129,63 +130,60 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                     }
                     """),
                 new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Foo<__universal X> { }
-
-                primitive class Atom { }
-
-                class Test {
-                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
-                        val = ref;
+                    """
+                    class Foo<__universal X> { }
+                    primitive class Atom { }
+                    class Test {
+                        void m(Foo<Atom> val, Foo<Atom.ref> ref) {
+                            val = ref;
+                        }
                     }
-                }
-                """),
+                    """),
                 new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom { }
-                class Test {
-                    void m(Foo<Atom> val, Foo<Atom.ref> ref) {
-                        ref = val;
+                    """
+                    class Foo<__universal X> { }
+                    primitive class Atom { }
+                    class Test {
+                        void m(Foo<Atom> val, Foo<Atom.ref> ref) {
+                            ref = val;
+                        }
                     }
-                }
-                """),
+                    """),
                 new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom {}
-                class Test {
-                    void bar(Foo<Atom.ref> f) {}
-                    void m() {
-                        Foo<Atom> val = null;
-                        bar(val);
+                    """
+                    class Foo<__universal X> { }
+                    primitive class Atom {}
+                    class Test {
+                        void bar(Foo<Atom.ref> f) {}
+                        void m() {
+                            Foo<Atom> val = null;
+                            bar(val);
+                        }
                     }
-                }
-                """),
+                    """),
                 new DiagAndCode("compiler.warn.unchecked.meth.invocation.applied",
-                """
-                class Foo<__universal X> { }
-                primitive class Atom {}
-                class Test {
-                    void bar(Foo<Atom> f) {}
-                    void m() {
-                        Foo<Atom.ref> ref = null;
-                        bar(ref);
+                    """
+                    class Foo<__universal X> { }
+                    primitive class Atom {}
+                    class Test {
+                        void bar(Foo<Atom> f) {}
+                        void m() {
+                            Foo<Atom.ref> ref = null;
+                            bar(ref);
+                        }
                     }
-                }
-                """),
+                    """),
                 new DiagAndCode("compiler.warn.prob.found.req",
-                """
-                class Wrapper<__universal T> {}
-                class Test<__universal T> {
-                    Wrapper<T.ref> newWrapper() { return null; }
-                    void m() {
-                        Wrapper<T> w = newWrapper();
+                    """
+                    class Wrapper<__universal T> {}
+                    class Test<__universal T> {
+                        Wrapper<T.ref> newWrapper() { return null; }
+                        void m() {
+                            Wrapper<T> w = newWrapper();
+                        }
                     }
-                }
-                """)
-
-            )) {
+                    """)
+                )) {
             testHelper(LINT_OPTIONS, diagAndCode.diag, TestResult.COMPILE_WITH_WARNING, diagAndCode.code);
             testHelper(EMPTY_OPTIONS, diagAndCode.code);
         }
@@ -248,18 +246,14 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
         for (String code : java.util.List.of(
                 """
                 primitive class Point {}
-
                 class C<__universal T> {
                     C<Point> cp;
                 }
                 """,
                 """
                 interface Shape {}
-
                 primitive class Point implements Shape {}
-
                 class Box<__universal T> {}
-
                 class Test {
                     void m(Box<Point> lp) {
                         // this invocation will provoke a subtype checking, basically a check testing if:
@@ -268,22 +262,17 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                         // `Point.ref` isBoundedBy Shape
                         foo(lp);
                     }
-
                     void foo(Box<? extends Shape> ls) {}
                 }
                 """,
                 """
                 interface Shape {}
-
                 primitive class Point implements Shape {}
-
                 class Box<__universal T> {}
-
                 class Test {
                     void m(Box<Shape> lp) {
                         foo(lp);
                     }
-
                     void foo(Box<? super Point> ls) {}
                 }
                 """,

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -119,7 +119,8 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                         v = f.apply(k, v);
                     }
                 }
-                """),
+                """)//,
+                /*
                 new DiagAndCode("compiler.warn.prob.found.req",
                 """
                 class Foo<__universal X> { }
@@ -175,7 +176,7 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                         Wrapper<T> w = newWrapper();
                     }
                 }
-                """)
+                """)*/
                 )) {
             testHelper(LINT_OPTIONS, diagAndCode.diag, TestResult.COMPILE_WITH_WARNING, diagAndCode.code);
             testHelper(EMPTY_OPTIONS, diagAndCode.code);


### PR DESCRIPTION
the current universal type variables prototype is not issuing unchecked warnings for conversions of types parameterized with primitives classes and its reference projection

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/665/head:pull/665` \
`$ git checkout pull/665`

Update a local copy of the PR: \
`$ git checkout pull/665` \
`$ git pull https://git.openjdk.java.net/valhalla pull/665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 665`

View PR using the GUI difftool: \
`$ git pr show -t 665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/665.diff">https://git.openjdk.java.net/valhalla/pull/665.diff</a>

</details>
