### PR TITLE
8292882: [lw4] PERMITS_VALUE should be removed from all source files

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4558,11 +4558,9 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
       return;
     }
 
-    // The JVMS says that super classes for value types must have the ACC_PERMITS_VALUE
-    // flag set.  However, since java.lang.Object has not yet been changed into an abstract
-    // class, it cannot have its ACC_PERMITS_VALUE flag set.  But, java.lang.Object must
-    // still be allowed to be a direct super class for a value classes.  So, it is treated
-    // as a special case for now.
+    // The JVMS says that super classes for value types must not have the ACC_IDENTITY
+    // flag set. But, java.lang.Object must still be allowed to be a direct super class
+    // for a value classes.  So, it is treated as a special case for now.
     if (this_klass->access_flags().is_value_class() &&
         super_ik->name() != vmSymbols::java_lang_Object() &&
         super_ik->is_identity_class()) {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -204,7 +204,6 @@ public final class Class<T> implements java.io.Serializable,
     private static final int ENUM       = 0x00004000;
     private static final int SYNTHETIC  = 0x00001000;
     private static final int VALUE_CLASS     = 0x00000040;
-    private static final int PERMITS_VALUE   = 0x00000100;
     private static final int PRIMITIVE_CLASS = 0x00000800;
 
     private static native void registerNatives();

--- a/src/java.base/share/native/include/classfile_constants.h.template
+++ b/src/java.base/share/native/include/classfile_constants.h.template
@@ -70,7 +70,6 @@ enum {
 #define JVM_ACC_SUPER_BIT         5
 #define JVM_ACC_VOLATILE_BIT      6
 #define JVM_ACC_BRIDGE_BIT        6
-#define JVM_ACC_PERMITS_VALUE_BIT 6
 #define JVM_ACC_TRANSIENT_BIT     7
 #define JVM_ACC_VARARGS_BIT       7
 #define JVM_ACC_NATIVE_BIT        8

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCICCETests.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACCICCETests.jcod
@@ -23,7 +23,7 @@
  */
 
 // This is an abstract class that cannot be a super class for value classes
-// because ACC_PERMITS_VALUE was removed from its class access flags.
+// because ACC_IDENTITY is set in its class access flags.
 // It's based on the following source:
 /*
 public abstract class NonPVSuper {
@@ -75,7 +75,7 @@ class NonPVSuper {
     Utf8 "NonPVSuper.java"; // #32     at 0x011E
   } // Constant Pool
 
-  0x0421; // access [ ACC_PUBLIC ACC_SUPER ACC_ABSTRACT ]
+  0x0421; // access [ ACC_PUBLIC ACC_IDENTITY ACC_ABSTRACT ]
   #22;// this_cpx
   #2;// super_cpx
 
@@ -177,7 +177,7 @@ class NonPVSuper {
 
 
 // Dot is a value class that tries to inherit from a super class (NonPVSuper)
-// that does not have access flag ACC_PERMIT_VALUES set.
+// that has access flag ACC_IDENTITY set.
 // Dot is based on the following source:
 /*
 public value final class Dot extends NonPVSuper {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_CFETest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_CFETest.java
@@ -25,7 +25,7 @@
 /*
  * @test ACC_CFETest
  * @bug 8281279
- * @summary test class access rules for classes that have ACC_PERMITS_VALUE set.
+ * @summary test class access rules for abstract classes that have ACC_VALUE set.
  * @compile ACCCFETests.jcod
  * @run main/othervm -XX:+EnableValhalla -Xverify:remote ACC_CFETest
  */

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_ICCETest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/ACC_ICCETest.java
@@ -25,8 +25,7 @@
 /*
  * @test ACC_ICCETest
  * @bug 8281279
- * @summary test that ACC_PERMITS_VALUE must be set for the super class of
- *          a value class (unless the super is java.lang.Object);
+ * @summary test that a value class cannot sub-class an identity class
  * @compile ACCICCETests.jcod
  * @run main/othervm -XX:+EnableValhalla ACC_ICCETest
  */
@@ -45,10 +44,6 @@ public class ACC_ICCETest {
     }
 
     public static void main(String[] args) throws Exception {
-
-        // Test has to be re-think now that ACC_PERMITS_VALUE has been removed
-        // and the model has changed to ACC_VALUE/ACC_IDENTITY modifiers
-        // Test illegal class that has both ACC_VALUE and ACC_PERMITS_VALUE set.
         runTest("Dot", "Value type Dot has an identity type as supertype");
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006.java
@@ -54,7 +54,7 @@ public class getclmdf006 {
     public static int run(String args[], PrintStream out) {
         check(getclmdf006a.class, 0);
         check(getclmdf006b.class, Modifier.FINAL);
-        check(getclmdf006c.class, Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
+        check(getclmdf006c.class, Modifier.ABSTRACT);
         check(getclmdf006d.class, Modifier.INTERFACE | Modifier.ABSTRACT);
         check(getclmdf006e.class, Modifier.PUBLIC | Modifier.INTERFACE |
                                   Modifier.ABSTRACT);
@@ -69,23 +69,22 @@ public class getclmdf006 {
         check(Inner09.class, Modifier.PROTECTED | Modifier.ABSTRACT);
         check(Inner10.class, Modifier.STATIC);
         check(Inner11.class, Modifier.STATIC | Modifier.FINAL);
-        check(Inner12.class, Modifier.STATIC | Modifier.ABSTRACT |
-                             Modifier.PERMITS_VALUE);
+        check(Inner12.class, Modifier.STATIC | Modifier.ABSTRACT);
         check(Inner13.class, Modifier.PUBLIC | Modifier.STATIC);
         check(Inner14.class, Modifier.PUBLIC | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner15.class, Modifier.PUBLIC | Modifier.STATIC |
-                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
+                             Modifier.ABSTRACT);
         check(Inner16.class, Modifier.PRIVATE | Modifier.STATIC);
         check(Inner17.class, Modifier.PRIVATE | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner18.class, Modifier.PRIVATE | Modifier.STATIC |
-                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
+                             Modifier.ABSTRACT);
         check(Inner19.class, Modifier.PROTECTED | Modifier.STATIC);
         check(Inner20.class, Modifier.PROTECTED | Modifier.STATIC |
                              Modifier.FINAL);
         check(Inner21.class, Modifier.PROTECTED | Modifier.STATIC |
-                             Modifier.ABSTRACT | Modifier.PERMITS_VALUE);
+                             Modifier.ABSTRACT);
         check(Inner22.class, Modifier.STATIC | Modifier.INTERFACE |
                              Modifier.ABSTRACT);
         check(Inner23.class, Modifier.PUBLIC | Modifier.STATIC |

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006/getclmdf006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassModifiers/getclmdf006/getclmdf006.cpp
@@ -39,7 +39,6 @@ extern "C" {
 #define ACC_STATIC      0x0008
 #define ACC_FINAL       0x0010
 #define ACC_SUPER       0x0020
-#define ACC_PERMITS_VALUE    0x0040
 #define ACC_INTERFACE   0x0200
 #define ACC_ABSTRACT    0x0400
 
@@ -83,7 +82,6 @@ void printModifiers(jint mod) {
     if (mod & ACC_SUPER) printf(" SUPER");
     if (mod & ACC_INTERFACE) printf(" INTERFACE");
     if (mod & ACC_ABSTRACT) printf(" ABSTRACT");
-    if (mod & ACC_PERMITS_VALUE) printf(" PERMITS_VALUE");
     printf(" (0x%0x)\n", mod);
 }
 

--- a/test/lib/org/openjdk/asmtools/jasm/JasmTokens.java
+++ b/test/lib/org/openjdk/asmtools/jasm/JasmTokens.java
@@ -404,7 +404,6 @@ public class JasmTokens {
 
         // Valhalla
         VALUE              (200, "VALUE",     "value",     EnumSet.of(TokenType.MODIFIER, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
-        PERMITS_VALUE      (201, "PERMITS_VALUE", "permits_value", EnumSet.of(TokenType.MODIFIER, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         PRIMITIVE          (202, "PRIMITIVE", "primitive", EnumSet.of(TokenType.MODIFIER, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         PRELOAD            (203, "PRELOAD",    "Preload",  EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD);
 

--- a/test/lib/org/openjdk/asmtools/jasm/Modifiers.java
+++ b/test/lib/org/openjdk/asmtools/jasm/Modifiers.java
@@ -43,7 +43,7 @@ public class Modifiers {
 
     public static final int MM_CLASS       = MM_ACCESS  | ACC_FINAL     |  ACC_SUPER    | ACC_ABSTRACT | ACC_ENUM |
                                              MM_ATTR    |  ACC_MODULE |
-                                             ACC_VALUE | ACC_PERMITS_VALUE | ACC_PRIMITIVE;
+                                             ACC_VALUE | ACC_PRIMITIVE;
 
     public static final int MM_FIELD       = MM_ACCESS    | ACC_STATIC | ACC_FINAL    |  ACC_VOLATILE | ACC_TRANSIENT |
                                             ACC_SYNTHETIC | ACC_ENUM   |
@@ -64,7 +64,7 @@ public class Modifiers {
 
     public static final int MM_INNERCLASS  = MM_ACCESS    | ACC_STATIC    | ACC_FINAL      | ACC_SUPER | ACC_INTERFACE |
                                              ACC_ABSTRACT | ACC_SYNTHETIC | ACC_ANNOTATION | ACC_ENUM  | MM_ATTR |
-                                             ACC_VALUE | ACC_PERMITS_VALUE | ACC_PRIMITIVE;
+                                             ACC_VALUE | ACC_PRIMITIVE;
 
     public static final int MM_REQUIRES    = ACC_TRANSITIVE | ACC_STATIC_PHASE  | ACC_SYNTHETIC | ACC_MANDATED ;
 
@@ -222,10 +222,6 @@ public class Modifiers {
 
     public static boolean isValue(int mod) {
         return (mod & ACC_VALUE) != 0;
-    }
-
-    public static boolean isPermitsValue(int mod) {
-        return (mod & ACC_PERMITS_VALUE) != 0;
     }
 
     public static boolean isPrimitive(int mod) {
@@ -427,9 +423,6 @@ public class Modifiers {
             if ((context != CF_Context.CTX_CLASS) || !isInterface(mod)) {
                 sb.append(Token.ABSTRACT.parseKey() + " ");
             }
-        }
-        if (context.isOneOf(CF_Context.CTX_CLASS, CF_Context.CTX_INNERCLASS) && isPermitsValue(mod)) {
-            sb.append(Token.PERMITS_VALUE.parseKey() + " ");
         }
         if (  context.isOneOf(CF_Context.CTX_CLASS, CF_Context.CTX_INNERCLASS, CF_Context.CTX_FIELD) && isFinal(mod)) {
             sb.append(Token.FINAL.parseKey() + " ");

--- a/test/lib/org/openjdk/asmtools/jasm/Parser.java
+++ b/test/lib/org/openjdk/asmtools/jasm/Parser.java
@@ -350,7 +350,6 @@ class Parser extends ParseBase {
             case IDENT:
             case BRIDGE:
             case VALUE:
-            case PERMITS_VALUE:
             case PRIMITIVE:
                 v = scanner.idValue;
                 scanner.scan();
@@ -527,7 +526,6 @@ class Parser extends ParseBase {
             case BRIDGE:
             case IDENT:
             case VALUE:
-            case PERMITS_VALUE:
             case PRIMITIVE:
                 v = scanner.idValue;
                 scanner.scan();
@@ -719,9 +717,6 @@ class Parser extends ParseBase {
                     break;
                 case VALUE:
                     nextmod = ACC_VALUE;
-                    break;
-                case PERMITS_VALUE:
-                    nextmod = ACC_PERMITS_VALUE;
                     break;
                 case PRIMITIVE:
                     nextmod = ACC_PRIMITIVE;

--- a/test/lib/org/openjdk/asmtools/jasm/RuntimeConstants.java
+++ b/test/lib/org/openjdk/asmtools/jasm/RuntimeConstants.java
@@ -47,7 +47,6 @@ public interface RuntimeConstants {
     int ACC_BRIDGE        = 0x0040; //                      method
     int ACC_TRANSIENT     = 0x0080; //               field
     int ACC_VARARGS       = 0x0080; //                      method
-    int ACC_PERMITS_VALUE = 0x0100; // class, inner
     int ACC_NATIVE        = 0x0100; //                      method
     int ACC_INTERFACE     = 0x0200; // class, inner
     int ACC_ABSTRACT      = 0x0400; // class, inner,        method
@@ -71,7 +70,6 @@ public interface RuntimeConstants {
                         put(ACC_FINAL        ,"final");
                         put(ACC_SUPER        ,"super");
                         put(ACC_SYNCHRONIZED ,"synchronized");
-                        put(ACC_PERMITS_VALUE,"permits_value");
                         put(ACC_VOLATILE     ,"volatile");
                         put(ACC_BRIDGE       ,"bridge");
                         put(ACC_TRANSIENT    ,"transient");


### PR DESCRIPTION
Please review those changes which remove all remains of ACC_PERMITS_VALUE.

Tested with Mach5, tier1-4.

Thank you.

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8292882](https://bugs.openjdk.org/browse/JDK-8292882): [lw4] PERMITS_VALUE should be removed from all source files


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/726/head:pull/726` \
`$ git checkout pull/726`

Update a local copy of the PR: \
`$ git checkout pull/726` \
`$ git pull https://git.openjdk.org/valhalla pull/726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 726`

View PR using the GUI difftool: \
`$ git pr show -t 726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/726.diff">https://git.openjdk.org/valhalla/pull/726.diff</a>

</details>
