### PR TITLE
8293183: [lworld] add missing tests for functional interfaces

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -457,9 +457,7 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                     }
                 }
                 """);
-        // currently failing but should be accepted
-        /*
-        assertOK(
+        assertFail("compiler.err.bad.functional.intf.anno.1",
                 """
                 identity interface I {
                     void m();
@@ -468,7 +466,41 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                 @FunctionalInterface
                 interface J extends I  {}
                 """);
-        */
+        assertFail("compiler.err.bad.functional.intf.anno.1",
+                """
+                value interface I {
+                    void m();
+                }
+
+                @FunctionalInterface
+                interface J extends I  {}
+                """);
+        assertFail("compiler.err.prob.found.req",
+                """
+                identity interface I {}
+                interface K extends I {}
+                interface J {
+                    void m();
+                }
+                class Test {
+                    void foo() {
+                        J j = (J&K)() -> {};
+                    }
+                }
+                """);
+        assertFail("compiler.err.prob.found.req",
+                """
+                value interface I {}
+                interface K extends I {}
+                interface J {
+                    void m();
+                }
+                class Test {
+                    void foo() {
+                        J j = (J&K)() -> {};
+                    }
+                }
+                """);
     }
 
     public void testMutuallyIncompatibleSupers() {


### PR DESCRIPTION
this PR is adding some additional regression tests for functional interfaces, covering this assertion on section: 9.8 Functional Interfaces of [1]:

 * A functional interface is an interface that is not declared with one of the modifiers sealed, identity, or value...

but this should apply too to functional interfaces which are not explicitly declared with the `identity` modifier. So this code should not be accepted:

    identity interface I {
        void m();
    }

    @FunctionalInterface
    interface J extends I {}

[1] http://cr.openjdk.java.net/~dlsmith/jep8277163/jep8277163-20220519/specs/value-objects-jls.html#jls-9.8

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293183](https://bugs.openjdk.org/browse/JDK-8293183): [lworld] add missing tests for functional interfaces


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/735/head:pull/735` \
`$ git checkout pull/735`

Update a local copy of the PR: \
`$ git checkout pull/735` \
`$ git pull https://git.openjdk.org/valhalla pull/735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 735`

View PR using the GUI difftool: \
`$ git pr show -t 735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/735.diff">https://git.openjdk.org/valhalla/pull/735.diff</a>

</details>
