### PR TITLE
8293536: [lworld] serviceability/jvmti/RedefineClasses/RedefineObject.java fails with added ACC_IDENTITY to object for old version

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6206,7 +6206,7 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
     if(!supports_inline_types()) {
       const bool is_module = (flags & JVM_ACC_MODULE) != 0;
       const bool is_interface = (flags & JVM_ACC_INTERFACE) != 0;
-      if (!is_module && !is_interface) {
+      if (!is_module && !is_interface && !is_java_lang_Object) {
         flags |= JVM_ACC_IDENTITY;
       }
     }


### PR DESCRIPTION
Never add ACC_IDENTITY to java.lang.Object

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293536](https://bugs.openjdk.org/browse/JDK-8293536): [lworld] serviceability/jvmti/RedefineClasses/RedefineObject.java fails with added ACC_IDENTITY to object for old version


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/749/head:pull/749` \
`$ git checkout pull/749`

Update a local copy of the PR: \
`$ git checkout pull/749` \
`$ git pull https://git.openjdk.org/valhalla pull/749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 749`

View PR using the GUI difftool: \
`$ git pr show -t 749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/749.diff">https://git.openjdk.org/valhalla/pull/749.diff</a>

</details>
