### PR TITLE
8293120: [lworld] javac is rejecting correct class declaration that has a combination of value and sealed modifiers

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4615,7 +4615,10 @@ public class JavacParser implements Parser {
                     yield afterNext.kind != INTERFACE || currentIsNonSealed;
                 }
                 case PUBLIC, PROTECTED, PRIVATE, ABSTRACT, STATIC, FINAL, STRICTFP, CLASS, INTERFACE, ENUM -> true;
-                case IDENTIFIER -> isNonSealedIdentifier(next, currentIsNonSealed ? 3 : 1) || next.name() == names.sealed;
+                case IDENTIFIER -> isNonSealedIdentifier(next, currentIsNonSealed ? 3 : 1) ||
+                        next.name() == names.sealed ||
+                        next.name() == names.value ||
+                        next.name() == names.identity;
                 default -> false;
             };
     }


### PR DESCRIPTION
Fixing a parser error that doesn't allow modifiers `sealed` + (`value` or `identity`) in a class declaration

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293120](https://bugs.openjdk.org/browse/JDK-8293120): [lworld] javac is rejecting correct class declaration that has a combination of value and sealed modifiers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/730/head:pull/730` \
`$ git checkout pull/730`

Update a local copy of the PR: \
`$ git checkout pull/730` \
`$ git pull https://git.openjdk.org/valhalla pull/730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 730`

View PR using the GUI difftool: \
`$ git pr show -t 730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/730.diff">https://git.openjdk.org/valhalla/pull/730.diff</a>

</details>
