### PR TITLE
8287203: Synthetic concrete classes generated by javac are lacking the ACC_IDENTITY bit.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -808,7 +808,7 @@ public class Lower extends TreeTranslator {
             if (isTranslatedClassAvailable(c))
                 continue;
             // Create class definition tree.
-            JCClassDecl cdec = makeEmptyClass(STATIC | SYNTHETIC,
+            JCClassDecl cdec = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE,
                     c.outermostClass(), c.flatname, false);
             swapAccessConstructorTag(c, cdec.sym);
             translated.append(cdec);
@@ -1289,7 +1289,7 @@ public class Lower extends TreeTranslator {
                                             i);
             ClassSymbol ctag = chk.getCompiled(topModle, flatname);
             if (ctag == null)
-                ctag = makeEmptyClass(STATIC | SYNTHETIC, topClass).sym;
+                ctag = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, topClass).sym;
             else if (!ctag.isAnonymous())
                 continue;
             // keep a record of all tags, to verify that all are generated as required
@@ -1871,7 +1871,7 @@ public class Lower extends TreeTranslator {
             if (sym.kind == TYP &&
                 sym.name == names.empty &&
                 (sym.flags() & INTERFACE) == 0) return (ClassSymbol) sym;
-        return makeEmptyClass(STATIC | SYNTHETIC, clazz).sym;
+        return makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, clazz).sym;
     }
 
     /** Create an attributed tree of the form left.name(). */
@@ -1923,7 +1923,7 @@ public class Lower extends TreeTranslator {
     private ClassSymbol assertionsDisabledClass() {
         if (assertionsDisabledClassCache != null) return assertionsDisabledClassCache;
 
-        assertionsDisabledClassCache = makeEmptyClass(STATIC | SYNTHETIC, outermostClassDef.sym).sym;
+        assertionsDisabledClassCache = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, outermostClassDef.sym).sym;
 
         return assertionsDisabledClassCache;
     }

--- a/test/langtools/tools/javac/classfiles/InnerClasses/SyntheticClasses.java
+++ b/test/langtools/tools/javac/classfiles/InnerClasses/SyntheticClasses.java
@@ -44,6 +44,11 @@ public class SyntheticClasses {
         File testClasses = new File(System.getProperty("test.classes"));
         for (File classFile : testClasses.listFiles(f -> f.getName().endsWith(".class"))) {
             ClassFile cf = ClassFile.read(classFile);
+            if ((cf.access_flags.flags & (AccessFlags.ACC_SYNTHETIC | AccessFlags.ACC_VALUE | AccessFlags.ACC_ABSTRACT)) == AccessFlags.ACC_SYNTHETIC) {
+                if ((cf.access_flags.flags & AccessFlags.ACC_IDENTITY) == 0) {
+                    throw new IllegalStateException("Missing ACC_IDENTITY on synthetic concrete identity class: " + cf.getName());
+                }
+            }
             if (cf.getName().matches(".*\\$[0-9]+")) {
                 EnclosingMethod_attribute encl =
                         (EnclosingMethod_attribute) cf.getAttribute(Attribute.EnclosingMethod);

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesTestBase.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesTestBase.java
@@ -302,7 +302,7 @@ public abstract class InnerClassesTestBase extends TestResult {
             if (hasSyntheticClass) {
                 // Source to generate synthetic classes
                 sb.append(syntheticClasses.stream().collect(Collectors.joining(" ", "{", "}")));
-                class2Flags.put("1", new HashSet<>(Arrays.asList("ACC_STATIC", "ACC_SYNTHETIC")));
+                class2Flags.put("1", new HashSet<>(Arrays.asList("ACC_STATIC", "ACC_IDENTITY", "ACC_SYNTHETIC")));
             }
             sb.append(suffix).append("\n}");
             getAdditionalFlags(class2Flags, outerClassType, outerMod.toArray(new Modifier[outerMod.size()]));


### PR DESCRIPTION
    Ensure that javac synthesized concrete identity classes carry the ACC_IDENTITY bit.
