### PR TITLE
8288644: [lw4] Unable to extend a separately compiled abstract value class

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -289,7 +289,7 @@ class ClassFileParser {
   Method* parse_method(const ClassFileStream* const cfs,
                        bool is_interface,
                        bool is_inline_type,
-                       bool is_permits_value_class,
+                       bool is_abstract_type,
                        const ConstantPool* cp,
                        AccessFlags* const promoted_flags,
                        TRAPS);
@@ -297,7 +297,7 @@ class ClassFileParser {
   void parse_methods(const ClassFileStream* const cfs,
                      bool is_interface,
                      bool is_inline_type,
-                     bool is_permits_value_class,
+                     bool is_abstract_type,
                      AccessFlags* const promoted_flags,
                      bool* const has_final_method,
                      bool* const declares_nonstatic_concrete_methods,
@@ -510,7 +510,7 @@ class ClassFileParser {
   void verify_legal_method_modifiers(jint flags,
                                      bool is_interface,
                                      bool is_inline_type,
-                                     bool is_permits_value_class,
+                                     bool is_abstract_type,
                                      const Symbol* name,
                                      TRAPS) const;
 
@@ -599,6 +599,7 @@ class ClassFileParser {
   bool is_hidden() const { return _is_hidden; }
   bool is_interface() const { return _access_flags.is_interface(); }
   bool is_inline_type() const { return _access_flags.is_value_class(); }
+  bool is_abstract_type() const { return _access_flags.is_abstract(); }
   bool is_permits_value_class() const { return _access_flags.is_permits_value_class(); }
   bool is_identity_class() const { return _access_flags.is_identity_class(); }
   bool is_value_capable_class() const;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2777,10 +2777,13 @@ public class Check {
                     valueSuper = t;
                 if (cIsValue &&  identitySuper != null) {
                     log.error(pos, Errors.ValueTypeHasIdentitySuperType(c, identitySuper));
+                    break;
                 } else if (cHasIdentity &&  valueSuper != null) {
                     log.error(pos, Errors.IdentityTypeHasValueSuperType(c, valueSuper));
+                    break;
                 } else if (identitySuper != null && valueSuper != null) {
                     log.error(pos, Errors.MutuallyIncompatibleSupers(c, identitySuper, valueSuper));
+                    break;
                 }
             }
         }

--- a/test/langtools/tools/javac/valhalla/value-objects/AbstractValueSuper.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/AbstractValueSuper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public abstract value class AbstractValueSuper {}

--- a/test/langtools/tools/javac/valhalla/value-objects/ConcreteValue.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ConcreteValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288644
+ * @summary [lw4] Unable to extend a separately compiled abstract value class
+ * @compile AbstractValueSuper.java ConcreteValue.java
+ * @compile ConcreteValue.java
+ * @run main ConcreteValue
+ */
+
+public value class ConcreteValue extends AbstractValueSuper {
+    public static void main(String [] args) {
+    }
+}


### PR DESCRIPTION
Lower constructors in abstract value classes into void <init> methods and in concrete value classes into static factory methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8288644](https://bugs.openjdk.org/browse/JDK-8288644): [lw4] Unable to extend a separately compiled abstract value class


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/717/head:pull/717` \
`$ git checkout pull/717`

Update a local copy of the PR: \
`$ git checkout pull/717` \
`$ git pull https://git.openjdk.org/valhalla pull/717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 717`

View PR using the GUI difftool: \
`$ git pr show -t 717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/717.diff">https://git.openjdk.org/valhalla/pull/717.diff</a>

</details>
