### PR TITLE
8282569: [lworld] C2 asserts with "re-allocation should be removed by Ideal transformation"

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1039,7 +1039,7 @@ void InlineTypeNode::remove_redundant_allocations(PhaseIterGVN* igvn, PhaseIdeal
       if (res == NULL || !res->is_CheckCastPP()) {
         break; // No unique CheckCastPP
       }
-      assert(!is_default(igvn) && !is_allocated(igvn), "re-allocation should be removed by Ideal transformation");
+      assert((!is_default(igvn) || !inline_klass()->is_initialized()) && !is_allocated(igvn), "re-allocation should be removed by Ideal transformation");
       // Search for a dominating allocation of the same inline type
       Node* res_dom = res;
       for (DUIterator_Fast jmax, j = fast_outs(jmax); j < jmax; j++) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUninitializedValueClass.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUninitializedValueClass.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.valhalla.inlinetypes;
+
+/**
+ * @test
+ * @bug 8282569
+ * @summary Test that uninitialized default value class is properly handled by C2.
+ * @run main/othervm -XX:CompileCommand=compileonly,*::<init> -Xcomp -XX:-TieredCompilation
+ *                   compiler.valhalla.inlinetypes.TestUninitializedValueClass
+ */
+
+value class MyValue {
+    static final MyValue EMPTY = new MyValue();
+    int value = 0;
+}
+
+public class TestUninitializedValueClass {
+
+    public static void main(String[] args) {
+        MyValue unused = new MyValue();
+    }
+}


### PR DESCRIPTION
Fixed a too strong assert in C2 and added a corresponding test.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282569](https://bugs.openjdk.java.net/browse/JDK-8282569): [lworld] C2 asserts with "re-allocation should be removed by Ideal transformation"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/682/head:pull/682` \
`$ git checkout pull/682`

Update a local copy of the PR: \
`$ git checkout pull/682` \
`$ git pull https://git.openjdk.java.net/valhalla pull/682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 682`

View PR using the GUI difftool: \
`$ git pr show -t 682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/682.diff">https://git.openjdk.java.net/valhalla/pull/682.diff</a>

</details>
