### PR TITLE
8287692: Move Class primitive APIs to jdk.internal.value.PrimitiveClass

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -62,6 +62,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaSecurityAccess;
+import jdk.internal.value.PrimitiveClass;
 import sun.reflect.misc.ReflectUtil;
 import static java.io.ObjectStreamField.*;
 
@@ -445,7 +446,7 @@ public class ObjectStreamClass implements Serializable {
             if (isEnum) {
                 deserializeEx = new ExceptionInfo(name, "enum type");
             } else if (cl.isValue() && writeReplaceMethod == null) {
-                deserializeEx = new ExceptionInfo(name, cl.isPrimitiveClass() ? "primitive class" : "value class");
+                deserializeEx = new ExceptionInfo(name, "value class");
             } else if (cons == null && !isRecord) {
                 deserializeEx = new ExceptionInfo(name, "no valid constructor");
             }

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -204,7 +204,6 @@ public final class Class<T> implements java.io.Serializable,
     private static final int ENUM       = 0x00004000;
     private static final int SYNTHETIC  = 0x00001000;
     private static final int VALUE_CLASS     = 0x00000040;
-    private static final int PERMITS_VALUE   = 0x00000100;
     private static final int PRIMITIVE_CLASS = 0x00000800;
 
     private static native void registerNatives();
@@ -511,8 +510,8 @@ public final class Class<T> implements java.io.Serializable,
 
     /** Called after security check for system loader access checks have been made. */
     private static native Class<?> forName0(String name, boolean initialize,
-                                    ClassLoader loader,
-                                    Class<?> caller)
+                                            ClassLoader loader,
+                                            Class<?> caller)
         throws ClassNotFoundException;
 
 
@@ -625,7 +624,7 @@ public final class Class<T> implements java.io.Serializable,
      * @see #asValueType()
      * @since Valhalla
      */
