### PR TITLE
8287330: (valhalla) Better modeling of access flags in core reflection

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.ObjectStreamField;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -1458,6 +1459,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @return the {@code int} representing the modifiers for this class
      * @see     java.lang.reflect.Modifier
+     * @see #accessFlags()
      * @see <a
      * href="{@docRoot}/java.base/java/lang/reflect/package-summary.html#LanguageJvmModel">Java
      * programming language and JVM modeling in core reflection</a>
@@ -1483,6 +1485,25 @@ public final class Class<T> implements java.io.Serializable,
      */
     native void setSigners(Object[] signers);
 
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag access
+     * flags} for this class, possibly empty}
+     * @see #getModifiers()
+     * @jvms 4.1 The ClassFile Structure
+     * @jvms 4.7.6 The InnerClasses Attribute
+     * @since 20
+     */
+    public Set<AccessFlag> accessFlags() {
+        // This likely needs some refinement. Exploration of hidden
+        // classes, array classes.  Location.CLASS allows SUPER and
+        // AccessFlag.MODULE which INNER_CLASS forbids. INNER_CLASS
+        // allows PRIVATE, PROTECTED, and STATIC, which are not
+        // allowed on Location.CLASS.
+        return AccessFlag.maskToAccessFlags(getModifiers(),
+                                            (isMemberClass() || isLocalClass() || isAnonymousClass()) ?
+                                            AccessFlag.Location.INNER_CLASS :
+                                            AccessFlag.Location.CLASS);
+    }
 
     /**
      * If this {@code Class} object represents a local or anonymous

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.AccessFlag;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -105,7 +106,7 @@ public class ModuleDescriptor
          * An open module. An open module does not declare any open packages
          * but the resulting module is treated as if all packages are open.
          */
-        OPEN,
+        OPEN(AccessFlag.OPEN.mask()),
 
         /**
          * An automatic module. An automatic module is treated as if it exports
@@ -114,19 +115,24 @@ public class ModuleDescriptor
          * @apiNote This modifier does not correspond to a module flag in the
          * binary form of a module declaration ({@code module-info.class}).
          */
-        AUTOMATIC,
+        AUTOMATIC(0 /* no flag per above comment */),
 
         /**
          * The module was not explicitly or implicitly declared.
          */
-        SYNTHETIC,
+        SYNTHETIC(AccessFlag.SYNTHETIC.mask()),
 
         /**
          * The module was implicitly declared.
          */
-        MANDATED;
-    }
+        MANDATED(AccessFlag.MANDATED.mask());
 
+        private int mask;
+        private Modifier(int mask) {
+            this.mask = mask;
+        }
+        private int mask() {return mask;}
+    }
 
     /**
      * <p> A dependence upon a module. </p>
@@ -152,28 +158,31 @@ public class ModuleDescriptor
              * module</i> to have an implicitly declared dependence on the module
              * named by the {@code Requires}.
              */
-            TRANSITIVE,
+            TRANSITIVE(AccessFlag.TRANSITIVE.mask()),
 
             /**
              * The dependence is mandatory in the static phase, during compilation,
              * but is optional in the dynamic phase, during execution.
              */
-            STATIC,
+            STATIC(AccessFlag.STATIC.mask()),
 
             /**
              * The dependence was not explicitly or implicitly declared in the
              * source of the module declaration.
              */
-            SYNTHETIC,
+            SYNTHETIC(AccessFlag.SYNTHETIC.mask()),
 
             /**
              * The dependence was implicitly declared in the source of the module
              * declaration.
              */
-            MANDATED;
-
+            MANDATED(AccessFlag.MANDATED.mask());
+            private int mask;
+            private Modifier(int mask) {
+                this.mask = mask;
+            }
+            private int mask() {return mask;}
         }
-
         private final Set<Modifier> mods;
         private final String name;
         private final Version compiledVersion;
