### PR TITLE
8293172: [lworld] Folding of default value loads is broken

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2055,15 +2055,12 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
       Node* base = AddPNode::Ideal_base_and_offset(adr, phase, offset);
       if (base != NULL && base->is_Load() && offset == in_bytes(InlineKlass::default_value_offset_offset())) {
         const TypeKlassPtr* tkls = phase->type(base->in(MemNode::Address))->isa_klassptr();
-        // TODO fix with JDK-8293172
-        /*
-        if (tkls != NULL && tkls->is_loaded() && tkls->klass_is_exact() && tkls->isa_inlinetype() &&
+        if (tkls != NULL && tkls->is_loaded() && tkls->klass_is_exact() && tkls->exact_klass()->is_inlinetype() &&
             tkls->offset() == in_bytes(InstanceKlass::adr_inlineklass_fixed_block_offset())) {
           assert(base->Opcode() == Op_LoadP, "must load an oop from klass");
           assert(Opcode() == Op_LoadI, "must load an int from fixed block");
-          return TypeInt::make(tkls->klass()->as_inline_klass()->default_value_offset());
+          return TypeInt::make(tkls->exact_klass()->as_inline_klass()->default_value_offset());
         }
-        */
       }
     }
   }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -468,6 +468,7 @@ public class TestIntrinsics {
     }
 
     @Test
+    @IR(failOn = IRNode.LOAD_I) // Load of the default value should be folded
     public Object test26() {
         Class<?>[] ca = new Class<?>[1];
         for (int i = 0; i < 1; ++i) {


### PR DESCRIPTION
While working on the merge, I noticed that the constant folding of the default value load in C2 is broken and none of our tests caught it. This change fixes the incorrect `tkls->isa_inlinetype()` check than can never be true and adds a regression test.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293172](https://bugs.openjdk.org/browse/JDK-8293172): [lworld] Folding of default value loads is broken


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/737/head:pull/737` \
`$ git checkout pull/737`

Update a local copy of the PR: \
`$ git checkout pull/737` \
`$ git pull https://git.openjdk.org/valhalla pull/737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 737`

View PR using the GUI difftool: \
`$ git pr show -t 737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/737.diff">https://git.openjdk.org/valhalla/pull/737.diff</a>

</details>