-    public boolean isPrimitiveClass() {
+    private boolean isPrimitiveClass() {
         return (this.getModifiers() & PRIMITIVE_CLASS) != 0;
     }
 
@@ -659,7 +658,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     @IntrinsicCandidate
-    public Class<?> asPrimaryType() {
+    /* package */ Class<?> asPrimaryType() {
         return isPrimitiveClass() ? primaryType : this;
     }
 
@@ -677,7 +676,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     @IntrinsicCandidate
-    public Class<?> asValueType() {
+    /* package */ Class<?> asValueType() {
         if (isPrimitiveClass())
             return secondaryType;
 
@@ -703,7 +702,7 @@ public final class Class<T> implements java.io.Serializable,
      * the primary type of this class or interface
      * @since Valhalla
      */
-    public boolean isPrimaryType() {
+    /* package */ boolean isPrimaryType() {
         if (isPrimitiveClass()) {
             return this == primaryType;
         }
@@ -718,7 +717,7 @@ public final class Class<T> implements java.io.Serializable,
      * the value type of a primitive class
      * @since Valhalla
      */
-    public boolean isPrimitiveValueType() {
+    /* package */ boolean isPrimitiveValueType() {
         return isPrimitiveClass() && this == secondaryType;
     }
 
@@ -866,10 +865,6 @@ public final class Class<T> implements java.io.Serializable,
      * superinterface of, the class or interface represented by the specified
      * {@code Class} parameter. It returns {@code true} if so;
      * otherwise it returns {@code false}. If this {@code Class}
-     * object represents the {@linkplain #isPrimaryType() reference type}
-     * of a {@linkplain #isPrimitiveClass() primitive class}, this method
-     * return {@code true} if the specified {@code Class} parameter represents
-     * the same primitive class. If this {@code Class}
      * object represents a primitive type, this method returns
      * {@code true} if the specified {@code Class} parameter is
      * exactly this {@code Class} object; otherwise it returns
@@ -878,9 +873,9 @@ public final class Class<T> implements java.io.Serializable,
      * <p> Specifically, this method tests whether the type represented by the
      * specified {@code Class} parameter can be converted to the type
      * represented by this {@code Class} object via an identity conversion
-     * or via a widening reference conversion or via a primitive widening
-     * conversion. See <cite>The Java Language Specification</cite>,
-     * sections {@jls 5.1.1} and {@jls 5.1.4}, for details.
+     * or via a widening reference conversion. See <cite>The Java Language
+     * Specification</cite>, sections {@jls 5.1.1} and {@jls 5.1.4},
+     * for details.
      *
      * @param     cls the {@code Class} object to be checked
      * @return    the {@code boolean} value indicating whether objects of the
@@ -1008,8 +1003,6 @@ public final class Class<T> implements java.io.Serializable,
      * <tr><th scope="row"> {@code char}    <td style="text-align:center"> {@code C}
      * <tr><th scope="row"> class or interface with <a href="ClassLoader.html#binary-name">binary name</a> <i>N</i>
      *                                      <td style="text-align:center"> {@code L}<em>N</em>{@code ;}
-     * <tr><th scope="row"> {@linkplain #isPrimitiveClass() primitive class} with <a href="ClassLoader.html#binary-name">binary name</a> <i>N</i>
-     *                                      <td style="text-align:center"> {@code Q}<em>N</em>{@code ;}
      * <tr><th scope="row"> {@code double}  <td style="text-align:center"> {@code D}
      * <tr><th scope="row"> {@code float}   <td style="text-align:center"> {@code F}
      * <tr><th scope="row"> {@code int}     <td style="text-align:center"> {@code I}
@@ -1028,14 +1021,8 @@ public final class Class<T> implements java.io.Serializable,
      *     returns "java.lang.String"
      * byte.class.getName()
      *     returns "byte"
-     * Point.class.getName()
-     *     returns "Point"
      * (new Object[3]).getClass().getName()
      *     returns "[Ljava.lang.Object;"
-     * (new Point[3]).getClass().getName()
-     *     returns "[QPoint;"
-     * (new Point.ref[3][4]).getClass().getName()
-     *     returns "[[LPoint;"
      * (new int[3][4][5][6][7][8][9]).getClass().getName()
      *     returns "[[[[[[[I"
      * </pre></blockquote>
@@ -1469,6 +1456,7 @@ public final class Class<T> implements java.io.Serializable,
      */
     @IntrinsicCandidate
     public native int getModifiers();
+
 
     /**
      * Gets the signers of this class.
@@ -4105,9 +4093,7 @@ public final class Class<T> implements java.io.Serializable,
      * @return the object after casting, or null if obj is null
      *
      * @throws ClassCastException if the object is not
-     * {@code null} and is not assignable to the type T.
-     * @throws NullPointerException if this class is an {@linkplain #isPrimitiveValueType()
-     * primitive value type} and the object is {@code null}
+     * null and is not assignable to the type T.
      *
      * @since 1.5
      */

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2492,6 +2492,21 @@ public final class System {
             public void exit(int statusCode) {
                 Shutdown.exit(statusCode);
             }
+
+            @Override
+            public Class<?> asPrimaryType(Class<?> clazz) {
+                return clazz.asPrimaryType();
+            }
+            public Class<?> asValueType(Class<?> clazz) {
+                return clazz.asValueType();
+            }
+
+            public boolean isPrimaryType(Class<?> clazz) {
+                return clazz.isPrimaryType();
+            }
+            public boolean isPrimitiveValueType(Class<?> clazz) {
+                return clazz.isPrimitiveValueType();
+            }
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
@@ -24,7 +24,7 @@
  */
 package java.lang.constant;
 
-import sun.invoke.util.Wrapper;
+import jdk.internal.value.PrimitiveClass;
 
 import java.lang.invoke.MethodHandles;
 
@@ -78,10 +78,10 @@ final class ClassDescImpl implements ClassDesc {
         else {
             Class<?> clazz = lookup.findClass(internalToBinary(dropFirstAndLastChar(c.descriptorString())));
             if (isValue) {
-                if (!clazz.isPrimitiveClass()) {
+                if (!PrimitiveClass.isPrimitiveClass(clazz)) {
                     throw new LinkageError(clazz.getName() + " is not a primitive class");
                 }
-                clazz = clazz.asValueType();
+                clazz = PrimitiveClass.asValueType(clazz);
             }
             for (int i = 0; i < depth; i++)
                 clazz = clazz.arrayType();

--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -24,6 +24,7 @@
  */
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
 import sun.invoke.util.Wrapper;
 
 import java.lang.reflect.Modifier;
@@ -268,7 +269,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
             }
 
             // check receiver type
-            if (!implClass.asPrimaryType().isAssignableFrom(receiverClass.asPrimaryType())) {
+            if (!PrimitiveClass.asPrimaryType(implClass).isAssignableFrom(PrimitiveClass.asPrimaryType(receiverClass))) {
                 throw new LambdaConversionException(
                         String.format("Invalid receiver type %s; not a subtype of implementation type %s",
                                       receiverClass.descriptorString(), implClass.descriptorString()));
@@ -321,7 +322,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
         for (int i = 0; i < dynamicMethodType.parameterCount(); i++) {
             Class<?> dynamicParamType = dynamicMethodType.parameterType(i);
             Class<?> descriptorParamType = descriptor.parameterType(i);
-            if (!descriptorParamType.asPrimaryType().isAssignableFrom(dynamicParamType.asPrimaryType())) {
+            if (!PrimitiveClass.asPrimaryType(descriptorParamType).isAssignableFrom(PrimitiveClass.asPrimaryType(dynamicParamType))) {
                 String msg = String.format("Type mismatch for dynamic parameter %d: %s is not a subtype of %s",
                                            i, dynamicParamType, descriptorParamType);
                 throw new LambdaConversionException(msg);
@@ -403,7 +404,7 @@ import static sun.invoke.util.Wrapper.isWrapperType;
 
         if (fromType.isValue() && toType.isValue()) {
             // val projection can be converted to ref projection; or vice verse
-            return fromType.asPrimaryType() == toType.asPrimaryType();
+            return PrimitiveClass.asPrimaryType(fromType) == PrimitiveClass.asPrimaryType(toType);
         }
 
         return false;

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -25,6 +25,7 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.Stable;
@@ -80,7 +81,7 @@ class DirectMethodHandle extends MethodHandle {
         if (!member.isStatic()) {
             if (!member.getDeclaringClass().isAssignableFrom(refc) || member.isObjectConstructor())
                 throw new InternalError(member.toString());
-            Class<?> receiverType = refc.isPrimitiveClass() ? refc.asValueType() : refc;
+            Class<?> receiverType = PrimitiveClass.isPrimitiveClass(refc) ? PrimitiveClass.asValueType(refc) : refc;
             mtype = mtype.insertParameterTypes(0, receiverType);
         }
         if (!member.isField()) {

--- a/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/InfoFromMemberName.java
@@ -25,6 +25,8 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
+
 import java.security.*;
 import java.lang.reflect.*;
 import java.lang.invoke.MethodHandles.Lookup;
@@ -116,7 +118,7 @@ final class InfoFromMemberName implements MethodHandleInfo {
                 // object constructor
                 throw new IllegalArgumentException("object constructor must be of void return type");
             } else if (MethodHandleNatives.refKindIsMethod(refKind) &&
-                       methodType.returnType() != defc.asValueType()) {
+                       methodType.returnType() != PrimitiveClass.asValueType(defc)) {
                 // TODO: allow to return Object or perhaps one of the supertypes of that class
                 // static init factory
                 throw new IllegalArgumentException("static constructor must be of " + defc.getName());

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -25,6 +25,7 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.CDS;
 import jdk.internal.org.objectweb.asm.*;
 import sun.invoke.util.BytecodeDescriptor;
@@ -641,7 +642,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             while (c.isArray()) {
                 c = c.getComponentType();
             }
-            return (c.isValue() && !c.isPrimitiveClass()) || c.isPrimitiveValueType();
+            return (c.isValue() && !PrimitiveClass.isPrimitiveClass(c)) || PrimitiveClass.isPrimitiveValueType(c);
         }
 
         boolean isEmpty() {

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -25,6 +25,7 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
 import sun.invoke.util.BytecodeDescriptor;
 import sun.invoke.util.VerifyAccess;
 
@@ -191,7 +192,7 @@ final class MemberName implements Member, Cloneable {
      */
     public MethodType getInvocationType() {
         MethodType itype = getMethodOrFieldType();
-        Class<?> c = clazz.isPrimitiveClass() ? clazz.asValueType() : clazz;
+        Class<?> c = PrimitiveClass.isPrimitiveClass(clazz) ? PrimitiveClass.asValueType(clazz) : clazz;
         if (isObjectConstructor() && getReferenceKind() == REF_newInvokeSpecial)
             return itype.changeReturnType(c);
         if (!isStatic())
@@ -479,7 +480,7 @@ final class MemberName implements Member, Cloneable {
     public boolean isInlineableField()  {
         if (isField()) {
             Class<?> type = getFieldType();
-            return type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
+            return PrimitiveClass.isPrimitiveValueType(type) || (type.isValue() && !PrimitiveClass.isPrimitiveClass(type));
         }
         return false;
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -26,6 +26,7 @@
 package java.lang.invoke;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.ClassReader;
@@ -1618,7 +1619,7 @@ public class MethodHandles {
         }
 
         private Lookup(Class<?> lookupClass, Class<?> prevLookupClass, int allowedModes) {
-            assert lookupClass.isPrimaryType();
+            assert PrimitiveClass.isPrimaryType(lookupClass);
             assert prevLookupClass == null || ((allowedModes & MODULE) == 0
                     && prevLookupClass.getModule() != lookupClass.getModule());
             assert !lookupClass.isArray() && !lookupClass.isPrimitive();
@@ -3842,7 +3843,7 @@ return mh1;
 
             // Step 3:
             Class<?> defc = m.getDeclaringClass();
-            if (!fullPrivilegeLookup && defc.asPrimaryType() != refc.asPrimaryType()) {
+            if (!fullPrivilegeLookup && PrimitiveClass.asPrimaryType(defc) != PrimitiveClass.asPrimaryType(refc)) {
                 ReflectUtil.checkPackageAccess(defc);
             }
         }
@@ -3925,12 +3926,12 @@ return mh1;
             int mods = m.getModifiers();
             // check the class first:
             boolean classOK = (Modifier.isPublic(defc.getModifiers()) &&
-                               (defc.asPrimaryType() == refc.asPrimaryType() ||
+                               (PrimitiveClass.asPrimaryType(defc) == PrimitiveClass.asPrimaryType(refc) ||
                                 Modifier.isPublic(refc.getModifiers())));
             if (!classOK && (allowedModes & PACKAGE) != 0) {
                 // ignore previous lookup class to check if default package access
                 classOK = (VerifyAccess.isClassAccessible(defc, lookupClass(), null, FULL_POWER_MODES) &&
-                           (defc.asPrimaryType() == refc.asPrimaryType() ||
+                           (PrimitiveClass.asPrimaryType(defc) == PrimitiveClass.asPrimaryType(refc) ||
                             VerifyAccess.isClassAccessible(refc, lookupClass(), null, FULL_POWER_MODES)));
             }
             if (!classOK)
@@ -5060,7 +5061,7 @@ assert((int)twice.invokeExact(21) == 42);
                 return zero(w, type);
             return insertArguments(identity(type), 0, value);
         } else {
-            if (!type.isPrimitiveValueType() && value == null)
+            if (!PrimitiveClass.isPrimitiveValueType(type) && value == null)
                 return zero(Wrapper.OBJECT, type);
             return identity(type).bindTo(value);
         }
@@ -5107,7 +5108,7 @@ assert((int)twice.invokeExact(21) == 42);
         Objects.requireNonNull(type);
         if (type.isPrimitive()) {
             return zero(Wrapper.forPrimitiveType(type), type);
-        } else if (type.isPrimitiveValueType()) {
+        } else if (PrimitiveClass.isPrimitiveValueType(type)) {
             // singleton default value
             Object value = UNSAFE.uninitializedDefaultValue(type);
             return identity(type).bindTo(value);

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -40,9 +40,9 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.Stable;
 import sun.invoke.util.BytecodeDescriptor;
 import sun.invoke.util.VerifyType;
@@ -51,7 +51,6 @@ import sun.security.util.SecurityConstants;
 
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 import static java.lang.invoke.MethodHandleStatics.newIllegalArgumentException;
-import static java.lang.invoke.MethodType.fromDescriptor;
 
 /**
  * A method type represents the arguments and return type accepted and
@@ -898,7 +897,7 @@ class MethodType
     }
 
     static String toSimpleName(Class<?> c) {
-        if (c.isPrimitiveClass() && c.isPrimaryType()) {
+        if (PrimitiveClass.isPrimitiveClass(c) && PrimitiveClass.isPrimaryType(c)) {
             return c.getSimpleName() + ".ref";
         } else {
             return c.getSimpleName();

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -31,15 +31,11 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
-import jdk.internal.util.Preconditions;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -1656,8 +1652,8 @@ public abstract class VarHandle implements Constable {
             // the field type (value) is mapped to the return type of MethodType
             // the receiver type is mapped to a parameter type of MethodType
             // So use the value type if it's a primitive class
-            if (receiver != null && receiver.isPrimitiveClass()) {
-                receiver = receiver.asValueType();
+            if (receiver != null && PrimitiveClass.isPrimitiveClass(receiver)) {
+                receiver = PrimitiveClass.asValueType(receiver);
             }
             switch (this) {
                 case GET:

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -25,6 +25,7 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.PrimitiveClass;
 import sun.invoke.util.Wrapper;
 
 import java.lang.reflect.Constructor;
@@ -225,7 +226,7 @@ final class VarHandles {
             // the redundant componentType.isPrimitiveValueType() check is
             // there to minimize the performance impact to non-value array.
             // It should be removed when Unsafe::isFlattenedArray is intrinsified.
-            return maybeAdapt(componentType.isPrimitiveValueType() && UNSAFE.isFlattenedArray(arrayClass)
+            return maybeAdapt(PrimitiveClass.isPrimitiveValueType(componentType) && UNSAFE.isFlattenedArray(arrayClass)
                 ? new VarHandleValues.Array(aoffset, ashift, arrayClass)
                 : new VarHandleReferences.Array(aoffset, ashift, arrayClass));
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -31,6 +31,8 @@ import java.lang.invoke.VarHandle.VarHandleDesc;
 import java.util.Objects;
 import java.util.Optional;
 
+import jdk.internal.value.PrimitiveClass;
+
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
@@ -148,7 +150,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object checkCast(FieldInstanceReadWrite handle, $type$ value) {
-            if (handle.fieldType.isPrimitiveValueType())
+            if (PrimitiveClass.isPrimitiveValueType(handle.fieldType))
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -501,7 +503,7 @@ final class VarHandle$Type$s {
 
 #if[Object]
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
-            if (handle.fieldType.isPrimitiveValueType())
+            if (PrimitiveClass.isPrimitiveValueType(handle.fieldType))
                 Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
@@ -744,7 +746,7 @@ final class VarHandle$Type$s {
 #if[Reference]
     static VarHandle makeVarHandleValuesArray(Class<?> arrayClass) {
         Class<?> componentType = arrayClass.getComponentType();
-        assert componentType.isPrimitiveValueType() && UNSAFE.isFlattenedArray(arrayClass);
+        assert PrimitiveClass.isPrimitiveValueType(componentType) && UNSAFE.isFlattenedArray(arrayClass);
         // should cache these VarHandle for performance
         return VarHandles.makeArrayElementHandle(arrayClass);
     }
@@ -803,7 +805,7 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
-            if (handle.componentType.isPrimitiveValueType())
+            if (PrimitiveClass.isPrimitiveValueType(handle.componentType))
                  Objects.requireNonNull(value);
 
             if (handle.arrayType == oarray.getClass()) {

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -25,6 +25,7 @@
 
 package java.lang.ref;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.access.JavaLangRefAccess;
@@ -500,8 +501,7 @@ public abstract sealed class Reference<T>
     Reference(T referent, ReferenceQueue<? super T> queue) {
         if (referent != null && referent.getClass().isValue()) {
             Class<?> c = referent.getClass();
-            throw new IllegalArgumentException("cannot reference a " +
-                    (c.isPrimitiveClass() ? "primitive class " : "value class ") +
+            throw new IllegalArgumentException("cannot reference a value class " +
                     c.getName());
         }
         this.referent = referent;

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.ConstructorAccessor;
@@ -124,7 +125,7 @@ public final class Constructor<T> extends Executable {
                 String signature,
                 byte[] annotations,
                 byte[] parameterAnnotations) {
-        assert declaringClass.isPrimaryType();
+        assert PrimitiveClass.isPrimaryType(declaringClass);
         this.clazz = declaringClass;
         this.parameterTypes = parameterTypes;
         this.exceptionTypes = checkedExceptions;

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -31,10 +31,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import sun.reflect.annotation.AnnotationParser;
 import sun.reflect.annotation.AnnotationSupport;
 import sun.reflect.annotation.TypeAnnotationParser;
@@ -802,8 +802,8 @@ public abstract sealed class Executable extends AccessibleObject
 
     String getDeclaringClassTypeName() {
         Class<?> c = getDeclaringClass();
-        if (c.isPrimitiveClass()) {
-            c = c.asValueType();
+        if (PrimitiveClass.isPrimitiveClass(c)) {
+            c = PrimitiveClass.asValueType(c);
         }
         return c.getTypeName();
     }

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.FieldAccessor;
 import jdk.internal.reflect.Reflection;
@@ -129,7 +130,7 @@ class Field extends AccessibleObject implements Member {
           String signature,
           byte[] annotations)
     {
-        assert declaringClass.isPrimaryType();
+        assert PrimitiveClass.isPrimaryType(declaringClass);
         this.clazz = declaringClass;
         this.name = name;
         this.type = type;
@@ -356,8 +357,8 @@ class Field extends AccessibleObject implements Member {
 
     String getDeclaringClassTypeName() {
         Class<?> c = getDeclaringClass();
-        if (c.isPrimitiveClass()) {
-            c = c.asValueType();
+        if (PrimitiveClass.isPrimitiveClass(c)) {
+            c = PrimitiveClass.asValueType(c);
         }
         return c.getTypeName();
     }

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.CallerSensitiveAdapter;
@@ -130,7 +131,7 @@ public final class Method extends Executable {
            byte[] annotations,
            byte[] parameterAnnotations,
            byte[] annotationDefault) {
-        assert declaringClass.isPrimaryType();
+        assert PrimitiveClass.isPrimaryType(declaringClass);
         this.clazz = declaringClass;
         this.name = name;
         this.parameterTypes = parameterTypes;

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -50,6 +50,7 @@ import java.util.function.BooleanSupplier;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.module.Modules;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
@@ -879,7 +880,7 @@ public class Proxy implements java.io.Serializable {
                 type = Class.forName(c.getName(), false, ld);
             } catch (ClassNotFoundException e) {
             }
-            if (type.asPrimaryType() != c.asPrimaryType()) {
+            if (PrimitiveClass.asPrimaryType(type) != PrimitiveClass.asPrimaryType(c)) {
                 throw new IllegalArgumentException(c.getName() +
                         " referenced from a method is not visible from class loader");
             }

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.VM;
 import jdk.internal.org.objectweb.asm.Attribute;
 import jdk.internal.org.objectweb.asm.ByteVector;
@@ -848,7 +849,7 @@ final class ProxyGenerator extends ClassWriter {
             while (c.isArray()) {
                 c = c.getComponentType();
             }
-            return (c.isValue() && !c.isPrimitiveClass()) || c.isPrimitiveValueType();
+            return (c.isValue() && !PrimitiveClass.isPrimitiveClass(c)) || PrimitiveClass.isPrimitiveValueType(c);
         }
 
         /**
@@ -914,7 +915,7 @@ final class ProxyGenerator extends ClassWriter {
                 }
             } else {
                 String internalName = dotToSlash(type.getName());
-                if (type.isPrimitiveValueType()) {
+                if (PrimitiveClass.isPrimitiveValueType(type)) {
                     internalName = 'Q' + internalName + ";";
                 }
                 mv.visitTypeInsn(CHECKCAST, internalName);
@@ -979,10 +980,11 @@ final class ProxyGenerator extends ClassWriter {
             mv.visitMethodInsn(INVOKESTATIC,
                     JL_CLASS,
                     "forName", "(Ljava/lang/String;)Ljava/lang/Class;", false);
-            if (cl.isPrimitiveValueType()) {
-              mv.visitMethodInsn(INVOKEVIRTUAL,
-                                 JL_CLASS,
-                                 "asValueType", "()Ljava/lang/Class;", false);
+            if (PrimitiveClass.isPrimitiveValueType(cl)) {
+              mv.visitMethodInsn(INVOKESTATIC,
+                      "jdk/internal/value/PrimitiveClass",
+                      "asValueType", "(Ljava/lang/Class;)Ljava/lang/Class;",
+                      false);
             }
         }
 

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -25,6 +25,8 @@
 
 package java.lang.runtime;
 
+import jdk.internal.value.PrimitiveClass;
+
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -416,7 +418,7 @@ public class ObjectMethods {
         requireNonNull(getters);
         Arrays.stream(getters).forEach(Objects::requireNonNull);
         MethodType methodType;
-        Class<?> receiverType = recordClass.isPrimitiveClass() ? recordClass.asValueType() : recordClass;
+        Class<?> receiverType = PrimitiveClass.isPrimitiveClass(recordClass) ? PrimitiveClass.asValueType(recordClass) : recordClass;
         if (type instanceof MethodType mt) {
             methodType = mt;
             if (mt.parameterType(0) != receiverType) {

--- a/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/PrimitiveObjectMethods.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.value.PrimitiveClass;
 import sun.invoke.util.Wrapper;
 import sun.security.action.GetIntegerAction;
 import sun.security.action.GetPropertyAction;
@@ -120,7 +121,7 @@ final class PrimitiveObjectMethods {
          * of the given primitive class are substitutable.
          */
         static MethodHandle primitiveTypeEquals(Class<?> type) {
-            assert type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
+            assert PrimitiveClass.isPrimitiveValueType(type) || (type.isValue() && !PrimitiveClass.isPrimitiveClass(type));
             MethodType mt = methodType(boolean.class, type, type);
             MethodHandle[] getters = getters(type, TYPE_SORTER);
             MethodHandle instanceTrue = dropArguments(TRUE, 0, type, Object.class).asType(mt);
@@ -142,7 +143,7 @@ final class PrimitiveObjectMethods {
         }
 
         static MethodHandle primitiveTypeHashCode(Class<?> type) {
-            assert type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass());
+            assert PrimitiveClass.isPrimitiveValueType(type) || (type.isValue() && !PrimitiveClass.isPrimitiveClass(type));
             MethodHandle target = dropArguments(constant(int.class, SALT), 0, type);
             MethodHandle cls = dropArguments(constant(Class.class, type),0, type);
             MethodHandle classHashCode = filterReturnValue(cls, hashCodeForType(Class.class));
@@ -187,8 +188,8 @@ final class PrimitiveObjectMethods {
             assert a != null && b != null && isSameValueClass(a, b);
             try {
                 Class<?> type = a.getClass();
-                if (type.isPrimitiveClass()) {
-                    type = type.asValueType();
+                if (PrimitiveClass.isPrimitiveClass(type)) {
+                    type = PrimitiveClass.asValueType(type);
                 }
                 return (boolean) substitutableInvoker(type).invoke(type.cast(a), type.cast(b));
             } catch (Error|RuntimeException e) {
@@ -370,8 +371,8 @@ final class PrimitiveObjectMethods {
 
         try {
             Class<?> type = a.getClass();
-            if (type.isPrimitiveClass()) {
-                type = type.asValueType();
+            if (PrimitiveClass.isPrimitiveClass(type)) {
+                type = PrimitiveClass.asValueType(type);
             }
             return (boolean) substitutableInvoker(type).invoke(a, b);
         } catch (Error|RuntimeException e) {
@@ -416,7 +417,7 @@ final class PrimitiveObjectMethods {
         if (type.isPrimitive())
             return MethodHandleBuilder.primitiveEquals(type);
 
-        if (type.isPrimitiveValueType() || (type.isValue() && !type.isPrimitiveClass())) {
+        if (PrimitiveClass.isPrimitiveValueType(type) || (type.isValue() && !PrimitiveClass.isPrimitiveClass(type))) {
             return SUBST_TEST_METHOD_HANDLES.get(type);
         }
         return MethodHandleBuilder.referenceTypeEquals(type);
@@ -441,7 +442,7 @@ final class PrimitiveObjectMethods {
             // risk for recursion for experts crafting byte-code
             if (!c.isValue())
                 throw new InternalError("must be value or primitive class: " + c.getName());
-            Class<?> type = c.isPrimitiveClass() ? c.asValueType() : c;
+            Class<?> type = PrimitiveClass.isPrimitiveClass(c) ? PrimitiveClass.asValueType(c) : c;
             return (int) HASHCODE_METHOD_HANDLES.get(type).invoke(o);
         } catch (Error|RuntimeException e) {
             throw e;

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -410,4 +410,28 @@ public interface JavaLangAccess {
      * @param statusCode the status code
      */
     void exit(int statusCode);
+
+    /**
+     * {@return the primary class for a primitive class}
+     * @param klass a class
+     */
+    Class<?> asPrimaryType(Class<?> klass);
+    /**
+     * {@return the value type of a primitive class}
+     * @param klass a class
+     */
+    Class<?> asValueType(Class<?> klass);
+
+    /**
+     * {@return true if the class is the primary type of a primitive class}
+     * @param klass a class
+     */
+    boolean isPrimaryType(Class<?> klass);
+
+    /**
+     * {@return true if the class is the primary type of a primitive class}
+     * @param klass a class
+     */
+    boolean isPrimitiveValueType(Class<?> klass);
+
 }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -26,6 +26,7 @@
 package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -269,7 +270,7 @@ public final class Unsafe {
      */
     public Object getReference(Object o, long offset, Class<?> pc) {
         Object ref = getReference(o, offset);
-        if (ref == null && pc.isPrimitiveValueType()) {
+        if (ref == null && PrimitiveClass.isPrimitiveValueType(pc)) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);
@@ -279,7 +280,7 @@ public final class Unsafe {
 
     public Object getReferenceVolatile(Object o, long offset, Class<?> pc) {
         Object ref = getReferenceVolatile(o, offset);
-        if (ref == null && pc.isPrimitiveValueType()) {
+        if (ref == null && PrimitiveClass.isPrimitiveValueType(pc)) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(pc);
@@ -1548,7 +1549,7 @@ public final class Unsafe {
                                                        Object x);
 
     private final boolean isInlineType(Object o) {
-        return o != null && o.getClass().isPrimitiveClass();
+        return o != null && PrimitiveClass.isPrimitiveClass(o.getClass());
     }
 
     /*
@@ -1562,7 +1563,7 @@ public final class Unsafe {
                                                     Class<?> valueType,
                                                     V expected,
                                                     V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             synchronized (valueLock) {
                 Object witness = getReference(o, offset);
                 if (witness == expected) {
@@ -1603,7 +1604,7 @@ public final class Unsafe {
                                                         Class<?> valueType,
                                                         V expected,
                                                         V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             synchronized (valueLock) {
                 Object witness = getReference(o, offset);
                 if (witness == expected) {
@@ -1685,7 +1686,7 @@ public final class Unsafe {
                                                              Class<?> valueType,
                                                              V expected,
                                                              V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1711,7 +1712,7 @@ public final class Unsafe {
                                                                Class<?> valueType,
                                                                V expected,
                                                                V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1737,7 +1738,7 @@ public final class Unsafe {
                                                                Class<?> valueType,
                                                                V expected,
                                                                V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1763,7 +1764,7 @@ public final class Unsafe {
                                                         Class<?> valueType,
                                                         V expected,
                                                         V x) {
-        if (valueType.isPrimitiveClass() || isInlineType(expected)) {
+        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -25,6 +25,8 @@
 
 package jdk.internal.reflect;
 
+import jdk.internal.value.PrimitiveClass;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -95,7 +97,7 @@ class MethodAccessorGenerator extends AccessorGenerator {
         return (ConstructorAccessor) generate(declaringClass,
                                               "<init>",
                                               parameterTypes,
-                                              isStaticFactory ? declaringClass.asValueType() : Void.TYPE,
+                                              isStaticFactory ? PrimitiveClass.asValueType(declaringClass) : Void.TYPE,
                                               checkedExceptions,
                                               modifiers,
                                               true,

--- a/src/java.base/share/classes/jdk/internal/reflect/UnsafeFieldAccessorImpl.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/UnsafeFieldAccessorImpl.java
@@ -27,6 +27,8 @@ package jdk.internal.reflect;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.Unsafe;
 
 /** Base class for jdk.internal.misc.Unsafe-based FieldAccessors. The
@@ -57,7 +59,7 @@ abstract class UnsafeFieldAccessorImpl extends FieldAccessorImpl {
     }
 
     protected boolean canBeNull() {
-        return !field.getType().isPrimitiveClass() || field.getType().isPrimaryType();
+        return !PrimitiveClass.isPrimitiveClass(field.getType()) || PrimitiveClass.isPrimaryType(field.getType());
     }
 
     protected Object checkValue(Object value) {
@@ -66,8 +68,8 @@ abstract class UnsafeFieldAccessorImpl extends FieldAccessorImpl {
 
         if (value != null) {
             Class<?> type = value.getClass();
-            if (type.isPrimitiveClass()) {
-                type = type.asValueType();
+            if (PrimitiveClass.isPrimitiveClass(type)) {
+                type = PrimitiveClass.asValueType(type);
             }
             if (!field.getType().isAssignableFrom(type)) {
                 throwSetIllegalArgumentException(value);

--- a/src/java.base/share/classes/jdk/internal/value/PrimitiveClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/PrimitiveClass.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.value;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.vm.annotation.IntrinsicCandidate;
+
+/**
+ * Utilities to access Primitive Classes as described in JEP 401.
+ */
+public class PrimitiveClass {
+
+    // ACC_PRIMITIVE from JEP 401
+    private static final int PRIMITIVE_CLASS = 0x00000800;
+
+    private static final JavaLangAccess javaLangAccess = SharedSecrets.getJavaLangAccess();
+
+
+    /**
+     * Returns a {@code Class} object representing the primary type
+     * of this class or interface.
+     * <p>
+     * If this {@code Class} object represents a primitive type or an array type,
+     * then this method returns this class.
+     * <p>
+     * If this {@code Class} object represents a {@linkplain #isPrimitiveClass(Class)
+     * primitive class}, then this method returns the <em>primitive reference type</em>
+     * type of this primitive class.
+     * <p>
+     * Otherwise, this {@code Class} object represents a non-primitive class or interface
+     * and this method returns this class.
+     *
+     * @param aClass a class
+     * @return the {@code Class} representing the primary type of
+     *         this class or interface
+     * @since Valhalla
+     */
+    @IntrinsicCandidate
+    public static <T> Class<?> asPrimaryType(Class<T> aClass) {
+        return javaLangAccess.asPrimaryType(aClass);
+    }
+
+    /**
+     * Returns a {@code Class} object representing the <em>primitive value type</em>
+     * of this class if this class is a {@linkplain #isPrimitiveClass(Class)}  primitive class}.
+     *
+     * @apiNote Alternatively, this method returns null if this class is not
+     *          a primitive class rather than throwing UOE.
+     *
+     * @param aClass a class
+     * @return the {@code Class} representing the {@linkplain #isPrimitiveValueType(Class)
+     * primitive value type} of this class if this class is a primitive class
+     * @throws UnsupportedOperationException if this class or interface
+     *         is not a primitive class
+     * @since Valhalla
+     */
+    @IntrinsicCandidate
+    public static <T> Class<?> asValueType(Class<T> aClass) {
+        return javaLangAccess.asValueType(aClass);
+
+    }
+
+    /**
+     * Returns {@code true} if this {@code Class} object represents the primary type
+     * of this class or interface.
+     * <p>
+     * If this {@code Class} object represents a primitive type or an array type,
+     * then this method returns {@code true}.
+     * <p>
+     * If this {@code Class} object represents a {@linkplain #isPrimitiveClass(Class)
+     * primitive}, then this method returns {@code true} if this {@code Class}
+     * object represents a primitive reference type, or returns {@code false}
+     * if this {@code Class} object represents a primitive value type.
+     * <p>
+     * If this {@code Class} object represents a non-primitive class or interface,
+     * then this method returns {@code true}.
+     *
+     * @param aClass a class
+     * @return {@code true} if this {@code Class} object represents
+     * the primary type of this class or interface
+     * @since Valhalla
+     */
+    public static <T> boolean isPrimaryType(Class<T> aClass) {
+        return javaLangAccess.isPrimaryType(aClass);
+
+    }
+
+    /**
+     * Returns {@code true} if this {@code Class} object represents
+     * a {@linkplain #isPrimitiveClass(Class)  primitive} value type.
+     *
+     * @return {@code true} if this {@code Class} object represents
+     * the value type of a primitive class
+     * @since Valhalla
+     */
+    public static <T> boolean isPrimitiveValueType(Class<T> aClass) {
+        return javaLangAccess.isPrimitiveValueType(aClass);
+    }
+
+    /**
+     * Returns {@code true} if this class is a primitive class.
+     * <p>
+     * Each primitive class has a {@linkplain #isPrimaryType(Class)  primary type}
+     * representing the <em>primitive reference type</em> and a
+     * {@linkplain #isPrimitiveValueType(Class)  secondary type} representing
+     * the <em>primitive value type</em>.  The primitive reference type
+     * and primitive value type can be obtained by calling the
+     * {@link #asPrimaryType(Class)} and {@link PrimitiveClass#asValueType} method
+     * of a primitive class respectively.
+     * <p>
+     * A primitive class is a {@linkplain Class#isValue() value class}.
+     *
+     * @param aClass a class
+     * @return {@code true} if this class is a primitive class, otherwise {@code false}
+     * @see Class#isValue()
+     * @see #asPrimaryType(Class)
+     * @see #asValueType(Class)
+     * @since Valhalla
+     */
+    public static <T> boolean isPrimitiveClass(Class<T> aClass) {
+        return (aClass.getModifiers() & PRIMITIVE_CLASS) != 0;
+    }
+}

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -255,6 +255,8 @@ module java.base {
         jdk.jfr;
     exports jdk.internal.util.random to
         jdk.random;
+    exports jdk.internal.value to  // Needed by Unsafe
+        jdk.unsupported;
     exports sun.net to
         java.net.http,
         jdk.naming.dns;

--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -25,6 +25,8 @@
 
 package sun.invoke.util;
 
+import jdk.internal.value.PrimitiveClass;
+
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,7 +93,7 @@ public class BytecodeDescriptor {
             String name = str.substring(begc, endc).replace('/', '.');
             try {
                 Class<?> clz = Class.forName(name, false, loader);
-                return c == 'Q' ? clz.asValueType() : clz.asPrimaryType();
+                return c == 'Q' ? PrimitiveClass.asValueType(clz) : PrimitiveClass.asPrimaryType(clz);
             } catch (ClassNotFoundException ex) {
                 throw new TypeNotPresentException(name, ex);
             }

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -27,6 +27,8 @@ package sun.invoke.util;
 
 import java.lang.reflect.Modifier;
 import static java.lang.reflect.Modifier.*;
+
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.reflect.Reflection;
 
 /**
@@ -105,7 +107,7 @@ public class VerifyAccess {
             return false;
         }
         // Usually refc and defc are the same, but verify defc also in case they differ.
-        if (defc.asPrimaryType() == lookupClass  &&
+        if (PrimitiveClass.asPrimaryType(defc) == lookupClass  &&
             (allowedModes & PRIVATE) != 0)
             return true;        // easy check; all self-access is OK with a private lookup
 
@@ -140,7 +142,7 @@ public class VerifyAccess {
                                  Reflection.areNestMates(defc, lookupClass));
             // for private methods the selected method equals the
             // resolved method - so refc == defc
-            assert (canAccess && refc.asPrimaryType() == defc.asPrimaryType()) || !canAccess;
+            assert (canAccess && PrimitiveClass.asPrimaryType(refc) == PrimitiveClass.asPrimaryType(defc)) || !canAccess;
             return canAccess;
         default:
             throw new IllegalArgumentException("bad modifiers: "+Modifier.toString(mods));
@@ -148,7 +150,7 @@ public class VerifyAccess {
     }
 
     static boolean isRelatedClass(Class<?> refc, Class<?> lookupClass) {
-        return (refc.asPrimaryType() == lookupClass.asPrimaryType() ||
+        return (PrimitiveClass.asPrimaryType(refc) == PrimitiveClass.asPrimaryType(lookupClass) ||
                 isSubClass(refc, lookupClass) ||
                 isSubClass(lookupClass, refc));
     }
@@ -273,7 +275,7 @@ public class VerifyAccess {
      * @param refc the class attempting to make the reference
      */
     public static boolean isTypeVisible(Class<?> type, Class<?> refc) {
-        if (type.asPrimaryType() == refc.asPrimaryType()) {
+        if (PrimitiveClass.asPrimaryType(type) == PrimitiveClass.asPrimaryType(refc)) {
             return true;  // easy check
         }
         while (type.isArray())  type = type.getComponentType();
@@ -334,7 +336,7 @@ public class VerifyAccess {
                         }
                     }
             });
-        return (type.asPrimaryType() == res);
+        return (PrimitiveClass.asPrimaryType(type) == res);
     }
 
     /**

--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -25,12 +25,12 @@
 
 package sun.misc;
 
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.util.Set;
 
@@ -651,7 +651,7 @@ public final class Unsafe {
         if (declaringClass.isHidden()) {
             throw new UnsupportedOperationException("can't get field offset on a hidden class: " + f);
         }
-        if (f.getDeclaringClass().isPrimitiveClass()) {
+        if (PrimitiveClass.isPrimitiveClass(f.getDeclaringClass())) {
             throw new UnsupportedOperationException("can't get field offset on an inline class: " + f);
         }
         if (declaringClass.isRecord()) {
@@ -693,7 +693,7 @@ public final class Unsafe {
         if (declaringClass.isHidden()) {
             throw new UnsupportedOperationException("can't get field offset on a hidden class: " + f);
         }
-        if (f.getDeclaringClass().isPrimitiveClass()) {
+        if (PrimitiveClass.isPrimitiveClass(f.getDeclaringClass())) {
             throw new UnsupportedOperationException("can't get static field offset on an inline class: " + f);
         }
         if (declaringClass.isRecord()) {
@@ -727,7 +727,7 @@ public final class Unsafe {
         if (declaringClass.isHidden()) {
             throw new UnsupportedOperationException("can't get base address on a hidden class: " + f);
         }
-        if (f.getDeclaringClass().isPrimitiveClass()) {
+        if (PrimitiveClass.isPrimitiveClass(f.getDeclaringClass())) {
             throw new UnsupportedOperationException("can't get base address on an inline class: " + f);
         }
         if (declaringClass.isRecord()) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import jdk.internal.value.PrimitiveClass;
+
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessPoint extends VarHandleBaseTest {
-    static final Class<?> type = Point.class.asValueType();
+    static final Class<?> type = PrimitiveClass.asValueType(Point.class);
 
     static final Point static_final_v = Point.getInstance(1,1);
 
@@ -1324,4 +1326,3 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
         });
     }
 }
-

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,10 +38,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import jdk.internal.value.PrimitiveClass;
+
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
-    static final Class<?> type = Point.class.asValueType();
+    static final Class<?> type = PrimitiveClass.asValueType(Point.class);
 
     static final Point static_final_v = Point.getInstance(1,1);
 
@@ -716,4 +718,3 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
         }
     }
 }
-

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,12 +42,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import jdk.internal.value.PrimitiveClass;
+
 import static org.testng.Assert.*;
 
 import static java.lang.invoke.MethodType.*;
 
 public class VarHandleTestMethodTypePoint extends VarHandleBaseTest {
-    static final Class<?> type = Point.class.asValueType();
+    static final Class<?> type = PrimitiveClass.asValueType(Point.class);
 
     static final Point static_final_v = Point.getInstance(1,1);
 

--- a/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
+++ b/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/InstructionHelper.java
@@ -35,6 +35,8 @@ import jdk.experimental.bytecode.TypedCodeBuilder;
 import jdk.experimental.bytecode.TypeHelper;
 import jdk.experimental.bytecode.TypeTag;
 
+import jdk.internal.value.PrimitiveClass;
+
 import java.io.FileOutputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -289,7 +291,7 @@ public class InstructionHelper {
             @Override
             public boolean isInlineClass(String desc) {
                 Class<?> aClass = symbol(desc);
-                return aClass != null && aClass.isPrimitiveValueType();
+                return aClass != null && PrimitiveClass.isPrimitiveValueType(aClass);
             }
 
             @Override
@@ -299,7 +301,7 @@ public class InstructionHelper {
                         return Class.forName(desc.replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
                     } else {
                         Class<?> c = Class.forName(basicTypeHelper.symbol(desc).replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
-                        return basicTypeHelper.isInlineClass(desc) ? c.asValueType() : c.asPrimaryType();
+                        return basicTypeHelper.isInlineClass(desc) ? PrimitiveClass.asValueType(c) : PrimitiveClass.asPrimaryType(c);
                     }
                 } catch (ReflectiveOperationException ex) {
                     throw new AssertionError(ex);

--- a/test/jdk/java/lang/invoke/condy/BootstrapMethodJumboArgsTest.java
+++ b/test/jdk/java/lang/invoke/condy/BootstrapMethodJumboArgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/valhalla/valuetypes/MHZeroValue.java
+++ b/test/jdk/valhalla/valuetypes/MHZeroValue.java
@@ -36,6 +36,8 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import static java.lang.invoke.MethodType.*;
 
+import jdk.internal.value.PrimitiveClass;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -60,8 +62,8 @@ public class MHZeroValue {
                 // for any type T, default value is always the same as (new T[1])[0]
                 new Object[] { int.class,               (new int[1])[0] },
                 new Object[] { Integer.class,           (new Integer[1])[0] },
-                new Object[] { P.class.asValueType(),   (new P[1])[0] },
-                new Object[] { P.class.asPrimaryType(), (new P.ref[1])[0] },
+                new Object[] { PrimitiveClass.asValueType(P.class),   (new P[1])[0] },
+                new Object[] { PrimitiveClass.asPrimaryType(P.class), (new P.ref[1])[0] },
                 new Object[] { V.class,                 (new V[1])[0] },
         };
     }
@@ -77,7 +79,7 @@ public class MHZeroValue {
                 // int : Integer
                 new Object[] { int.class,             Integer.class },
                 // Point : Point.ref
-                new Object[] { P.class.asValueType(), P.class.asPrimaryType() },
+                new Object[] { PrimitiveClass.asValueType(P.class), PrimitiveClass.asPrimaryType(P.class) },
                 new Object[] { null,                  V.class },
         };
     }
@@ -99,8 +101,8 @@ public class MHZeroValue {
 
     @DataProvider
     public static Object[][] emptyTypes() {
-        Class<?> pref = P.class.asPrimaryType();
-        Class<?> pval = P.class.asValueType();
+        Class<?> pref = PrimitiveClass.asPrimaryType(P.class);
+        Class<?> pval = PrimitiveClass.asValueType(P.class);
         return new Object[][] {
                 new Object[] { methodType(int.class, int.class, Object.class),     new V(), 0 },
                 new Object[] { methodType(Integer.class, int.class, Object.class), new P(), null },

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import java.lang.invoke.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
+
+import jdk.internal.value.PrimitiveClass;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -151,10 +153,10 @@ public class MethodHandleTest {
         // set an array element to null
         try {
             Object v = (Object)setter.invoke(array, 1, null);
-            assertFalse(elementType.isPrimitiveValueType(), "should fail to set a primitive class array element to null");
+            assertFalse(PrimitiveClass.isPrimitiveValueType(elementType), "should fail to set a primitive class array element to null");
             assertNull((Object)getter.invoke(array, 1));
         } catch (NullPointerException e) {
-            assertTrue(elementType.isPrimitiveValueType(), "should only fail to set a primitive class array element to null");
+            assertTrue(PrimitiveClass.isPrimitiveValueType(elementType), "should only fail to set a primitive class array element to null");
         }
     }
 
@@ -166,7 +168,7 @@ public class MethodHandleTest {
         Class<?> c = f.getDeclaringClass();
         assertFalse(Modifier.isFinal(f.getModifiers()));
         assertFalse(Modifier.isStatic(f.getModifiers()));
-        boolean canBeNull = f.getType().isPrimaryType();
+        boolean canBeNull = PrimitiveClass.isPrimaryType(f.getType());
         // test reflection
         try {
             f.set(o, null);
@@ -236,7 +238,7 @@ public class MethodHandleTest {
         Field f = c.getDeclaredField(name);
         boolean isStatic = Modifier.isStatic(f.getModifiers());
         assertTrue(f.getType().isValue());
-        assertTrue(f.getType().isPrimitiveValueType() == isPrimitiveValue);
+        assertTrue(PrimitiveClass.isPrimitiveValueType(f.getType()) == isPrimitiveValue);
         assertTrue((isStatic && obj == null) || (!isStatic && obj != null));
         Object v = f.get(obj);
 

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -38,6 +38,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+import jdk.internal.value.PrimitiveClass;
+
 public class ObjectMethods {
     static final int SALT = 1;
     static final Point P1 = Point.makePoint(1, 2);
@@ -167,14 +169,14 @@ public class ObjectMethods {
     Object[][] hashcodeTests() {
         // this is sensitive to the order of the returned fields from Class::getDeclaredFields
         return new Object[][]{
-            { P1,                   hash(Point.class.asValueType(), 1, 2) },
-            { LINE1,                hash(Line.class.asValueType(), Point.makePoint(1, 2), Point.makePoint(3, 4)) },
+            { P1,                   hash(PrimitiveClass.asValueType(Point.class), 1, 2) },
+            { LINE1,                hash(PrimitiveClass.asValueType(Line.class), Point.makePoint(1, 2), Point.makePoint(3, 4)) },
             { VALUE,                hash(hashCodeComponents(VALUE))},
             { VALUE1,               hash(hashCodeComponents(VALUE1))},
-            { Point.makePoint(0,0), hash(Point.class.asValueType(), 0, 0) },
-            { Point.default,        hash(Point.class.asValueType(), 0, 0) },
-            { MyValue1.default,     hash(MyValue1.class.asValueType(), Point.default, null) },
-            { new MyValue1(0, 0, null), hash(MyValue1.class.asValueType(), Point.makePoint(0,0), null) },
+            { Point.makePoint(0,0), hash(PrimitiveClass.asValueType(Point.class), 0, 0) },
+            { Point.default,        hash(PrimitiveClass.asValueType(Point.class), 0, 0) },
+            { MyValue1.default,     hash(PrimitiveClass.asValueType(MyValue1.class), Point.default, null) },
+            { new MyValue1(0, 0, null), hash(PrimitiveClass.asValueType(MyValue1.class), Point.makePoint(0,0), null) },
             { new ValueOptional(P1), hash(ValueOptional.class, P1) },
         };
     }
@@ -197,8 +199,8 @@ public class ObjectMethods {
                     throw new RuntimeException(e);
                 }
             });
-        if (type.isPrimitiveClass()) {
-            type = type.asValueType();
+        if (PrimitiveClass.isPrimitiveClass(type)) {
+            type = PrimitiveClass.asValueType(type);
         }
         return Stream.concat(Stream.of(type), fields).toArray(Object[]::new);
     }

--- a/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,9 @@
 /*
  * @test
  * @summary Test ObjectMethods::bootstrap call via condy
+ * @modules java.base/jdk.internal.value:+open
  * @modules java.base/jdk.internal.org.objectweb.asm
- * @run testng ObjectMethodsViaCondy
+ * @run testng/othervm ObjectMethodsViaCondy
  */
 
 import java.io.IOException;
@@ -41,6 +42,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
+
+import jdk.internal.value.PrimitiveClass;
 
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.ConstantDynamic;
@@ -67,9 +70,9 @@ public class ObjectMethodsViaCondy {
     public static primitive record PrimitiveRecord(int i, String name) {
         static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
-        static final MethodType EQUALS_DESC = methodType(boolean.class, PrimitiveRecord.class.asValueType(), Object.class);
-        static final MethodType HASHCODE_DESC = methodType(int.class, PrimitiveRecord.class.asValueType());
-        static final MethodType TO_STRING_DESC = methodType(String.class, PrimitiveRecord.class.asValueType());
+        static final MethodType EQUALS_DESC = methodType(boolean.class, PrimitiveClass.asValueType(PrimitiveRecord.class), Object.class);
+        static final MethodType HASHCODE_DESC = methodType(int.class, PrimitiveClass.asValueType(PrimitiveRecord.class));
+        static final MethodType TO_STRING_DESC = methodType(String.class, PrimitiveClass.asValueType(PrimitiveRecord.class));
 
         static final Handle[] ACCESSORS = accessors();
         static final String NAME_LIST = "i;name";
@@ -94,7 +97,7 @@ public class ObjectMethodsViaCondy {
          */
         static MethodHandle makeBootstrapMethod(String methodName) throws Throwable {
             ClassFileBuilder builder = new ClassFileBuilder("Test-" + methodName);
-            builder.bootstrapMethod(methodName, TO_STRING_DESC, PrimitiveRecord.class.asValueType(), NAME_LIST, ACCESSORS);
+            builder.bootstrapMethod(methodName, TO_STRING_DESC, PrimitiveClass.asValueType(PrimitiveRecord.class), NAME_LIST, ACCESSORS);
             byte[] bytes = builder.build();
             MethodHandles.Lookup lookup = LOOKUP.defineHiddenClass(bytes, true, ClassOption.NESTMATE);
             MethodType mtype = MethodType.methodType(Object.class);

--- a/test/jdk/valhalla/valuetypes/PrimitiveTypeConversionTest.java
+++ b/test/jdk/valhalla/valuetypes/PrimitiveTypeConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ import static java.lang.invoke.MethodType.*;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+import jdk.internal.value.PrimitiveClass;
+
 public class PrimitiveTypeConversionTest {
     static primitive class Value {
         Point val;
@@ -61,8 +63,8 @@ public class PrimitiveTypeConversionTest {
     @Test
     public static void primitiveWidening() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh1 = lookup.findStatic(PrimitiveTypeConversionTest.class, "narrow", methodType(Value.class.asValueType(), Value.ref.class));
-        MethodHandle mh2 = mh1.asType(methodType(Value.class.asValueType(), Value.class.asValueType()));
+        MethodHandle mh1 = lookup.findStatic(PrimitiveTypeConversionTest.class, "narrow", methodType(PrimitiveClass.asValueType(Value.class), Value.ref.class));
+        MethodHandle mh2 = mh1.asType(methodType(PrimitiveClass.asValueType(Value.class), PrimitiveClass.asValueType(Value.class)));
         Object v = mh1.invoke(VALUE);
         assertEquals(v, VALUE);
         try {
@@ -79,7 +81,7 @@ public class PrimitiveTypeConversionTest {
     @Test
     public static void primitiveNarrowing() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh = lookup.findStatic(PrimitiveTypeConversionTest.class, "widen", methodType(Value.ref.class, Value.class.asValueType()));
+        MethodHandle mh = lookup.findStatic(PrimitiveTypeConversionTest.class, "widen", methodType(Value.ref.class, PrimitiveClass.asValueType(Value.class)));
         Object v = mh.invoke(VALUE);
         assertTrue(v == null);
         try {
@@ -88,7 +90,7 @@ public class PrimitiveTypeConversionTest {
         } catch (NullPointerException e) {
             e.printStackTrace();
         }
-        MethodHandle mh2 = mh.asType(methodType(Value.class.asValueType(), Value.ref.class));
+        MethodHandle mh2 = mh.asType(methodType(PrimitiveClass.asValueType(Value.class), Value.ref.class));
         try {
             Value v2 = (Value) mh2.invoke((Value.ref)null);
             fail("Expected NullPointerException but not thrown");
@@ -100,8 +102,8 @@ public class PrimitiveTypeConversionTest {
     @Test
     public static void valToRef() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh1 = lookup.findGetter(Value.class.asValueType(), "val", Point.class.asValueType());
-        MethodHandle mh2 = mh1.asType(methodType(Point.ref.class, Value.class.asValueType()));
+        MethodHandle mh1 = lookup.findGetter(PrimitiveClass.asValueType(Value.class), "val", PrimitiveClass.asValueType(Point.class));
+        MethodHandle mh2 = mh1.asType(methodType(Point.ref.class, PrimitiveClass.asValueType(Value.class)));
         Value v = new Value(new Point(10,10), null);
 
         Point p1 = (Point) mh1.invokeExact(VALUE);
@@ -111,8 +113,8 @@ public class PrimitiveTypeConversionTest {
 
     @Test
     public static void refToVal() throws Throwable {
-        MethodHandle mh1 = MethodHandles.lookup().findGetter(Value.class.asValueType(), "ref", Point.ref.class);
-        MethodHandle mh2 = mh1.asType(methodType(Point.class.asValueType(), Value.class.asValueType()));
+        MethodHandle mh1 = MethodHandles.lookup().findGetter(PrimitiveClass.asValueType(Value.class), "ref", Point.ref.class);
+        MethodHandle mh2 = mh1.asType(methodType(PrimitiveClass.asValueType(Point.class), PrimitiveClass.asValueType(Value.class)));
         Point.ref p1 = (Point.ref) mh1.invokeExact(VALUE);
         Point p2 = (Point) mh2.invokeExact(VALUE);
         assertEquals(p1, p2);
@@ -121,8 +123,8 @@ public class PrimitiveTypeConversionTest {
     @Test
     public static void valToRef1() throws Throwable {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
-        MethodHandle mh1 = lookup.findGetter(Value.class.asValueType(), "val", Point.class.asValueType());
-        MethodHandle mh2 = mh1.asType(methodType(Point.class.asValueType(), Value.ref.class));
+        MethodHandle mh1 = lookup.findGetter(PrimitiveClass.asValueType(Value.class), "val", PrimitiveClass.asValueType(Point.class));
+        MethodHandle mh2 = mh1.asType(methodType(PrimitiveClass.asValueType(Point.class), Value.ref.class));
 
         Point p1 = (Point) mh1.invokeExact(VALUE);
         Point p2 = (Point) mh2.invoke(VALUE);
@@ -133,7 +135,7 @@ public class PrimitiveTypeConversionTest {
 
     @Test
     public static void refToVal1() throws Throwable {
-        MethodHandle mh1 = MethodHandles.lookup().findGetter(Value.class.asValueType(), "ref", Point.ref.class);
+        MethodHandle mh1 = MethodHandles.lookup().findGetter(PrimitiveClass.asValueType(Value.class), "ref", Point.ref.class);
         MethodHandle mh2 = mh1.asType(methodType(Point.ref.class, Value.ref.class));
         Value v = new Value(new Point(10,10), null);
 
@@ -146,8 +148,8 @@ public class PrimitiveTypeConversionTest {
 
     @Test
     public static void refToVal2() throws Throwable {
-        MethodHandle mh1 = MethodHandles.lookup().findGetter(Value.class.asValueType(), "ref", Point.ref.class);
-        MethodHandle mh2 = mh1.asType(methodType(Point.class.asValueType(), Value.class.asValueType()));
+        MethodHandle mh1 = MethodHandles.lookup().findGetter(PrimitiveClass.asValueType(Value.class), "ref", Point.ref.class);
+        MethodHandle mh2 = mh1.asType(methodType(PrimitiveClass.asValueType(Point.class), PrimitiveClass.asValueType(Value.class)));
         Value v = new Value(new Point(10,10), null);
 
         Point.ref p1 = (Point.ref) mh1.invokeExact(v);

--- a/test/jdk/valhalla/valuetypes/ProxyTest.java
+++ b/test/jdk/valhalla/valuetypes/ProxyTest.java
@@ -30,6 +30,7 @@
 import java.lang.reflect.*;
 import java.util.Arrays;
 
+
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 

--- a/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
+++ b/test/jdk/valhalla/valuetypes/QTypeDescriptorTest.java
@@ -35,6 +35,8 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.*;
 import java.util.function.*;
 
+import jdk.internal.value.PrimitiveClass;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -59,8 +61,8 @@ public class QTypeDescriptorTest {
 
     @Test
     public void testMethodInvoke() throws Exception {
-        Class<?> pointQType = Point.class.asValueType();
-        Class<?> nonFlattenValueQType = NonFlattenValue.class.asValueType();
+        Class<?> pointQType = PrimitiveClass.asValueType(Point.class);
+        Class<?> nonFlattenValueQType = PrimitiveClass.asValueType(NonFlattenValue.class);
         Method m = QTypeDescriptorTest.class
             .getDeclaredMethod("toLine", pointQType, nonFlattenValueQType);
         makeLine(m, P0, NFV);
@@ -107,13 +109,13 @@ public class QTypeDescriptorTest {
     @DataProvider
     static Object[][] descriptors() {
         return new Object[][]{
-            { QTypeDescriptorTest.class, "toLine", new Class<?>[] { Point.class.asValueType(), NonFlattenValue.class.asValueType()},     true},
-            { QTypeDescriptorTest.class, "toLine", new Class<?>[] { Point.ref.class, NonFlattenValue.class.asValueType()}, false},
+            { QTypeDescriptorTest.class, "toLine", new Class<?>[] { PrimitiveClass.asValueType(Point.class), PrimitiveClass.asValueType(NonFlattenValue.class)},     true},
+            { QTypeDescriptorTest.class, "toLine", new Class<?>[] { Point.ref.class, PrimitiveClass.asValueType(NonFlattenValue.class)}, false},
             { QTypeDescriptorTest.class, "toLine", new Class<?>[] { Point[].class },                         true},
-            { NonFlattenValue.class.asValueType(), "point",      null,                                                     true},
-            { NonFlattenValue.class.asValueType(), "pointValue", null,                                                     true},
-            { NonFlattenValue.class.asValueType(), "has",        new Class<?>[] { Point.class.asValueType(), Point.ref.class},           true},
-            { NonFlattenValue.class.asValueType(), "has",        new Class<?>[] { Point.class.asValueType(), Point.class.asValueType()},               false},
+            { PrimitiveClass.asValueType(NonFlattenValue.class), "point",      null,                                                     true},
+            { PrimitiveClass.asValueType(NonFlattenValue.class), "pointValue", null,                                                     true},
+            { PrimitiveClass.asValueType(NonFlattenValue.class), "has",        new Class<?>[] { PrimitiveClass.asValueType(Point.class), Point.ref.class},           true},
+            { PrimitiveClass.asValueType(NonFlattenValue.class), "has",        new Class<?>[] { PrimitiveClass.asValueType(Point.class), PrimitiveClass.asValueType(Point.class)},               false},
         };
     }
 
@@ -132,11 +134,11 @@ public class QTypeDescriptorTest {
         ClassLoader loader = QTypeDescriptorTest.class.getClassLoader();
         return new Object[][]{
             { "point",      MethodType.methodType(Point.ref.class),                                      true },
-            { "pointValue", MethodType.methodType(Point.class.asValueType()),                                          true },
-            { "has",        MethodType.methodType(boolean.class, Point.class.asValueType(), Point.ref.class),          true },
-            { "point",      MethodType.methodType(Point.class.asValueType()),                                          false },
+            { "pointValue", MethodType.methodType(PrimitiveClass.asValueType(Point.class)),                                          true },
+            { "has",        MethodType.methodType(boolean.class, PrimitiveClass.asValueType(Point.class), Point.ref.class),          true },
+            { "point",      MethodType.methodType(PrimitiveClass.asValueType(Point.class)),                                          false },
             { "pointValue", MethodType.methodType(Point.ref.class),                                      false },
-            { "has",        MethodType.methodType(boolean.class, Point.ref.class, Point.class.asValueType()),          false },
+            { "has",        MethodType.methodType(boolean.class, Point.ref.class, PrimitiveClass.asValueType(Point.class)),          false },
             { "point",      MethodType.fromMethodDescriptorString("()LPoint;", loader),        true },
             { "point",      MethodType.fromMethodDescriptorString("()QPoint;", loader),        false },
             { "pointValue", MethodType.fromMethodDescriptorString("()QPoint;", loader),        true },
@@ -149,7 +151,7 @@ public class QTypeDescriptorTest {
     @Test(dataProvider = "methodTypes")
     public void methodHandleLookup(String name, MethodType mtype, boolean found) throws Throwable {
         try {
-            MethodHandles.lookup().findVirtual(NonFlattenValue.class.asValueType(), name, mtype);
+            MethodHandles.lookup().findVirtual(PrimitiveClass.asValueType(NonFlattenValue.class), name, mtype);
             if (!found) throw new AssertionError("Expected NoSuchMethodException");
         } catch (NoSuchMethodException e) {
             if (found) throw e;

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,18 +35,20 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import jdk.internal.value.PrimitiveClass;
+
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class Reflection {
     @Test
     public static void testPointClass() throws Exception  {
-        Object o = Point.class.asValueType().newInstance();
-        assertEquals(o.getClass(), Point.class.asPrimaryType());
+        Object o = PrimitiveClass.asValueType(Point.class).newInstance();
+        assertEquals(o.getClass(), PrimitiveClass.asPrimaryType(Point.class));
 
         Constructor<?> ctor = Point.class.getDeclaredConstructor(int.class, int.class);
         o = ctor.newInstance(20, 30);
-        assertEquals(o.getClass(), Point.class.asPrimaryType());
+        assertEquals(o.getClass(), PrimitiveClass.asPrimaryType(Point.class));
 
         Field field = Point.class.getField("x");
         if (field.getInt(o) != 20) {
@@ -68,18 +70,18 @@ public class Reflection {
 
     @Test
     public static void testLineClass() throws Exception {
-        checkInstanceField(Line.class.asValueType(), "p1", Point.class.asValueType());
-        checkInstanceField(Line.class.asValueType(), "p2", Point.class.asValueType());
-        checkInstanceMethod(Line.class.asValueType(), "p1", Point.class.asValueType());
-        checkInstanceMethod(Line.class.asValueType(), "p2", Point.class.asValueType());
+        checkInstanceField(PrimitiveClass.asValueType(Line.class), "p1", PrimitiveClass.asValueType(Point.class));
+        checkInstanceField(PrimitiveClass.asValueType(Line.class), "p2", PrimitiveClass.asValueType(Point.class));
+        checkInstanceMethod(PrimitiveClass.asValueType(Line.class), "p1", PrimitiveClass.asValueType(Point.class));
+        checkInstanceMethod(PrimitiveClass.asValueType(Line.class), "p2", PrimitiveClass.asValueType(Point.class));
     }
 
     @Test
     public static void testNonFlattenValue() throws Exception {
-        checkInstanceField(NonFlattenValue.class.asValueType(), "nfp", Point.ref.class);
-        checkInstanceMethod(NonFlattenValue.class.asValueType(), "pointValue", Point.class.asValueType());
-        checkInstanceMethod(NonFlattenValue.class.asValueType(), "point", Point.ref.class);
-        checkInstanceMethod(NonFlattenValue.class.asValueType(), "has", boolean.class, Point.class.asValueType(), Point.ref.class);
+        checkInstanceField(PrimitiveClass.asValueType(NonFlattenValue.class), "nfp", Point.ref.class);
+        checkInstanceMethod(PrimitiveClass.asValueType(NonFlattenValue.class), "pointValue", PrimitiveClass.asValueType(Point.class));
+        checkInstanceMethod(PrimitiveClass.asValueType(NonFlattenValue.class), "point", Point.ref.class);
+        checkInstanceMethod(PrimitiveClass.asValueType(NonFlattenValue.class), "has", boolean.class, PrimitiveClass.asValueType(Point.class), Point.ref.class);
     }
 
     @Test

--- a/test/jdk/valhalla/valuetypes/StaticFactoryMethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryMethodHandleTest.java
@@ -37,6 +37,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
+import jdk.internal.value.PrimitiveClass;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -80,7 +82,7 @@ public class StaticFactoryMethodHandleTest {
     @Test
     public void testNoArgStaticFactory() throws Throwable {
         // test default static init factory
-        Class<? extends Cons> cls = (Class<? extends Cons>)DefaultConstructor.class.asValueType();
+        Class<? extends Cons> cls = (Class<? extends Cons>)PrimitiveClass.asValueType(DefaultConstructor.class);
         MethodHandle mh = staticInitFactory(cls, methodType(cls));
         DefaultConstructor o = (DefaultConstructor)mh.invokeExact();
         assertEquals(o, new DefaultConstructor());
@@ -89,7 +91,7 @@ public class StaticFactoryMethodHandleTest {
 
     @DataProvider(name="ctorWithArgs")
     static Object[][] ctorWithArgs() {
-        Class<? extends Cons> cls = (Class<? extends Cons>)ConstructorWithArgs.class.asValueType();
+        Class<? extends Cons> cls = (Class<? extends Cons>)PrimitiveClass.asValueType(ConstructorWithArgs.class);
         return new Object[][]{
                 new Object[] { cls, methodType(cls, int.class), Modifier.PUBLIC, new ConstructorWithArgs(1) },
                 new Object[] { cls, methodType(cls, int.class, int.class), 0, new ConstructorWithArgs(1, 2) },
@@ -147,14 +149,14 @@ public class StaticFactoryMethodHandleTest {
         //
         MethodHandle mh = lookup.findStatic(c, "<init>", mtype);
         try {
-            lookup.findConstructor(DefaultConstructor.class.asValueType(), mtype);
+            lookup.findConstructor(PrimitiveClass.asValueType(DefaultConstructor.class), mtype);
             throw new RuntimeException("findConstructor should not find the static init factory");
         } catch (NoSuchMethodException e) {
         }
 
         // crack method handle
         MethodHandleInfo minfo = lookup.revealDirect(mh);
-        assertEquals(minfo.getDeclaringClass(), c.asPrimaryType());
+        assertEquals(minfo.getDeclaringClass(), PrimitiveClass.asPrimaryType(c));
         assertEquals(minfo.getName(), "<init>");
         assertEquals(minfo.getReferenceKind(), MethodHandleInfo.REF_invokeStatic);
         assertEquals(minfo.getMethodType(), mtype);

--- a/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
+++ b/test/jdk/valhalla/valuetypes/StaticFactoryTest.java
@@ -37,6 +37,8 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jdk.internal.value.PrimitiveClass;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -81,7 +83,7 @@ public class StaticFactoryTest {
         Class<?> clz = Class.forName(cn);
 
         assertTrue(clz.isValue());
-        assertTrue(clz.isPrimitiveClass() == isPrimitiveClass);
+        assertTrue(PrimitiveClass.isPrimitiveClass(clz) == isPrimitiveClass);
 
         Constructor<?> ctor = clz.getDeclaredConstructor();
         Object o = ctor.newInstance();

--- a/test/jdk/valhalla/valuetypes/TEST.properties
+++ b/test/jdk/valhalla/valuetypes/TEST.properties
@@ -1,5 +1,2 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false
-
 # Reflection methods for primitive classes are in PrimitiveClass instead of java.lang.class
 modules = java.base/jdk.internal.value:+open

--- a/test/jdk/valhalla/valuetypes/UninitializedValueTest.java
+++ b/test/jdk/valhalla/valuetypes/UninitializedValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,9 @@
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
+
+import jdk.internal.value.PrimitiveClass;
+
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -76,7 +79,7 @@ public class UninitializedValueTest {
 
         // field of primitive value type must be non-null
         Field f1 = v.getClass().getDeclaredField("empty");
-        assertTrue(f1.getType() == EmptyValue.class.asValueType());
+        assertTrue(f1.getType() == PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue empty = (EmptyValue)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
     }
@@ -90,12 +93,12 @@ public class UninitializedValueTest {
 
         // field of primitive value type type must be non-null
         Field f1 = v.getClass().getDeclaredField("empty");
-        assertTrue(f1.getType() == EmptyValue.class.asValueType());
+        assertTrue(f1.getType() == PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue empty = (EmptyValue)f1.get(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
         Field f2 = v.getClass().getDeclaredField("vempty");
-        assertTrue(f2.getType() == EmptyValue.class.asValueType());
+        assertTrue(f2.getType() == PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue vempty = (EmptyValue)f2.get(v);
         assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
 
@@ -108,7 +111,7 @@ public class UninitializedValueTest {
     @Test
     public void testMethodHandleValue() throws Throwable {
         Value v = new Value();
-        MethodHandle mh = MethodHandles.lookup().findGetter(Value.class.asValueType(), "empty", EmptyValue.class.asValueType());
+        MethodHandle mh = MethodHandles.lookup().findGetter(PrimitiveClass.asValueType(Value.class), "empty", PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue empty = (EmptyValue) mh.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
     }
@@ -116,20 +119,20 @@ public class UninitializedValueTest {
     @Test
     public void testMethodHandleMutableValue() throws Throwable {
         MutableValue v = new MutableValue();
-        MethodHandle getter = MethodHandles.lookup().findGetter(MutableValue.class, "empty", EmptyValue.class.asValueType());
+        MethodHandle getter = MethodHandles.lookup().findGetter(MutableValue.class, "empty", PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue empty = (EmptyValue) getter.invokeExact(v);
         assertTrue(empty.isEmpty());        // test if empty is non-null with default value
 
-        MethodHandle getter1 = MethodHandles.lookup().findGetter(MutableValue.class, "vempty", EmptyValue.class.asValueType());
+        MethodHandle getter1 = MethodHandles.lookup().findGetter(MutableValue.class, "vempty", PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue vempty = (EmptyValue) getter1.invokeExact(v);
         assertTrue(vempty.isEmpty());        // test if vempty is non-null with default value
 
-        MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyValue.class.asValueType());
+        MethodHandle setter = MethodHandles.lookup().findSetter(MutableValue.class, "empty", PrimitiveClass.asValueType(EmptyValue.class));
         setter.invokeExact(v, new EmptyValue());
         empty = (EmptyValue) getter.invokeExact(v);
         assertTrue(empty == new EmptyValue());
 
-        MethodHandle setter1 = MethodHandles.lookup().findSetter(MutableValue.class, "vempty", EmptyValue.class.asValueType());
+        MethodHandle setter1 = MethodHandles.lookup().findSetter(MutableValue.class, "vempty", PrimitiveClass.asValueType(EmptyValue.class));
         setter1.invokeExact(v, new EmptyValue());
         vempty = (EmptyValue) getter1.invokeExact(v);
         assertTrue(vempty == new EmptyValue());
@@ -152,7 +155,7 @@ public class UninitializedValueTest {
     @Test(expectedExceptions = { NullPointerException.class})
     public void nonNullableField_MethodHandle() throws Throwable {
         MutableValue v = new MutableValue();
-        MethodHandle mh = MethodHandles.lookup().findSetter(MutableValue.class, "empty", EmptyValue.class.asValueType());
+        MethodHandle mh = MethodHandles.lookup().findSetter(MutableValue.class, "empty", PrimitiveClass.asValueType(EmptyValue.class));
         EmptyValue.ref e = null;
         EmptyValue empty = (EmptyValue) mh.invokeExact(v, (EmptyValue)e);
     }

--- a/test/jdk/valhalla/valuetypes/ValueArray.java
+++ b/test/jdk/valhalla/valuetypes/ValueArray.java
@@ -35,11 +35,13 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+import jdk.internal.value.PrimitiveClass;
+
 public class ValueArray {
     @DataProvider(name="elementTypes")
     static Object[][] elementTypes() {
         return new Object[][]{
-            new Object[] { Point.class.asValueType(), Point.default },
+            new Object[] { PrimitiveClass.asValueType(Point.class), Point.default },
             new Object[] { Point.ref.class, null },
             new Object[] { ValueOptional.class, null },
         };
@@ -51,15 +53,15 @@ public class ValueArray {
     @Test(dataProvider="elementTypes")
     public void testElementType(Class<?> elementType, Object defaultValue) {
         assertTrue(elementType.isValue());
-        assertTrue(elementType.isPrimaryType() || defaultValue != null);
+        assertTrue(PrimitiveClass.isPrimaryType(elementType) || defaultValue != null);
 
         Object[] array = (Object[])Array.newInstance(elementType, 1);
         Class<?> arrayType = array.getClass();
         assertTrue(arrayType.componentType() == elementType);
         // Array is a reference type
         assertTrue(arrayType.isArray());
-        assertTrue(arrayType.isPrimaryType());
-        assertEquals(arrayType.asPrimaryType(), arrayType);
+        assertTrue(PrimitiveClass.isPrimaryType(arrayType));
+        assertEquals(PrimitiveClass.asPrimaryType(arrayType), arrayType);
         assertTrue(array[0] == defaultValue);
 
         // check the element type of multi-dimensional array
@@ -108,9 +110,9 @@ public class ValueArray {
         testClassName(arrayClass);
         testArrayElements(arrayClass, array);
         Class<?> componentType = arrayClass.componentType();
-        if (componentType.isPrimitiveClass()) {
-            Object[] qArray = (Object[]) Array.newInstance(componentType.asValueType(), 0);
-            Object[] lArray = (Object[]) Array.newInstance(componentType.asPrimaryType(), 0);
+        if (PrimitiveClass.isPrimitiveClass(componentType)) {
+            Object[] qArray = (Object[]) Array.newInstance(PrimitiveClass.asValueType(componentType), 0);
+            Object[] lArray = (Object[]) Array.newInstance(PrimitiveClass.asPrimaryType(componentType), 0);
             testArrayCovariance(componentType, qArray, lArray);
         }
     }
@@ -127,7 +129,7 @@ public class ValueArray {
             sb.append("[");
             c = c.getComponentType();
         }
-        sb.append(c.isPrimitiveValueType() ? "Q" : "L").append(c.getName()).append(";");
+        sb.append(PrimitiveClass.isPrimitiveValueType(c) ? "Q" : "L").append(c.getName()).append(";");
         assertEquals(sb.toString(), arrayClassName);
     }
 
@@ -154,7 +156,7 @@ public class ValueArray {
         Arrays.setAll(newArray, i -> array[i]);
 
         // test nullable
-        if (!componentType.isPrimitiveValueType()) {
+        if (!PrimitiveClass.isPrimitiveValueType(componentType)) {
             for (int i = 0; i < newArray.length; i++) {
                 Array.set(newArray, i, null);
             }
@@ -173,7 +175,7 @@ public class ValueArray {
      * Point[] is a subtype of Point.ref[], which is a subtype of Object[].
      */
     static void testArrayCovariance(Class<?> componentType, Object[] qArray, Object[] lArray) {
-        assertTrue(componentType.isPrimitiveClass());
+        assertTrue(PrimitiveClass.isPrimitiveClass(componentType));
 
         // Class.instanceOf (self)
         assertTrue(qArray.getClass().isInstance(qArray));

--- a/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
+++ b/test/jdk/valhalla/valuetypes/ValueConstantDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ import org.testng.annotations.Test;
 import java.lang.constant.ClassDesc;
 import java.lang.invoke.MethodHandles;
 
+import jdk.internal.value.PrimitiveClass;
+
 import static org.testng.Assert.*;
 
 public class ValueConstantDesc {
@@ -43,7 +45,7 @@ public class ValueConstantDesc {
     @DataProvider(name="descs")
     static Object[][] descs() {
         return new Object[][]{
-            new Object[] { Point.class.asValueType(),     ClassDesc.ofDescriptor("Q" + NAME + ";"), NAME},
+            new Object[] { PrimitiveClass.asValueType(Point.class),     ClassDesc.ofDescriptor("Q" + NAME + ";"), NAME},
             new Object[] { Point.ref.class, ClassDesc.ofDescriptor("L" + NAME + ";"), NAME},
             new Object[] { Point[].class,   ClassDesc.ofDescriptor("[Q" + NAME + ";"), NAME + "[]"},
             new Object[] { Point.ref[][].class, ClassDesc.ofDescriptor("[[L" + NAME + ";"), NAME + "[][]"},
@@ -71,7 +73,7 @@ public class ValueConstantDesc {
     @DataProvider(name="componentTypes")
     static Object[][] componentTypes() {
         return new Object[][]{
-            new Object[] { Point.class.asValueType() },
+            new Object[] { PrimitiveClass.asValueType(Point.class) },
             new Object[] { Point.ref.class },
             new Object[] { ValueOptional.class }
         };
@@ -92,7 +94,7 @@ public class ValueConstantDesc {
     @DataProvider(name="valueDesc")
     static Object[][] valueDesc() {
         return new Object[][]{
-                new Object[] { Point.class.asValueType(),         "Q" + NAME + ";"},
+                new Object[] { PrimitiveClass.asValueType(Point.class),         "Q" + NAME + ";"},
                 new Object[] { Point.ref.class,     "L" + NAME + ";"},
                 new Object[] { Point[].class,       "[Q" + NAME + ";"},
                 new Object[] { Point.ref[][].class, "[[L" + NAME + ";"},
@@ -108,7 +110,7 @@ public class ValueConstantDesc {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         Class<?> c = (Class<?>) cd.resolveConstantDesc(lookup);
         assertTrue(c == type);
-        assertTrue(cd.isPrimitiveValueType() == type.isPrimitiveValueType());
+        assertTrue(cd.isPrimitiveValueType() == PrimitiveClass.isPrimitiveValueType(type));
     }
 
     @Test(expectedExceptions = {LinkageError.class})

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.java
@@ -2,8 +2,11 @@
  * @test /nodynamiccopyright/
  * @bug 8221323
  * @summary  Javac should support class literals for projection types.
+ * @modules java.base/jdk.internal.value:+open
  * @compile/fail/ref=ClassLiteralTypingNegativeTest.out -XDrawDiagnostics ClassLiteralTypingNegativeTest.java
  */
+
+import jdk.internal.value.PrimitiveClass;
 
 public class ClassLiteralTypingNegativeTest {
 
@@ -11,7 +14,7 @@ public class ClassLiteralTypingNegativeTest {
         final int value = 0;
 
         public static void main(String[] args) {
-            Class<? extends Foo.ref> cFooRef = Foo.class.asValueType(); // Error
+            Class<? extends Foo.ref> cFooRef; // NYI:  = Foo.class.asValueType(); // Error
             cFooRef = new Foo().getClass(); // OK.
             cFooRef = Foo.ref.class; // OK.
             cFooRef = Foo.val.class; // Error.
@@ -28,7 +31,7 @@ public class ClassLiteralTypingNegativeTest {
         final int value = 0;
 
         public static void main(String[] args) {
-            Class<? extends Bar.ref> cBarRef = Bar.class.asValueType(); // Error
+            Class<? extends Bar.ref> cBarRef;   // NYI: = Bar.class.asValueType(); // Error
             cBarRef = new Bar().getClass(); // OK.
             cBarRef = Bar.ref.class; // OK.
             cBarRef = Bar.val.class; // Error.

--- a/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.out
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ClassLiteralTypingNegativeTest.out
@@ -1,5 +1,3 @@
-ClassLiteralTypingNegativeTest.java:14:69: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ?>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
-ClassLiteralTypingNegativeTest.java:17:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
-ClassLiteralTypingNegativeTest.java:31:69: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ?>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
-ClassLiteralTypingNegativeTest.java:34:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
-4 errors
+ClassLiteralTypingNegativeTest.java:20:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Foo.ref>)
+ClassLiteralTypingNegativeTest.java:37:30: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends java.lang.Object&ClassLiteralTypingNegativeTest.I>, java.lang.Class<? extends ClassLiteralTypingNegativeTest.Bar.ref>)
+2 errors

--- a/test/langtools/tools/javac/valhalla/lworld-values/TestReflectiveMirrors.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/TestReflectiveMirrors.java
@@ -27,8 +27,11 @@
  * @test
  * @bug 8269956
  * @summary  javac should generate `ldc LPoint;` for class literal Point.class
+ * @modules java.base/jdk.internal.value:+open
  * @run main TestReflectiveMirrors
  */
+
+import jdk.internal.value.PrimitiveClass;
 
 public class TestReflectiveMirrors {
 
@@ -44,7 +47,7 @@ public class TestReflectiveMirrors {
             throw new AssertionError("Wrong mirror");
         }
 
-        if (ValDefault.val.class != new ValDefault().getClass().asValueType()) {
+        if (ValDefault.val.class != PrimitiveClass.asValueType(new ValDefault().getClass())) {
             throw new AssertionError("Wrong mirror");
         }
 
@@ -56,7 +59,7 @@ public class TestReflectiveMirrors {
             throw new AssertionError("Wrong mirror");
         }
 
-        if (TestReflectiveMirrors.ValDefault.val.class != new ValDefault().getClass().asValueType()) {
+        if (TestReflectiveMirrors.ValDefault.val.class != PrimitiveClass.asValueType(new ValDefault().getClass())) {
             throw new AssertionError("Wrong mirror");
         }
     }

--- a/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/UnifiedPrimitiveClassNestHostTest.java
@@ -27,10 +27,12 @@
  * @test
  * @bug 8265423
  * @summary Experimental support for generating a single class file per primitive class
+ * @modules java.base/jdk.internal.value:+open
  * @run main UnifiedPrimitiveClassNestHostTest
  */
 
 import java.util.Arrays;
+import jdk.internal.value.PrimitiveClass;
 
 public primitive class UnifiedPrimitiveClassNestHostTest implements java.io.Serializable {
 
@@ -63,7 +65,7 @@ public primitive class UnifiedPrimitiveClassNestHostTest implements java.io.Seri
         if (!members[0].equals(nestHost))
             throw new AssertionError("Wrong initial member: " + members[0]);
 
-        if (!members[1].equals(Inner.class.asPrimaryType()))
+        if (!members[1].equals(PrimitiveClass.asPrimaryType(Inner.class)))
             throw new AssertionError("Wrong initial member: " + members[1]);
 
         if (!members[1].getNestHost().equals(nestHost))

--- a/test/langtools/tools/javac/valhalla/lworld-values/ValueBootstrapMethodsTest.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/ValueBootstrapMethodsTest.java
@@ -25,11 +25,13 @@
 /*
  * @test
  * @summary test value bootstrap methods
+ * @modules java.base/jdk.internal.value:+open
  * @run main/othervm -Dvalue.bsm.salt=1 ValueBootstrapMethodsTest
  */
 
 import java.util.List;
 import java.util.Objects;
+import jdk.internal.value.PrimitiveClass;
 
 public class ValueBootstrapMethodsTest {
 
@@ -46,7 +48,7 @@ public class ValueBootstrapMethodsTest {
         }
 
         private List<Object> values() {
-            return List.of(Value.class.asValueType(), i, d, s, l);
+            return List.of(PrimitiveClass.asValueType(Value.class), i, d, s, l);
         }
 
         public int localHashCode() {
@@ -55,7 +57,7 @@ public class ValueBootstrapMethodsTest {
 
         public String localToString() {
             System.out.println(l);
-            return String.format("%s@%s", Value.class.asValueType().getName(), Integer.toHexString(localHashCode()));
+            return String.format("%s@%s", PrimitiveClass.asValueType(Value.class).getName(), Integer.toHexString(localHashCode()));
         }
 
         @Override


### PR DESCRIPTION
To avoid confusion with the reflection support for [Value Objects](https://bugs.openjdk.java.net/browse/JDK-8277163)
the java.lang.Class APIs in support of JEP 401 (Primitive Objects) should be hidden.

The methods `Class.asValueType`, `asPrimaryType`, `isPrimaryType`, `isPrimitiveClass`, and `asPrimitiveValueType`
are moved to be static methods of `jdk.internal.value.PrimitiveClass`.

To access those methods, add `--exports java.base/jdk.internal.value:+open` to the command line
in addition to other flags needed to enable Primitive Objects and convert to invoke them as static methods with the class.

The openjdk classes and tests are modified to use the alternate API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287692](https://bugs.openjdk.java.net/browse/JDK-8287692): Move Class primitive APIs to jdk.internal.value.PrimitiveClass


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/704/head:pull/704` \
`$ git checkout pull/704`

Update a local copy of the PR: \
`$ git checkout pull/704` \
`$ git pull https://git.openjdk.java.net/valhalla pull/704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 704`

View PR using the GUI difftool: \
`$ git pr show -t 704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/704.diff">https://git.openjdk.java.net/valhalla/pull/704.diff</a>

</details>
