### PR TITLE
[lworld] Disable getModifiersTest until 8291719 is fixed

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java
@@ -187,7 +187,8 @@ public class TestResolvedJavaType extends TypeUniverse {
         assertEquals(javaName, internalNameToJava(typeName, true, true));
     }
 
-    @Test
+    // TODO 8291719
+    // @Test
     public void getModifiersTest() {
         for (Class<?> c : classes) {
             ResolvedJavaType type = metaAccess.lookupJavaType(c);


### PR DESCRIPTION
This test is still failing in the CI. I'm disabling it until JDK-8291719 is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/759/head:pull/759` \
`$ git checkout pull/759`

Update a local copy of the PR: \
`$ git checkout pull/759` \
`$ git pull https://git.openjdk.org/valhalla pull/759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 759`

View PR using the GUI difftool: \
`$ git pr show -t 759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/759.diff">https://git.openjdk.org/valhalla/pull/759.diff</a>

</details>