@@ -201,6 +210,21 @@ public class ModuleDescriptor
          */
         public Set<Modifier> modifiers() {
             return mods;
+        }
+
+        /**
+         * {@return an unmodifiable set of the module {@linkplain AccessFlag
+         * requires flags, possibly empty}}
+         * @see #modifiers()
+         * @jvms 4.7.25 The Module Attribute
+         * @since 20
+         */
+        public Set<AccessFlag> accessFlags() {
+            int mask = 0;
+            for (var modifier : mods) {
+                mask |= modifier.mask();
+            }
+            return AccessFlag.maskToAccessFlags(mask, AccessFlag.Location.MODULE_REQUIRES);
         }
 
         /**
@@ -376,14 +400,19 @@ public class ModuleDescriptor
              * The export was not explicitly or implicitly declared in the
              * source of the module declaration.
              */
-            SYNTHETIC,
+            SYNTHETIC(AccessFlag.SYNTHETIC.mask()),
 
             /**
              * The export was implicitly declared in the source of the module
              * declaration.
              */
-            MANDATED;
+            MANDATED(AccessFlag.MANDATED.mask());
 
+            private int mask;
+            private Modifier(int mask) {
+                this.mask = mask;
+            }
+            private int mask() {return mask;}
         }
 
         private final Set<Modifier> mods;
@@ -415,6 +444,21 @@ public class ModuleDescriptor
          */
         public Set<Modifier> modifiers() {
             return mods;
+        }
+
+        /**
+         * {@return an unmodifiable set of the module {@linkplain AccessFlag
+         * export flags} for this module descriptor, possibly empty}
+         * @see #modifiers()
+         * @jvms 4.7.25 The Module Attribute
+         * @since 20
+         */
+        public Set<AccessFlag> accessFlags() {
+            int mask = 0;
+            for (var modifier : mods) {
+                mask |= modifier.mask();
+            }
+            return AccessFlag.maskToAccessFlags(mask, AccessFlag.Location.MODULE_EXPORTS);
         }
 
         /**
@@ -579,14 +623,18 @@ public class ModuleDescriptor
              * The open package was not explicitly or implicitly declared in
              * the source of the module declaration.
              */
-            SYNTHETIC,
+            SYNTHETIC(AccessFlag.SYNTHETIC.mask()),
 
             /**
              * The open package was implicitly declared in the source of the
              * module declaration.
              */
-            MANDATED;
-
+            MANDATED(AccessFlag.MANDATED.mask());
+            private int mask;
+            private Modifier(int mask) {
+                this.mask = mask;
+            }
+            private int mask() {return mask;}
         }
 
         private final Set<Modifier> mods;
