### PR TITLE
8293609: [lworld] Update vmTestbase/nsk/jdi/Accessible/modifiers001 to allow ACC_IDENTITY

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifiers/modifiers001.java
@@ -188,9 +188,6 @@ public class modifiers001 extends Log {
             String s_type = classes_for_check[i][2];
             String s_modifiers = classes_for_check[i][1];
             int got_modifiers = refType.modifiers();
-            // Class.getModifiers() will never return ACC_SUPER
-            // but Accessible.modifers() can, so ignore this bit
-            got_modifiers &= ~0x20; // 0x20 == ACC_SUPER
             logHandler.display("");
             if ( got_modifiers != expected_modifiers ) {
                 logHandler.complain("##> modifiers001: UNEXPECTED modifiers() method result ("


### PR DESCRIPTION
With identity classes Class.getModifiers() can return 0x20 as ACC_IDENTITY.
Previously it never returned the 0x20 bit (was ACC_SUPER).

test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/modifier/modifiers001.java should not be clearing 0x20.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293609](https://bugs.openjdk.org/browse/JDK-8293609): [lworld] Update vmTestbase/nsk/jdi/Accessible/modifiers001 to allow ACC_IDENTITY


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/751/head:pull/751` \
`$ git checkout pull/751`

Update a local copy of the PR: \
`$ git checkout pull/751` \
`$ git pull https://git.openjdk.org/valhalla pull/751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 751`

View PR using the GUI difftool: \
`$ git pr show -t 751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/751.diff">https://git.openjdk.org/valhalla/pull/751.diff</a>

</details>
