### PR TITLE
changing universal lint warning to unchecked warning

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -630,9 +630,8 @@ public class Types {
                     !t.hasTag(BOT) && isSubtype(t, allowUniversalTVars && (tUndet || sUndet) ? s : s.referenceProjection());
             if (result && (allowUniversalTVars && !t.hasTag(BOT) &&
                     s.isPrimitiveClass() && !t.isPrimitiveClass() &&
-                    s.referenceProjectionOrSelf().tsym == t.tsym) &&
-                    warn != noWarnings) {
-                chk.warnUniversalTVar(warn.pos(), Warnings.PrimitiveValueConversion);
+                    s.referenceProjectionOrSelf().tsym == t.tsym)) {
+                chk.warnUnchecked(warn.pos(), Warnings.PrimitiveValueConversion);
             }
             return result;
         }

--- a/test/langtools/tools/javac/diags/examples/PrimitiveValueConversionTest.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveValueConversionTest.java
@@ -22,7 +22,7 @@
  */
 
 // key: compiler.warn.primitive.value.conversion
-// options: -Xlint:universal
+// options: -Xlint:unchecked
 
 class PrimitiveValueConversionTest {
     primitive class Point {}

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8237072
  * @summary Test various relationships between a value type and its reference projection.
- * @compile/fail/ref=GenericInlineTest.out -XDrawDiagnostics GenericInlineTest.java
+ * @compile/fail/ref=GenericInlineTest.out -XDrawDiagnostics -Xlint:unchecked GenericInlineTest.java
  */
 
 abstract class Low<T, U> {}
@@ -13,7 +13,7 @@ primitive
 class GenericInlineTest<T, U> extends High<U, T> {
 
     int x = 0;
-    @SuppressWarnings("universal")
+
     void foo() {
 
         GenericInlineTest<String, Integer> g = new GenericInlineTest<String, Integer>();

--- a/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/GenericInlineTest.out
@@ -3,6 +3,8 @@ GenericInlineTest.java:27:35: compiler.err.prob.found.req: (compiler.misc.inconv
 GenericInlineTest.java:29:35: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: GenericInlineTest<java.lang.String,java.lang.Integer>, Low<java.lang.String,java.lang.Integer>)
 GenericInlineTest.java:33:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: Low<java.lang.Integer,java.lang.String>, GenericInlineTest<java.lang.String,java.lang.Integer>)
 GenericInlineTest.java:37:53: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: GenericInlineTest<java.lang.String,java.lang.Integer>, GenericInlineTest.ref<java.lang.Integer,java.lang.String>)
+GenericInlineTest.java:39:13: compiler.warn.primitive.value.conversion
 GenericInlineTest.java:40:13: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: GenericInlineTest.ref<java.lang.Integer,java.lang.String>, GenericInlineTest<java.lang.String,java.lang.Integer>)
 GenericInlineTest.java:41:50: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: GenericInlineTest.ref<java.lang.Integer,java.lang.String>, GenericInlineTest<java.lang.String,java.lang.Integer>)
 7 errors
+1 warning

--- a/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/Rectangle.java
@@ -29,7 +29,7 @@ public primitive class Rectangle {
 
     static Point origin;
 
-    @SuppressWarnings("universal")
+    @SuppressWarnings("unchecked")
     static Rectangle from (Point.ref topLeft, Point.ref bottomRight) {
         return new Rectangle(topLeft, bottomRight);
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.java
@@ -2,11 +2,10 @@
  * @test /nodynamiccopyright/
  * @bug 8222792
  * @summary Javac should enforce the latest relationship rules between an inline type and its nullable projection
- * @compile/fail/ref=TypeRelationsNegativeTest.out -XDrawDiagnostics TypeRelationsNegativeTest.java
+ * @compile/fail/ref=TypeRelationsNegativeTest.out -XDrawDiagnostics -Xlint:unchecked TypeRelationsNegativeTest.java
  */
 
 final primitive class TypeRelationsNegativeTest {
-    @SuppressWarnings("universal")
     void foo() {
         TypeRelationsNegativeTest x = null; // error
         TypeRelationsNegativeTest.ref xq = null;

--- a/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TypeRelationsNegativeTest.out
@@ -1,4 +1,7 @@
-TypeRelationsNegativeTest.java:11:39: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, TypeRelationsNegativeTest)
-TypeRelationsNegativeTest.java:21:77: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, TypeRelationsNegativeTest)
-TypeRelationsNegativeTest.java:26:14: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TypeRelationsNegativeTest.ref[], TypeRelationsNegativeTest[])
+TypeRelationsNegativeTest.java:10:39: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, TypeRelationsNegativeTest)
+TypeRelationsNegativeTest.java:16:13: compiler.warn.primitive.value.conversion
+TypeRelationsNegativeTest.java:17:13: compiler.warn.primitive.value.conversion
+TypeRelationsNegativeTest.java:20:77: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, TypeRelationsNegativeTest)
+TypeRelationsNegativeTest.java:25:14: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: TypeRelationsNegativeTest.ref[], TypeRelationsNegativeTest[])
 3 errors
