### PR TITLE
8293523: test/langtools/tools/javac/preview/PreviewTest is failing after the merge with 'master'

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2049,6 +2049,10 @@ public class Check {
             return;
         }
 
+        if (shouldCheckPreview(m, other, origin)) {
+            checkPreview(tree.pos(), m, other);
+        }
+
         Type mt = types.memberType(origin.type, m);
         Type ot = types.memberType(origin.type, other);
         // Error if overriding result type is different


### PR DESCRIPTION
just restoring a missing piece of code in the compiler for test `test/langtools/tools/javac/preview/PreviewTest` to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293523](https://bugs.openjdk.org/browse/JDK-8293523): test/langtools/tools/javac/preview/PreviewTest is failing after the merge with 'master'


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/748/head:pull/748` \
`$ git checkout pull/748`

Update a local copy of the PR: \
`$ git checkout pull/748` \
`$ git pull https://git.openjdk.org/valhalla pull/748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 748`

View PR using the GUI difftool: \
`$ git pr show -t 748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/748.diff">https://git.openjdk.org/valhalla/pull/748.diff</a>

</details>
