### PR TITLE
8283777: [lworld] TestArrayCopyAsLoadsStores.java triggers assert after merging jdk-19+15

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -74,8 +74,6 @@ compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-all
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
-compiler/arraycopy/TestArrayCopyAsLoadsStores.java 8283777 generic-all
-compiler/arraycopy/TestArrayCopyAsLoadsStores.java#id1 8283777 generic-all
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
We hit a dominance assert because `maybe_cast_profiled_obj` replaces `original` in the map while there can still be a bailout afterwards. This code is not Valhalla specific but was moved up to before the uncommon trap long ago with https://github.com/openjdk/valhalla/commit/09f099cab74c483c4aee3e927f2bc3c41ad784c9. I don't think that's required anymore, so this change simply restores the mainline version.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8283777](https://bugs.openjdk.org/browse/JDK-8283777): [lworld] TestArrayCopyAsLoadsStores.java triggers assert after merging jdk-19+15


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/710/head:pull/710` \
`$ git checkout pull/710`

Update a local copy of the PR: \
`$ git checkout pull/710` \
`$ git pull https://git.openjdk.org/valhalla pull/710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 710`

View PR using the GUI difftool: \
`$ git pr show -t 710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/710.diff">https://git.openjdk.org/valhalla/pull/710.diff</a>

</details>
