### PR TITLE
8287768: [lw4] Record component may not have the name isValueObject

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1357,7 +1357,8 @@ public class Attr extends JCTree.Visitor {
                 return true;
             }
         }
-        return false;
+        // isValueObject is not included in Object yet so we need a work around
+        return name == names.isValueObject;
     }
 
     Fragment canInferLocalVarType(JCVariableDecl tree) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -106,6 +106,7 @@ public class Names {
     public final Name values;
     public final Name readResolve;
     public final Name readObject;
+    public final Name isValueObject;
 
     // class names
     public final Name java_io_Serializable;
@@ -300,6 +301,7 @@ public class Names {
         values = fromString("values");
         readResolve = fromString("readResolve");
         readObject = fromString("readObject");
+        isValueObject = fromString("isValueObject");
         dollarThis = fromString("$this");
 
         // class names

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -120,7 +120,7 @@ public class RecordCompilationTests extends CompilationTestCase {
     private static String[] OPTIONS_WITH_AP = {"-processor", SimplestAP.class.getName()};
 
     private static final List<String> BAD_COMPONENT_NAMES = List.of(
-            "clone", "finalize", "getClass", "hashCode",
+            "clone", "finalize", "getClass", "hashCode", "isValueObject",
             "notify", "notifyAll", "toString", "wait");
 
     /* simplest annotation processor just to force a round of annotation processing for all tests


### PR DESCRIPTION
Javac should issue an error if a record declares a record component named: `isValueObject`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8287768](https://bugs.openjdk.org/browse/JDK-8287768): [lw4] Record component may not have the name isValueObject


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/722/head:pull/722` \
`$ git checkout pull/722`

Update a local copy of the PR: \
`$ git checkout pull/722` \
`$ git pull https://git.openjdk.org/valhalla pull/722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 722`

View PR using the GUI difftool: \
`$ git pr show -t 722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/722.diff">https://git.openjdk.org/valhalla/pull/722.diff</a>

</details>
