### PR TITLE
8287359: ACC_IDENTITY bit not consistently set in Inner class flags

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2787,6 +2787,9 @@ public class ClassReader {
     }
 
     long adjustClassFlags(long flags) {
+        if ((flags & (ABSTRACT | ACC_VALUE | ACC_MODULE)) == 0) {
+            flags |= ACC_IDENTITY;
+        }
         if ((flags & ACC_MODULE) != 0) {
             flags &= ~ACC_MODULE;
             flags |= MODULE;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2789,7 +2789,7 @@ public class ClassReader {
     }
 
     long adjustClassFlags(long flags) {
-        if ((flags & (ABSTRACT | ACC_VALUE | ACC_MODULE)) == 0) {
+        if ((flags & (ABSTRACT | INTERFACE | ACC_VALUE | ACC_MODULE)) == 0) {
             flags |= ACC_IDENTITY;
         }
         if ((flags & ACC_MODULE) != 0) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2541,6 +2541,8 @@ public class ClassReader {
         // read flags, or skip if this is an inner class
         long f = nextChar();
         long flags = adjustClassFlags(f);
+        if (c == syms.objectType.tsym)
+            flags &= ~IDENTITY_TYPE; // jlO lacks identity even while being a concrete class.
         if ((flags & MODULE) == 0) {
             if (c.owner.kind == PCK || c.owner.kind == ERR) c.flags_field = flags;
             // read own class name and check that it matches


### PR DESCRIPTION
Properly align with the spec in setting ACC_IDENTITY bit for inner classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287359](https://bugs.openjdk.java.net/browse/JDK-8287359): ACC_IDENTITY bit not consistently set in Inner class flags


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/699/head:pull/699` \
`$ git checkout pull/699`

Update a local copy of the PR: \
`$ git checkout pull/699` \
`$ git pull https://git.openjdk.java.net/valhalla pull/699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 699`

View PR using the GUI difftool: \
`$ git pr show -t 699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/699.diff">https://git.openjdk.java.net/valhalla/pull/699.diff</a>

</details>
