### PR TITLE
8293126: [lworld] follow-up for JDK-8293120

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1468,8 +1468,14 @@ public class Check {
                 implicit |= VALUE_CLASS | FINAL;
 
             // concrete value classes are implicitly final
-            if ((flags & (ABSTRACT | INTERFACE | VALUE_CLASS)) == VALUE_CLASS)
+            if ((flags & (ABSTRACT | INTERFACE | VALUE_CLASS)) == VALUE_CLASS) {
                 implicit |= FINAL;
+                if ((flags & NON_SEALED) != 0) {
+                    // cant declare a final value class non-sealed
+                    log.error(pos,
+                            Errors.ModNotAllowedHere(asFlagSet(NON_SEALED)));
+                }
+            }
 
             // TYPs can't be declared synchronized
             mask &= ~SYNCHRONIZED;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -25,7 +25,7 @@
  * ValueObjectCompilationTests
  *
  * @test
- * @bug 8287136 8292630 8279368 8287136 8287770 8279840 8279672 8292753 8287763 8279901 8287767
+ * @bug 8287136 8292630 8279368 8287136 8287770 8279840 8279672 8292753 8287763 8279901 8287767 8293183 8293120
  * @summary Negative compilation tests, and positive compilation (smoke) tests for Value Objects
  * @library /lib/combo /tools/lib
  * @modules
@@ -500,5 +500,47 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                 value interface VI {}
                 class BIC implements VI {} // Error
                 """);
+    }
+
+    public void testInteractionWithSealedClasses() {
+        assertOK(
+                """
+                abstract sealed value class SC {}
+                value class VC extends SC {}
+                """
+        );assertOK(
+                """
+                abstract sealed value interface SI {}
+                value class VC implements SI {}
+                """
+        );
+        assertOK(
+                """
+                abstract sealed identity class SC {}
+                final identity class IC extends SC {}
+                non-sealed identity class IC2 extends SC {}
+                final identity class IC3 extends IC2 {}
+                """
+        );
+        assertOK(
+                """
+                abstract sealed identity interface SI {}
+                final identity class IC implements SI {}
+                non-sealed identity class IC2 implements SI {}
+                final identity class IC3 extends IC2 {}
+                """
+        );
+        assertFail("compiler.err.mod.not.allowed.here",
+                """
+                abstract sealed value class SC {}
+                non-sealed value class VC extends SC {}
+                """
+        );
+        assertFail("compiler.err.mod.not.allowed.here",
+                """
+                sealed value interface SI {}
+                non-sealed value class VC implements SI {}
+                """
+        );
     }
 }


### PR DESCRIPTION
This PR is providing tests that were missing in the initial PR that fixed [1]. Also we realized that javac is accepting this code as kosher:
```
    abstract sealed value class SC {}
    non-sealed value class VC extends SC {}
```
even when concrete value classes are implicitly final, so can't be `non-sealed` at the same time.

[1] https://bugs.openjdk.org/browse/JDK-8293120

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293126](https://bugs.openjdk.org/browse/JDK-8293126): [lworld] follow-up for JDK-8293120


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/738/head:pull/738` \
`$ git checkout pull/738`

Update a local copy of the PR: \
`$ git checkout pull/738` \
`$ git pull https://git.openjdk.org/valhalla pull/738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 738`

View PR using the GUI difftool: \
`$ git pr show -t 738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/738.diff">https://git.openjdk.org/valhalla/pull/738.diff</a>

</details>
