### PR TITLE
8284040: Allow 'super()' calls in "empty" constructors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -140,8 +140,8 @@ public class Flags {
     public static final int HASINITBLOCK         = 1<<18;
 
     /** Flag is set for a method symbol if it is an empty no-arg ctor.
-     *  i.e one that simply returns (jlO) or merely chains to a super's
-     *  EMPTYNOARGCONSTR
+     *  i.e. one that simply returns (jlO) or merely chains to a super's
+     *  no-arg ctor
      */
     public static final int EMPTYNOARGCONSTR         = 1<<18;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2380,12 +2380,8 @@ public class Types {
                                 return true;
                             } else if (s.isConstructor()) {
                                 MethodSymbol m = (MethodSymbol)s;
-                                if (m.getParameters().size() > 0) {
+                                if (m.getParameters().size() > 0 || (m.flags() & EMPTYNOARGCONSTR) == 0) {
                                     return true;
-                                } else {
-                                    if ((m.flags() & (GENERATEDCONSTR | EMPTYNOARGCONSTR)) == 0) {
-                                        return true;
-                                    }
                                 }
                             }
                             break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -794,7 +794,7 @@ public class Check {
                         if (m.getParameters().size() > 0) {
                             log.error(pos, Errors.SuperConstructorCannotTakeArguments(m, c, st));
                         } else {
-                            if ((m.flags() & (GENERATEDCONSTR | EMPTYNOARGCONSTR)) == 0) {
+                            if ((m.flags() & EMPTYNOARGCONSTR) == 0) {
                                 log.error(pos, Errors.SuperNoArgConstructorMustBeEmpty(m, c, st));
                             }
                         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -231,9 +231,17 @@ public class MemberEnter extends JCTree.Visitor {
         }
 
         if (m.isConstructor() && m.type.getParameterTypes().size() == 0) {
-            if (tree.body.stats.size() == 0 || (m.flags() & GENERATEDCONSTR) != 0) {
-                // generated constructors do have a super() call, but these are ignored for value classes.
+            int statsSize = tree.body.stats.size();
+            if (statsSize == 0) {
                 m.flags_field |= EMPTYNOARGCONSTR;
+            } else if (statsSize == 1 && TreeInfo.isSuperCall(tree.body.stats.head)) {
+                JCExpressionStatement exec = (JCExpressionStatement) tree.body.stats.head;
+                JCMethodInvocation meth = (JCMethodInvocation)exec.expr;
+                if (meth.args.size() == 0) {
+                    // Deem a constructor "empty" even if it contains a 'super' call,
+                    // as long as it has no argument expressions (to respect common coding style).
+                    m.flags_field |= EMPTYNOARGCONSTR;
+                }
             }
         }
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassConstraints.out
@@ -1,9 +1,8 @@
 SuperclassConstraints.java:14:15: compiler.err.concrete.supertype.for.value.class: SuperclassConstraints.I0, SuperclassConstraints.BadSuper
 SuperclassConstraints.java:44:15: compiler.err.super.field.not.allowed: x, SuperclassConstraints.I6, SuperclassConstraints.SuperWithInstanceField
-SuperclassConstraints.java:68:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithEmptyNoArgCtor_01(), SuperclassConstraints.I8, SuperclassConstraints.SuperWithEmptyNoArgCtor_01
 SuperclassConstraints.java:76:15: compiler.err.super.no.arg.constructor.must.be.empty: SuperclassConstraints.SuperWithNonEmptyNoArgCtor(), SuperclassConstraints.I9, SuperclassConstraints.SuperWithNonEmptyNoArgCtor
 SuperclassConstraints.java:85:15: compiler.err.super.constructor.cannot.take.arguments: SuperclassConstraints.SuperWithArgedCtor(java.lang.String), SuperclassConstraints.I10, SuperclassConstraints.SuperWithArgedCtor
 SuperclassConstraints.java:98:15: compiler.err.super.class.declares.init.block: SuperclassConstraints.I11, SuperclassConstraints.SuperWithInstanceInit
 SuperclassConstraints.java:106:15: compiler.err.super.method.cannot.be.synchronized: foo(), SuperclassConstraints.I12, SuperclassConstraints.SuperWithSynchronizedMethod
 SuperclassConstraints.java:110:15: compiler.err.super.class.cannot.be.inner: SuperclassConstraints.I13, SuperclassConstraints.InnerSuper
-8 errors
+7 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/PermitsValueTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/PermitsValueTest.java
@@ -82,12 +82,18 @@ public class PermitsValueTest {
     }
 
     static abstract class A10 {
-        // Not ACC_PERMITS_VALUE as it defines a non empty constructor.
+        // ACC_PERMITS_VALUE as its constructor is deemed empty due to mere vacuous chaining.
         A10() {
             super();
         }
     }
-
+    static abstract class A10_Alt {
+        // Not ACC_PERMITS_VALUE as it defines a non empty constructor.
+        A10_Alt() {
+            super();
+            System.out.println("");
+        }
+    }
     static abstract class A11 { // Permits value.
         static int f; // static field is OK.
         static {
@@ -155,6 +161,9 @@ public class PermitsValueTest {
             throw new Exception("ACC_PERMITS_VALUE flag should not be set!");
 
         cls = ClassFile.read(PermitsValueTest.class.getResourceAsStream("PermitsValueTest$A10.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_PERMITS_VALUE))
+            throw new Exception("ACC_PERMITS_VALUE flag should be set!");
+        cls = ClassFile.read(PermitsValueTest.class.getResourceAsStream("PermitsValueTest$A10_Alt.class"));
         if (cls.access_flags.is(AccessFlags.ACC_PERMITS_VALUE))
             throw new Exception("ACC_PERMITS_VALUE flag should not be set!");
 


### PR DESCRIPTION
Deem a constructor empty even when it contains a super() call as long as there are no arguments and the constructor is otherwise empty

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8284040](https://bugs.openjdk.java.net/browse/JDK-8284040): Allow 'super()' calls in "empty" constructors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/680/head:pull/680` \
`$ git checkout pull/680`

Update a local copy of the PR: \
`$ git checkout pull/680` \
`$ git pull https://git.openjdk.java.net/valhalla pull/680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 680`

View PR using the GUI difftool: \
`$ git pr show -t 680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/680.diff">https://git.openjdk.java.net/valhalla/pull/680.diff</a>

</details>
