### PR TITLE
8293314: [lworld] C2 OSR compilation fails with assert(_gvn.type(l)->higher_equal(type)) failed: must constrain OSR typestate

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6478,10 +6478,9 @@ const TypeKlassPtr *TypeAryKlassPtr::cast_to_exactness(bool klass_is_exact) cons
       not_null_free = true;
     } else {
       // Klass is not exact (anymore), re-compute null-free/flat properties
-      not_null_free = !k->as_array_klass()->element_klass()->can_be_inline_klass(false);
-      not_flat = !UseFlatArray || not_null_free || (k->as_array_klass()->element_klass() != NULL &&
-                                                    k->as_array_klass()->element_klass()->is_inlinetype() &&
-                                                    !k->as_array_klass()->element_klass()->flatten_array());
+      const TypeOopPtr* exact_etype = TypeOopPtr::make_from_klass_unique(k->as_array_klass()->element_klass());
+      not_null_free = !exact_etype->can_be_inline_type();
+      not_flat = !UseFlatArray || not_null_free || (exact_etype->is_inlinetypeptr() && !exact_etype->inline_klass()->flatten_array());
     }
   }
   return make(klass_is_exact ? Constant : NotNull, elem, k, _offset, not_flat, not_null_free, _null_free);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -3522,4 +3522,39 @@ public class TestArrays {
     public void test148_verifier() {
         test148(MyValue1.createWithFieldsInline(rI, rL));
     }
+
+    // Abstract class without any primitive class implementers
+    static abstract class MyAbstract149 {
+        public abstract int get();
+    }
+
+    static class TestClass149 extends MyAbstract149 {
+        final int x;
+
+        public int get() { return x; };
+
+        public TestClass149(int x) {
+            this.x = x;
+        }
+    }
+
+    // Test OSR compilation with array known to be not null-free/flat
+    @Test
+    public int test149(MyAbstract149[] array) {
+        int res = 0;
+        // Trigger OSR compilation
+        for (int i = 0; i < 10_000; ++i) {
+            res += array[i % 10].get();
+        }
+        return res;
+    }
+
+    @Run(test = "test149")
+    public void test149_verifier() {
+        TestClass149[] array = new TestClass149[10];
+        for (int i = 0; i < 10; ++i) {
+            array[i] = new TestClass149(i);
+        }
+        Asserts.assertEquals(test149(array), 45000);
+    }
 }


### PR DESCRIPTION
We hit an assert during OSR compilation because when casting an array to its type (known from typeflow analysis) in `Parse::check_interpreter_type`, we lose the non null-free/flat property. The fix is to properly re-compute the null-free/flat properties when casting to not-exact.

Thanks,
Tobias