### PR TITLE
8287767: [lw4] Javac tolerates mutually incompatible super types.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2764,15 +2764,19 @@ public class Check {
 
         boolean cIsValue = (c.tsym.flags() & VALUE_CLASS) != 0;
         boolean cHasIdentity = (c.tsym.flags() & IDENTITY_TYPE) != 0;
-
-        if (cIsValue || cHasIdentity) {
-            for (Type t : types.closure(c)) {
-                if (t != c) {
-                    if (cIsValue && (t.tsym.flags() & IDENTITY_TYPE) != 0) {
-                        log.error(pos, Errors.ValueTypeHasIdentitySuperType(c, t));
-                    } else if (cHasIdentity && (t.tsym.flags() & VALUE_CLASS) != 0) {
-                        log.error(pos, Errors.IdentityTypeHasValueSuperType(c, t));
-                    }
+        Type identitySuper = null, valueSuper = null;
+        for (Type t : types.closure(c)) {
+            if (t != c) {
+                if ((t.tsym.flags() & IDENTITY_TYPE) != 0)
+                    identitySuper = t;
+                else if ((t.tsym.flags() & VALUE_CLASS) != 0)
+                    valueSuper = t;
+                if (cIsValue &&  identitySuper != null) {
+                    log.error(pos, Errors.ValueTypeHasIdentitySuperType(c, identitySuper));
+                } else if (cHasIdentity &&  valueSuper != null) {
+                    log.error(pos, Errors.IdentityTypeHasValueSuperType(c, valueSuper));
+                } else if (identitySuper != null && valueSuper != null) {
+                    log.error(pos, Errors.MutuallyIncompatibleSupers(c, identitySuper, valueSuper));
                 }
             }
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3957,6 +3957,10 @@ compiler.err.value.type.has.identity.super.type=\
 compiler.err.identity.type.has.value.super.type=\
     The value type {1} cannot be a supertype of the identity type {0}
 
+# 0: type, 1: type, 2: type
+compiler.err.mutually.incompatible.supers=\
+    The type {0} has mutually incompatible supertypes: the identity type {1} and the value type {2}
+
 # 0: symbol, 1: type
 compiler.err.concrete.supertype.for.value.class=\
     The concrete class {1} is not allowed to be a super class of the value class {0} either directly or indirectly

--- a/test/langtools/tools/javac/diags/examples/IdentityValueClash.java
+++ b/test/langtools/tools/javac/diags/examples/IdentityValueClash.java
@@ -24,6 +24,7 @@
 // key: compiler.err.illegal.combination.of.modifiers
 // key: compiler.err.identity.type.has.value.super.type
 // key: compiler.err.value.type.has.identity.super.type
+// key: compiler.err.mutually.incompatible.supers
 
 value identity class IdentityValueClass {}
 
@@ -32,3 +33,4 @@ class C implements VI {}
 
 identity interface II {}
 value class V implements II {}
+abstract class B implements VI, II {}

--- a/test/langtools/tools/javac/valhalla/value-objects/MutuallyIncompatibleSupers.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/MutuallyIncompatibleSupers.java
@@ -1,0 +1,23 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8287767
+ * @summary [lw4] Javac tolerates mutually incompatible super types.
+ * @compile/fail/ref=MutuallyIncompatibleSupers.out -XDrawDiagnostics -XDdev MutuallyIncompatibleSupers.java
+ */
+
+public class MutuallyIncompatibleSupers {
+
+    identity interface II {}
+    value interface VI {}
+
+    static abstract class X implements II, VI {} // mutually incompatible supers.
+
+    interface GII extends II {} // OK.
+    value interface BVI extends GII {} // Error
+
+    interface GVI extends VI {} // OK.
+    identity interface BII extends GVI {} // Error
+
+    static value class BVC implements II {} // Error
+    class BIC implements VI {} // Error
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/MutuallyIncompatibleSupers.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/MutuallyIncompatibleSupers.out
@@ -1,0 +1,6 @@
+MutuallyIncompatibleSupers.java:13:21: compiler.err.mutually.incompatible.supers: MutuallyIncompatibleSupers.X, MutuallyIncompatibleSupers.II, MutuallyIncompatibleSupers.VI
+MutuallyIncompatibleSupers.java:16:11: compiler.err.value.type.has.identity.super.type: MutuallyIncompatibleSupers.BVI, MutuallyIncompatibleSupers.II
+MutuallyIncompatibleSupers.java:19:14: compiler.err.identity.type.has.value.super.type: MutuallyIncompatibleSupers.BII, MutuallyIncompatibleSupers.VI
+MutuallyIncompatibleSupers.java:21:18: compiler.err.value.type.has.identity.super.type: MutuallyIncompatibleSupers.BVC, MutuallyIncompatibleSupers.II
+MutuallyIncompatibleSupers.java:22:5: compiler.err.identity.type.has.value.super.type: MutuallyIncompatibleSupers.BIC, MutuallyIncompatibleSupers.VI
+5 errors


### PR DESCRIPTION
Restore behavior inadvertently deleted earlier.  