### PR TITLE
8287241: Add IdentityException to report that a value object is not valid

### DIFF
--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -29,16 +29,18 @@ package java.lang;
  * Identity objects are required for synchronization and locking.
  * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">Value-based</a>
  * objects do not have identity and cannot be used for synchronization or locking.
+ *
+ * @since Valhalla
  */
 public class IdentityException extends RuntimeException {
     /**
-     * Create an IdentityException with no message.
+     * Create an {@code IdentityException} with no message.
      */
     public IdentityException() {
     }
 
     /**
-     * Create an IdentityException with the class name and default message.
+     * Create an {@code IdentityException} with the class name and default message.
      *
      * @param clazz the class of the object
      */
@@ -47,7 +49,7 @@ public class IdentityException extends RuntimeException {
     }
 
     /**
-     * Create an IdentityException with a message.
+     * Create an {@code IdentityException} with a message.
      *
      * @param  message the detail message; can be {@code null}
      */
@@ -56,7 +58,7 @@ public class IdentityException extends RuntimeException {
     }
 
     /**
-     * Create an IdentityException with a message and cause.
+     * Create an {@code IdentityException} with a message and cause.
      *
      * @param  message the detail message; can be {@code null}
      * @param  cause the cause; {@code null} is permitted, and indicates

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package java.lang;
+
+
+/**
+ * Thrown when an identity object is required but a value object is supplied.
+ * <p>
+ * Identity objects are required for synchronization and locking.
+ * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">Value-based</a>
+ * objects do not have identity and cannot be used for synchronization or locking.
+ */
+public class IdentityException extends RuntimeException {
+    /**
+     * Create an IdentityException with no message.
+     */
+    public IdentityException() {
+    }
+
+    /**
+     * Create an IdentityException with the class name and default message.
+     *
+     * @param clazz the class of the object
+     */
+    public IdentityException(Class<?> clazz) {
+        super(clazz.getName() + " is not an identity class");
+    }
+
+    /**
+     * Create an IdentityException with a message.
+     *
+     * @param  message the detail message; can be {@code null}
+     */
+    public IdentityException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create an IdentityException with a message and cause.
+     *
+     * @param  message the detail message; can be {@code null}
+     * @param  cause the cause; {@code null} is permitted, and indicates
+     *               that the cause is nonexistent or unknown.
+     */
+    public IdentityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -33,6 +33,9 @@ package java.lang;
  * @since Valhalla
  */
 public class IdentityException extends RuntimeException {
+    @java.io.Serial
+    private static final long serialVersionUID = 1L;
+
     /**
      * Create an {@code IdentityException} with no message.
      */
@@ -58,6 +61,16 @@ public class IdentityException extends RuntimeException {
     }
 
     /**
+     * Create an {@code IdentityException} with a cause.
+     *
+     * @param  cause the cause; {@code null} is permitted, and indicates
+     *               that the cause is nonexistent or unknown.
+     */
+    public IdentityException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
      * Create an {@code IdentityException} with a message and cause.
      *
      * @param  message the detail message; can be {@code null}
@@ -67,7 +80,4 @@ public class IdentityException extends RuntimeException {
     public IdentityException(String message, Throwable cause) {
         super(message, cause);
     }
-
-    @java.io.Serial
-    private static final long serialVersionUID = 1L;
 }

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -31,11 +31,17 @@ import jdk.internal.access.JavaLangRefAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.ref.Cleaner;
 
+import java.util.Objects;
+
 /**
  * Abstract base class for reference objects.  This class defines the
  * operations common to all reference objects.  Because reference objects are
  * implemented in close cooperation with the garbage collector, this class may
  * not be subclassed directly.
+ * <p>
+ * References can only refer to identity objects.
+ * Attempts to create a reference to a {@linkplain Class#isValue() value object}
+ * results in an {@link IdentityException}.
  *
  * @author   Mark Reinhold
  * @since    1.2
@@ -498,11 +504,8 @@ public abstract sealed class Reference<T>
     }
 
     Reference(T referent, ReferenceQueue<? super T> queue) {
-        if (referent != null && referent.getClass().isValue()) {
-            Class<?> c = referent.getClass();
-            throw new IllegalArgumentException("cannot reference a " +
-                    (c.isPrimitiveClass() ? "primitive class " : "value class ") +
-                    c.getName());
+        if (referent != null) {
+            Objects.requireIdentity(referent);
         }
         this.referent = referent;
         this.queue = (queue == null) ? ReferenceQueue.NULL : queue;

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -212,8 +212,8 @@ public final class Objects {
      * Checks that the specified object reference is an identity object.
      *
      * @param obj the object reference to check for identity
-     * @param message detail message to be used in the event that a {@code
-     *                IdentityException} is thrown
+     * @param message detail message to be used in the event that an
+     *        {@code IdentityException} is thrown
      * @param <T> the type of the reference
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
@@ -225,6 +225,27 @@ public final class Objects {
         Objects.requireNonNull(obj);
         if (obj.getClass().isValue())
             throw new IdentityException(message);
+        return obj;
+    }
+
+    /**
+     * Checks that the specified object reference is an identity object.
+     *
+     * @param obj the object reference to check for identity
+     * @param messageSupplier supplier of the detail message to be
+     *        used in the event that an {@code IdentityException} is thrown
+     * @param <T> the type of the reference
+     * @return {@code obj} if {@code obj} is an identity object
+     * @throws NullPointerException if {@code obj} is {@code null}
+     * @throws IdentityException if {@code obj} is not an identity object
+     * @since Valhalla
+     */
+    @ForceInline
+    public static <T> T requireIdentity(T obj, Supplier<String> messageSupplier) {
+        Objects.requireNonNull(obj);
+        if (obj.getClass().isValue())
+            throw new IdentityException(messageSupplier == null ?
+                    null : messageSupplier.get());
         return obj;
     }
 

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -190,6 +190,45 @@ public final class Objects {
     }
 
     /**
+     * Checks that the specified object reference is an identity object.
+     *
+     * @param obj the object reference to check for identity
+     * @param <T> the type of the reference
+     * @return {@code obj} if {@code obj} is an identity object
+     * @throws NullPointerException if {@code obj} is {@code null}
+     * @throws IdentityException if {@code obj} is not an identity object
+     * @since Valhalla
+     */
+    @ForceInline
+    public static <T> T requireIdentity(T obj) {
+        Objects.requireNonNull(obj);
+        var cl = obj.getClass();
+        if (cl.isValue())
+            throw new IdentityException(cl);
+        return obj;
+    }
+
+    /**
+     * Checks that the specified object reference is an identity object.
+     *
+     * @param obj the object reference to check for identity
+     * @param message detail message to be used in the event that a {@code
+     *                IdentityException} is thrown
+     * @param <T> the type of the reference
+     * @return {@code obj} if {@code obj} is an identity object
+     * @throws NullPointerException if {@code obj} is {@code null}
+     * @throws IdentityException if {@code obj} is not an identity object
+     * @since Valhalla
+     */
+    @ForceInline
+    public static <T> T requireIdentity(T obj, String message) {
+        Objects.requireNonNull(obj);
+        if (obj.getClass().isValue())
+            throw new IdentityException(message);
+        return obj;
+    }
+
+    /**
      * Returns 0 if the arguments are identical and {@code
      * c.compare(a, b)} otherwise.
      * Consequently, if both arguments are {@code null} 0

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -213,7 +213,7 @@ public final class Objects {
      *
      * @param obj the object reference to check for identity
      * @param message detail message to be used in the event that an
-     *        {@code IdentityException} is thrown
+     *        {@code IdentityException} is thrown; may be null
      * @param <T> the type of the reference
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}
@@ -233,7 +233,7 @@ public final class Objects {
      *
      * @param obj the object reference to check for identity
      * @param messageSupplier supplier of the detail message to be
-     *        used in the event that an {@code IdentityException} is thrown
+     *        used in the event that an {@code IdentityException} is thrown; may be null
      * @param <T> the type of the reference
      * @return {@code obj} if {@code obj} is an identity object
      * @throws NullPointerException if {@code obj} is {@code null}

--- a/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
+++ b/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
+++ b/test/jdk/valhalla/valuetypes/WeakReferenceTest.java
@@ -37,13 +37,13 @@ import static org.testng.Assert.*;
 @Test
 public class WeakReferenceTest {
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IdentityException.class)
     static void test1() {
         Point.ref p = new Point(10,20);
         WeakReference<Point.ref> r = new WeakReference<>(p);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IdentityException.class)
     static void test2() {
         ReferenceQueue<Object> q = new ReferenceQueue<>();
         Point.ref p = new Point(1,2);


### PR DESCRIPTION
Add class java.lang.IdentityException, when thrown indicates that an identity object was required but a value object was supplied.

Also add methods `java.util.Objects.requireIdentity(obj)` and `Objects.requireIdentity(obj, message)` to check and throw.

Updated java.lang.ref.Reference and related tests to use new exception and method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287241](https://bugs.openjdk.org/browse/JDK-8287241): Add IdentityException to report that a value object is not valid


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer) ⚠️ Review applies to [0785a81f](https://git.openjdk.org/valhalla/pull/696/files/0785a81fee0508db005c6151b63636680bc280c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/696/head:pull/696` \
`$ git checkout pull/696`

Update a local copy of the PR: \
`$ git checkout pull/696` \
`$ git pull https://git.openjdk.org/valhalla pull/696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 696`

View PR using the GUI difftool: \
`$ git pr show -t 696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/696.diff">https://git.openjdk.org/valhalla/pull/696.diff</a>

</details>
