### PR TITLE
8287898: [lw4] test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java fails

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3320,9 +3320,9 @@ u2 ClassFileParser::parse_classfile_inner_classes_attribute(const ClassFileStrea
     if (_major_version >= JAVA_9_VERSION) {
       recognized_modifiers |= JVM_ACC_MODULE;
     }
-    // JVM_ACC_VALUE, JVM_ACC_PRIMITIVE, and JVM_ACC_PERMITS_VALUE are defined for class file version 62 and later
+    // JVM_ACC_VALUE and JVM_ACC_PRIMITIVE are defined for class file version 62 and later
     if (supports_inline_types()) {
-      recognized_modifiers |= JVM_ACC_PRIMITIVE | JVM_ACC_VALUE | JVM_ACC_PERMITS_VALUE;
+      recognized_modifiers |= JVM_ACC_PRIMITIVE | JVM_ACC_VALUE;
     }
 
     // Access flags
@@ -6178,7 +6178,7 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
   }
   // JVM_ACC_VALUE and JVM_ACC_PRIMITIVE are defined for class file version 55 and later
   if (supports_inline_types()) {
-    recognized_modifiers |= JVM_ACC_PRIMITIVE | JVM_ACC_VALUE | JVM_ACC_PERMITS_VALUE;
+    recognized_modifiers |= JVM_ACC_PRIMITIVE | JVM_ACC_VALUE;
   }
 
   // Access flags


### PR DESCRIPTION
…er/VerifierInlineTypes.java fails

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287898](https://bugs.openjdk.org/browse/JDK-8287898): [lw4] test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VerifierInlineTypes.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/706/head:pull/706` \
`$ git checkout pull/706`

Update a local copy of the PR: \
`$ git checkout pull/706` \
`$ git pull https://git.openjdk.java.net/valhalla pull/706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 706`

View PR using the GUI difftool: \
`$ git pr show -t 706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/706.diff">https://git.openjdk.java.net/valhalla/pull/706.diff</a>

</details>
