### PR TITLE
8288098: [lworld] C2 fails to scalarize value class arguments

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -166,16 +166,6 @@ static inline bool is_class_loader(const Symbol* class_name,
 
 bool InstanceKlass::field_is_null_free_inline_type(int index) const { return Signature::basic_type(field(index)->signature(constants())) == T_PRIMITIVE_OBJECT; }
 
-bool InstanceKlass::is_preload_class(Symbol* name) const {
-  for (int i = 0; i < _preload_classes->length(); i++) {
-    Symbol* class_name = _constants->klass_at_noresolve(_preload_classes->at(i));
-    if (class_name == name) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // private: called to verify that k is a static member of this nest.
 // We know that k is an instance class in the same package and hence the
 // same classloader.

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -550,7 +550,6 @@ class InstanceKlass: public Klass {
 
   Array<u2>* preload_classes() const { return _preload_classes; }
   void set_preload_classes(Array<u2>* c) { _preload_classes = c; }
-  bool is_preload_class(Symbol* name) const;
 
   // inner classes
   Array<u2>* inner_classes() const       { return _inner_classes; }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValueClass1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/MyValueClass1.java
@@ -172,4 +172,9 @@ public value class MyValueClass1 extends MyAbstract {
     static MyValueClass1 setV4(MyValueClass1 v, MyValueClass2 v4) {
         return new MyValueClass1(v.x, v.y, v.z, v.o, v.oa, v.v1, v.v2, v4, v.c);
     }
+
+    @DontInline
+    void dontInline(MyValueClass1 arg) {
+
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2687,9 +2687,9 @@ public class TestNullableInlineTypes {
     // Same as test96 but with MyValue3 return
     @Test
     @IR(applyIf = {"InlineTypeReturnedAsFields", "true"},
-        failOn = {ALLOC_G})
+        counts = {ALLOC_G, " = 1"}) // 1 Object allocation
     @IR(applyIf = {"InlineTypeReturnedAsFields", "false"},
-        counts = {ALLOC_G, " = 1"})
+        counts = {ALLOC_G, " = 2"}) // 1 MyValue3 allocation + 1 Object allocation
     public MyValue3.ref test97(int c, boolean b) {
         MyValue3.ref res = null;
         if (c == 1) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestValueClasses.java
@@ -536,6 +536,7 @@ public class TestValueClasses {
         test15_helper1(vt);
         test15_helper2(vt);
         test15_helper3(vt);
+        vt.dontInline(vt);
         return res;
     }
 


### PR DESCRIPTION
C2 fails to scalarize a value class argument because its class is not listed for preloading (because the argument class is equal to the method holder class). We should not rely on the preload attribute here but simply check if the argument class is a loaded value class. Proper mismatch handling will be added by [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443).

I also added a regression test and fixed unrelated `TestNullableInlineTypes::test97` which failed due to recent changes.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288098](https://bugs.openjdk.org/browse/JDK-8288098): [lworld] C2 fails to scalarize value class arguments


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/valhalla pull/709/head:pull/709` \
`$ git checkout pull/709`

Update a local copy of the PR: \
`$ git checkout pull/709` \
`$ git pull https://git.openjdk.java.net/valhalla pull/709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 709`

View PR using the GUI difftool: \
`$ git pr show -t 709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/valhalla/pull/709.diff">https://git.openjdk.java.net/valhalla/pull/709.diff</a>

</details>
