### PR TITLE
8293173: [lworld] Fully apply refactoring from JDK-8275201 to Valhalla

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4855,18 +4855,18 @@ Compile::SubTypeCheckResult Compile::static_subtype_check(const TypeKlassPtr* su
     return SSC_always_false; // (2) true path dead; no dynamic test needed
   }
 
-  // Do not fold the subtype check to an array klass pointer comparison for [V? arrays.
-  // [QMyValue is a subtype of [LMyValue but the klass for [QMyValue is not equal to
-  // the klass for [LMyValue. Perform a full test.
-  if (superk->isa_aryklassptr() && !superk->is_aryklassptr()->is_null_free() &&
-      superk->is_aryklassptr()->elem()->isa_klassptr() && superk->is_aryklassptr()->elem()->is_klassptr()->klass()->is_inlinetype()) {
-    return SSC_full_test;
-  }
-
   const Type* superelem = superk;
   if (superk->isa_aryklassptr()) {
     int ignored;
     superelem = superk->is_aryklassptr()->base_element_type(ignored);
+
+    // Do not fold the subtype check to an array klass pointer comparison for [V? arrays.
+    // [QMyValue is a subtype of [LMyValue but the klass for [QMyValue is not equal to
+    // the klass for [LMyValue. Perform a full test.
+    if (!superk->is_aryklassptr()->is_null_free() && superk->is_aryklassptr()->elem()->isa_instklassptr() &&
+        superk->is_aryklassptr()->elem()->is_instklassptr()->instance_klass()->is_inlinetype()) {
+      return SSC_full_test;
+    }
   }
 
   if (superelem->isa_instklassptr()) {

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -213,8 +213,6 @@ private:
 
   Node* make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, Node* ctl, Node* mem, BasicType ft, const Type *ftype, AllocateNode *alloc);
 
-  bool can_try_zeroing_elimination(AllocateArrayNode* alloc, Node* src, Node* dest) const;
-
 public:
   PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {
     _igvn.set_delay_transform(true);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1000,11 +1000,7 @@ Node* LoadNode::can_see_arraycopy_value(Node* st, PhaseGVN* phase) const {
       if (is_reference_type(ary_elem, true)) ary_elem = T_OBJECT;
 
       uint header = arrayOopDesc::base_offset_in_bytes(ary_elem);
-      uint shift  = exact_log2(type2aelembytes(ary_elem));
-      if (ary_t->klass()->is_flat_array_klass()) {
-        ciFlatArrayKlass* vak = ary_t->klass()->as_flat_array_klass();
-        shift = vak->log2_element_size();
-      }
+      uint shift  = ary_t->is_flat() ? ary_t->flat_log_elem_size() : exact_log2(type2aelembytes(ary_elem));
 
       Node* diff = phase->transform(new SubINode(ac->in(ArrayCopyNode::SrcPos), ac->in(ArrayCopyNode::DestPos)));
 #ifdef _LP64
@@ -2059,12 +2055,15 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
       Node* base = AddPNode::Ideal_base_and_offset(adr, phase, offset);
       if (base != NULL && base->is_Load() && offset == in_bytes(InlineKlass::default_value_offset_offset())) {
         const TypeKlassPtr* tkls = phase->type(base->in(MemNode::Address))->isa_klassptr();
+        // TODO fix with JDK-8293172
+        /*
         if (tkls != NULL && tkls->is_loaded() && tkls->klass_is_exact() && tkls->isa_inlinetype() &&
             tkls->offset() == in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset())) {
           assert(base->Opcode() == Op_LoadP, "must load an oop from klass");
           assert(Opcode() == Op_LoadI, "must load an int from fixed block");
           return TypeInt::make(tkls->klass()->as_inline_klass()->default_value_offset());
         }
+        */
       }
     }
   }
@@ -2176,9 +2175,8 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
       // The mark word may contain property bits (inline, flat, null-free)
       Node* klass_node = alloc->in(AllocateNode::KlassNode);
       const TypeKlassPtr* tkls = phase->type(klass_node)->is_klassptr();
