### PR TITLE
8288186: [lw4] Many runtime/cds/appcds/ tests are still referring to IdentityObject

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
@@ -51,8 +51,7 @@ public class CheckCachedMirrorTest {
         String classlist[] = new String[] {
             "CheckCachedMirrorApp",            // built-in app loader
             "java/lang/Object id: 1",          // boot loader
-            "java/lang/IdentityObject id: 2",  // boot loader
-            "Hello id: 3 super: 1 interfaces: 2 source: " + helloJarPath // custom loader
+            "Hello id: 2 super: 1 source: " + helloJarPath // custom loader
         };
 
         TestCommon.testDump(appJar, classlist, use_whitebox_jar);

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedResolvedReferences.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedResolvedReferences.java
@@ -51,8 +51,7 @@ public class CheckCachedResolvedReferences {
         String classlist[] = new String[] {
             "CheckCachedResolvedReferencesApp",            // built-in app loader
             "java/lang/Object id: 1",                      // boot loader
-            "java/lang/IdentityObject id: 2",              // boot loader
-            "Hello id: 3 super: 1 interfaces: 2 source: " + helloJarPath // custom loader
+            "Hello id: 2 super: 1 source: " + helloJarPath // custom loader
         };
 
         TestCommon.testDump(appJar, classlist, use_whitebox_jar);

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatA.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatA.java
@@ -98,11 +98,10 @@ public class ClassListFormatA extends ClassListFormatBase {
             appJar, classlist(
                 "Hello   ",                   // trailing spaces
                 "java/lang/Object\tid:\t1",   // \t instead of ' '
-                "java/lang/IdentityObject id: 2",
-                "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath,
-                "CustomInterface2_ia id: 4 super: 1 source: " + customJarPath + " ",
-                "CustomInterface2_ib id: 5 super: 1 source: " + customJarPath + "\t\t\r" ,
-                "CustomLoadee2 id: 6 super: 1 interfaces: 2 4 5 source: " + customJarPath      // preceding spaces
+                "CustomLoadee id: 2 super: 1 source: " + customJarPath,
+                "CustomInterface2_ia id: 3 super: 1 source: " + customJarPath + " ",
+                "CustomInterface2_ib id: 4 super: 1 source: " + customJarPath + "\t\t\r" ,
+                "CustomLoadee2 id: 5 super: 1 interfaces: 3 4 source: " + customJarPath      // preceding spaces
             ));
 
         int _max_allowed_line = 4096; // Must match ClassListParser::_max_allowed_line in C code.

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatD.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatD.java
@@ -54,8 +54,7 @@ public class ClassListFormatD extends ClassListFormatBase {
             appJar, classlist(
                 "Hello",
                 "java/lang/Object id: 1",
-                "java/lang/IdentityObject id: 2",
-                "CustomLoadee id: 1 super: 1 interfaces: 2 source: " + customJarPath
+                "CustomLoadee id: 1 super: 1 source: " + customJarPath
             ),
             "Duplicated ID 1 for class CustomLoadee");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatE.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassListFormatE.java
@@ -95,12 +95,11 @@ public class ClassListFormatE extends ClassListFormatBase {
             appJar, classlist(
                 "Hello",
                 "java/lang/Object id: 1",
-                "java/lang/IdentityObject id: 2",
-                "CustomInterface2_ia id: 3 super: 1 source: " + customJarPath,
-                "CustomInterface2_ib id: 4 super: 1 source: " + customJarPath,
-                "CustomLoadee id: 5 super: 1 interfaces: 2 source: " + customJarPath,
-                "CustomLoadee2 id: 6 super: 5 interfaces: 2 3 4 source: " + customJarPath
+                "CustomInterface2_ia id: 2 super: 1 source: " + customJarPath,
+                "CustomInterface2_ib id: 3 super: 1 source: " + customJarPath,
+                "CustomLoadee id: 4 super: 1 source: " + customJarPath,
+                "CustomLoadee2 id: 5 super: 4 interfaces: 2 3 source: " + customJarPath
             ),
-            "The specified super class CustomLoadee (id 5) does not match actual super class java.lang.Object");
+            "The specified super class CustomLoadee (id 4) does not match actual super class java.lang.Object");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/HelloCustom.java
@@ -63,8 +63,7 @@ public class HelloCustom {
         String classlist[] = new String[] {
             "HelloUnload",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath
         };
 
         OutputAnalyzer output;

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/LoaderSegregationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/LoaderSegregationTest.java
@@ -77,18 +77,17 @@ public class LoaderSegregationTest {
         String classlist[] = new String[] {
             "LoaderSegregation",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
 
             // These are the UNREGISTERED classes: they have "source:"
             // but they don't have "loader:".
-            "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath,
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath,
 
-            "CustomInterface2_ia id: 4 super: 1 source: " + customJarPath,
-            "CustomInterface2_ib id: 5 super: 1 source: " + customJarPath,
-            "CustomLoadee2 id: 6 super: 1 interfaces: 2 4 5 source: " + customJarPath,
+            "CustomInterface2_ia id: 3 super: 1 source: " + customJarPath,
+            "CustomInterface2_ib id: 4 super: 1 source: " + customJarPath,
+            "CustomLoadee2 id: 5 super: 1 interfaces: 3 4 source: " + customJarPath,
 
-            "CustomLoadee3 id: 7 super: 1 interfaces: 2 source: " + customJarPath,
-            "CustomLoadee3Child id: 8 super: 7 source: " + customJarPath,
+            "CustomLoadee3 id: 6 super: 1 source: " + customJarPath,
+            "CustomLoadee3Child id: 7 super: 6 source: " + customJarPath,
 
             // At dump time, the following BUILTIN classes are loaded after the UNREGISTERED
             // classes from above. However, at dump time, they cannot use the UNREGISTERED classes are their
@@ -100,7 +99,7 @@ public class LoaderSegregationTest {
             // Check that BUILTIN and UNREGISTERED classes can be loaded only by their
             // corresponding type of loaders.
             "OnlyBuiltin",
-            "OnlyUnregistered id: 10 super: 1 interfaces: 2 source: " + customJarPath,
+            "OnlyUnregistered id: 9 super: 1 source: " + customJarPath,
         };
 
         OutputAnalyzer output;

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ParallelTestBase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ParallelTestBase.java
@@ -55,11 +55,10 @@ public class ParallelTestBase {
 
         for (int i = 0, n=0; i<MAX_CLASSES; i++) {
             int super_id = 1;
-            int identity_object_interf_id = 2;
             if (mode == FINGERPRINT_MODE) {
                 // fingerprint mode -- no need to use the "loader:" option.
-                int id = i + 3;
-                cust_list[i] = cust_classes[i] + " id: " + id + " super: " + super_id + " interfaces: " + identity_object_interf_id + " source: " + customJarPath;
+                int id = i + 2;
+                cust_list[i] = cust_classes[i] + " id: " + id + " super: " + super_id + " source: " + customJarPath;
             } else {
                 throw new RuntimeException("Only FINGERPRINT_MODE is supported");
             }
@@ -76,7 +75,6 @@ public class ParallelTestBase {
                                       "ParallelLoadWatchdog");
             app_list = new String[] {
                 "java/lang/Object id: 1",
-                "java/lang/IdentityObject id: 2",
                 "ParallelLoad",
                 "ParallelLoadThread",
                 "ParallelLoadWatchdog"

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/PrintSharedArchiveAndExit.java
@@ -59,8 +59,7 @@ public class PrintSharedArchiveAndExit {
         String classlist[] = new String[] {
             "HelloUnload",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath
         };
 
         OutputAnalyzer output;

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ProtectionDomain.java
@@ -42,9 +42,8 @@ public class ProtectionDomain {
             "ProtDomainClassForArchive", "ProtDomainNotForArchive");
         String[] classlist = new String[] {
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "ProtDomain id: 3 super: 1 interfaces: 2 source: " + appJar,
-            "ProtDomainClassForArchive id: 4 super: 1 interfaces: 2 source: " + customJar
+            "ProtDomain id: 2 super: 1 source: " + appJar,
+            "ProtDomainClassForArchive id: 3 super: 1 source: " + customJar
         };
 
         TestCommon.testDump(appJar, classlist);

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/SameNameInTwoLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/SameNameInTwoLoadersTest.java
@@ -83,8 +83,7 @@ public class SameNameInTwoLoadersTest {
         return new String[] {
             "SameNameUnrelatedLoaders",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "CustomLoadee id: 10 super: 1 interfaces: 2 source: " + customJar,
+            "CustomLoadee id: 10 super: 1 source: " + customJar,
         };
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnintendedLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnintendedLoadersTest.java
@@ -49,10 +49,9 @@ public class UnintendedLoadersTest {
         String classlist[] = new String[] {
             "UnintendedLoadersTest",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
 
             // Without "loader:" keyword.
-            "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath,
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath,
         };
 
         OutputAnalyzer output;

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnloadUnregisteredLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/UnloadUnregisteredLoaderTest.java
@@ -65,8 +65,7 @@ public class UnloadUnregisteredLoaderTest {
             "jdk/test/lib/classloader/ClassUnloadCommon$1",
             "jdk/test/lib/classloader/ClassUnloadCommon$TestFailure",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "CustomLoadee id: 3 super: 1 interfaces: 2 source: " + customJarPath,
+            "CustomLoadee id: 2 super: 1 source: " + customJarPath,
         };
 
         OutputAnalyzer output;

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
@@ -130,18 +130,16 @@ public class TransformRelatedClassesAppCDS extends TransformRelatedClasses {
             return new String[] {
                 "CustomLoaderApp",
                 "java/lang/Object id: 0",
-                "java/lang/IdentityObject id: 1",
-                parent + " id: 2 super: 0 interfaces: 1 source: " + customJar,
-                child +  " id: 3 super: 2 source: " + customJar,
+                parent + " id: 1 super: 0 source: " + customJar,
+                child +  " id: 2 super: 1 source: " + customJar,
             };
 
         case "Implementor-unregistered":
             return new String[] {
                 "CustomLoaderApp",
                 "java/lang/Object id: 0",
-                "java/lang/IdentityObject id: 1",
-                parent + " id: 2 super: 0 source: " + customJar,
-                child +  " id: 3 super: 0 interfaces: 1 2 source: " + customJar,
+                parent + " id: 1 super: 0 source: " + customJar,
+                child +  " id: 2 super: 0 interfaces: 1 source: " + customJar,
             };
 
         default:


### PR DESCRIPTION
Revert "8265719: [lworld] CDS tests fail after the merge with master"
This reverts commit 74dbd64e4577489843b992f43ae1f8104762c328.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288186](https://bugs.openjdk.org/browse/JDK-8288186): [lw4] Many runtime/cds/appcds/ tests are still referring to IdentityObject


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/712/head:pull/712` \
`$ git checkout pull/712`

Update a local copy of the PR: \
`$ git checkout pull/712` \
`$ git pull https://git.openjdk.org/valhalla pull/712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 712`

View PR using the GUI difftool: \
`$ git pr show -t 712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/712.diff">https://git.openjdk.org/valhalla/pull/712.diff</a>

</details>
