### PR TITLE
8288600: [test] Revert IdentityObject interface change in java.naming test RunBasic

### DIFF
--- a/test/jdk/javax/naming/module/src/test/test/StoreObject.ldap
+++ b/test/jdk/javax/naming/module/src/test/test/StoreObject.ldap
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -128,10 +128,10 @@
 #        :     }
 #        :   }
 #
-0000: 30 82 02 70 02 01 02 68   82 02 4C 04 21 63 6E 3D  0..p...h..L.!cn=
+0000: 30 82 02 55 02 01 02 68   82 02 31 04 21 63 6E 3D  0..U...h..1.!cn=
 0010: 6D 79 65 76 65 6E 74 2C   64 63 3D 69 65 2C 64 63  myevent,dc=ie,dc
 0020: 3D 6F 72 61 63 6C 65 2C   64 63 3D 63 6F 6D 30 82  =oracle,dc=com0.
-0030: 02 25 30 81 FD 04 12 6A   61 76 61 53 65 72 69 61  .%0....javaSeria
+0030: 02 0A 30 81 FD 04 12 6A   61 76 61 53 65 72 69 61  ..0....javaSeria
 0040: 6C 69 7A 65 64 44 61 74   61 31 81 E6 04 81 E3 AC  lizedData1......
 0050: ED 00 05 73 72 00 1A 6A   61 76 61 2E 61 77 74 2E  ...sr..java.awt.
 0060: 65 76 65 6E 74 2E 41 63   74 69 6F 6E 45 76 65 6E  event.ActionEven
@@ -151,23 +151,21 @@
 0140: 73 31 36 04 03 74 6F 70   04 0D 6A 61 76 61 43 6F  s16..top..javaCo
 0150: 6E 74 61 69 6E 65 72 04   0A 6A 61 76 61 4F 62 6A  ntainer..javaObj
 0160: 65 63 74 04 14 6A 61 76   61 53 65 72 69 61 6C 69  ect..javaSeriali
-0170: 7A 65 64 4F 62 6A 65 63   74 30 81 9B 04 0E 6A 61  zedObject0....ja
-0180: 76 61 43 6C 61 73 73 4E   61 6D 65 73 31 81 88 04  vaClassNames1...
-0190: 1A 6A 61 76 61 2E 61 77   74 2E 65 76 65 6E 74 2E  .java.awt.event.
-01A0: 41 63 74 69 6F 6E 45 76   65 6E 74 04 11 6A 61 76  ActionEvent..jav
-01B0: 61 2E 61 77 74 2E 41 57   54 45 76 65 6E 74 04 15  a.awt.AWTEvent..
-01C0: 6A 61 76 61 2E 75 74 69   6C 2E 45 76 65 6E 74 4F  java.util.EventO
-01D0: 62 6A 65 63 74 04 10 6A   61 76 61 2E 6C 61 6E 67  bject..java.lang
-01E0: 2E 4F 62 6A 65 63 74 04   14 6A 61 76 61 2E 69 6F  .Object..java.io
-01F0: 2E 53 65 72 69 61 6C 69   7A 61 62 6C 65 04 18 6A  .Serializable..j
-0200: 61 76 61 2E 6C 61 6E 67   2E 49 64 65 6E 74 69 74  ava.lang.Identit
-0210: 79 4F 62 6A 65 63 74 30   2D 04 0D 6A 61 76 61 43  yObject0-..javaC
-0220: 6C 61 73 73 4E 61 6D 65   31 1C 04 1A 6A 61 76 61  lassName1...java
-0230: 2E 61 77 74 2E 65 76 65   6E 74 2E 41 63 74 69 6F  .awt.event.Actio
-0240: 6E 45 76 65 6E 74 30 0F   04 02 63 6E 31 09 04 07  nEvent0...cn1...
-0250: 6D 79 65 76 65 6E 74 A0   1B 30 19 04 17 32 2E 31  myevent..0...2.1
-0260: 36 2E 38 34 30 2E 31 2E   31 31 33 37 33 30 2E 33  6.840.1.113730.3
-0270: 2E 34 2E 32                                        .4.2
+0170: 7A 65 64 4F 62 6A 65 63   74 30 81 80 04 0E 6A 61  zedObject0....ja
+0180: 76 61 43 6C 61 73 73 4E   61 6D 65 73 31 6E 04 1A  vaClassNames1n..
+0190: 6A 61 76 61 2E 61 77 74   2E 65 76 65 6E 74 2E 41  java.awt.event.A
+01A0: 63 74 69 6F 6E 45 76 65   6E 74 04 11 6A 61 76 61  ctionEvent..java
+01B0: 2E 61 77 74 2E 41 57 54   45 76 65 6E 74 04 15 6A  .awt.AWTEvent..j
+01C0: 61 76 61 2E 75 74 69 6C   2E 45 76 65 6E 74 4F 62  ava.util.EventOb
+01D0: 6A 65 63 74 04 10 6A 61   76 61 2E 6C 61 6E 67 2E  ject..java.lang.
+01E0: 4F 62 6A 65 63 74 04 14   6A 61 76 61 2E 69 6F 2E  Object..java.io.
+01F0: 53 65 72 69 61 6C 69 7A   61 62 6C 65 30 2D 04 0D  Serializable0-..
+0200: 6A 61 76 61 43 6C 61 73   73 4E 61 6D 65 31 1C 04  javaClassName1..
+0210: 1A 6A 61 76 61 2E 61 77   74 2E 65 76 65 6E 74 2E  .java.awt.event.
+0220: 41 63 74 69 6F 6E 45 76   65 6E 74 30 0F 04 02 63  ActionEvent0...c
+0230: 6E 31 09 04 07 6D 79 65   76 65 6E 74 A0 1B 30 19  n1...myevent..0.
+0240: 04 17 32 2E 31 36 2E 38   34 30 2E 31 2E 31 31 33  ..2.16.840.1.113
+0250: 37 33 30 2E 33 2E 34 2E   32                       730.3.4.2
 
 # LDAP AddResponse:
 #
