### PR TITLE
8293868: [lworld] remove support for @__primitive__ and @__value__ for declaring primitive, value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3406,15 +3406,8 @@ public class JavacParser implements Parser {
                     // if first modifier is an annotation, set pos to annotation's.
                     if (flags == 0 && annotations.isEmpty())
                         pos = ann.pos;
-                    final Name name = TreeInfo.name(ann.annotationType);
-                    if (name == names.__primitive__ || name == names.java_lang___primitive__) {
-                        flag = Flags.PRIMITIVE_CLASS;
-                    } else if (name == names.__value__ || name == names.java_lang___value__) {
-                        flag = Flags.VALUE_CLASS;
-                    } else {
-                        annotations.append(ann);
-                        flag = 0;
-                    }
+                    annotations.append(ann);
+                    flag = 0;
                 }
             }
             flags |= flag;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -116,10 +116,6 @@ public class Names {
     public final Name java_lang_Enum;
     public final Name java_lang_Object;
     public final Name java_lang_System;
-    public final Name __primitive__;
-    public final Name java_lang___primitive__;
-    public final Name __value__;
-    public final Name java_lang___value__;
 
     // names of builtin classes
     public final Name Array;
@@ -314,10 +310,6 @@ public class Names {
         java_lang_Enum = fromString("java.lang.Enum");
         java_lang_Object = fromString("java.lang.Object");
         java_lang_System = fromString("java.lang.System");
-        __primitive__ = fromString("__primitive__");
-        java_lang___primitive__ = fromString("java.lang.__primitive__");
-        __value__ = fromString("__value__");
-        java_lang___value__ = fromString("java.lang.__value__");
 
         // names of builtin classes
         Array = fromString("Array");

--- a/test/langtools/tools/javac/diags/CheckResourceKeys.java
+++ b/test/langtools/tools/javac/diags/CheckResourceKeys.java
@@ -309,9 +309,7 @@ public class CheckResourceKeys {
             "java.",
             "javac.",
             "verbose.",
-            "locn.",
-            "java.lang.__primitive__",
-            "java.lang.__value__"
+            "locn."
     ));
 
     /**

--- a/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues1.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues1.java
@@ -30,7 +30,7 @@
  * @compile GenericsAndValues1.java
  */
 
- @__primitive__ class Foo implements Comparable<Foo.ref>{
+ primitive class Foo implements Comparable<Foo.ref>{
     final int value;
   
     public Foo(int value) {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues2.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues2.java
@@ -32,7 +32,7 @@
 
 import java.util.function.Consumer;
 
-  @__primitive__ class CaptureBug {
+  primitive class CaptureBug {
     final int value;
   
     public CaptureBug(int value) {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues3.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/GenericsAndValues3.java
@@ -32,7 +32,7 @@
 
 import java.util.stream.IntStream;
 
-@__primitive__ class StreamBug {
+primitive class StreamBug {
   final int value;
   
   public StreamBug(int value) {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/InlineAnnotationOnAnonymousClass.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/InlineAnnotationOnAnonymousClass.java
@@ -7,9 +7,9 @@
 
 class InlineAnnotationOnAnonymousClass {
     interface I {}
-    @__primitive__
+    primitive
     public static void main(String args []) {
-        new @__primitive__ I() {
+        new primitive I() {
         };
     }
 }

--- a/test/langtools/tools/javac/valhalla/primitive-classes/InlineAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/InlineAnnotationTest.java
@@ -5,15 +5,15 @@
  * @compile/fail/ref=InlineAnnotationTest.out -XDrawDiagnostics InlineAnnotationTest.java
  */
 
-@__primitive__
+primitive
 class InlineAnnotationTest01 extends Object { 
 }
 
-@__primitive__
+primitive
 class InlineAnnotationTest02 { 
 }
 
-@java.lang.__primitive__
+primitive
 class InlineAnnotationTest03  { 
     int x = 10;
     InlineAnnotationTest03() {
@@ -21,6 +21,6 @@ class InlineAnnotationTest03  {
     }
 }
 
-@__primitive__
+primitive
 interface InlineAnnotationTest04 { 
 }

--- a/test/langtools/tools/javac/valhalla/primitive-classes/ValueAnnotationOnAnonymousClass.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/ValueAnnotationOnAnonymousClass.java
@@ -7,9 +7,9 @@
 
 class ValueAnnotationOnAnonymousClass {
     interface I {}
-    @__primitive__
+    primitive
     public static void main(String args []) {
-        new @__primitive__ I() {
+        new primitive I() {
         };
     }
 }

--- a/test/langtools/tools/javac/valhalla/primitive-classes/ValueAnnotationTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/ValueAnnotationTest.java
@@ -5,15 +5,15 @@
  * @compile/fail/ref=ValueAnnotationTest.out -XDrawDiagnostics ValueAnnotationTest.java
  */
 
-@__primitive__
+primitive
 class ValueAnnotationTest01 extends Object { 
 }
 
-@__primitive__
+primitive
 class ValueAnnotationTest02 { 
 }
 
-@java.lang.__primitive__
+primitive
 class ValueAnnotationTest03  { 
     int x = 10;
     ValueAnnotationTest03() {
@@ -21,6 +21,6 @@ class ValueAnnotationTest03  {
     }
 }
 
-@__primitive__
+primitive
 interface ValueAnnotationTest04 { 
 }


### PR DESCRIPTION
This PR is removing support for, I think, experimental annotations `@__primitive__` and `@__value__`, there is no mention to them in any spec or JEP document

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293868](https://bugs.openjdk.org/browse/JDK-8293868): [lworld] remove support for @__primitive__ and @__value__ for declaring primitive, value classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/757/head:pull/757` \
`$ git checkout pull/757`

Update a local copy of the PR: \
`$ git checkout pull/757` \
`$ git pull https://git.openjdk.org/valhalla pull/757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 757`

View PR using the GUI difftool: \
`$ git pr show -t 757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/757.diff">https://git.openjdk.org/valhalla/pull/757.diff</a>

</details>
