### PR TITLE
8282695: [lworld] assert(oopDesc::is_oop(obj)) in compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java

### DIFF
--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -135,11 +135,11 @@ arrayOop oopFactory::new_valueArray(Klass* k, int length, TRAPS) {
 
   arrayOop oop;
   if (array_klass->is_flatArray_klass()) {
-    oop = (arrayOop) FlatArrayKlass::cast(array_klass)->allocate(length, THREAD);
+    oop = (arrayOop) FlatArrayKlass::cast(array_klass)->allocate(length, CHECK_NULL);
     assert(oop == NULL || oop->is_flatArray(), "sanity");
     assert(oop == NULL || oop->klass()->is_flatArray_klass(), "sanity");
   } else {
-    oop = (arrayOop) ObjArrayKlass::cast(array_klass)->allocate(length, THREAD);
+    oop = (arrayOop) ObjArrayKlass::cast(array_klass)->allocate(length, CHECK_NULL);
   }
   assert(oop == NULL || oop->klass()->is_null_free_array_klass(), "sanity");
   assert(oop == NULL || oop->is_null_free_array(), "sanity");

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -184,7 +184,8 @@ objArrayOop ObjArrayKlass::allocate(int length, TRAPS) {
   size_t size = objArrayOopDesc::object_size(length);
   bool populate_null_free = is_null_free_array_klass();
   objArrayOop array =  (objArrayOop)Universe::heap()->array_allocate(this, size, length,
-                                                       /* do_zero */ true, THREAD);
+                                                       /* do_zero */ true, CHECK_NULL);
+  objArrayHandle array_h(THREAD, array);
   if (populate_null_free) {
     assert(dimension() == 1, "Can only populate the final dimension");
     assert(element_klass()->is_inline_klass(), "Unexpected");
@@ -192,13 +193,12 @@ objArrayOop ObjArrayKlass::allocate(int length, TRAPS) {
     assert(!InlineKlass::cast(element_klass())->flatten_array(), "Expected flatArrayOop allocation");
     element_klass()->initialize(CHECK_NULL);
     // Populate default values...
-    objArrayHandle array_h(THREAD, array);
     instanceOop value = (instanceOop) InlineKlass::cast(element_klass())->default_value();
     for (int i = 0; i < length; i++) {
       array_h->obj_at_put(i, value);
     }
   }
-  return array;
+  return array_h();
 }
 
 oop ObjArrayKlass::multi_allocate(int rank, jint* sizes, TRAPS) {


### PR DESCRIPTION
Please review this small patch fixing a naked oop and some missing pending exception checks.

Tested with Mach5, Tier 3 (the one where the failures were the most frequent).

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282695](https://bugs.openjdk.java.net/browse/JDK-8282695): [lworld] assert(oopDesc::is_oop(obj)) in compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/668/head:pull/668` \
`$ git checkout pull/668`

Update a local copy of the PR: \
`$ git checkout pull/668` \
`$ git pull https://git.openjdk.java.net/valhalla pull/668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 668`

View PR using the GUI difftool: \
`$ git pr show -t 668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/668.diff">https://git.openjdk.java.net/valhalla/pull/668.diff</a>

</details>
