### PR TITLE
8265121: [lworld] Better optimize null-checks in C1

### DIFF
--- a/src/hotspot/share/c1/c1_CFGPrinter.cpp
+++ b/src/hotspot/share/c1/c1_CFGPrinter.cpp
@@ -244,13 +244,11 @@ void CFGPrinterOutput::print_block(BlockBegin* block) {
   output()->cr();
 
   output()->indent();
+  output()->print("successors ");
   if (block->end() != NULL) {
-    output()->print("successors ");
     for (i = 0; i < block->number_of_sux(); i++) {
       output()->print("\"B%d\" ", block->sux_at(i)->block_id());
     }
-  } else {
-    output()->print("(block has no end, cannot print successors)");
   }
   output()->cr();
 

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -640,7 +640,7 @@ void Canonicalizer::do_Convert        (Convert*         x) {
 }
 
 void Canonicalizer::do_NullCheck      (NullCheck*       x) {
-  if (x->obj()->as_NewArray() != NULL || x->obj()->as_NewInstance() != NULL) {
+  if (x->obj()->as_NewArray() != NULL || x->obj()->as_NewInstance() != NULL || x->obj()->as_NewInlineTypeInstance()) {
     set_canonical(x->obj());
   } else {
     Constant* con = x->obj()->as_Constant();
@@ -692,7 +692,7 @@ void Canonicalizer::do_InstanceOf     (InstanceOf*      x) {
   if (x->klass()->is_loaded()) {
     Value obj = x->obj();
     ciType* exact = obj->exact_type();
-    if (exact != NULL && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray())) {
+    if (exact != NULL && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray() || obj->as_NewInlineTypeInstance())) {
       set_constant(exact->is_subtype_of(x->klass()) ? 1 : 0);
       return;
     }
@@ -815,7 +815,7 @@ void Canonicalizer::do_If(If* x) {
       }
     }
   } else if (rt == objectNull &&
-           (l->as_NewInstance() || l->as_NewArray() ||
+           (l->as_NewInstance() || l->as_NewArray() || l->as_NewInlineTypeInstance() ||
              (l->as_Local() && l->as_Local()->is_receiver()))) {
     if (x->cond() == Instruction::eql) {
       BlockBegin* sux = x->fsux();

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2788,7 +2788,7 @@ Instruction* GraphBuilder::append_split(StateSplit* instr) {
 
 
 void GraphBuilder::null_check(Value value) {
-  if (value->as_NewArray() != NULL || value->as_NewInstance() != NULL) {
+  if (value->as_NewArray() != NULL || value->as_NewInstance() != NULL || value->as_NewInlineTypeInstance()) {
     return;
   } else {
     Constant* con = value->as_Constant();
@@ -2801,6 +2801,7 @@ void GraphBuilder::null_check(Value value) {
         }
       }
     }
+    if (value->is_null_free()) return;
   }
   append(new NullCheck(value, copy_state_for_exception()));
 }


### PR DESCRIPTION
Please review those small changes in C1 that eliminates a few more unnecessary null checks.
I've experimented some changes in the NullCheckEliminator to handle inline types explicitly,
but it had no effect on generated code, in all cases, existing null check eliminations were already
sufficient to remove unnecessary checks.

The changeset also reverts a change in the CFG file generation which makes log file unreadable
by the C1Visualizer tool.

Tested with Mach5, tier1-3.

Thank you.

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8265121](https://bugs.openjdk.java.net/browse/JDK-8265121): [lworld] Better optimize null-checks in C1


### Reviewers
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/672/head:pull/672` \
`$ git checkout pull/672`

Update a local copy of the PR: \
`$ git checkout pull/672` \
`$ git pull https://git.openjdk.java.net/valhalla pull/672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 672`

View PR using the GUI difftool: \
`$ git pr show -t 672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/672.diff">https://git.openjdk.java.net/valhalla/pull/672.diff</a>

</details>
