### PR TITLE
8293487: [lworld] SIGSEGV with -XX:+VerifyAdapterSharing

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -675,7 +675,8 @@ class AdapterHandlerEntry : public CHeapObj<mtCode> {
     _c2i_inline_ro_entry(c2i_inline_ro_entry),
     _c2i_unverified_entry(c2i_unverified_entry),
     _c2i_unverified_inline_entry(c2i_unverified_inline_entry),
-    _c2i_no_clinit_check_entry(c2i_no_clinit_check_entry)
+    _c2i_no_clinit_check_entry(c2i_no_clinit_check_entry),
+    _sig_cc(NULL)
 #ifdef ASSERT
     , _saved_code_length(0)
 #endif


### PR DESCRIPTION
Oversight from the recent merge.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293487](https://bugs.openjdk.org/browse/JDK-8293487): [lworld] SIGSEGV with -XX:+VerifyAdapterSharing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/745/head:pull/745` \
`$ git checkout pull/745`

Update a local copy of the PR: \
`$ git checkout pull/745` \
`$ git pull https://git.openjdk.org/valhalla pull/745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 745`

View PR using the GUI difftool: \
`$ git pr show -t 745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/745.diff">https://git.openjdk.org/valhalla/pull/745.diff</a>

</details>
