### PR TITLE
8292753: [lworld] javac is accepting erroneous synchronized statements

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -875,14 +875,19 @@ public class Check {
      *  @param pos           Position to be used for error reporting.
      *  @param t             The type to be checked.
      */
-    Type checkIdentityType(DiagnosticPosition pos, Type t) {
-
+    void checkIdentityType(DiagnosticPosition pos, Type t) {
+        if (t.hasTag(TYPEVAR)) {
+            t = types.skipTypeVars(t, false);
+        }
+        if (t.isIntersection()) {
+            IntersectionClassType ict = (IntersectionClassType)t;
+            for (Type component : ict.getExplicitComponents()) {
+                checkIdentityType(pos, component);
+            }
+            return;
+        }
         if (t.isPrimitive() || t.isValueClass() || t.isValueInterface() || t.isReferenceProjection())
-            return typeTagError(pos,
-                    diags.fragment(Fragments.TypeReqIdentity),
-                    t);
-
-        return t;
+            typeTagError(pos, diags.fragment(Fragments.TypeReqIdentity), t);
     }
 
     /** Check that type is a reference type, i.e. a class, interface or array type

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8279672
+ * @bug 8279672 8292753
  * @summary Implement semantic checks for value classes
  * @compile/fail/ref=SemanticsViolationsTest.out -XDrawDiagnostics --should-stop=at=FLOW -XDdev SemanticsViolationsTest.java
  */

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.java
@@ -90,4 +90,25 @@ public class SemanticsViolationsTest {
         synchronized void foo() { } // Error;
         synchronized static void soo() {} // OK.
     }
+
+    // another set of test cases considering type variables and intersections
+    interface I {}
+
+    value interface VI extends I {}
+
+    class C {}
+
+    value class VC<T extends VC> {
+        void m(T t) {
+            synchronized(t) {} // error
+        }
+
+        void foo(Object o) {
+            synchronized ((VC & I)o) {} // error
+        }
+
+        void bar(Object o) {
+            synchronized ((I & VI)o) {} // error
+        }
+    }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/SemanticsViolationsTest.out
@@ -11,7 +11,10 @@ SemanticsViolationsTest.java:47:11: compiler.err.super.field.not.allowed: xx, (c
 SemanticsViolationsTest.java:59:13: compiler.err.call.to.super.not.allowed.in.value.ctor
 SemanticsViolationsTest.java:67:11: compiler.err.type.found.req: SemanticsViolationsTest.BrokenValue5, (compiler.misc.type.req.identity)
 SemanticsViolationsTest.java:72:21: compiler.err.value.class.may.not.override: finalize
+SemanticsViolationsTest.java:103:13: compiler.err.type.found.req: SemanticsViolationsTest.VC, (compiler.misc.type.req.identity)
+SemanticsViolationsTest.java:107:13: compiler.err.type.found.req: SemanticsViolationsTest.VC, (compiler.misc.type.req.identity)
+SemanticsViolationsTest.java:111:13: compiler.err.type.found.req: SemanticsViolationsTest.VI, (compiler.misc.type.req.identity)
 SemanticsViolationsTest.java:32:9: compiler.err.var.might.not.have.been.initialized: z
 SemanticsViolationsTest.java:81:17: compiler.err.this.exposed.prematurely
 SemanticsViolationsTest.java:81:16: compiler.err.this.exposed.prematurely
-16 errors
+19 errors


### PR DESCRIPTION
javac should issue an error for this code:
```
value class C<T extends C> {
    void m(T t) {
        synchronized(t) {}
    }
}
```
as type variable `T` is bounded by a value class. Also code like this one should be rejected:
```
value class C<T extends C> {
    void foo(Object o) {
        synchronized ((C & I)o) {} // one of the superclasses of the intersection type is a value class
    }
}
```

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8292753](https://bugs.openjdk.org/browse/JDK-8292753): [lworld] javac is accepting erroneous synchronized statements


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/724/head:pull/724` \
`$ git checkout pull/724`

Update a local copy of the PR: \
`$ git checkout pull/724` \
`$ git pull https://git.openjdk.org/valhalla pull/724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 724`

View PR using the GUI difftool: \
`$ git pr show -t 724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/724.diff">https://git.openjdk.org/valhalla/pull/724.diff</a>

</details>
