### PR TITLE
8293253: [lw4] Code fixing access flags in old class files is incorrect and incomplete

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3339,7 +3339,7 @@ u2 ClassFileParser::parse_classfile_inner_classes_attribute(const ClassFileStrea
     }
 
     if (EnableValhalla) {
-      if(!supports_inline_types()) {
+      if (!supports_inline_types()) {
         const bool is_module = (flags & JVM_ACC_MODULE) != 0;
         const bool is_interface = (flags & JVM_ACC_INTERFACE) != 0;
         if (!is_module && !is_interface) {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3338,6 +3338,16 @@ u2 ClassFileParser::parse_classfile_inner_classes_attribute(const ClassFileStrea
       flags |= JVM_ACC_ABSTRACT;
     }
 
+    if (EnableValhalla) {
+      if(!supports_inline_types()) {
+        const bool is_module = (flags & JVM_ACC_MODULE) != 0;
+        const bool is_interface = (flags & JVM_ACC_INTERFACE) != 0;
+        if (!is_module && !is_interface) {
+          flags |= JVM_ACC_IDENTITY;
+        }
+      }
+    }
+
     const char* name = inner_name_index == 0 ? "unnamed" : cp->symbol_at(inner_name_index)->as_utf8();
     verify_legal_class_modifiers(flags, name, false, CHECK_0);
     AccessFlags inner_access_flags(flags);
@@ -6177,8 +6187,6 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
     flags |= JVM_ACC_ABSTRACT;
   }
 
-  _access_flags.set_flags(flags);
-
   // This class and superclass
   _this_class_index = stream->get_u2_fast();
   check_property(
@@ -6202,6 +6210,11 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
         flags |= JVM_ACC_IDENTITY;
       }
     }
+  }
+
+  _access_flags.set_flags(flags);
+
+  if (EnableValhalla) {
     if (_access_flags.is_identity_class()) set_carries_identity_modifier();
     if (_access_flags.is_value_class()) set_carries_value_modifier();
     if (carries_identity_modifier() && carries_value_modifier()) {

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -187,8 +187,7 @@ public class TestResolvedJavaType extends TypeUniverse {
         assertEquals(javaName, internalNameToJava(typeName, true, true));
     }
 
-    // TODO Re-enable once JDK-8291719 is fixed.
-    // @Test
+    @Test
     public void getModifiersTest() {
         for (Class<?> c : classes) {
             ResolvedJavaType type = metaAccess.lookupJavaType(c);


### PR DESCRIPTION
Please review this code fixing the code that adds the missing ACC_SUPER/ACC_IDENTITY flag in old class files.
Those changes fix both JDK-8291719 and JDK-8293169.

Tested with Mach5, tier1-3.

But those changes also trigger new failures that should be addressed in additional CR:

java/lang/invoke/defineHiddenClass/BasicTest.java:
  - assertion failure because test doesn't expect ACC_IDENTITY to be present
    not sure about the fix if non-Valhalla configurations are run
    BTW, the test already uses ACC_IDENTITY in some places

 java/lang/reflect/AccessFlag/ClassAccessFlagTest.java:
  - another Java test surprised by the presence of ACC_IDENTITY

serviceability/jvmti/RedefineClasses/RedefineObject.java:
  - changes in access flags leads to the class redefinition code to reject
    an attempt to redefine a class because it sees a mismatch in access flags
    (forbidden by class redefinition rules)

tools/javac/preview/PreviewTest.java
  - not sure about this one, need input from a javac expert

Still some failures in JCK test, vm/classfmt/cpl and vm/instr/invokespecial
but they will be addressed in another patch.

Thank you,

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293253](https://bugs.openjdk.org/browse/JDK-8293253): [lw4] Code fixing access flags in old class files is incorrect and incomplete


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [41aa059a](https://git.openjdk.org/valhalla/pull/739/files/41aa059a151be37748b1a0315de985e4ee969d65)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/739/head:pull/739` \
`$ git checkout pull/739`

Update a local copy of the PR: \
`$ git checkout pull/739` \
`$ git pull https://git.openjdk.org/valhalla pull/739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 739`

View PR using the GUI difftool: \
`$ git pr show -t 739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/739.diff">https://git.openjdk.org/valhalla/pull/739.diff</a>

</details>