+2 warnings

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassBytecodeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassBytecodeTest.java
@@ -41,7 +41,6 @@ public class UnifiedPrimitiveClassBytecodeTest {
 
         X.ref xr = null;
 
-        @SuppressWarnings("universal")
         public void foo(X.ref[] xra, X[] xa) {
             xa = new X[10];
             xra = new X.ref[10];

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline128int.java
@@ -45,7 +45,6 @@ public class Inline128int extends StatesQ128int {
         System.arraycopy(s.arr, 0, d.arr, 0, s.arr.length);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64byte.java
@@ -45,7 +45,6 @@ public class Inline64byte extends StatesQ64byte {
         System.arraycopy(s.arr, 0, d.arr, 0, s.arr.length);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64int.java
@@ -45,7 +45,6 @@ public class Inline64int extends StatesQ64int {
         System.arraycopy(s.arr, 0, d.arr, 0, s.arr.length);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/InlineOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/InlineOpt.java
@@ -46,7 +46,6 @@ public class InlineOpt extends StatesQOpt {
         System.arraycopy(s.arr, 0, d.arr, 0, s.arr.length);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline128int.java
@@ -70,7 +70,6 @@ public class Inline128int extends StatesQ128int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat(Val_as_Val st) {
@@ -89,7 +88,6 @@ public class Inline128int extends StatesQ128int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst(Val_as_Val st, RefInstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline32int.java
@@ -70,7 +70,6 @@ public class Inline32int extends StatesQ32int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat(Val_as_Val st) {
@@ -89,7 +88,6 @@ public class Inline32int extends StatesQ32int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst(Val_as_Val st, RefInstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64byte.java
@@ -70,7 +70,6 @@ public class Inline64byte extends StatesQ64byte {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat(Val_as_Val st) {
@@ -89,7 +88,6 @@ public class Inline64byte extends StatesQ64byte {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst(Val_as_Val st, RefInstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64int.java
@@ -70,7 +70,6 @@ public class Inline64int extends StatesQ64int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat(Val_as_Val st) {
@@ -89,7 +88,6 @@ public class Inline64int extends StatesQ64int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst(Val_as_Val st, RefInstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/InlineOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/InlineOpt.java
@@ -72,7 +72,6 @@ public class InlineOpt extends StatesQOpt {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat(Val_as_Val st) {
@@ -91,7 +90,6 @@ public class InlineOpt extends StatesQOpt {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst(Val_as_Val st, RefInstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline128int.java
@@ -69,7 +69,6 @@ public class Inline128int extends StatesQ128int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline32int.java
@@ -69,7 +69,6 @@ public class Inline32int extends StatesQ32int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline64byte.java
@@ -69,7 +69,6 @@ public class Inline64byte extends StatesQ64byte {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline64int.java
@@ -69,7 +69,6 @@ public class Inline64int extends StatesQ64int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline128int.java
@@ -57,7 +57,6 @@ public class Inline128int extends StatesQ128int {
         return new Q128int(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline32int.java
@@ -57,7 +57,6 @@ public class Inline32int extends StatesQ32int {
         return new Q32int(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline64byte.java
@@ -57,7 +57,6 @@ public class Inline64byte extends StatesQ64byte {
         return new Q64byte(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline64int.java
@@ -57,7 +57,6 @@ public class Inline64int extends StatesQ64int {
         return new Q64int(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy0.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy0.java
@@ -820,7 +820,6 @@ public class InlineCopy0 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
@@ -921,7 +920,6 @@ public class InlineCopy0 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy1.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy1.java
@@ -741,7 +741,6 @@ public class InlineCopy1 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
@@ -832,7 +831,6 @@ public class InlineCopy1 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy2.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy2.java
@@ -811,7 +811,6 @@ public class InlineCopy2 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Ref_copy(Ref_as_Ref s, Val_as_Ref d) {
@@ -822,7 +821,6 @@ public class InlineCopy2 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
@@ -923,7 +921,6 @@ public class InlineCopy2 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy3.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy3.java
@@ -741,7 +741,6 @@ public class InlineCopy3 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
@@ -832,7 +831,6 @@ public class InlineCopy3 extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstRef.java
@@ -40,7 +40,6 @@ public class Inline64longFillInstRef extends StatesQ64long {
         Q64long.ref f = new Q64long(42);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst0(Val_as_Val st, InstanceField f) {
@@ -50,7 +49,6 @@ public class Inline64longFillInstRef extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillinst1(Val_as_Val st, InstanceField f) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillRef.java
@@ -37,7 +37,6 @@ public class Inline64longFillRef extends StatesQ64long {
         return new Q64long(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fill0(Val_as_Val st) {
@@ -48,7 +47,6 @@ public class Inline64longFillRef extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fill1(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatRef.java
@@ -36,7 +36,6 @@ public class Inline64longFillStatRef extends StatesQ64long {
         static Q64long.ref f = new Q64long(42);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat0(Val_as_Val st) {
@@ -46,7 +45,6 @@ public class Inline64longFillStatRef extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fillstat1(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/read/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/read/Inline64long.java
@@ -82,7 +82,6 @@ public class Inline64long extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
@@ -146,7 +145,6 @@ public class Inline64long extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_as_Ref_to_Val_read(Ref_as_Ref st) {

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetRef.java
@@ -35,7 +35,6 @@ public class Inline64longSetRef extends StatesQ64long {
         return new Q64long(i);
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set0(Val_as_Val st) {
@@ -45,7 +44,6 @@ public class Inline64longSetRef extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_set1(Val_as_Val st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline128int.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.CompilerControl;
 
 public class Inline128int extends StatesQ128int {
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(RefState s, ValState d) {

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline32int.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.CompilerControl;
 
 public class Inline32int extends StatesQ32int {
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(RefState s, ValState d) {

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64byte.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.CompilerControl;
 
 public class Inline64byte extends StatesQ64byte {
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(RefState s, ValState d) {

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64int.java
@@ -28,7 +28,6 @@ import org.openjdk.jmh.annotations.CompilerControl;
 
 public class Inline64int extends StatesQ64int {
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(RefState s, ValState d) {

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64long.java
@@ -140,7 +140,6 @@ public class Inline64long extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(RefState s, ValState d) {

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline128int.java
@@ -55,7 +55,6 @@ public class Inline128int extends StatesQ128int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_read(RefState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline32int.java
@@ -55,7 +55,6 @@ public class Inline32int extends StatesQ32int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_read(RefState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64byte.java
@@ -55,7 +55,6 @@ public class Inline64byte extends StatesQ64byte {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_read(RefState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64int.java
@@ -55,7 +55,6 @@ public class Inline64int extends StatesQ64int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_read(RefState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64long.java
@@ -82,7 +82,6 @@ public class Inline64long extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_read(RefState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline128int.java
@@ -48,7 +48,6 @@ public class Inline128int extends StatesQ128int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_set(ValState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline32int.java
@@ -48,7 +48,6 @@ public class Inline32int extends StatesQ32int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_set(ValState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64byte.java
@@ -48,7 +48,6 @@ public class Inline64byte extends StatesQ64byte {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_set(ValState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64int.java
@@ -48,7 +48,6 @@ public class Inline64int extends StatesQ64int {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_set(ValState st) {

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64long.java
@@ -77,7 +77,6 @@ public class Inline64long extends StatesQ64long {
         }
     }
 
-    @SuppressWarnings("universal")
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_set(ValState st) {


### PR DESCRIPTION
A `universal` lint warning was being issue instead of an unchecked one, this patch is fixing this bug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/671/head:pull/671` \
`$ git checkout pull/671`

Update a local copy of the PR: \
`$ git checkout pull/671` \
`$ git pull https://git.openjdk.java.net/valhalla pull/671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 671`

View PR using the GUI difftool: \
`$ git pr show -t 671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/671.diff">https://git.openjdk.java.net/valhalla/pull/671.diff</a>

</details>
