### PR TITLE
8292630: [lworld] javac is accepting annotation interface declarations with modifiers: identity and value

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1526,7 +1526,13 @@ public class Check {
                            FINAL | NON_SEALED)
                  && checkDisjoint(pos, flags,
                                 SEALED,
-                                ANNOTATION)) {
+                                ANNOTATION)
+                 && checkDisjoint(pos, flags,
+                                IDENTITY_TYPE,
+                                ANNOTATION)
+                && checkDisjoint(pos, flags,
+                                VALUE_CLASS,
+                                ANNOTATION) ) {
             // skip
         }
         return flags & (mask | ~ExtendedStandardFlags) | implicit;

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerClassTest.java
@@ -43,7 +43,7 @@ public class InnerAnnotationsInInnerClassTest extends InnerClassesInInnerClassTe
 
     @Override
     public void setProperties() {
-        setInnerOtherModifiers(Modifier.EMPTY, Modifier.ABSTRACT, Modifier.STATIC, Modifier.IDENTITY);
+        setInnerOtherModifiers(Modifier.EMPTY, Modifier.ABSTRACT, Modifier.STATIC);
         setForbiddenWithoutStaticInOuterMods(true);
         setOuterClassType(ClassType.CLASS);
         setInnerClassType(ClassType.ANNOTATION);

--- a/test/langtools/tools/javac/valhalla/value-objects/AnnotationsConstraints.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/AnnotationsConstraints.java
@@ -1,0 +1,13 @@
+/*
+ * @test
+ * @bug 8292630
+ * @summary [lworld] javac is accepting annotation interface declarations with modifiers: identity and value
+ * @compile/fail/ref=AnnotationsConstraints.out -XDrawDiagnostics AnnotationsConstraints.java
+ */
+
+public class AnnotationsConstraints {
+    // annotations can't have the `identity`
+    identity @interface IA {}
+    // nor the `value` modifiers
+    value @interface VA {}
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/AnnotationsConstraints.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/AnnotationsConstraints.out
@@ -1,0 +1,3 @@
+AnnotationsConstraints.java:10:15: compiler.err.illegal.combination.of.modifiers: identity, annotation
+AnnotationsConstraints.java:12:12: compiler.err.illegal.combination.of.modifiers: value, annotation
+2 errors


### PR DESCRIPTION
Please review this fix which is syncing the compiler implementation with the spec. The current spec [1] mentions that:

   * It is a compile-time error if an annotation interface declaration has the modifier sealed, or non-sealed, identity, or value (9.1.1.4).

So code code like:
```
value @interface I {} and
identity @interface I {}
```

should be rejected by the compiler.

 [1] http://cr.openjdk.java.net/~dlsmith/jep8277163/jep8277163-20220519/specs/value-objects-jls.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8292630](https://bugs.openjdk.org/browse/JDK-8292630): [lworld] javac is accepting annotation interface declarations with modifiers: identity and value


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/723/head:pull/723` \
`$ git checkout pull/723`

Update a local copy of the PR: \
`$ git checkout pull/723` \
`$ git pull https://git.openjdk.org/valhalla pull/723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 723`

View PR using the GUI difftool: \
`$ git pr show -t 723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/723.diff">https://git.openjdk.org/valhalla/pull/723.diff</a>

</details>