-      ciKlass* klass = tkls->klass();
-      if (klass != NULL && klass->is_loaded() && tkls->klass_is_exact()) {
-        return TypeX::make(klass->prototype_header().value());
+      if (tkls->is_loaded() && tkls->klass_is_exact()) {
+        return TypeX::make(tkls->exact_klass()->prototype_header().value());
       }
     } else {
       return TypeX::make(markWord::prototype().value());

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4824,6 +4824,18 @@ const TypeAryPtr* TypeAryPtr::update_properties(const TypeAryPtr* from) const {
   return this;
 }
 
+jint TypeAryPtr::flat_layout_helper() const {
+  return klass()->as_flat_array_klass()->layout_helper();
+}
+
+int TypeAryPtr::flat_elem_size() const {
+  return klass()->as_flat_array_klass()->element_byte_size();
+}
+
+int TypeAryPtr::flat_log_elem_size() const {
+  return klass()->as_flat_array_klass()->log2_element_size();
+}
+
 //------------------------------cast_to_stable---------------------------------
 const TypeAryPtr* TypeAryPtr::cast_to_stable(bool stable, int stable_dimension) const {
   if (stable_dimension <= 0 || (stable_dimension == 1 && stable == this->is_stable()))

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1183,10 +1183,9 @@ protected:
   virtual const Type *filter_helper(const Type *kills, bool include_speculative) const;
 
   virtual ciKlass* exact_klass_helper() const { return NULL; }
+  virtual ciKlass* klass() const { return _klass; }
 
 public:
-  // TODO Tobias
-  virtual ciKlass* klass() const { return _klass; }
 
   bool is_java_subtype_of(const TypeOopPtr* other) const {
     return is_java_subtype_of_helper(other, klass_is_exact(), other->klass_is_exact());
@@ -1245,6 +1244,7 @@ public:
   bool is_known_instance_field() const { return is_known_instance() && _offset.get() >= 0; }
 
   virtual bool can_be_inline_type() const { return (_klass == NULL || _klass->can_be_inline_klass(_klass_is_exact)); }
+  bool can_be_inline_array() const { return (_klass == NULL || _klass->can_be_inline_array_klass()); }
 
   virtual intptr_t get_con() const;
 
@@ -1425,10 +1425,9 @@ class TypeAryPtr : public TypeOopPtr {
   ciKlass* compute_klass(DEBUG_ONLY(bool verify = false)) const;
 
   ciKlass* exact_klass_helper() const;
-public:
-  // TODO Tobias
   ciKlass* klass() const;
 
+public:
 
   bool is_same_java_type_as(const TypeOopPtr* other) const;
   bool is_java_subtype_of_helper(const TypeOopPtr* other, bool this_exact, bool other_exact) const;
@@ -1495,6 +1494,9 @@ public:
   const TypeAryPtr* cast_to_not_flat(bool not_flat = true) const;
   const TypeAryPtr* cast_to_not_null_free(bool not_null_free = true) const;
   const TypeAryPtr* update_properties(const TypeAryPtr* new_type) const;
+  jint flat_layout_helper() const;
+  int flat_elem_size() const;
+  int flat_log_elem_size() const;
 
   const TypeAryPtr* cast_to_stable(bool stable, int stable_dimension = 1) const;
   int stable_dimension() const;
@@ -1600,10 +1602,9 @@ protected:
 
   virtual bool must_be_exact() const { ShouldNotReachHere(); return false; }
   virtual ciKlass* exact_klass_helper() const;
-public:
-  // TODO Tobias
   virtual ciKlass* klass() const { return  _klass; }
 
+public:
 
   bool is_java_subtype_of(const TypeKlassPtr* other) const {
     return is_java_subtype_of_helper(other, klass_is_exact(), other->klass_is_exact());
@@ -1639,6 +1640,8 @@ public:
   virtual intptr_t get_con() const;
 
   virtual const TypeKlassPtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return NULL; }
+
+  bool can_be_inline_array() const { return (_klass == NULL || _klass->can_be_inline_array_klass()); }
 };
 
 // Instance klass pointer, mirrors TypeInstPtr


### PR DESCRIPTION
When merging master into Valhalla, we omitted/disabled some of the refactoring from [JDK-8275201](https://bugs.openjdk.org/browse/JDK-8275201) (and old [JDK-8266550](https://bugs.openjdk.org/browse/JDK-8266550)) for simplicity because it affects new, Valhalla specific code. This change applies the required changes.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293173](https://bugs.openjdk.org/browse/JDK-8293173): [lworld] Fully apply refactoring from JDK-8275201 to Valhalla


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/736/head:pull/736` \
`$ git checkout pull/736`

Update a local copy of the PR: \
`$ git checkout pull/736` \
`$ git pull https://git.openjdk.org/valhalla pull/736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 736`

View PR using the GUI difftool: \
`$ git pr show -t 736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/736.diff">https://git.openjdk.org/valhalla/pull/736.diff</a>

</details>
