### PR TITLE
8288084: [lw4] Tier1 hotspot runtime test ClassHierarchyTest.java fails

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/ClassHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @compile -XDnoTopInterfaceInjection ClassHierarchyTest.java
  * @run testng ClassHierarchyTest
  */
 
@@ -67,12 +66,10 @@ public class ClassHierarchyTest {
     // java.lang.Object/null
     // |--DcmdBaseClass/0xa4abcd48
     // |  implements Intf2/0xa4abcd48 (declared intf)
-    // |  implements java.lang.IdentityObject/null (declared intf)
     // |  implements Intf1/0xa4abcd48 (inherited intf)
     // |  |--DcmdTestClass/0xa4abcd48
     // |  |  implements Intf1/0xa4abcd48 (inherited intf)
     // |  |  implements Intf2/0xa4abcd48 (inherited intf)
-    // |  |  implements java.lang.IdentityObject/null (inherited intf)
 
     static Pattern expected_lambda_line =
         Pattern.compile("\\|--DcmdTestClass\\$\\$Lambda.*");
@@ -81,12 +78,10 @@ public class ClassHierarchyTest {
         Pattern.compile("java.lang.Object/null"),
         Pattern.compile("\\|--DcmdBaseClass/0x(\\p{XDigit}*)"),
         Pattern.compile("\\|  implements Intf2/0x(\\p{XDigit}*) \\(declared intf\\)"),
-        Pattern.compile("\\|  implements java.lang.IdentityObject/null \\(declared intf\\)"),
         Pattern.compile("\\|  implements Intf1/0x(\\p{XDigit}*) \\(inherited intf\\)"),
         Pattern.compile("\\|  \\|--DcmdTestClass/0x(\\p{XDigit}*)"),
         Pattern.compile("\\|  \\|  implements Intf1/0x(\\p{XDigit}*) \\(inherited intf\\)"),
-        Pattern.compile("\\|  \\|  implements Intf2/0x(\\p{XDigit}*) \\(inherited intf\\)"),
-        Pattern.compile("\\|  \\|  implements java.lang.IdentityObject/null \\(inherited intf\\)")
+        Pattern.compile("\\|  \\|  implements Intf2/0x(\\p{XDigit}*) \\(inherited intf\\)")
     };
 
     public void run(CommandExecutor executor) throws ClassNotFoundException {
@@ -144,7 +139,7 @@ public class ClassHierarchyTest {
                 Assert.fail("Failed to match line #" + i + ": " + line);
             }
             // "implements" lines should not be in this output.
-            if (i == 2 || i == 6) i += 3;
+            if (i == 2 || i == 4) i += 2;
         }
         if (lines.hasNext()) {
             String line = lines.next();
@@ -168,7 +163,7 @@ public class ClassHierarchyTest {
                 // subsequent lines.
                 classLoaderAddr = m.group(1);
                 System.out.println(classLoaderAddr);
-            } else if (i > 2 && i != 4 && i != 9) {
+            } else if (i > 2) {
                 if (!classLoaderAddr.equals(m.group(1))) {
                     Assert.fail("Classloader address didn't match on line #"
                                         + i + ": " + line);


### PR DESCRIPTION
This test is still expecting IdentityObject in the class hierarchy. The changes made for JDK-8245216 need to be reversed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288084](https://bugs.openjdk.org/browse/JDK-8288084): [lw4] Tier1 hotspot runtime test ClassHierarchyTest.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/707/head:pull/707` \
`$ git checkout pull/707`

Update a local copy of the PR: \
`$ git checkout pull/707` \
`$ git pull https://git.openjdk.java.net/valhalla pull/707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 707`

View PR using the GUI difftool: \
`$ git pr show -t 707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/707.diff">https://git.openjdk.java.net/valhalla/pull/707.diff</a>

</details>