@@ -250,10 +248,10 @@
 #        :     }
 #        :   }
 #
-0000: 30 82 02 72 02 01 03 68   82 02 4E 04 22 63 6E 3D  0..r...h..N."cn=
+0000: 30 82 02 57 02 01 03 68   82 02 33 04 22 63 6E 3D  0..W...h..3."cn=
 0010: 6D 79 65 76 65 6E 74 32   2C 64 63 3D 69 65 2C 64  myevent2,dc=ie,d
 0020: 63 3D 6F 72 61 63 6C 65   2C 64 63 3D 63 6F 6D 30  c=oracle,dc=com0
-0030: 82 02 26 30 81 FD 04 12   6A 61 76 61 53 65 72 69  ..&0....javaSeri
+0030: 82 02 0B 30 81 FD 04 12   6A 61 76 61 53 65 72 69  ...0....javaSeri
 0040: 61 6C 69 7A 65 64 44 61   74 61 31 81 E6 04 81 E3  alizedData1.....
 0050: AC ED 00 05 73 72 00 1A   6A 61 76 61 2E 61 77 74  ....sr..java.awt
 0060: 2E 65 76 65 6E 74 2E 41   63 74 69 6F 6E 45 76 65  .event.ActionEve
@@ -273,23 +271,21 @@
 0140: 73 73 31 36 04 03 74 6F   70 04 0D 6A 61 76 61 43  ss16..top..javaC
 0150: 6F 6E 74 61 69 6E 65 72   04 0A 6A 61 76 61 4F 62  ontainer..javaOb
 0160: 6A 65 63 74 04 14 6A 61   76 61 53 65 72 69 61 6C  ject..javaSerial
-0170: 69 7A 65 64 4F 62 6A 65   63 74 30 81 9B 04 0E 6A  izedObject0....j
-0180: 61 76 61 43 6C 61 73 73   4E 61 6D 65 73 31 81 88  avaClassNames1..
-0190: 04 1A 6A 61 76 61 2E 61   77 74 2E 65 76 65 6E 74  ..java.awt.event
-01A0: 2E 41 63 74 69 6F 6E 45   76 65 6E 74 04 11 6A 61  .ActionEvent..ja
-01B0: 76 61 2E 61 77 74 2E 41   57 54 45 76 65 6E 74 04  va.awt.AWTEvent.
-01C0: 15 6A 61 76 61 2E 75 74   69 6C 2E 45 76 65 6E 74  .java.util.Event
-01D0: 4F 62 6A 65 63 74 04 10   6A 61 76 61 2E 6C 61 6E  Object..java.lan
-01E0: 67 2E 4F 62 6A 65 63 74   04 14 6A 61 76 61 2E 69  g.Object..java.i
-01F0: 6F 2E 53 65 72 69 61 6C   69 7A 61 62 6C 65 04 18  o.Serializable..
-0200: 6A 61 76 61 2E 6C 61 6E   67 2E 49 64 65 6E 74 69  java.lang.Identi
-0210: 74 79 4F 62 6A 65 63 74   30 2D 04 0D 6A 61 76 61  tyObject0-..java
-0220: 43 6C 61 73 73 4E 61 6D   65 31 1C 04 1A 6A 61 76  ClassName1...jav
-0230: 61 2E 61 77 74 2E 65 76   65 6E 74 2E 41 63 74 69  a.awt.event.Acti
-0240: 6F 6E 45 76 65 6E 74 30   10 04 02 63 6E 31 0A 04  onEvent0...cn1..
-0250: 08 6D 79 65 76 65 6E 74   32 A0 1B 30 19 04 17 32  .myevent2..0...2
-0260: 2E 31 36 2E 38 34 30 2E   31 2E 31 31 33 37 33 30  .16.840.1.113730
-0270: 2E 33 2E 34 2E 32                                  .3.4.2
+0170: 69 7A 65 64 4F 62 6A 65   63 74 30 81 80 04 0E 6A  izedObject0....j
+0180: 61 76 61 43 6C 61 73 73   4E 61 6D 65 73 31 6E 04  avaClassNames1n.
+0190: 1A 6A 61 76 61 2E 61 77   74 2E 65 76 65 6E 74 2E  .java.awt.event.
+01A0: 41 63 74 69 6F 6E 45 76   65 6E 74 04 11 6A 61 76  ActionEvent..jav
+01B0: 61 2E 61 77 74 2E 41 57   54 45 76 65 6E 74 04 15  a.awt.AWTEvent..
+01C0: 6A 61 76 61 2E 75 74 69   6C 2E 45 76 65 6E 74 4F  java.util.EventO
+01D0: 62 6A 65 63 74 04 10 6A   61 76 61 2E 6C 61 6E 67  bject..java.lang
+01E0: 2E 4F 62 6A 65 63 74 04   14 6A 61 76 61 2E 69 6F  .Object..java.io
+01F0: 2E 53 65 72 69 61 6C 69   7A 61 62 6C 65 30 2D 04  .Serializable0-.
+0200: 0D 6A 61 76 61 43 6C 61   73 73 4E 61 6D 65 31 1C  .javaClassName1.
+0210: 04 1A 6A 61 76 61 2E 61   77 74 2E 65 76 65 6E 74  ..java.awt.event
+0220: 2E 41 63 74 69 6F 6E 45   76 65 6E 74 30 10 04 02  .ActionEvent0...
+0230: 63 6E 31 0A 04 08 6D 79   65 76 65 6E 74 32 A0 1B  cn1...myevent2..
+0240: 30 19 04 17 32 2E 31 36   2E 38 34 30 2E 31 2E 31  0...2.16.840.1.1
+0250: 31 33 37 33 30 2E 33 2E   34 2E 32                 13730.3.4.2
 
 # LDAP AddResponse:
 #
