### PR TITLE
8289686: [lworld] Unnecessary buffering because constant getters with scalarized arg are not C2 compiled

### DIFF
--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -92,9 +92,10 @@ class Method : public Metadata {
     _intrinsic_candidate   = 1 << 5,
     _reserved_stack_access = 1 << 6,
     _scalarized_args       = 1 << 7,
-    _c1_needs_stack_repair = 1 << 8,
-    _c2_needs_stack_repair = 1 << 9,
-    _scoped                = 1 << 10
+    _scalarized_return     = 1 << 8,
+    _c1_needs_stack_repair = 1 << 9,
+    _c2_needs_stack_repair = 1 << 10,
+    _scoped                = 1 << 11
   };
   mutable u2 _flags;
 
@@ -900,6 +901,14 @@ public:
 
   void set_has_scalarized_args(bool x) {
     _flags = x ? (_flags | _scalarized_args) : (_flags & ~_scalarized_args);
+  }
+
+  bool has_scalarized_return() const {
+    return (_flags & _scalarized_return) != 0;
+  }
+
+  void set_has_scalarized_return(bool x) {
+    _flags = x ? (_flags | _scalarized_return) : (_flags & ~_scalarized_return);
   }
 
   bool is_scalarized_arg(int idx) const;


### PR DESCRIPTION
The fix for [JDK-8275825](https://bugs.openjdk.org/browse/JDK-8275825) is incomplete. Getter methods returning a nullable inline type in scalarized form are still treated as trivial and therefore not C2 compiled which leads to buffering. Also, constant getter methods with an (unused) scalarized inline type receiver/argument should not be treated as trivial.

Thanks to @kuksenko for reporting!

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8289686](https://bugs.openjdk.org/browse/JDK-8289686): [lworld] Unnecessary buffering because constant getters with scalarized arg are not C2 compiled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/719/head:pull/719` \
`$ git checkout pull/719`

Update a local copy of the PR: \
`$ git checkout pull/719` \
`$ git pull https://git.openjdk.org/valhalla pull/719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 719`

View PR using the GUI difftool: \
`$ git pr show -t 719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/719.diff">https://git.openjdk.org/valhalla/pull/719.diff</a>

</details>
