### PR TITLE
8293134: Valhalla: Verifier error in method call with abstract value class arg

### DIFF
--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -64,7 +64,13 @@ bool VerificationType::resolve_and_check_assignability(InstanceKlass* klass, Sym
     }
   }
 
-  if (this_class->access_flags().is_primitive_class()) return false;
+  // Need to do this check when called from CDS.
+  if (this_class->access_flags().is_primitive_class()) {
+    Klass* from_class = SystemDictionary::resolve_or_fail(
+      from_name, Handle(THREAD, klass->class_loader()),
+      Handle(THREAD, klass->protection_domain()), true, CHECK_false);
+    return from_class == this_class;
+  }
   if (this_class->is_interface() && (!from_field_is_protected ||
       from_name != vmSymbols::java_lang_Object())) {
     // If we are not trying to access a protected field or method in

--- a/src/hotspot/share/classfile/verificationType.cpp
+++ b/src/hotspot/share/classfile/verificationType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ bool VerificationType::resolve_and_check_assignability(InstanceKlass* klass, Sym
     }
   }
 
-  if (this_class->access_flags().is_value_class()) return false;
+  if (this_class->access_flags().is_primitive_class()) return false;
   if (this_class->is_interface() && (!from_field_is_protected ||
       from_name != vmSymbols::java_lang_Object())) {
     // If we are not trying to access a protected field or method in

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AbstractValueClassTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AbstractValueClassTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293134
+ * @summary Test that a super abstract value class is allowed.
+ * @run main AbstractValueClassTest
+ */
+
+public class AbstractValueClassTest {
+
+    public static void main(String[] args) {
+        A a = new A();
+        a.doit(a);
+    }
+    public static abstract value class T {
+        public abstract void doit(T t);
+    }
+
+    public static final value class A extends T {
+        public void doit(T t) {
+            System.out.println(t);
+        }
+    }
+    public static final value class B extends T {
+        public void doit(T t) {
+            System.out.println(t);
+        }
+    }
+}


### PR DESCRIPTION
Please review this small fix for JDK-8293134.  Since a value class can be abstract and a super class, only return false at line 64 for primitive classes.

The fix is tested by running mach5 tiers 1-2 on Linux, Mac OS, and Windows, and mach5 tiers 3-5 on Linux x64.  (testing is in progress.)

Thanks, Harold

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293134](https://bugs.openjdk.org/browse/JDK-8293134): Valhalla: Verifier error in method call with abstract value class arg


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/750/head:pull/750` \
`$ git checkout pull/750`

Update a local copy of the PR: \
`$ git checkout pull/750` \
`$ git pull https://git.openjdk.org/valhalla pull/750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 750`

View PR using the GUI difftool: \
`$ git pr show -t 750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/750.diff">https://git.openjdk.org/valhalla/pull/750.diff</a>

</details>
