### PR TITLE
8288171: [lw4] Revert JDK-8253873 to fix failures in jdi, jvmti and jwdp tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/allInterfaces/allinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,7 +172,7 @@ public class allinterfaces001 {
 
                 switch (i2) {
 
-                case 0:         // Class0ForCheck - 1 injected interface (java.lang.IdentityObject)
+                case 0:         // Class0ForCheck - 0 interfaces
 
                         List list0 = vm.classesByName(mName + ".Class0ForCheck");
 
@@ -181,15 +181,15 @@ public class allinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface0list.size() != 1) {
-                            log3("ERROR : iface0list.size() != 1 in case: Class0ForCheck");
+                        if (iface0list.size() != 0) {
+                            log3("ERROR : iface0list.size() != 0 in case: Class0ForCheck");
                             expresult = 1;
                             break;
                         }
 
                         break ;
 
-                case 1:         // Class1forCheck - 1 direct, 1 indirect, and 1 injected (java.lang.IdentityObject) interfaces
+                case 1:         // Class1forCheck - 1 direct and 1 indirect interfaces
 
                         List list1 = vm.classesByName(mName + ".Class1ForCheck");
 
@@ -198,8 +198,8 @@ public class allinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface1list.size() != 3) {
-                            log3("ERROR : iface1list.size() != 3 in case: Class1forCheck   :"  + iface1list.size());
+                        if (iface1list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2 in case: Class1forCheck   :"  + iface1list.size());
                             expresult = 1;
                             break;
                         }
@@ -208,7 +208,7 @@ public class allinterfaces001 {
                         name = reftype.name();
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
-                                log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2') in Class1forCheck, name: " + name);
+                                log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2') in Class1forCheck");
                                 expresult = 1;
                                 break;
                             }
@@ -217,16 +217,14 @@ public class allinterfaces001 {
                         name = reftype.name();
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
-                                if (!name.equals("java.lang.IdentityObject")) {
-                                    log3("ERROR :name2: !name.equals('.Iface1' or '.Iface2 or 'java.lang.IdentityObject') in Class1forCheck, name: " + name);
-                                    expresult = 1;
-                                    break;
-                                }
+                                log3("ERROR :name2: !name.equals('.Iface1' or '.Iface2') in Class1forCheck");
+                                expresult = 1;
+                                break;
                             }
                         }
                         break;
 
-                case 2:         // Class2ForCheck - 1 direct, 2 indirect, and 1 injected (java.lang.IdentityObject) interfaces
+                case 2:         // Class2ForCheck - 1 direct and 2 indirect interfaces
 
                         List list2 = vm.classesByName(mName + ".Class2ForCheck");
 
@@ -235,8 +233,8 @@ public class allinterfaces001 {
                         List iface2list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface2list.size() != 4) {
-                            log3("ERROR : iface2list.size() != 4 in case: Class2forCheck");
+                        if (iface2list.size() != 3) {
+                            log3("ERROR : iface2list.size() != 3 in case: Class2forCheck");
                             expresult = 1;
                             break;
                         }
@@ -246,7 +244,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class2forCheck, name: " + name);
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
                                     expresult = 1;
                                     break;
                                 }
@@ -257,11 +255,9 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    if (!name.equals("java.lang.IdentityObject")) {
-                                        log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3' or 'java.lang.IdentityObject') in Class2forCheck, name: " + name);
-                                        expresult = 1;
-                                        break;
-                                    }
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
+                                    expresult = 1;
+                                    break;
                                 }
                             }
                         }
@@ -270,7 +266,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck, name: " + name);
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class2forCheck");
                                     expresult = 1;
                                     break;
                                 }
@@ -278,7 +274,7 @@ public class allinterfaces001 {
                         }
                         break;
 
-                case 3:         // Class3ForCheck - 1 direct, 2 indirect, and 1 injected (java.lang.IdentityObject) interfaces
+                case 3:         // Class3ForCheck - 1 direct and 2 indirect interfaces
 
                         List list3 = vm.classesByName(mName + ".Class3ForCheck");
 
@@ -287,8 +283,8 @@ public class allinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).allInterfaces();
 
-                        if (iface3list.size() != 4) {
-                            log3("ERROR : iface3list.size() != 4 in case: Class3forCheck");
+                        if (iface3list.size() != 3) {
+                            log3("ERROR : iface3list.size() != 3 in case: Class3forCheck");
                             expresult = 1;
                             break;
                         }
@@ -298,7 +294,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class3forCheck, name: " + name);
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
                                     expresult = 1;
                                     break;
                                 }
@@ -309,11 +305,9 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    if (!name.equals("java.lang.IdentityObject")) {
-                                        log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3' or 'java.lang.IdentityObject') in Class3forCheck, name: " + name);
-                                        expresult = 1;
-                                        break;
-                                    }
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
+                                    expresult = 1;
+                                    break;
                                 }
                             }
                         }
