### PR TITLE
JDK-8284000: [lworld] sun/reflect/ReflectionFactory/ReflectionFactoryTest.java fails after JDK-8283573

### DIFF
--- a/test/jdk/sun/reflect/ReflectionFactory/ReflectionFactoryTest.java
+++ b/test/jdk/sun/reflect/ReflectionFactory/ReflectionFactoryTest.java
@@ -88,7 +88,10 @@ public class ReflectionFactoryTest {
         Constructor<?> c = factory.newConstructorForSerialization(type);
 
         Object o = c.newInstance();
-        Assert.assertEquals(o.getClass(), type, "Instance is wrong type");
+        // java.lang.Object is an abstract class.  For compatibility reason,
+        // newInstance is supported on Object.class and returns a new Identity instance.
+        Class<?> expectedType = type == Object.class ? Identity.class : type;
+        Assert.assertEquals(o.getClass(), expectedType, "Instance is wrong type");
         if (o instanceof Foo) {
             Foo foo = (Foo)o;
             foo.check();


### PR DESCRIPTION
The ReflectionFactory.java test fails in checking the declaring class of an instance returned from calling `Class::newInstance` on `Object.class`.   The test should check for `Identity.class` instead.

A separate JBS issue will follow up the impact to the core reflection API and `sun.reflect.ReflectionFactory` API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8284000](https://bugs.openjdk.java.net/browse/JDK-8284000): [lworld] sun/reflect/ReflectionFactory/ReflectionFactoryTest.java fails after JDK-8283573


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/674/head:pull/674` \
`$ git checkout pull/674`

Update a local copy of the PR: \
`$ git checkout pull/674` \
`$ git pull https://git.openjdk.java.net/valhalla pull/674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 674`

View PR using the GUI difftool: \
`$ git pr show -t 674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/674.diff">https://git.openjdk.java.net/valhalla/pull/674.diff</a>

</details>
