### PR TITLE
8293500: [lworld] runtime/NMT/MallocLimitTest.java#invalid-settings crashes after merge

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -140,7 +140,6 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
  */
 enum class MEMFLAGS {
   MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_ENUM)
-  mtValueTypes,        // memory for buffered value types
   mt_number_of_types   // number of memory types (mtDontTrack
                        // is not included as validate type)
 };

--- a/src/hotspot/share/services/nmtCommon.cpp
+++ b/src/hotspot/share/services/nmtCommon.cpp
@@ -34,7 +34,6 @@ STATIC_ASSERT(NMT_detail > NMT_summary);
 
 NMTUtil::S NMTUtil::_strings[] = {
   MEMORY_TYPES_DO(MEMORY_TYPE_DECLARE_NAME)
-  "Value Types",
 };
 
 const char* NMTUtil::scale_name(size_t scale) {


### PR DESCRIPTION
Removed unused mtValueTypes

Trivial revert to "master" revision

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293500](https://bugs.openjdk.org/browse/JDK-8293500): [lworld] runtime/NMT/MallocLimitTest.java#invalid-settings crashes after merge


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/746/head:pull/746` \
`$ git checkout pull/746`

Update a local copy of the PR: \
`$ git checkout pull/746` \
`$ git pull https://git.openjdk.org/valhalla pull/746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 746`

View PR using the GUI difftool: \
`$ git pr show -t 746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/746.diff">https://git.openjdk.org/valhalla/pull/746.diff</a>

</details>
