### PR TITLE
8287763: [lw4] Javac does not implement the spec for non-trivial constructors in toto 

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -752,7 +752,7 @@ public class Check {
         for (Type st : types.closure(c.type)) {
             if (st == null || st.tsym == null || st.tsym.kind == ERR)
                 continue;
-            if  (st.tsym == syms.objectType.tsym || st.isInterface())
+            if  (st.tsym == syms.objectType.tsym || st.tsym == syms.recordType.tsym || st.isInterface())
                 continue;
             if (!st.tsym.isAbstract()) {
                 if (c != st.tsym) {
@@ -785,10 +785,14 @@ public class Check {
                         MethodSymbol m = (MethodSymbol)s;
                         if (m.getParameters().size() > 0) {
                             log.error(pos, Errors.SuperConstructorCannotTakeArguments(m, fragment));
-                        } else {
-                            if ((m.flags() & EMPTYNOARGCONSTR) == 0) {
+                        } else if (m.getTypeParameters().size() > 0) {
+                            log.error(pos, Errors.SuperConstructorCannotBeGeneric(m, fragment));
+                        } else if (m.type.getThrownTypes().size() > 0) {
+                            log.error(pos, Errors.SuperConstructorCannotThrow(m, fragment));
+                        } else if (protection(m.flags()) > protection(m.owner.flags())) {
+                            log.error(pos, Errors.SuperConstructorAccessRestricted(m, fragment));
+                        } else if ((m.flags() & EMPTYNOARGCONSTR) == 0) {
                                 log.error(pos, Errors.SuperNoArgConstructorMustBeEmpty(m, fragment));
-                            }
                         }
                     }
                     break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1100,7 +1100,7 @@ public class TypeEnter implements Completer {
                 tree.sym.setAnnotationTypeMetadata(new AnnotationTypeMetadata(tree.sym, annotate.annotationTypeSourceCompleter()));
             }
 
-            if (tree.sym != syms.objectType.tsym) {
+            if (tree.sym != syms.objectType.tsym && tree.sym != syms.recordType.tsym) {
                 if ((tree.sym.flags() & (ABSTRACT | INTERFACE | VALUE_CLASS)) == 0) {
                     tree.sym.flags_field |= IDENTITY_TYPE;
                 }
@@ -1141,7 +1141,11 @@ public class TypeEnter implements Completer {
                                 return true;
                             } else if (s.isConstructor()) {
                                 MethodSymbol m = (MethodSymbol)s;
-                                if (m.getParameters().size() > 0 || (m.flags() & EMPTYNOARGCONSTR) == 0) {
+                                if (m.getParameters().size() > 0
+                                        || m.getTypeParameters().size() > 0
+                                        || m.type.getThrownTypes().nonEmpty()
+                                        || (m.flags() & EMPTYNOARGCONSTR) == 0
+                                        || (Check.protection(m.flags()) > Check.protection(m.owner.flags()))) {
                                     return true;
                                 }
                             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3974,6 +3974,18 @@ compiler.err.super.constructor.cannot.take.arguments=\
     {1} defines a constructor {0} that takes arguments. This is disallowed
 
 # 0: symbol, 1: message segment
+compiler.err.super.constructor.cannot.be.generic=\
+    {1} defines a generic constructor {0}. This is disallowed
+
+# 0: symbol, 1: message segment
+compiler.err.super.constructor.cannot.throw=\
+    {1} defines a constructor {0} that throws an exception. This is disallowed
+
+# 0: symbol, 1: message segment
+compiler.err.super.constructor.access.restricted=\
+    {1} defines a constructor {0} with a weaker access privilege than the declaring class. This is disallowed
+
+# 0: symbol, 1: message segment
 compiler.err.super.field.not.allowed=\
     {1} defines an instance field {0}. This is disallowed
 

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -218,6 +218,9 @@ compiler.err.concrete.supertype.for.value.class
 compiler.err.super.class.cannot.be.inner
 compiler.err.super.class.declares.init.block
 compiler.err.super.constructor.cannot.take.arguments
+compiler.err.super.constructor.access.restricted
+compiler.err.super.constructor.cannot.be.generic
+compiler.err.super.constructor.cannot.throw
 compiler.err.super.field.not.allowed
 compiler.err.super.method.cannot.be.synchronized
 compiler.err.super.no.arg.constructor.must.be.empty

--- a/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
+++ b/test/langtools/tools/javac/valhalla/lworld-values/SuperclassCollections.java
@@ -44,12 +44,12 @@ public class SuperclassCollections {
         static int x;
     }
     public static abstract class SuperWithEmptyNoArgCtor {
-        SuperWithEmptyNoArgCtor() {
+        public SuperWithEmptyNoArgCtor() {
             // Programmer supplied ctor but injected super call
         }
     }
     public static abstract class SuperWithEmptyNoArgCtor_01 extends SuperWithEmptyNoArgCtor {
-        SuperWithEmptyNoArgCtor_01() {
+        public SuperWithEmptyNoArgCtor_01() {
             super();  // programmer coded chaining no-arg constructor
         }
     }
@@ -58,15 +58,15 @@ public class SuperclassCollections {
     }
 
     public static abstract class SuperWithNonEmptyNoArgCtor {
-        SuperWithNonEmptyNoArgCtor() {
+        public SuperWithNonEmptyNoArgCtor() {
             System.out.println("Non-Empty");
         }
     }
     public static abstract class SuperWithNonEmptyNoArgCtor_01 extends SuperWithNonEmptyNoArgCtor {}
 
     public static abstract class SuperWithArgedCtor {
-        SuperWithArgedCtor() {}
-        SuperWithArgedCtor(String s) {
+        public SuperWithArgedCtor() {}
+        public SuperWithArgedCtor(String s) {
         }
     }
     public static abstract class SuperWithArgedCtor_01 extends SuperWithArgedCtor {}

--- a/test/langtools/tools/javac/valhalla/value-objects/NontrivialConstructor.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NontrivialConstructor.java
@@ -1,0 +1,37 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8287763
+ * @summary [lw4] Javac does not implement the spec for non-trivial constructors in toto
+ * @compile/fail/ref=NontrivialConstructor.out -XDrawDiagnostics -XDdev NontrivialConstructor.java
+ */
+
+public class NontrivialConstructor {
+
+    abstract static value class I0 {
+        public I0() { // trivial ctor.
+        }
+    }
+
+    abstract static value class I1 {
+        private I1() {} // non-trivial, more restrictive access than the class.
+    }
+
+    abstract static value class I2 {
+        public I2(int x) {} // non-trivial ctor as it declares formal parameters.
+    }
+
+    abstract static value class I3 {
+        <T> I3() {} // non trivial as it declares type parameters.
+    }
+
+
+    abstract static value class I4 {
+        I4() throws Exception {} // non-trivial as it throws
+    }
+
+    abstract static value class I5 {
+        I5() {
+            System.out.println("");
+        } // non-trivial as it has a body.
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/NontrivialConstructor.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/NontrivialConstructor.out
@@ -1,0 +1,6 @@
+NontrivialConstructor.java:15:27: compiler.err.super.constructor.access.restricted: NontrivialConstructor.I1(), (compiler.misc.abstract.value.class: NontrivialConstructor.I1)
+NontrivialConstructor.java:19:27: compiler.err.super.constructor.cannot.take.arguments: NontrivialConstructor.I2(int), (compiler.misc.abstract.value.class: NontrivialConstructor.I2)
+NontrivialConstructor.java:23:27: compiler.err.super.constructor.cannot.be.generic: <T>NontrivialConstructor.I3(), (compiler.misc.abstract.value.class: NontrivialConstructor.I3)
+NontrivialConstructor.java:28:27: compiler.err.super.constructor.cannot.throw: NontrivialConstructor.I4(), (compiler.misc.abstract.value.class: NontrivialConstructor.I4)
+NontrivialConstructor.java:32:27: compiler.err.super.no.arg.constructor.must.be.empty: NontrivialConstructor.I5(), (compiler.misc.abstract.value.class: NontrivialConstructor.I5)
+5 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/NontrivialCtorInducedIdentity.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NontrivialCtorInducedIdentity.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8287763
+ * @summary [lw4] Javac does not implement the spec for non-trivial constructors in toto
+ * @modules jdk.jdeps/com.sun.tools.classfile
+ * @run main NontrivialCtorInducedIdentity
+ */
+
+import com.sun.tools.classfile.*;
+
+public class NontrivialCtorInducedIdentity {
+
+    public static abstract class A0 { // Trivial constructor - no induced identity. 
+        public A0() {
+            super();
+        }
+    }
+
+    public static abstract class A1 {
+        private A1() {} // restricted constructor
+    }
+
+    public static abstract class A2 {
+        public <T> A2() {} // generic constructor
+    }
+
+    public static abstract class A3 {
+        public A3() throws RuntimeException {} // throws
+    }
+
+    public static abstract class A4 {
+        public A4(int x) {} // not no-arg
+    }
+
+    public static abstract class A5 {
+        public A5() {
+            System.out.println("Bodied constructor");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClassFile cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A0.class"));
+        if (cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should NOT be set!");
+
+        cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A1.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should be set!");
+
+        cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A2.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should be set!");
+
+        cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A3.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should be set!");
+
+        cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A4.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should be set!");
+
+        cls = ClassFile.read(NontrivialCtorInducedIdentity.class.getResourceAsStream("NontrivialCtorInducedIdentity$A5.class"));
+        if (!cls.access_flags.is(AccessFlags.ACC_IDENTITY))
+            throw new Exception("ACC_IDENTITY flag should be set!");
+    }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/NontrivialCtorInducedIdentity.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/NontrivialCtorInducedIdentity.java
@@ -35,7 +35,7 @@ import com.sun.tools.classfile.*;
 
 public class NontrivialCtorInducedIdentity {
 
-    public static abstract class A0 { // Trivial constructor - no induced identity. 
+    public static abstract class A0 { // Trivial constructor - no induced identity.
         public A0() {
             super();
         }


### PR DESCRIPTION
Align with JLS changes to mark abstract classes with various forms of non-trivial constructors as being identity classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287763](https://bugs.openjdk.org/browse/JDK-8287763): [lw4] Javac does not implement the spec for non-trivial constructors in toto


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/708/head:pull/708` \
`$ git checkout pull/708`

Update a local copy of the PR: \
`$ git checkout pull/708` \
`$ git pull https://git.openjdk.java.net/valhalla pull/708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 708`

View PR using the GUI difftool: \
`$ git pr show -t 708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/708.diff">https://git.openjdk.java.net/valhalla/pull/708.diff</a>

</details>
