### PR TITLE
bug: no warning shown for parameterized conversions

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2029,12 +2029,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isValueProjection() {
             return isUniversal() && !isReferenceProjection();
         }
-
-        public Type withTypeVar(Type t) {
-            return t.hasTag(TYPEVAR) && t.isReferenceProjection() && t == projection ?
-                    referenceProjection() :
-                    this;
-        }
     }
 
     /** A captured type variable comes from wildcards which can have
@@ -2100,10 +2094,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             sb.append(" of ");
             sb.append(wildcard);
             return sb.toString();
-        }
-
-        public Type withTypeVar(Type t) {
-            return this;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2029,6 +2029,12 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isValueProjection() {
             return isUniversal() && !isReferenceProjection();
         }
+
+        public Type withTypeVar(Type t) {
+            return t.hasTag(TYPEVAR) && t.isReferenceProjection() && t == projection ?
+                    referenceProjection() :
+                    this;
+        }
     }
 
     /** A captured type variable comes from wildcards which can have
@@ -2094,6 +2100,10 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             sb.append(" of ");
             sb.append(wildcard);
             return sb.toString();
+        }
+
+        public Type withTypeVar(Type t) {
+            return this;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1178,6 +1178,10 @@ public class Types {
         if (t.equalsIgnoreMetadata(s))
             return true;
         if (t.hasTag(TYPEVAR) && s.hasTag(TYPEVAR) && t.tsym == s.tsym) {
+            // warnStack.head is != null if we are checking for an assignment
+            if (warnStack.head != null && allowUniversalTVars && t.isReferenceProjection() != s.isReferenceProjection()) {
+                warnStack.head.warn(LintCategory.UNCHECKED);
+            }
             return true;
         }
         if (s.isPartial())
@@ -1201,7 +1205,8 @@ public class Types {
                 return isSubtype(capture ? capture(t) : t, lower, false);
         }
 
-        return isSubtype.visit(capture ? capture(t) : t, s);
+        t = capture ? capture(t) : t;
+        return isSubtype.visit(t, s);
     }
     // where
         private TypeRelation isSubtype = new TypeRelation()

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1183,10 +1183,10 @@ public class Types {
     TypeRelations typeRelations = new TypeRelations(false, new IsSubtypeRelation(), new ContainsType());
     TypeRelations typeRelationsUnchecked = new TypeRelations(true, new IsSubtypeUncheckedRelation(), new ContainsTypeUnchecked());
 
-    public boolean isSubtype(Type t, Type s, boolean capture, TypeRelations subtypingParameters) {
+    public boolean isSubtype(Type t, Type s, boolean capture, TypeRelations typeRelations) {
         if (t.equalsIgnoreMetadata(s))
             return true;
-        if (subtypingParameters.uncheckedAllowed() && t.hasTag(TYPEVAR) && s.hasTag(TYPEVAR) && t.tsym == s.tsym) {
+        if (typeRelations.uncheckedAllowed() && t.hasTag(TYPEVAR) && s.hasTag(TYPEVAR) && t.tsym == s.tsym) {
             if (warnStack.head != null && allowUniversalTVars && t.isReferenceProjection() != s.isReferenceProjection()) {
                 warnStack.head.warn(LintCategory.UNCHECKED);
             }
@@ -1197,7 +1197,7 @@ public class Types {
 
         if (s.isCompound()) {
             for (Type s2 : interfaces(s).prepend(supertype(s))) {
-                if (!isSubtype(t, s2, capture, subtypingParameters))
+                if (!isSubtype(t, s2, capture, typeRelations))
                     return false;
             }
             return true;
@@ -1210,11 +1210,11 @@ public class Types {
             // TODO: JDK-8039198, bounds checking sometimes passes in a wildcard as s
             Type lower = cvarLowerBound(wildLowerBound(s));
             if (s != lower && !lower.hasTag(BOT))
-                return isSubtype(capture ? capture(t) : t, lower, false, subtypingParameters);
+                return isSubtype(capture ? capture(t) : t, lower, false, typeRelations);
         }
 
         t = capture ? capture(t) : t;
-        return subtypingParameters.subtypingRelation().visit(t, s);
+        return typeRelations.subtypingRelation().visit(t, s);
     }
     // where
         class IsSubtypeRelation extends TypeRelation {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1805,7 +1805,6 @@ public class Types {
                     return containedBy(s, t);
                 else {
                     boolean result = isSameType(t, s, this);
-                    // warnStack.head is != null if we are checking for an assignment, in other cases we should be strict
                     // the order in the condition below matters
                     if (warnStack.head != null && allowUniversalTVars && !result) {
                         result = isSameType(t.referenceProjectionOrSelf(), s.referenceProjectionOrSelf());

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4939,7 +4939,7 @@ public class Types {
 
     private boolean containsTypeEquivalent(Type t, Type s) {
         return isSameType(t, s) || // shortcut
-            containsType(t, s) && containsType(s, t);
+            containsType(t, s, containsTypeUnchecked) && containsType(s, t, containsTypeUnchecked);
     }
 
     // <editor-fold defaultstate="collapsed" desc="adapt">

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1685,8 +1685,18 @@ public class Types {
             public Boolean visitType(Type t, Type s) {
                 if (s.isPartial())
                     return containedBy(s, t);
-                else
-                    return isSameType(t, s);
+                else {
+                    boolean result = isSameType(t, s);
+                    // warnStack.head is != null if we are checking for an assignment, in other cases we should be strict
+                    // the order in the condition below matters
+                    if (warnStack.head != null && allowUniversalTVars && !result) {
+                        result = isSameType(t.referenceProjectionOrSelf(), s.referenceProjectionOrSelf());
+                        if (result) {
+                            warnStack.head.warn(LintCategory.UNCHECKED);
+                        }
+                    }
+                    return result;
+                }
             }
 
 //            void debugContainsType(WildcardType t, Type s) {
@@ -1740,8 +1750,12 @@ public class Types {
             public Boolean visitTypeVar(TypeVar t, Type s) {
                 if (s.hasTag(TYPEVAR)) {
                     TypeVar other = (TypeVar)s;
-                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym)
+                    if (allowUniversalTVars && t.isValueProjection() != other.isValueProjection() && t.tsym == other.tsym) {
+                        if (warnStack.head != null) {
+                            warnStack.head.warn(LintCategory.UNCHECKED);
+                        }
                         return true;
+                    }
                 }
                 return isSameType(t, s);
             }

--- a/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/universal-type-variables/UniversalTVarsCompilationTests.java
@@ -180,6 +180,90 @@ public class UniversalTVarsCompilationTests extends CompilationTestCase {
                             Wrapper<T> w = newWrapper();
                         }
                     }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MyFunction<__universal T, __universal R> {
+                        R apply(T t);
+                    }
+                    primitive class Point {}
+                    class Color {
+                        static Color gray() { return new Color(); }
+                    }
+                    class Test {
+                        void plot(MyFunction<Point.ref, Color> f) {}
+                        void m() {
+                            MyFunction<Point, Color> gradient = p -> Color.gray();
+                            plot(gradient);
+                        }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MyFunction<__universal T, __universal R> {
+                        R apply(T t);
+                    }
+                    primitive class Point {}
+                    class Color {
+                        static Color gray() { return new Color(); }
+                    }
+                    class Test {
+                        void plot(MyFunction<Point, Color> f) {}
+                        void m() {
+                            MyFunction<Point.ref, Color> gradient = p -> Color.gray();
+                            plot(gradient);
+                        }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MySupplier<__universal S> {
+                        S get();
+                    }
+                    class Test<__universal T> {
+                        void m() {
+                            MySupplier<? extends T.ref> factory = nullFactory();
+                        }
+                        MySupplier<? extends T> nullFactory() { return () -> null; }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MySupplier<__universal S> {
+                        S get();
+                    }
+                    class Test<__universal T> {
+                        void m() {
+                            MySupplier<? extends T> factory = nullFactory();
+                        }
+                        MySupplier<? extends T.ref> nullFactory() { return () -> null; }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MySet<__universal E> {}
+                    interface MyMap<__universal K, __universal V> {
+                        interface Entry<__universal K, __universal V> {}
+                    }
+                    class Test<__universal T> {
+                        MySet<MyMap.Entry<String, T.ref>> allEntries() { return null; }
+                        void m() {
+                            MySet<MyMap.Entry<String, T>> entries = allEntries();
+                        }
+                    }
+                    """),
+                new DiagAndCode("compiler.warn.prob.found.req",
+                    """
+                    interface MySet<__universal E> {}
+                    interface MyMap<__universal K, __universal V> {
+                        interface Entry<__universal K, __universal V> {}
+                    }
+                    class Test<__universal T> {
+                        MySet<MyMap.Entry<String, T>> allEntries() { return null; }
+                        void m() {
+                            MySet<MyMap.Entry<String, T.ref>> entries = allEntries();
+                        }
+                    }
                     """)
                 )) {
             testHelper(LINT_OPTIONS, diagAndCode.diag, TestResult.COMPILE_WITH_WARNING, diagAndCode.code);


### PR DESCRIPTION
no warning is shown for parameterized conversions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Maurizio Cimadamore](https://openjdk.java.net/census#mcimadamore) (@mcimadamore - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/666/head:pull/666` \
`$ git checkout pull/666`

Update a local copy of the PR: \
`$ git checkout pull/666` \
`$ git pull https://git.openjdk.java.net/valhalla pull/666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 666`

View PR using the GUI difftool: \
`$ git pr show -t 666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/666.diff">https://git.openjdk.java.net/valhalla/pull/666.diff</a>

</details>
