### PR TITLE
JDK-8284019: [lworld] Constructor::newInstance on abstract Object class throws InstantiationException

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -183,7 +183,7 @@ public class ReflectionFactory {
 
     public ConstructorAccessor newConstructorAccessor(Constructor<?> c) {
         Class<?> declaringClass = c.getDeclaringClass();
-        if (Modifier.isAbstract(declaringClass.getModifiers())) {
+        if (Modifier.isAbstract(declaringClass.getModifiers()) && declaringClass != Object.class) {
             return new InstantiationExceptionConstructorAccessorImpl(null);
         }
         if (declaringClass == Class.class) {

--- a/test/jdk/valhalla/valuetypes/ObjectNewInstance.java
+++ b/test/jdk/valhalla/valuetypes/ObjectNewInstance.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng/othervm ObjectNewInstance
+ * @summary Method handle and core reflection to invoke on the constructor of
+ *          java.lang.Object (abstract class) should return an Identity instance
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class ObjectNewInstance {
+    @Test
+    public void classNewInstance() throws ReflectiveOperationException {
+        Object o = Object.class.newInstance();
+        assertTrue(o.getClass() == Identity.class);
+    }
+
+    @Test
+    public void constructorNewInstance() throws ReflectiveOperationException {
+        Constructor<Object> ctor = Object.class.getDeclaredConstructor();
+        Object o = ctor.newInstance();
+        assertTrue(o.getClass() == Identity.class);
+    }
+
+    @Test
+    public void methodHandle() throws Throwable {
+        MethodHandle mh = MethodHandles.publicLookup()
+                                       .findConstructor(Object.class, MethodType.methodType(void.class));
+        Object o = mh.invokeExact();
+        assertTrue(o.getClass() == Identity.class);
+    }
+}


### PR DESCRIPTION
The implementation of `Constructor::newInstance` throws InstantiationException for any abstract class.   `Object.class` should be a special case that `DirectConstructorHandleAccessor` should be created instead of `InstantiationExceptionConstructorAccessorImpl`.  The method handle accessor for `Object`'s constructor already returns an Identity instance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8284019](https://bugs.openjdk.java.net/browse/JDK-8284019): [lworld] Constructor::newInstance on abstract Object class throws InstantiationException


### Reviewers
 * [Frederic Parain](https://openjdk.java.net/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/679/head:pull/679` \
`$ git checkout pull/679`

Update a local copy of the PR: \
`$ git checkout pull/679` \
`$ git pull https://git.openjdk.java.net/valhalla pull/679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 679`

View PR using the GUI difftool: \
`$ git pr show -t 679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/679.diff">https://git.openjdk.java.net/valhalla/pull/679.diff</a>

</details>
