### PR TITLE
8289747: [lworld] Remove injected interfaces from CDS tests

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -189,7 +189,7 @@ public class TestDumpClassListSource {
 
         checkFileExistence("ClassList", fileList);
 
-        checkMatch(listFileName, "Hello id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/test-hello.jar", EXPECT_MATCH,
+        checkMatch(listFileName, "Hello id: [0-9]+ super: [0-9]+ source: .*/test-hello.jar", EXPECT_MATCH,
                    "Class Hello should be printed in classlist");
         //      2.3.2 dump shared archive based on listFileName
         String archive = "test-hello.jsa";

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/CustomClassListDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/CustomClassListDump.java
@@ -74,13 +74,13 @@ public class CustomClassListDump {
 
         String listData = new String(Files.readAllBytes(Paths.get(classList)));
         check(listData, true, "CustomLoaderApp id: [0-9]+");
-        check(listData, true, "CustomLoadee id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomInterface2_ia id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomInterface2_ib id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee2 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ [0-9]+ [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee3 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee2 id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee3 id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
         check(listData, true, "CustomLoadee3Child id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
-        check(listData, true, "CustomLoadee4WithLambda id: [0-9]+ super: [0-9]+ interfaces: [0-9]+ source: .*/custom.jar");
+        check(listData, true, "CustomLoadee4WithLambda id: [0-9]+ super: [0-9]+ source: .*/custom.jar");
 
         // We don't support archiving of Lambda proxies for custom loaders.
         check(listData, false, "@lambda-proxy.*CustomLoadee4WithLambda");

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/OldClassAndInf.java
@@ -57,20 +57,18 @@ public class OldClassAndInf {
         String classlist[] = new String[] {
             "OldClassApp",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "OldSuper id: 3 super: 1 interfaces: 2 source: " + loadeesJar,
-            "ChildOldSuper id: 4 super: 3 source: " + loadeesJar,
-            "GChild id: 5 super: 4 source: " + loadeesJar
+            "OldSuper id: 2 super: 1 source: " + loadeesJar,
+            "ChildOldSuper id: 3 super: 2 source: " + loadeesJar,
+            "GChild id: 4 super: 3 source: " + loadeesJar
         };
         doTest(classlist, loadeesJar, "true",  "OldSuper", "ChildOldSuper", "GChild");
 
         String classlist2[] = new String[] {
             "OldClassApp",
             "java/lang/Object id: 1",
-            "java/lang/IdentityObject id: 2",
-            "OldInf id: 3 super: 1 source: " + loadeesJar2,
-            "ChildOldInf id: 4 super: 1 interfaces: 2 3 source: " + loadeesJar2,
-            "GChild2 id: 5 super: 4 source: " + loadeesJar2
+            "OldInf id: 2 super: 1 source: " + loadeesJar2,
+            "ChildOldInf id: 3 super: 1 interfaces: 2 source: " + loadeesJar2,
+            "GChild2 id: 4 super: 3 source: " + loadeesJar2
         };
         doTest(classlist2, loadeesJar2, "true", "OldInf", "ChildOldInf", "GChild2");
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/LoaderConstraintsTest.java
@@ -94,13 +94,12 @@ public class LoaderConstraintsTest  {
         String src = " source: " + appJar;
         String classList[] =
             TestCommon.concat(loaderClasses,
-                              "java/lang/IdentityObject id: 0",
                               "java/lang/Object id: 1",
-                              mainClass + " id: 2 super: 1 interfaces: 0" + src,
+                              mainClass + " id: 2 super: 1" + src,
                               httpHandlerClass + " id: 3",
-                              "MyHttpHandler id: 5 super: 1 interfaces: 3 0" + src,
+                              "MyHttpHandler id: 5 super: 1 interfaces: 3" + src,
                               "MyHttpHandlerB id: 6 super: 1 interfaces: 3" + src,
-                              "MyHttpHandlerC id: 7 super: 1 interfaces: 3 0" + src);
+                              "MyHttpHandlerC id: 7 super: 1 interfaces: 3" + src);
         TestCommon.dump(loaderJar, classList, "-Xlog:cds");
 
         String cmdLine[] =


### PR DESCRIPTION
Revert previous test changes that accommodated interface injection

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8289747](https://bugs.openjdk.org/browse/JDK-8289747): [lworld] Remove injected interfaces from CDS tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/720/head:pull/720` \
`$ git checkout pull/720`

Update a local copy of the PR: \
`$ git checkout pull/720` \
`$ git pull https://git.openjdk.org/valhalla pull/720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 720`

View PR using the GUI difftool: \
`$ git pr show -t 720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/720.diff">https://git.openjdk.org/valhalla/pull/720.diff</a>

</details>