@@ -396,44 +392,42 @@
 #        :     }
 #        :   }
 #
-0000: 30 82 02 53 02 01 04 64   82 02 4C 04 21 63 6E 3D  0..S...d..L.!cn=
+0000: 30 82 02 38 02 01 04 64   82 02 31 04 21 63 6E 3D  0..8...d..1.!cn=
 0010: 6D 79 65 76 65 6E 74 2C   64 63 3D 69 65 2C 64 63  myevent,dc=ie,dc
 0020: 3D 6F 72 61 63 6C 65 2C   64 63 3D 63 6F 6D 30 82  =oracle,dc=com0.
-0030: 02 25 30 81 FD 04 12 6A   61 76 61 53 65 72 69 61  .%0....javaSeria
-0040: 6C 69 7A 65 64 44 61 74   61 31 81 E6 04 81 E3 AC  lizedData1......
-0050: ED 00 05 73 72 00 1A 6A   61 76 61 2E 61 77 74 2E  ...sr..java.awt.
-0060: 65 76 65 6E 74 2E 41 63   74 69 6F 6E 45 76 65 6E  event.ActionEven
-0070: 74 95 8A DA 7A 58 11 2F   2B 02 00 03 49 00 09 6D  t...zX./+...I..m
-0080: 6F 64 69 66 69 65 72 73   4A 00 04 77 68 65 6E 4C  odifiersJ..whenL
-0090: 00 0D 61 63 74 69 6F 6E   43 6F 6D 6D 61 6E 64 74  ..actionCommandt
-00A0: 00 12 4C 6A 61 76 61 2F   6C 61 6E 67 2F 53 74 72  ..Ljava/lang/Str
-00B0: 69 6E 67 3B 78 72 00 11   6A 61 76 61 2E 61 77 74  ing;xr..java.awt
-00C0: 2E 41 57 54 45 76 65 6E   74 E6 AB 2D E1 18 DF 8A  .AWTEvent..-....
-00D0: C3 02 00 03 5A 00 08 63   6F 6E 73 75 6D 65 64 49  ....Z..consumedI
-00E0: 00 02 69 64 5B 00 05 62   64 61 74 61 74 00 02 5B  ..id[..bdatat..[
-00F0: 42 78 72 00 15 6A 61 76   61 2E 75 74 69 6C 2E 45  Bxr..java.util.E
-0100: 76 65 6E 74 4F 62 6A 65   63 74 4C 8D 09 4E 18 6D  ventObjectL..N.m
-0110: 7D A8 02 00 00 78 70 00   00 00 00 01 70 00 00 00  .....xp.....p...
-0120: 00 00 00 00 00 00 00 00   00 74 00 06 48 65 6C 6C  .........t..Hell
-0130: 6F 31 30 45 04 0B 6F 62   6A 65 63 74 43 6C 61 73  o10E..objectClas
-0140: 73 31 36 04 03 74 6F 70   04 0D 6A 61 76 61 43 6F  s16..top..javaCo
-0150: 6E 74 61 69 6E 65 72 04   0A 6A 61 76 61 4F 62 6A  ntainer..javaObj
-0160: 65 63 74 04 14 6A 61 76   61 53 65 72 69 61 6C 69  ect..javaSeriali
-0170: 7A 65 64 4F 62 6A 65 63   74 30 81 9B 04 0E 6A 61  zedObject0....ja
-0180: 76 61 43 6C 61 73 73 4E   61 6D 65 73 31 81 88 04  vaClassNames1...
-0190: 1A 6A 61 76 61 2E 61 77   74 2E 65 76 65 6E 74 2E  .java.awt.event.
-01A0: 41 63 74 69 6F 6E 45 76   65 6E 74 04 11 6A 61 76  ActionEvent..jav
-01B0: 61 2E 61 77 74 2E 41 57   54 45 76 65 6E 74 04 15  a.awt.AWTEvent..
-01C0: 6A 61 76 61 2E 75 74 69   6C 2E 45 76 65 6E 74 4F  java.util.EventO
-01D0: 62 6A 65 63 74 04 10 6A   61 76 61 2E 6C 61 6E 67  bject..java.lang
-01E0: 2E 4F 62 6A 65 63 74 04   14 6A 61 76 61 2E 69 6F  .Object..java.io
-01F0: 2E 53 65 72 69 61 6C 69   7A 61 62 6C 65 04 18 6A  .Serializable..j
-0200: 61 76 61 2E 6C 61 6E 67   2E 49 64 65 6E 74 69 74  ava.lang.Identit
-0210: 79 4F 62 6A 65 63 74 30   2D 04 0D 6A 61 76 61 43  yObject0-..javaC
-0220: 6C 61 73 73 4E 61 6D 65   31 1C 04 1A 6A 61 76 61  lassName1...java
-0230: 2E 61 77 74 2E 65 76 65   6E 74 2E 41 63 74 69 6F  .awt.event.Actio
-0240: 6E 45 76 65 6E 74 30 0F   04 02 63 6E 31 09 04 07  nEvent0...cn1...
-0250: 6D 79 65 76 65 6E 74                               myevent
+0030: 02 0A 30 0F 04 02 63 6E   31 09 04 07 6D 79 65 76  ..0...cn1...myev
+0040: 65 6E 74 30 81 80 04 0E   6A 61 76 61 43 6C 61 73  ent0....javaClas
+0050: 73 4E 61 6D 65 73 31 6E   04 1A 6A 61 76 61 2E 61  sNames1n..java.a
+0060: 77 74 2E 65 76 65 6E 74   2E 41 63 74 69 6F 6E 45  wt.event.ActionE
+0070: 76 65 6E 74 04 11 6A 61   76 61 2E 61 77 74 2E 41  vent..java.awt.A
+0080: 57 54 45 76 65 6E 74 04   15 6A 61 76 61 2E 75 74  WTEvent..java.ut
+0090: 69 6C 2E 45 76 65 6E 74   4F 62 6A 65 63 74 04 10  il.EventObject..
+00A0: 6A 61 76 61 2E 6C 61 6E   67 2E 4F 62 6A 65 63 74  java.lang.Object
+00B0: 04 14 6A 61 76 61 2E 69   6F 2E 53 65 72 69 61 6C  ..java.io.Serial
+00C0: 69 7A 61 62 6C 65 30 2D   04 0D 6A 61 76 61 43 6C  izable0-..javaCl
+00D0: 61 73 73 4E 61 6D 65 31   1C 04 1A 6A 61 76 61 2E  assName1...java.
+00E0: 61 77 74 2E 65 76 65 6E   74 2E 41 63 74 69 6F 6E  awt.event.Action
+00F0: 45 76 65 6E 74 30 45 04   0B 6F 62 6A 65 63 74 43  Event0E..objectC
+0100: 6C 61 73 73 31 36 04 0A   6A 61 76 61 4F 62 6A 65  lass16..javaObje
+0110: 63 74 04 03 74 6F 70 04   14 6A 61 76 61 53 65 72  ct..top..javaSer
+0120: 69 61 6C 69 7A 65 64 4F   62 6A 65 63 74 04 0D 6A  ializedObject..j
+0130: 61 76 61 43 6F 6E 74 61   69 6E 65 72 30 81 FD 04  avaContainer0...
+0140: 12 6A 61 76 61 53 65 72   69 61 6C 69 7A 65 64 44  .javaSerializedD
+0150: 61 74 61 31 81 E6 04 81   E3 AC ED 00 05 73 72 00  ata1.........sr.
+0160: 1A 6A 61 76 61 2E 61 77   74 2E 65 76 65 6E 74 2E  .java.awt.event.
+0170: 41 63 74 69 6F 6E 45 76   65 6E 74 95 8A DA 7A 58  ActionEvent...zX
+0180: 11 2F 2B 02 00 03 49 00   09 6D 6F 64 69 66 69 65  ./+...I..modifie
+0190: 72 73 4A 00 04 77 68 65   6E 4C 00 0D 61 63 74 69  rsJ..whenL..acti
+01A0: 6F 6E 43 6F 6D 6D 61 6E   64 74 00 12 4C 6A 61 76  onCommandt..Ljav
+01B0: 61 2F 6C 61 6E 67 2F 53   74 72 69 6E 67 3B 78 72  a/lang/String;xr
+01C0: 00 11 6A 61 76 61 2E 61   77 74 2E 41 57 54 45 76  ..java.awt.AWTEv
+01D0: 65 6E 74 E6 AB 2D E1 18   DF 8A C3 02 00 03 5A 00  ent..-........Z.
+01E0: 08 63 6F 6E 73 75 6D 65   64 49 00 02 69 64 5B 00  .consumedI..id[.
+01F0: 05 62 64 61 74 61 74 00   02 5B 42 78 72 00 15 6A  .bdatat..[Bxr..j
+0200: 61 76 61 2E 75 74 69 6C   2E 45 76 65 6E 74 4F 62  ava.util.EventOb
+0210: 6A 65 63 74 4C 8D 09 4E   18 6D 7D A8 02 00 00 78  jectL..N.m.....x
+0220: 70 00 00 00 00 01 70 00   00 00 00 00 00 00 00 00  p.....p.........
+0230: 00 00 00 74 00 06 48 65   6C 6C 6F 31              ...t..Hello1
 
 # LDAP SearchResultDone:
 #
@@ -540,44 +534,42 @@
 #        :     }
 #        :   }
 #
-0000: 30 82 02 55 02 01 05 64   82 02 4E 04 22 63 6E 3D  0..U...d..N."cn=
+0000: 30 82 02 3A 02 01 05 64   82 02 33 04 22 63 6E 3D  0..:...d..3."cn=
 0010: 6D 79 65 76 65 6E 74 32   2C 64 63 3D 69 65 2C 64  myevent2,dc=ie,d
 0020: 63 3D 6F 72 61 63 6C 65   2C 64 63 3D 63 6F 6D 30  c=oracle,dc=com0
-0030: 82 02 26 30 81 FD 04 12   6A 61 76 61 53 65 72 69  ..&0....javaSeri
-0040: 61 6C 69 7A 65 64 44 61   74 61 31 81 E6 04 81 E3  alizedData1.....
-0050: AC ED 00 05 73 72 00 1A   6A 61 76 61 2E 61 77 74  ....sr..java.awt
-0060: 2E 65 76 65 6E 74 2E 41   63 74 69 6F 6E 45 76 65  .event.ActionEve
-0070: 6E 74 95 8A DA 7A 58 11   2F 2B 02 00 03 49 00 09  nt...zX./+...I..
-0080: 6D 6F 64 69 66 69 65 72   73 4A 00 04 77 68 65 6E  modifiersJ..when
-0090: 4C 00 0D 61 63 74 69 6F   6E 43 6F 6D 6D 61 6E 64  L..actionCommand
-00A0: 74 00 12 4C 6A 61 76 61   2F 6C 61 6E 67 2F 53 74  t..Ljava/lang/St
-00B0: 72 69 6E 67 3B 78 72 00   11 6A 61 76 61 2E 61 77  ring;xr..java.aw
-00C0: 74 2E 41 57 54 45 76 65   6E 74 E6 AB 2D E1 18 DF  t.AWTEvent..-...
-00D0: 8A C3 02 00 03 5A 00 08   63 6F 6E 73 75 6D 65 64  .....Z..consumed
-00E0: 49 00 02 69 64 5B 00 05   62 64 61 74 61 74 00 02  I..id[..bdatat..
-00F0: 5B 42 78 72 00 15 6A 61   76 61 2E 75 74 69 6C 2E  [Bxr..java.util.
-0100: 45 76 65 6E 74 4F 62 6A   65 63 74 4C 8D 09 4E 18  EventObjectL..N.
-0110: 6D 7D A8 02 00 00 78 70   00 00 00 00 02 70 00 00  m.....xp.....p..
-0120: 00 00 00 00 00 00 00 00   00 00 74 00 06 48 65 6C  ..........t..Hel
-0130: 6C 6F 32 30 45 04 0B 6F   62 6A 65 63 74 43 6C 61  lo20E..objectCla
-0140: 73 73 31 36 04 03 74 6F   70 04 0D 6A 61 76 61 43  ss16..top..javaC
-0150: 6F 6E 74 61 69 6E 65 72   04 0A 6A 61 76 61 4F 62  ontainer..javaOb
-0160: 6A 65 63 74 04 14 6A 61   76 61 53 65 72 69 61 6C  ject..javaSerial
-0170: 69 7A 65 64 4F 62 6A 65   63 74 30 81 9B 04 0E 6A  izedObject0....j
-0180: 61 76 61 43 6C 61 73 73   4E 61 6D 65 73 31 81 88  avaClassNames1..
-0190: 04 1A 6A 61 76 61 2E 61   77 74 2E 65 76 65 6E 74  ..java.awt.event
-01A0: 2E 41 63 74 69 6F 6E 45   76 65 6E 74 04 11 6A 61  .ActionEvent..ja
-01B0: 76 61 2E 61 77 74 2E 41   57 54 45 76 65 6E 74 04  va.awt.AWTEvent.
-01C0: 15 6A 61 76 61 2E 75 74   69 6C 2E 45 76 65 6E 74  .java.util.Event
-01D0: 4F 62 6A 65 63 74 04 10   6A 61 76 61 2E 6C 61 6E  Object..java.lan
-01E0: 67 2E 4F 62 6A 65 63 74   04 14 6A 61 76 61 2E 69  g.Object..java.i
-01F0: 6F 2E 53 65 72 69 61 6C   69 7A 61 62 6C 65 04 18  o.Serializable..
-0200: 6A 61 76 61 2E 6C 61 6E   67 2E 49 64 65 6E 74 69  java.lang.Identi
-0210: 74 79 4F 62 6A 65 63 74   30 2D 04 0D 6A 61 76 61  tyObject0-..java
-0220: 43 6C 61 73 73 4E 61 6D   65 31 1C 04 1A 6A 61 76  ClassName1...jav
-0230: 61 2E 61 77 74 2E 65 76   65 6E 74 2E 41 63 74 69  a.awt.event.Acti
-0240: 6F 6E 45 76 65 6E 74 30   10 04 02 63 6E 31 0A 04  onEvent0...cn1..
-0250: 08 6D 79 65 76 65 6E 74   32                       .myevent2
+0030: 82 02 0B 30 10 04 02 63   6E 31 0A 04 08 6D 79 65  ...0...cn1...mye
+0040: 76 65 6E 74 32 30 81 80   04 0E 6A 61 76 61 43 6C  vent20....javaCl
+0050: 61 73 73 4E 61 6D 65 73   31 6E 04 1A 6A 61 76 61  assNames1n..java
+0060: 2E 61 77 74 2E 65 76 65   6E 74 2E 41 63 74 69 6F  .awt.event.Actio
+0070: 6E 45 76 65 6E 74 04 11   6A 61 76 61 2E 61 77 74  nEvent..java.awt
+0080: 2E 41 57 54 45 76 65 6E   74 04 15 6A 61 76 61 2E  .AWTEvent..java.
+0090: 75 74 69 6C 2E 45 76 65   6E 74 4F 62 6A 65 63 74  util.EventObject
+00A0: 04 10 6A 61 76 61 2E 6C   61 6E 67 2E 4F 62 6A 65  ..java.lang.Obje
+00B0: 63 74 04 14 6A 61 76 61   2E 69 6F 2E 53 65 72 69  ct..java.io.Seri
+00C0: 61 6C 69 7A 61 62 6C 65   30 2D 04 0D 6A 61 76 61  alizable0-..java
+00D0: 43 6C 61 73 73 4E 61 6D   65 31 1C 04 1A 6A 61 76  ClassName1...jav
+00E0: 61 2E 61 77 74 2E 65 76   65 6E 74 2E 41 63 74 69  a.awt.event.Acti
+00F0: 6F 6E 45 76 65 6E 74 30   45 04 0B 6F 62 6A 65 63  onEvent0E..objec
+0100: 74 43 6C 61 73 73 31 36   04 0A 6A 61 76 61 4F 62  tClass16..javaOb
+0110: 6A 65 63 74 04 03 74 6F   70 04 14 6A 61 76 61 53  ject..top..javaS
+0120: 65 72 69 61 6C 69 7A 65   64 4F 62 6A 65 63 74 04  erializedObject.
+0130: 0D 6A 61 76 61 43 6F 6E   74 61 69 6E 65 72 30 81  .javaContainer0.
+0140: FD 04 12 6A 61 76 61 53   65 72 69 61 6C 69 7A 65  ...javaSerialize
+0150: 64 44 61 74 61 31 81 E6   04 81 E3 AC ED 00 05 73  dData1.........s
+0160: 72 00 1A 6A 61 76 61 2E   61 77 74 2E 65 76 65 6E  r..java.awt.even
+0170: 74 2E 41 63 74 69 6F 6E   45 76 65 6E 74 95 8A DA  t.ActionEvent...
+0180: 7A 58 11 2F 2B 02 00 03   49 00 09 6D 6F 64 69 66  zX./+...I..modif
+0190: 69 65 72 73 4A 00 04 77   68 65 6E 4C 00 0D 61 63  iersJ..whenL..ac
+01A0: 74 69 6F 6E 43 6F 6D 6D   61 6E 64 74 00 12 4C 6A  tionCommandt..Lj
+01B0: 61 76 61 2F 6C 61 6E 67   2F 53 74 72 69 6E 67 3B  ava/lang/String;
+01C0: 78 72 00 11 6A 61 76 61   2E 61 77 74 2E 41 57 54  xr..java.awt.AWT
+01D0: 45 76 65 6E 74 E6 AB 2D   E1 18 DF 8A C3 02 00 03  Event..-........
+01E0: 5A 00 08 63 6F 6E 73 75   6D 65 64 49 00 02 69 64  Z..consumedI..id
+01F0: 5B 00 05 62 64 61 74 61   74 00 02 5B 42 78 72 00  [..bdatat..[Bxr.
+0200: 15 6A 61 76 61 2E 75 74   69 6C 2E 45 76 65 6E 74  .java.util.Event
+0210: 4F 62 6A 65 63 74 4C 8D   09 4E 18 6D 7D A8 02 00  ObjectL..N.m....
+0220: 00 78 70 00 00 00 00 02   70 00 00 00 00 00 00 00  .xp.....p.......
+0230: 00 00 00 00 00 74 00 06   48 65 6C 6C 6F 32        .....t..Hello2
 
 # LDAP SearchResultDone:
 #
@@ -669,4 +661,3 @@
 0000: 30 22 02 01 08 42 00 A0   1B 30 19 04 17 32 2E 31  0"...B...0...2.1
 0010: 36 2E 38 34 30 2E 31 2E   31 31 33 37 33 30 2E 33  6.840.1.113730.3
 0020: 2E 34 2E 32                                        .4.2
-

--- a/test/jdk/javax/naming/module/src/test/test/StoreRemote.ldap
+++ b/test/jdk/javax/naming/module/src/test/test/StoreRemote.ldap
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -136,10 +136,10 @@
 #         :     }
 #         :   }
 #
-0000: 30 82 03 31 02 01 02 68   82 03 0D 04 22 63 6E 3D  0..1...h...."cn=
+0000: 30 82 03 17 02 01 02 68   82 02 F3 04 22 63 6E 3D  0......h...."cn=
 0010: 6D 79 72 65 6D 6F 74 65   2C 64 63 3D 69 65 2C 64  myremote,dc=ie,d
 0020: 63 3D 6F 72 61 63 6C 65   2C 64 63 3D 63 6F 6D 30  c=oracle,dc=com0
-0030: 82 02 E5 30 82 01 58 04   12 6A 61 76 61 53 65 72  ...0..X..javaSer
+0030: 82 02 CB 30 82 01 58 04   12 6A 61 76 61 53 65 72  ...0..X..javaSer
 0040: 69 61 6C 69 7A 65 64 44   61 74 61 31 82 01 40 04  ializedData1..@.
 0050: 82 01 3C AC ED 00 05 73   72 00 1B 6F 72 67 2E 65  ..<....sr..org.e
 0060: 78 61 6D 70 6C 65 2E 68   65 6C 6C 6F 2E 48 65 6C  xample.hello.Hel
@@ -165,8 +165,8 @@
 01A0: 04 03 74 6F 70 04 0D 6A   61 76 61 43 6F 6E 74 61  ..top..javaConta
 01B0: 69 6E 65 72 04 0A 6A 61   76 61 4F 62 6A 65 63 74  iner..javaObject
 01C0: 04 14 6A 61 76 61 53 65   72 69 61 6C 69 7A 65 64  ..javaSerialized
-01D0: 4F 62 6A 65 63 74 30 81   FD 04 0E 6A 61 76 61 43  Object0....javaC
-01E0: 6C 61 73 73 4E 61 6D 65   73 31 81 EA 04 1B 6F 72  lassNames1....or
+01D0: 4F 62 6A 65 63 74 30 81   E3 04 0E 6A 61 76 61 43  Object0....javaC
+01E0: 6C 61 73 73 4E 61 6D 65   73 31 81 D0 04 1B 6F 72  lassNames1....or
 01F0: 67 2E 65 78 61 6D 70 6C   65 2E 68 65 6C 6C 6F 2E  g.example.hello.
 0200: 48 65 6C 6C 6F 49 6D 70   6C 04 23 6A 61 76 61 2E  HelloImpl.#java.
 0210: 72 6D 69 2E 73 65 72 76   65 72 2E 55 6E 69 63 61  rmi.server.Unica
@@ -178,16 +178,14 @@
 0270: 2E 6C 61 6E 67 2E 4F 62   6A 65 63 74 04 0F 6A 61  .lang.Object..ja
 0280: 76 61 2E 72 6D 69 2E 52   65 6D 6F 74 65 04 14 6A  va.rmi.Remote..j
 0290: 61 76 61 2E 69 6F 2E 53   65 72 69 61 6C 69 7A 61  ava.io.Serializa
-02A0: 62 6C 65 04 18 6A 61 76   61 2E 6C 61 6E 67 2E 49  ble..java.lang.I
-02B0: 64 65 6E 74 69 74 79 4F   62 6A 65 63 74 04 17 6F  dentityObject..o
-02C0: 72 67 2E 65 78 61 6D 70   6C 65 2E 68 65 6C 6C 6F  rg.example.hello
-02D0: 2E 48 65 6C 6C 6F 30 2E   04 0D 6A 61 76 61 43 6C  .Hello0...javaCl
-02E0: 61 73 73 4E 61 6D 65 31   1D 04 1B 6F 72 67 2E 65  assName1...org.e
-02F0: 78 61 6D 70 6C 65 2E 68   65 6C 6C 6F 2E 48 65 6C  xample.hello.Hel
-0300: 6C 6F 49 6D 70 6C 30 10   04 02 63 6E 31 0A 04 08  loImpl0...cn1...
-0310: 6D 79 72 65 6D 6F 74 65   A0 1B 30 19 04 17 32 2E  myremote..0...2.
-0320: 31 36 2E 38 34 30 2E 31   2E 31 31 33 37 33 30 2E  16.840.1.113730.
-0330: 33 2E 34 2E 32                                     3.4.2
+02A0: 62 6C 65 04 17 6F 72 67   2E 65 78 61 6D 70 6C 65  ble..org.example
+02B0: 2E 68 65 6C 6C 6F 2E 48   65 6C 6C 6F 30 2E 04 0D  .hello.Hello0...
+02C0: 6A 61 76 61 43 6C 61 73   73 4E 61 6D 65 31 1D 04  javaClassName1..
+02D0: 1B 6F 72 67 2E 65 78 61   6D 70 6C 65 2E 68 65 6C  .org.example.hel
+02E0: 6C 6F 2E 48 65 6C 6C 6F   49 6D 70 6C 30 10 04 02  lo.HelloImpl0...
+02F0: 63 6E 31 0A 04 08 6D 79   72 65 6D 6F 74 65 A0 1B  cn1...myremote..
+0300: 30 19 04 17 32 2E 31 36   2E 38 34 30 2E 31 2E 31  0...2.16.840.1.1
+0310: 31 33 37 33 30 2E 33 2E   34 2E 32                 13730.3.4.2
 
 # LDAP AddResponse:
 #
@@ -303,10 +301,10 @@
 #         :     }
 #         :   }
 #
-0000: 30 82 03 14 02 01 03 64   82 03 0D 04 22 63 6E 3D  0......d...."cn=
+0000: 30 82 02 FA 02 01 03 64   82 02 F3 04 22 63 6E 3D  0......d...."cn=
 0010: 6D 79 72 65 6D 6F 74 65   2C 64 63 3D 69 65 2C 64  myremote,dc=ie,d
 0020: 63 3D 6F 72 61 63 6C 65   2C 64 63 3D 63 6F 6D 30  c=oracle,dc=com0
-0030: 82 02 E5 30 82 01 58 04   12 6A 61 76 61 53 65 72  ...0..X..javaSer
+0030: 82 02 CB 30 82 01 58 04   12 6A 61 76 61 53 65 72  ...0..X..javaSer
 0040: 69 61 6C 69 7A 65 64 44   61 74 61 31 82 01 40 04  ializedData1..@.
 0050: 82 01 3C AC ED 00 05 73   72 00 1B 6F 72 67 2E 65  ..<....sr..org.e
 0060: 78 61 6D 70 6C 65 2E 68   65 6C 6C 6F 2E 48 65 6C  xample.hello.Hel
@@ -332,8 +330,8 @@
 01A0: 04 03 74 6F 70 04 0D 6A   61 76 61 43 6F 6E 74 61  ..top..javaConta
 01B0: 69 6E 65 72 04 0A 6A 61   76 61 4F 62 6A 65 63 74  iner..javaObject
 01C0: 04 14 6A 61 76 61 53 65   72 69 61 6C 69 7A 65 64  ..javaSerialized
-01D0: 4F 62 6A 65 63 74 30 81   FD 04 0E 6A 61 76 61 43  Object0....javaC
-01E0: 6C 61 73 73 4E 61 6D 65   73 31 81 EA 04 1B 6F 72  lassNames1....or
+01D0: 4F 62 6A 65 63 74 30 81   E3 04 0E 6A 61 76 61 43  Object0....javaC
+01E0: 6C 61 73 73 4E 61 6D 65   73 31 81 D0 04 1B 6F 72  lassNames1....or
 01F0: 67 2E 65 78 61 6D 70 6C   65 2E 68 65 6C 6C 6F 2E  g.example.hello.
 0200: 48 65 6C 6C 6F 49 6D 70   6C 04 23 6A 61 76 61 2E  HelloImpl.#java.
 0210: 72 6D 69 2E 73 65 72 76   65 72 2E 55 6E 69 63 61  rmi.server.Unica
@@ -345,14 +343,12 @@
 0270: 2E 6C 61 6E 67 2E 4F 62   6A 65 63 74 04 0F 6A 61  .lang.Object..ja
 0280: 76 61 2E 72 6D 69 2E 52   65 6D 6F 74 65 04 14 6A  va.rmi.Remote..j
 0290: 61 76 61 2E 69 6F 2E 53   65 72 69 61 6C 69 7A 61  ava.io.Serializa
-02A0: 62 6C 65 04 18 6A 61 76   61 2E 6C 61 6E 67 2E 49  ble..java.lang.I
-02B0: 64 65 6E 74 69 74 79 4F   62 6A 65 63 74 04 17 6F  dentityObject..o
-02C0: 72 67 2E 65 78 61 6D 70   6C 65 2E 68 65 6C 6C 6F  rg.example.hello
-02D0: 2E 48 65 6C 6C 6F 30 2E   04 0D 6A 61 76 61 43 6C  .Hello0...javaCl
-02E0: 61 73 73 4E 61 6D 65 31   1D 04 1B 6F 72 67 2E 65  assName1...org.e
-02F0: 78 61 6D 70 6C 65 2E 68   65 6C 6C 6F 2E 48 65 6C  xample.hello.Hel
-0300: 6C 6F 49 6D 70 6C 30 10   04 02 63 6E 31 0A 04 08  loImpl0...cn1...
-0310: 6D 79 72 65 6D 6F 74 65                            myremote
+02A0: 62 6C 65 04 17 6F 72 67   2E 65 78 61 6D 70 6C 65  ble..org.example
+02B0: 2E 68 65 6C 6C 6F 2E 48   65 6C 6C 6F 30 2E 04 0D  .hello.Hello0...
+02C0: 6A 61 76 61 43 6C 61 73   73 4E 61 6D 65 31 1D 04  javaClassName1..
+02D0: 1B 6F 72 67 2E 65 78 61   6D 70 6C 65 2E 68 65 6C  .org.example.hel
+02E0: 6C 6F 2E 48 65 6C 6C 6F   49 6D 70 6C 30 10 04 02  lo.HelloImpl0...
+02F0: 63 6E 31 0A 04 08 6D 79   72 65 6D 6F 74 65        cn1...myremote
 
 # LDAP SearchResultDone:
 #


### PR DESCRIPTION
The removal of the IdentityObject interface needs to be reflected in the ldap test golden files. 
The interface does not appear in serialized objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288600](https://bugs.openjdk.org/browse/JDK-8288600): [test] Revert IdentityObject interface change in java.naming test RunBasic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/715/head:pull/715` \
`$ git checkout pull/715`

Update a local copy of the PR: \
`$ git checkout pull/715` \
`$ git pull https://git.openjdk.org/valhalla pull/715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 715`

View PR using the GUI difftool: \
`$ git pr show -t 715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/715.diff">https://git.openjdk.org/valhalla/pull/715.diff</a>

</details>
