### PR TITLE
8287770: [lw4] Javac tolerates synchronizing on an instance of a value interface

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -864,7 +864,7 @@ public class Check {
                                 t);
     }
 
-    /** Check that type is an identity type, i.e. not a primitive type
+    /** Check that type is an identity type, i.e. not a primitive/value type
      *  nor its reference projection. When not discernible statically,
      *  give it the benefit of doubt and defer to runtime.
      *
@@ -873,7 +873,7 @@ public class Check {
      */
     Type checkIdentityType(DiagnosticPosition pos, Type t) {
 
-        if (t.isPrimitive() || t.isValueClass() || t.isReferenceProjection())
+        if (t.isPrimitive() || t.isValueClass() || t.isValueInterface() || t.isReferenceProjection())
             return typeTagError(pos,
                     diags.fragment(Fragments.TypeReqIdentity),
                     t);

--- a/test/langtools/tools/javac/valhalla/value-objects/SynchronizeOnValueInterfaceInstance.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/SynchronizeOnValueInterfaceInstance.java
@@ -1,0 +1,14 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8287770
+ * @summary [lw4] Javac tolerates synchronizing on an instance of a value interface
+ * @compile/fail/ref=SynchronizeOnValueInterfaceInstance.out -XDrawDiagnostics -XDdev SynchronizeOnValueInterfaceInstance.java
+ */
+
+public value interface SynchronizeOnValueInterfaceInstance {
+
+    default void foo(SynchronizeOnValueInterfaceInstance sovii) {
+        synchronized (sovii) {} // Error
+    }
+
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/SynchronizeOnValueInterfaceInstance.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/SynchronizeOnValueInterfaceInstance.out
@@ -1,0 +1,2 @@
+SynchronizeOnValueInterfaceInstance.java:11:9: compiler.err.type.found.req: SynchronizeOnValueInterfaceInstance, (compiler.misc.type.req.identity)
+1 error


### PR DESCRIPTION
Reject synchronization attempt on any value type instance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287770](https://bugs.openjdk.java.net/browse/JDK-8287770): [lw4] Javac tolerates synchronizing on an instance of a value interface


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/703/head:pull/703` \
`$ git checkout pull/703`

Update a local copy of the PR: \
`$ git checkout pull/703` \
`$ git pull https://git.openjdk.java.net/valhalla pull/703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 703`

View PR using the GUI difftool: \
`$ git pr show -t 703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/703.diff">https://git.openjdk.java.net/valhalla/pull/703.diff</a>

</details>
