### PR TITLE
8284159: [lworld] C2 failures with migrated wrapper classes

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -754,8 +754,9 @@ Node* InlineTypeNode::make_from_oop(GraphKit* kit, Node* oop, ciInlineKlass* vk,
     Node* init_ctl = kit->control();
     vt->set_is_init(gvn);
     vt->load(kit, oop, oop, vk, /* holder_offset */ 0);
-    assert(!null_free || vt->as_InlineType()->is_default(&gvn) || init_ctl != kit->control() || !gvn.type(oop)->is_inlinetypeptr() || oop->is_Con() || oop->Opcode() == Op_InlineTypePtr ||
-           AllocateNode::Ideal_allocation(oop, &gvn) != NULL || vt->as_InlineType()->is_loaded(&gvn) == oop, "inline type should be loaded");
+// TODO fix with JDK-8278390
+//    assert(!null_free || vt->as_InlineType()->is_default(&gvn) || init_ctl != kit->control() || !gvn.type(oop)->is_inlinetypeptr() || oop->is_Con() || oop->Opcode() == Op_InlineTypePtr ||
+//           AllocateNode::Ideal_allocation(oop, &gvn) != NULL || vt->as_InlineType()->is_loaded(&gvn) == oop, "inline type should be loaded");
   }
   assert(!null_free || vt->is_allocated(&gvn), "inline type should be allocated");
   kit->record_for_igvn(vt);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4758,8 +4758,12 @@ const TypeAryPtr* TypeAryPtr::cast_to_autobox_cache() const {
   if (is_autobox_cache())  return this;
   const TypeOopPtr* etype = elem()->make_oopptr();
   if (etype == NULL)  return this;
-  // The pointers in the autobox arrays are always non-null.
-  etype = etype->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
+  // TODO fix with JDK-8284164
+  // Ignore inline types to not confuse logic in TypeAryPtr::compute_klass
+  if (!etype->is_inlinetypeptr()) {
+    // The pointers in the autobox arrays are always non-null.
+    etype = etype->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
+  }
   const TypeAry* new_ary = TypeAry::make(etype, size(), is_stable(), is_not_flat(), is_not_null_free());
   return make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset, _instance_id, _speculative, _inline_depth, /*is_autobox_cache=*/true);
 }


### PR DESCRIPTION
This patch adds workaround for two issues in C2 that block investigations for migrating wrapper classes like `java.lang.Integer` to values classes:
- Disabled a too strong assert that will be fixed by [JDK-8278390](https://bugs.openjdk.java.net/browse/JDK-8278390)
- Disabled the code that casts autobox cache elements to non-null if they are inline types because that confuses the logic in `TypeAryPtr::compute_klass` that attempts to infer the array type from the element type. This will be properly fixed by [JDK-8284164](https://bugs.openjdk.java.net/browse/JDK-8284164).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8284159](https://bugs.openjdk.java.net/browse/JDK-8284159): [lworld] C2 failures with migrated wrapper classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/677/head:pull/677` \
`$ git checkout pull/677`

Update a local copy of the PR: \
`$ git checkout pull/677` \
`$ git pull https://git.openjdk.java.net/valhalla pull/677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 677`

View PR using the GUI difftool: \
`$ git pr show -t 677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/677.diff">https://git.openjdk.java.net/valhalla/pull/677.diff</a>

</details>
