### PR TITLE
8293357: [lworld] TestTrivialMethods fails with "constantGetter is not C2 compiled"

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestTrivialMethods.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestTrivialMethods.java
@@ -33,6 +33,7 @@
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbatch
  *                   -XX:+InlineTypePassFieldsAsArgs -XX:+InlineTypeReturnedAsFields
  *                   -XX:CompileCommand=dontinline,*::getter* -XX:CompileCommand=dontinline,*::setter*
+ *                   -XX:CompileCommand=dontinline,*::constantGetter*
  *                   compiler.valhalla.inlinetypes.TestTrivialMethods
  */
 


### PR DESCRIPTION
The test fails because a dontinline statement is missing for some of the test methods.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293357](https://bugs.openjdk.org/browse/JDK-8293357): [lworld] TestTrivialMethods fails with "constantGetter is not C2 compiled"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/743/head:pull/743` \
`$ git checkout pull/743`

Update a local copy of the PR: \
`$ git checkout pull/743` \
`$ git pull https://git.openjdk.org/valhalla pull/743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 743`

View PR using the GUI difftool: \
`$ git pr show -t 743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/743.diff">https://git.openjdk.org/valhalla/pull/743.diff</a>

</details>