@@ -322,7 +316,7 @@ public class allinterfaces001 {
                         if (!name.equals(mName + ".Iface1")) {
                             if (!name.equals(mName + ".Iface2")) {
                                 if (!name.equals(mName + ".Iface3")) {
-                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface2' or 'Iface3) in Class3forCheck, name: " + name);
+                                    log3("ERROR : name1: !name.equals('.Iface1' or '.Iface3' or 'Iface3) in Class3forCheck");
                                     expresult = 1;
                                     break;
                                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassType/interfaces/interfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,7 @@ public class interfaces001 {
 
                 switch (i2) {
 
-                case 0:         // Class0ForCheck - 1 interface (injected java.lang.IdentityObject)
+                case 0:         // Class0ForCheck - 0 interfaces
 
                         List list0 = vm.classesByName(mName + ".Class0ForCheck");
 
@@ -176,15 +176,15 @@ public class interfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 1) {
-                            log3("ERROR : iface0list.size() != 1 in case: Class0ForCheck");
+                        if (iface0list.size() != 0) {
+                            log3("ERROR : iface0list.size() != 0 in case: Class0ForCheck");
                             expresult = 1;
                             break;
                         }
 
                         break;
 
-                case 1:         // Class1forCheck - 2 interfaces (includes injected java.lang.IdentityObject)
+                case 1:         // Class1forCheck - 1 interface
 
                         List list1 = vm.classesByName(mName + ".Class1ForCheck");
 
@@ -193,8 +193,8 @@ public class interfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) {
-                            log3("ERROR : iface1list.size() != 2 in case: Class1forCheck");
+                        if (iface1list.size() != 1) {
+                            log3("ERROR : iface1list.size() != 1 in case: Class1forCheck");
                             expresult = 1;
                             break;
                         }
@@ -209,7 +209,7 @@ public class interfaces001 {
 
                         break;
 
-                case 2:         // Class2ForCheck - 3 interfaces (includes injected java.lang.IdentityObject)
+                case 2:         // Class2ForCheck - 2 interfaces
 
                         List list2 = vm.classesByName(mName + ".Class2ForCheck");
 
@@ -218,8 +218,8 @@ public class interfaces001 {
                         List iface2list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface2list.size() != 3) {
-                            log3("ERROR : iface1list.size() != 3 in case: Class2forCheck");
+                        if (iface2list.size() != 2) {
+                            log3("ERROR : iface1list.size() != 2 in case: Class2forCheck");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/implementors/implementors001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,8 +178,8 @@ public class implementors001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface0list.size() != 2  in case: Iface1");
+                        if (iface0list.size() != 1) {
+                            log3("ERROR : iface0list.size() != 1  in case: Iface1");
                             expresult = 1;
                             break;
                         }
@@ -222,8 +222,8 @@ public class implementors001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) {
-                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
+                        if (iface1list.size() != 1) {
+                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -255,8 +255,8 @@ public class implementors001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface3list.size() != 2  in case: Iface3");
+                        if (iface3list.size() != 1) {
+                            log3("ERROR : iface3list.size() != 1  in case: Iface3");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/subinterfaces/subinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,8 +177,8 @@ public class subinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface0list.size() != 2  in case: Iface3");
+                        if (iface0list.size() != 1) {
+                            log3("ERROR : iface0list.size() != 1  in case: Iface3");
                             expresult = 1;
                             break;
                         }
@@ -201,8 +201,8 @@ public class subinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
+                        if (iface1list.size() != 1) {
+                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -234,8 +234,8 @@ public class subinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface3list.size() != 2  in case: Iface1");
+                        if (iface3list.size() != 1) {
+                            log3("ERROR : iface3list.size() != 1  in case: Iface1");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/InterfaceType/superinterfaces/superinterfaces001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,8 +180,8 @@ public class superinterfaces001 {
                         List iface0list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface0list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface0list.size() != 2  in case: Iface1");
+                        if (iface0list.size() != 1) {
+                            log3("ERROR : iface0list.size() != 1  in case: Iface1");
                             expresult = 1;
                             break;
                         }
@@ -204,8 +204,8 @@ public class superinterfaces001 {
                         List iface1list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface1list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface1list.size() != 2  in case: Iface2");
+                        if (iface1list.size() != 1) {
+                            log3("ERROR : iface1list.size() != 1  in case: Iface2");
                             expresult = 1;
                             break;
                         }
@@ -237,8 +237,8 @@ public class superinterfaces001 {
                         List iface3list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface3list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface3list.size() != 2  in case: Iface3");
+                        if (iface3list.size() != 1) {
+                            log3("ERROR : iface3list.size() != 1  in case: Iface3");
                             expresult = 1;
                             break;
                         }
@@ -262,8 +262,8 @@ public class superinterfaces001 {
                         List iface4list =
                              ((ClassType) classRefType).interfaces();
 
-                        if (iface4list.size() != 2) { // includes injected java.lang.IdentityObject
-                            log3("ERROR : iface4list.size() != 2  in case: Iface4");
+                        if (iface4list.size() != 1) {
+                            log3("ERROR : iface4list.size() != 1  in case: Iface4");
                             expresult = 1;
                             break;
                         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java
@@ -46,12 +46,10 @@ public class interfaces001 {
 
     static final String class_interfaces [][] = {
                     { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface1", "" },
-                    { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface2", "" },
-                    { "java.lang.IdentityObject", ""}
+                    { DEBUGEE_CLASS_NAME + "$" + "TestedClassInterface2", "" }
                 };
     static final int DECLARED_INTERFACES = class_interfaces.length;
     static final long interfaceIDs[] = new long[DECLARED_INTERFACES];
-    static long identityObjectID;
 
     public static void main (String argv[]) {
         System.exit(run(argv,System.out) + JCK_STATUS_BASE);
@@ -100,7 +98,6 @@ public class interfaces001 {
                         log.display("Getting ReferenceTypeID for interface signature: " + class_interfaces[i][1]);
                         interfaceIDs[i] = debugee.getReferenceTypeID(class_interfaces[i][1]);
                     }
-                    identityObjectID = debugee.getReferenceTypeID("Ljava/lang/IdentityObject;");
 
                     // begin test of JDWP command
 
@@ -140,19 +137,12 @@ public class interfaces001 {
                         long interfaceID = reply.getReferenceTypeID();
                         log.display("    interfaceID: " + interfaceID);
 
-                        if (i < DECLARED_INTERFACES) {
-                            if (interfaceID != interfaceIDs[i]) {
-                                log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
-                                             + " (expected: " + interfaceIDs[i] + ")");
-                                success = false;
-                            }
-                        } else {
-                            if (interfaceID != identityObjectID) {
-                                log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
-                                             + " (expected identityObjectID: " + identityObjectID + ")");
-                                success = false;
-                            }
+                        if (interfaceID != interfaceIDs[i]) {
+                            log.complain("Unexpected interface ID for interface #" + i + " in the reply packet: " + interfaceID
+                                         + " (expected: " + interfaceIDs[i] + ")");
+                            success = false;
                         }
+
                     }
 
                     if (! reply.isParsed()) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
@@ -60,7 +60,7 @@ static size_t eventsCount = 0;
 static size_t eventsExpected = 0;
 static class_info classes[] = {
     { "Lnsk/jvmti/ClassPrepare/classprep001$TestInterface;", EXP_STATUS, 2, 1, 0 },
-    { "Lnsk/jvmti/ClassPrepare/classprep001$TestClass;", EXP_STATUS, 3, 2, 2 }
+    { "Lnsk/jvmti/ClassPrepare/classprep001$TestClass;", EXP_STATUS, 3, 2, 1 }
 };
 // These classes are loaded on a different thread.
 // We should not get ClassPrepare events for them.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/getintrf007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetImplementedInterfaces/getintrf007/getintrf007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,19 +67,15 @@ static iface_info i9[] = {
     { "Lnsk/jvmti/GetImplementedInterfaces/OuterInterface2;" }
 };
 
-static iface_info jlio[] = {
-    { "Ljava/lang/IdentityObject;" }
-};
-
 static class_info classes[] = {
-    { "InnerClass1", 1, jlio },
+    { "InnerClass1", 0, NULL },
     { "InnerInterface1", 0, NULL },
     { "InnerInterface2", 1, i2 },
-    { "InnerClass2", 2, i3 },
-    { "OuterClass1", 1, jlio },
+    { "InnerClass2", 1, i3 },
+    { "OuterClass1", 0, NULL },
     { "OuterClass2", 0, NULL },
     { "OuterInterface1", 0, NULL },
-    { "OuterClass3", 2, i7 },
+    { "OuterClass3", 1, i7 },
     { "OuterInterface2", 1, i8 },
     { "OuterClass4", 1, i9 },
     { "OuterClass5", 0, NULL }
@@ -159,11 +155,9 @@ Java_nsk_jvmti_GetImplementedInterfaces_getintrf007_check(JNIEnv *env, jclass cl
                 }
                 if ((j < classes[i].icount) && (sig == NULL ||
                         strcmp(sig, classes[i].ifaces[j].sig) != 0)) {
-                    if (strcmp(sig, "Ljava/lang/IdentityObject;") != 0) {
-                        printf("(%d:%d) wrong interface: \"%s\"", i, j, sig);
-                        printf(", expected: \"%s\"\n", classes[i].ifaces[j].sig);
-                        result = STATUS_FAILED;
-                    }
+                    printf("(%d:%d) wrong interface: \"%s\"", i, j, sig);
+                    printf(", expected: \"%s\"\n", classes[i].ifaces[j].sig);
+                    result = STATUS_FAILED;
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 644b057b80b716e009f32a9d22ef5dd07e9dd12c
Also reverts changes made to test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/Interfaces/interfaces001.java for JDK-8248662

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288171](https://bugs.openjdk.org/browse/JDK-8288171): [lw4] Revert JDK-8253873 to fix failures in jdi, jvmti and jwdp tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/711/head:pull/711` \
`$ git checkout pull/711`

Update a local copy of the PR: \
`$ git checkout pull/711` \
`$ git pull https://git.openjdk.org/valhalla pull/711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 711`

View PR using the GUI difftool: \
`$ git pr show -t 711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/711.diff">https://git.openjdk.org/valhalla/pull/711.diff</a>

</details>
