### PR TITLE
8292812: jvm test RunWithfieldTests.java fails with VerifyError exception

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/withfieldTests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/withfieldTests/withfieldTests.jcod
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -365,7 +365,7 @@ class putfieldPrimitive {
     Utf8 "putfieldPrimitive.java"; // #19     at 0x9D
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #7;// super_cpx
 
@@ -506,7 +506,7 @@ class withfieldPrimitive {
     Utf8 "withfieldPrimitive.java"; // #19     at 0x9D
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #7;// super_cpx
 
@@ -629,7 +629,7 @@ class withfieldNull {
     Utf8 "withfieldNull.java"; // #14     at 0x80
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #7;// super_cpx
 
@@ -739,7 +739,7 @@ class WrongPrimWF$Dot {
     Utf8 "Dot"; // #19     at 0xE8
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #7;// super_cpx
 
@@ -828,7 +828,7 @@ class WrongPrimWF$Loc {
     Utf8 "Loc"; // #19     at 0xE8
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #7;// super_cpx
 
@@ -931,7 +931,7 @@ class WrongPrimWF$Both {
     Utf8 "Loc"; // #33     at 0x018B
   } // Constant Pool
 
-  0x0931; // access [ ACC_PRIMITIVE ACC_VALUE ACC_PUBLIC ACC_SUPER ACC_FINAL ]
+  0x0851; // access [ ACC_PRIMITIVE ACC_VALUE ACC_FINAL ACC_PUBLIC ]
   #1;// this_cpx
   #15;// super_cpx
 


### PR DESCRIPTION
Please review this small fix for JVM test RunWithfieldTests.java.  The test failed because it had out of date access flags.  The fix was tested by running the test locally.
Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8292812](https://bugs.openjdk.org/browse/JDK-8292812): jvm test RunWithfieldTests.java fails with VerifyError exception


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/725/head:pull/725` \
`$ git checkout pull/725`

Update a local copy of the PR: \
`$ git checkout pull/725` \
`$ git pull https://git.openjdk.org/valhalla pull/725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 725`

View PR using the GUI difftool: \
`$ git pr show -t 725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/725.diff">https://git.openjdk.org/valhalla/pull/725.diff</a>

</details>
