### PR TITLE
8293448: [lworld] ClassAccessFlagsRawTest fail

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -28,7 +28,7 @@
  * @summary Test getting a class's raw access flags using java.lang.Class API
  * @modules java.base/java.lang:open
  * @compile classAccessFlagsRaw.jcod
- * @run main/othervm ClassAccessFlagsRawTest
+ * @run main/othervm -XX:-EnableValhalla ClassAccessFlagsRawTest
  */
 
 import java.lang.reflect.*;
@@ -51,8 +51,8 @@ public class ClassAccessFlagsRawTest {
         m = cl.getDeclaredMethod("getClassAccessFlagsRaw", new Class[0]);
         m.setAccessible(true);
 
-        testIt("SUPERset", Modifier.PUBLIC | Modifier.IDENTITY);
-        testIt("SUPERnotset", Modifier.PUBLIC | Modifier.IDENTITY);
+        testIt("SUPERset", 0x21);  // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
+        testIt("SUPERnotset", Modifier.PUBLIC);
 
         // test primitive array.  should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
         int flags = (int)m.invoke((new int[3]).getClass());
@@ -63,16 +63,16 @@ public class ClassAccessFlagsRawTest {
 
         // test object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[2]).getClass());
-        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
+        if (flags != Modifier.PUBLIC) {
             throw new RuntimeException(
-                "expected 0x21, got 0x" + Integer.toHexString(flags) + " for object array");
+                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
         }
 
         // test multi-dimensional object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[4][2]).getClass());
-        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
+        if (flags != Modifier.PUBLIC) {
             throw new RuntimeException(
-                "expected 0x21, got 0x" + Integer.toHexString(flags) + " for object array");
+                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -24,7 +24,7 @@
 
 /**
  * @test
- * @bug 8291360
+ * @bug 8291360 8293448
  * @summary Test getting a class's raw access flags using java.lang.Class API
  * @modules java.base/java.lang:open
  * @compile classAccessFlagsRaw.jcod
@@ -51,8 +51,8 @@ public class ClassAccessFlagsRawTest {
         m = cl.getDeclaredMethod("getClassAccessFlagsRaw", new Class[0]);
         m.setAccessible(true);
 
-        testIt("SUPERset", 0x21);  // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
-        testIt("SUPERnotset", Modifier.PUBLIC);
+        testIt("SUPERset", Modifier.PUBLIC | Modifier.IDENTITY);
+        testIt("SUPERnotset", Modifier.PUBLIC | Modifier.IDENTITY);
 
         // test primitive array.  should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
         int flags = (int)m.invoke((new int[3]).getClass());
@@ -63,16 +63,16 @@ public class ClassAccessFlagsRawTest {
 
         // test object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[2]).getClass());
-        if (flags != Modifier.PUBLIC) {
+        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
             throw new RuntimeException(
-                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
+                "expected 0x21, got 0x" + Integer.toHexString(flags) + " for object array");
         }
 
         // test multi-dimensional object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[4][2]).getClass());
-        if (flags != Modifier.PUBLIC) {
+        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
             throw new RuntimeException(
-                "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
+                "expected 0x21, got 0x" + Integer.toHexString(flags) + " for object array");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
@@ -26,7 +26,7 @@
 class SUPERset {
   0xCAFEBABE;
   0; // minor version
-  64; // version
+  63; // version should be the last version that does not override ACC_SUPER with ACC_IDENTITY
   [14] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A
@@ -116,7 +116,7 @@ class SUPERset {
 class SUPERnotset {
   0xCAFEBABE;
   0; // minor version
-  64; // version
+  63; // version should be the last version that does not override ACC_SUPER with ACC_IDENTITY
   [14] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A

--- a/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
+++ b/test/hotspot/jtreg/runtime/ClassFile/classAccessFlagsRaw.jcod
@@ -26,7 +26,7 @@
 class SUPERset {
   0xCAFEBABE;
   0; // minor version
-  63; // version should be the last version that does not override ACC_SUPER with ACC_IDENTITY
+  64; // version
   [14] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A
@@ -116,7 +116,7 @@ class SUPERset {
 class SUPERnotset {
   0xCAFEBABE;
   0; // minor version
-  63; // version should be the last version that does not override ACC_SUPER with ACC_IDENTITY
+  64; // version
   [14] { // Constant Pool
     ; // first element is empty
     Method #2 #3; // #1     at 0x0A


### PR DESCRIPTION
Fix test of ClassAccessFlagsRawTest to verify ACC_IDENTITY when it is inserted based on the class file version being read.
ACC_IDENTITY is seen for all concrete classes and arrays of same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293448](https://bugs.openjdk.org/browse/JDK-8293448): [lworld] ClassAccessFlagsRawTest fail


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - Committer)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/744/head:pull/744` \
`$ git checkout pull/744`

Update a local copy of the PR: \
`$ git checkout pull/744` \
`$ git pull https://git.openjdk.org/valhalla pull/744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 744`

View PR using the GUI difftool: \
`$ git pr show -t 744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/744.diff">https://git.openjdk.org/valhalla/pull/744.diff</a>

</details>