@@ -618,6 +666,21 @@ public class ModuleDescriptor
          */
         public Set<Modifier> modifiers() {
             return mods;
+        }
+
+        /**
+         * {@return an unmodifiable set of the module {@linkplain AccessFlag
+         * opens flags}, possibly empty}
+         * @see #modifiers()
+         * @jvms 4.7.25 The Module Attribute
+         * @since 20
+         */
+        public Set<AccessFlag> accessFlags() {
+            int mask = 0;
+            for (var modifier : mods) {
+                mask |= modifier.mask();
+            }
+            return AccessFlag.maskToAccessFlags(mask, AccessFlag.Location.MODULE_OPENS);
         }
 
         /**
@@ -1288,6 +1351,21 @@ public class ModuleDescriptor
      */
     public Set<Modifier> modifiers() {
         return modifiers;
+    }
+
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag
+     * module flags}, possibly empty}
+     * @see #modifiers()
+     * @jvms 4.7.25 The Module Attribute
+     * @since 20
+     */
+    public Set<AccessFlag> accessFlags() {
+        int mask = 0;
+        for (var modifier : modifiers) {
+            mask |= modifier.mask();
+        }
+        return AccessFlag.maskToAccessFlags(mask, AccessFlag.Location.MODULE);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang.reflect;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import static java.util.Map.entry;
+
+/**
+ * Represents a JVM access or module-related flag on a runtime member,
+ * such as a {@linkplain Class class}, {@linkplain Field field}, or
+ * {@linkplain Executable method}.
+ *
+ * <P>JVM access and module-related flags are related to, but distinct
+ * from Java language {@linkplain Modifier modifiers}. Some modifiers
+ * and access flags have a one-to-one correspondence, such as {@code
+ * public}. In other cases, some language-level modifiers do
+ * <em>not</em> have an access flag, such as {@code sealed} (JVMS
+ * {@jvms 4.7.31}) and some access flags have no corresponding
+ * modifier, such as {@linkplain #SYNTHETIC synthetic}.
+ *
+ * <p>The values for the constants representing the access and module
+ * flags are taken from sections of <cite>The Java Virtual Machine
+ * Specification</cite> including {@jvms 4.1} (class access and
+ * property modifiers), {@jvms 4.5} (field access and property flags),
+ * {@jvms 4.6} (method access and property flags), {@jvms 4.7.6}
+ * (nested class access and property flags), {@jvms 4.7.24} (method
+ * parameters), and {@jvms 4.7.25} (module flags and requires,
+ * exports, and opens flags).
+ *
+ * <p>The {@linkplain #mask() mask} values for the different access
+ * flags are <em>not</em> distinct. Flags are defined for different
+ * kinds of JVM structures and the same bit position has different
+ * meanings in different contexts. For example, {@code 0x0000_0040}
+ * indicates a {@link #VOLATILE volatile} field but a {@linkplain
+ * #BRIDGE bridge method}; {@code 0x0000_0080} indicates a {@link
+ * #TRANSIENT transient} field but a {@linkplain #VARARGS variable
+ * arity (varargs)} method.
+ *
+ * <p>The access flag constants are ordered by non-decreasing mask
+ * value; that is the mask value of a constant is greater than or
+ * equal to the mask value of an immediate neighbor to its (syntactic)
+ * left. If new constants are added, this property will be
+ * maintained. That implies new constants will not necessarily be
+ * added at the end of the existing list.
+ *
+ * @see java.lang.reflect.Modifier
+ * @see java.lang.module.ModuleDescriptor.Modifier
+ * @see java.lang.module.ModuleDescriptor.Requires.Modifier
+ * @see java.lang.module.ModuleDescriptor.Exports.Modifier
+ * @see java.lang.module.ModuleDescriptor.Opens.Modifier
+ * @see java.compiler/javax.lang.model.element.Modifier
+ * @since 20
+ */
+@SuppressWarnings("doclint:reference") // cross-module link
+public enum AccessFlag {
+    /**
+     * The access flag {@code ACC_PUBLIC}, corresponding to the source
+     * modifier {@link Modifier#PUBLIC public} with a mask value of
+     * {@code 0x0001}.
+     */
+    PUBLIC(Modifier.PUBLIC, true,
+           Set.of(Location.CLASS, Location.FIELD, Location.METHOD,
+                  Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_PRIVATE}, corresponding to the
+     * source modifier {@link Modifier#PRIVATE private} with a mask
+     * value of {@code 0x0002}.
+     */
+    PRIVATE(Modifier.PRIVATE, true,
+            Set.of(Location.FIELD, Location.METHOD, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_PROTECTED}, corresponding to the
+     * source modifier {@link Modifier#PROTECTED protected} with a mask
+     * value of {@code 0x0004}.
+     */
+    PROTECTED(Modifier.PROTECTED, true,
+              Set.of(Location.FIELD, Location.METHOD, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_STATIC}, corresponding to the source
+     * modifier {@link Modifier#STATIC static} with a mask value of
+     * {@code 0x0008}.
+     */
+    STATIC(Modifier.STATIC, true,
+           Set.of(Location.FIELD, Location.METHOD, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_FINAL}, corresponding to the source
+     * modifier {@link Modifier#FINAL final} with a mask
+     * value of {@code 0x0010}.
+     */
+    FINAL(Modifier.FINAL, true,
+          Set.of(Location.CLASS, Location.FIELD, Location.METHOD,
+                 Location.INNER_CLASS, Location.METHOD_PARAMETER)),
+
+    /**
+     * The access flag {@code ACC_SUPER} with a mask value of {@code
+     * 0x0020}.
+     */
+    SUPER(0x0000_0020, false, Set.of(Location.CLASS)),
+
+    /**
+     * The module flag {@code ACC_OPEN} with a mask value of {@code
+     * 0x0020}.
+     * @see java.lang.module.ModuleDescriptor#isOpen
+     */
+    OPEN(0x0000_0020, false, Set.of(Location.MODULE)),
+
+    /**
+     * The module requires flag {@code ACC_TRANSITIVE} with a mask
+     * value of {@code 0x0020}.
+     * @see java.lang.module.ModuleDescriptor.Requires.Modifier#TRANSITIVE
+     */
+    TRANSITIVE(0x0000_0020, false, Set.of(Location.MODULE_REQUIRES)),
+
+    /**
+     * The access flag {@code ACC_SYNCHRONIZED}, corresponding to the
+     * source modifier {@link Modifier#SYNCHRONIZED synchronized} with
+     * a mask value of {@code 0x0020}.
+     */
+    SYNCHRONIZED(Modifier.SYNCHRONIZED, true, Set.of(Location.METHOD)),
+
+    /**
+     * The module requires flag {@code ACC_STATIC_PHASE} with a mask
+     * value of {@code 0x0040}.
+     * @see java.lang.module.ModuleDescriptor.Requires.Modifier#STATIC
+     */
+    STATIC_PHASE(0x0000_0040, false, Set.of(Location.MODULE_REQUIRES)),
+
+     /**
+      * The access flag {@code ACC_VOLATILE}, corresponding to the
+      * source modifier {@link Modifier#VOLATILE volatile} with a mask
+      * value of {@code 0x0040}.
+      */
+    VOLATILE(Modifier.VOLATILE, true, Set.of(Location.FIELD)),
+
+    /**
+     * The access flag {@code ACC_BRIDGE} with a mask value of {@code
+     * 0x0040}.
+     * @see Method#isBridge()
+     */
+    BRIDGE(0x0000_0040, false, Set.of(Location.METHOD)),
+
+    /**
+     * The access flag {@code ACC_TRANSIENT}, corresponding to the
+     * source modifier {@link Modifier#TRANSIENT transient} with a
+     * mask value of {@code 0x0080}.
+     */
+    TRANSIENT(Modifier.TRANSIENT, true, Set.of(Location.FIELD)),
+
+    /**
+     * The access flag {@code ACC_VARARGS} with a mask value of {@code
+     * 0x0080}.
+     * @see Executable#isVarArgs()
+     */
+    VARARGS(0x0000_0080, false, Set.of(Location.METHOD)),
+
+    /**
+     * The access flag {@code ACC_NATIVE}, corresponding to the source
+     * modifier {@link Modifier#NATIVE native} with a mask value of {@code
+     * 0x0100}.
+     */
+    NATIVE(Modifier.NATIVE, true, Set.of(Location.METHOD)),
+
+    /**
+     * The access flag {@code ACC_INTERFACE} with a mask value of
+     * {@code 0x0200}.
+     * @see Class#isInterface()
+     */
+    INTERFACE(Modifier.INTERFACE, false,
+              Set.of(Location.CLASS, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_ABSTRACT}, corresponding to the
+     * source modifier {@link Modifier#ABSTRACT abstract} with a mask
+     * value of {@code 0x0400}.
+     */
+    ABSTRACT(Modifier.ABSTRACT, true,
+             Set.of(Location.CLASS, Location.METHOD, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_STRICT}, corresponding to the source
+     * modifier {@link Modifier#STRICT strictfp} with a mask value of
+     * {@code 0x0800}.
+     */
+    STRICT(Modifier.STRICT, true, Set.of(Location.METHOD)),
+
+    /**
+     * The access flag {@code ACC_SYNTHETIC} with a mask value of
+     * {@code 0x1000}.
+     * @see Class#isSynthetic()
+     * @see Executable#isSynthetic()
+     * @see java.lang.module.ModuleDescriptor.Modifier#SYNTHETIC
+     */
+    SYNTHETIC(0x0000_1000, false,
+              Set.of(Location.CLASS, Location.FIELD, Location.METHOD,
+                     Location.INNER_CLASS, Location.METHOD_PARAMETER,
+                     Location.MODULE, Location.MODULE_REQUIRES,
+                     Location.MODULE_EXPORTS, Location.MODULE_OPENS)),
+
+    /**
+     * The access flag {@code ACC_ANNOTATION} with a mask value of
+     * {@code 0x2000}.
+     * @see Class#isAnnotation()
+     */
+    ANNOTATION(0x0000_2000, false,
+               Set.of(Location.CLASS, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_ENUM} with a mask value of {@code
+     * 0x4000}.
+     * @see Class#isEnum()
+     */
+    ENUM(0x0000_4000, false,
+         Set.of(Location.CLASS, Location.FIELD, Location.INNER_CLASS)),
+
+    /**
+     * The access flag {@code ACC_MANDATED} with a mask value of
+     * {@code 0x8000}.
+     */
+    MANDATED(0x0000_8000, false,
+             Set.of(Location.METHOD_PARAMETER,
+                    Location.MODULE, Location.MODULE_REQUIRES,
+                    Location.MODULE_EXPORTS, Location.MODULE_OPENS)),
+
+    /**
+     * The access flag {@code ACC_MODULE} with a mask value of {@code
+     * 0x8000}.
+     */
+    MODULE(0x0000_8000, false, Set.of(Location.CLASS))
+    ;
+
+    // May want to override toString for a different enum constant ->
+    // name mapping.
+
+    private int mask;
+    private boolean sourceModifier;
+
+    // Intentionally using Set rather than EnumSet since EnumSet is
+    // mutable.
+    private Set<Location> locations;
+
+    private AccessFlag(int mask, boolean sourceModifier, Set<Location> locations) {
+        this.mask = mask;
+        this.sourceModifier = sourceModifier;
+        this.locations = locations;
+    }
+
+    /**
+     * {@return the corresponding integer mask for the access flag}
+     */
+    public int mask() {
+        return mask;
+    }
+
+    /**
+     * {@return whether or not the flag has a directly corresponding
+     * modifier in the Java programming language}
+     */
+    public boolean sourceModifier() {
+        return sourceModifier;
+    }
+
+    /**
+     * {@return kinds of constructs the flag can be applied to}
+     */
+    public Set<Location> locations() {
+        return locations;
+    }
+
+    /**
+     * {@return a set of access flags for the given mask value
+     * appropriate for the location in question}
+     *
+     * @param mask bit mask of access flags
+     * @param location context to interpret mask value
+     * @throws IllegalArgumentException if the mask contains bit
+     * positions not support for the location in question
+     */
+    public static Set<AccessFlag> maskToAccessFlags(int mask, Location location) {
+        Set<AccessFlag> result = java.util.EnumSet.noneOf(AccessFlag.class);
+        for (var accessFlag : LocationToFlags.locationToFlags.get(location)) {
+            int accessMask = accessFlag.mask();
+            if ((mask &  accessMask) != 0) {
+                result.add(accessFlag);
+                mask = mask & ~accessMask;
+            }
+        }
+        if (mask != 0) {
+            throw new IllegalArgumentException("Unmatched bit position 0x" +
+                                               Integer.toHexString(mask) +
+                                               " for location " + location);
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    /**
+     * A location within a class file where flags can be applied.
+     *
+     * Note that since these locations represent class file structures
+     * rather than language structures many language structures, such
+     * as constructors and interfaces, are <em>not</em> present.
+     * @since 20
+     */
+    public enum Location {
+        /**
+         * Class location.
+         * @jvms 4.1 The ClassFile Structure
+         */
+        CLASS,
+
+        /**
+         * Field location.
+         * @jvms 4.5 Fields
+         */
+        FIELD,
+
+        /**
+         * Method location.
+         * @jvms 4.6 Method
+         */
+        METHOD,
+
+        /**
+         * Inner class location.
+         * @jvms 4.7.6 The InnerClasses Attribute
+         */
+        INNER_CLASS,
+
+        /**
+         * Method parameter loccation.
+         * @jvms 4.7.24. The MethodParameters Attribute
+         */
+        METHOD_PARAMETER,
+
+        /**
+         * Module location
+         * @jvms 4.7.25. The Module Attribute
+         */
+        MODULE,
+
+        /**
+         * Module requires location
+         * @jvms 4.7.25. The Module Attribute
+         */
+        MODULE_REQUIRES,
+
+        /**
+         * Module exports location
+         * @jvms 4.7.25. The Module Attribute
+         */
+        MODULE_EXPORTS,
+
+        /**
+         * Module opens location
+         * @jvms 4.7.25. The Module Attribute
+         */
+        MODULE_OPENS;
+
+    }
+
+    private static class LocationToFlags {
+        private static Map<Location, Set<AccessFlag>> locationToFlags =
+            Map.ofEntries(entry(Location.CLASS,
+                                Set.of(PUBLIC, FINAL, SUPER,
+                                       INTERFACE, ABSTRACT,
+                                       SYNTHETIC, ANNOTATION,
+                                       ENUM, AccessFlag.MODULE)),
+                          entry(Location.FIELD,
+                                Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                       STATIC, FINAL, VOLATILE,
+                                       TRANSIENT, SYNTHETIC, ENUM)),
+                          entry(Location.METHOD,
+                                Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                       STATIC, FINAL, SYNCHRONIZED,
+                                       BRIDGE, VARARGS, NATIVE,
+                                       ABSTRACT, STRICT, SYNTHETIC)),
+                          entry(Location.INNER_CLASS,
+                                Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                       STATIC, FINAL, INTERFACE, ABSTRACT,
+                                       SYNTHETIC, ANNOTATION, ENUM)),
+                          entry(Location.METHOD_PARAMETER,
+                                Set.of(FINAL, SYNTHETIC, MANDATED)),
+                          entry(Location.MODULE,
+                                Set.of(OPEN, SYNTHETIC, MANDATED)),
+                          entry(Location.MODULE_REQUIRES,
+                                Set.of(TRANSITIVE, STATIC_PHASE, SYNTHETIC, MANDATED)),
+                          entry(Location.MODULE_EXPORTS,
+                                Set.of(SYNTHETIC, MANDATED)),
+                          entry(Location.MODULE_OPENS,
+                                Set.of(SYNTHETIC, MANDATED)));
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -28,6 +28,7 @@ package java.lang.reflect;
 import java.lang.annotation.*;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
@@ -204,8 +205,28 @@ public abstract sealed class Executable extends AccessibleObject
     /**
      * {@return the Java language {@linkplain Modifier modifiers} for
      * the executable represented by this object}
+     * @see #accessFlags
      */
     public abstract int getModifiers();
+
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag
+     * access flags} for the executable represented by this object,
+     * possibly empty}
+     *
+     * @implSpec
+     * Map this executable's {@linkplain #getModifiers() modifiers} to
+     * access flags using {@link AccessFlag#maskToAccessFlags} for a
+     * {@linkplain AccessFlag.Location#METHOD method location}
+     *
+     * @see #getModifiers()
+     * @jvms 4.6 Methods
+     * @since 20
+     */
+    @Override
+    public Set<AccessFlag> accessFlags() {
+        return AccessFlag.maskToAccessFlags(getModifiers(), AccessFlag.Location.METHOD);
+    }
 
     /**
      * Returns an array of {@code TypeVariable} objects that represent the

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -37,6 +37,7 @@ import sun.reflect.generics.factory.GenericsFactory;
 import sun.reflect.generics.scope.ClassScope;
 import java.lang.annotation.Annotation;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import sun.reflect.annotation.AnnotationParser;
 import sun.reflect.annotation.AnnotationSupport;
@@ -203,11 +204,24 @@ class Field extends AccessibleObject implements Member {
      * be used to decode the modifiers.
      *
      * @see Modifier
+     * @see #accessFlags()
      * @jls 8.3 Field Declarations
      * @jls 9.3 Field (Constant) Declarations
      */
     public int getModifiers() {
         return modifiers;
+    }
+
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag
+     * access flags} for this field, possibly empty}
+     * @see #getModifiers()
+     * @jvms 4.5 Fields
+     * @since 20
+     */
+    @Override
+    public Set<AccessFlag> accessFlags() {
+        return AccessFlag.maskToAccessFlags(getModifiers(), AccessFlag.Location.FIELD);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/Member.java
+++ b/src/java.base/share/classes/java/lang/reflect/Member.java
@@ -25,6 +25,8 @@
 
 package java.lang.reflect;
 
+import java.util.Set;
+
 /**
  * Member is an interface that reflects identifying information about
  * a single member (a field or a method) or a constructor.
@@ -76,8 +78,23 @@ public interface Member {
      *
      * @return the Java language modifiers for the underlying member
      * @see Modifier
+     * @see #accessFlags()
      */
     public int getModifiers();
+
+
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag
+     * access flags} for this member, possibly empty}
+     *
+     * @implSpec
+     * The default implementation returns an empty set.
+     * @see #getModifiers()
+     * @since 20
+     */
+    public default Set<AccessFlag> accessFlags() {
+        return Set.of();
+    }
 
     /**
      * Returns {@code true} if this member was introduced by

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -266,36 +266,42 @@ public class Modifier {
     /**
      * The {@code int} value representing the {@code public}
      * modifier.
+     * @see AccessFlag#PUBLIC
      */
     public static final int PUBLIC           = 0x00000001;
 
     /**
      * The {@code int} value representing the {@code private}
      * modifier.
+     * @see AccessFlag#PRIVATE
      */
     public static final int PRIVATE          = 0x00000002;
 
     /**
      * The {@code int} value representing the {@code protected}
      * modifier.
+     * @see AccessFlag#PROTECTED
      */
     public static final int PROTECTED        = 0x00000004;
 
     /**
      * The {@code int} value representing the {@code static}
      * modifier.
+     * @see AccessFlag#STATIC
      */
     public static final int STATIC           = 0x00000008;
 
     /**
      * The {@code int} value representing the {@code final}
      * modifier.
+     * @see AccessFlag#FINAL
      */
     public static final int FINAL            = 0x00000010;
 
     /**
      * The {@code int} value representing the {@code synchronized}
      * modifier.
+     * @see AccessFlag#SYNCHRONIZED
      */
     public static final int SYNCHRONIZED     = 0x00000020;
 
@@ -308,30 +314,35 @@ public class Modifier {
     /**
      * The {@code int} value representing the {@code volatile}
      * modifier.
+     * @see AccessFlag#VOLATILE
      */
     public static final int VOLATILE         = 0x00000040;
 
     /**
      * The {@code int} value representing the {@code transient}
      * modifier.
+     * @see AccessFlag#TRANSIENT
      */
     public static final int TRANSIENT        = 0x00000080;
 
     /**
      * The {@code int} value representing the {@code native}
      * modifier.
+     * @see AccessFlag#NATIVE
      */
     public static final int NATIVE           = 0x00000100;
 
     /**
      * The {@code int} value representing the {@code interface}
      * modifier.
+     * @see AccessFlag#INTERFACE
      */
     public static final int INTERFACE        = 0x00000200;
 
     /**
      * The {@code int} value representing the {@code abstract}
      * modifier.
+     * @see AccessFlag#ABSTRACT
      */
     public static final int ABSTRACT         = 0x00000400;
 

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -27,6 +27,7 @@ package java.lang.reflect;
 import java.lang.annotation.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import sun.reflect.annotation.AnnotationSupport;
 
@@ -159,6 +160,20 @@ public final class Parameter implements AnnotatedElement {
      */
     public int getModifiers() {
         return modifiers;
+    }
+
+    /**
+     * {@return an unmodifiable set of the {@linkplain AccessFlag
+     * access flags} for the parameter represented by this object,
+     * possibly empty}
+     *
+     * @see #getModifiers()
+     * @jvms 4.7.24 The MethodParameters Attribute
+     * @since 20
+     */
+    public Set<AccessFlag> accessFlags() {
+        return AccessFlag.maskToAccessFlags(getModifiers(),
+                                            AccessFlag.Location.METHOD_PARAMETER);
     }
 
     /**

--- a/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8266670
+ * @summary Basic tests of AccessFlag
+ */
+
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BasicAccessFlagTest {
+    public static void main(String... args) throws Exception {
+        testSourceModifiers();
+        testMaskOrdering();
+        testDisjoint();
+        testMaskToAccessFlagsPositive();
+    }
+
+    private static void testSourceModifiers() throws Exception {
+        Class<?> modifierClass = Modifier.class;
+
+        for(AccessFlag accessFlag : AccessFlag.values()) {
+            if (accessFlag.sourceModifier()) {
+                // Check for consistency
+                Field f = modifierClass.getField(accessFlag.name());
+                if (accessFlag.mask() != f.getInt(null) ) {
+                    throw new RuntimeException("Unexpected mask for " +
+                                               accessFlag);
+                }
+            }
+        }
+    }
+
+    // The mask values of the enum constants must be non-decreasing;
+    // in other words stay the same (for colliding mask values) or go
+    // up.
+    private static void testMaskOrdering() {
+        AccessFlag[] values = AccessFlag.values();
+        for (int i = 1; i < values.length; i++) {
+            AccessFlag left  = values[i-1];
+            AccessFlag right = values[i];
+            if (left.mask() > right.mask()) {
+                throw new RuntimeException(left
+                                           + "has a greater mask than "
+                                           + right);
+            }
+        }
+    }
+
+    // Test that if access flags have a matching mask, their locations
+    // are disjoint.
+    private static void testDisjoint() {
+        // First build the mask -> access flags map...
+        Map<Integer, Set<AccessFlag>> maskToFlags = new LinkedHashMap<>();
+
+        for (var accessFlag : AccessFlag.values()) {
+            Integer mask = accessFlag.mask();
+            Set<AccessFlag> flags = maskToFlags.get(mask);
+
+            if (flags == null ) {
+                flags = new HashSet<>();
+                flags.add(accessFlag);
+                maskToFlags.put(mask, flags);
+            } else {
+                flags.add(accessFlag);
+            }
+        }
+
+        // Then test for disjointness
+        for (var entry : maskToFlags.entrySet()) {
+            var value = entry.getValue();
+            if (value.size() == 0) {
+                throw new AssertionError("Bad flag set " + entry);
+            } else if (value.size() == 1) {
+                // Need at least two flags to be non-disjointness to
+                // be possible
+                continue;
+            }
+
+            Set<AccessFlag.Location> locations = new HashSet<>();
+            for (var accessFlag : value) {
+                for (var location : accessFlag.locations()) {
+                    boolean added = locations.add(location);
+                    if (!added) {
+                        reportError(location, accessFlag,
+                                    entry.getKey(), value);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void reportError(AccessFlag.Location location,
+                                    AccessFlag accessFlag,
+                                    Integer mask, Set<AccessFlag> value) {
+        System.err.println("Location " + location +
+                           " from " + accessFlag +
+                           " already present for 0x" +
+                           Integer.toHexString(mask) + ": " + value);
+        throw new RuntimeException();
+    }
+
+    // For each access flag, make sure it is recognized on every kind
+    // of location it can apply to
+    private static void testMaskToAccessFlagsPositive() {
+        for (var accessFlag : AccessFlag.values()) {
+            Set<AccessFlag> expectedSet = EnumSet.of(accessFlag);
+            for (var location : accessFlag.locations()) {
+                Set<AccessFlag> computedSet =
+                    AccessFlag.maskToAccessFlags(accessFlag.mask(), location);
+                if (!expectedSet.equals(computedSet)) {
+                    throw new RuntimeException("Bad set computation on " +
+                                               accessFlag + ", " + location);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Import, verbatim, the new API for access flags to Valhalla;  (Not in mainline until jdk 20).
The API is unmodified from the mainline version. [Mainline Review openjdk/jdk/7445](https://git.openjdk.java.net/jdk/pull/7445) 

The Valhalla modifiers will be added in the new AccessFlags class in a subsequent PR.
The existing Modifiers class will not include Valhalla specific modifiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287330](https://bugs.openjdk.java.net/browse/JDK-8287330): (valhalla) Better modeling of access flags in core reflection


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/697/head:pull/697` \
`$ git checkout pull/697`

Update a local copy of the PR: \
`$ git checkout pull/697` \
`$ git pull https://git.openjdk.java.net/valhalla pull/697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 697`

View PR using the GUI difftool: \
`$ git pr show -t 697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/697.diff">https://git.openjdk.java.net/valhalla/pull/697.diff</a>

</details>
