### PR TITLE
8293934: [lworld] TestCallingConvention triggers "code buffer not large enough" assert

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2728,7 +2728,7 @@ AdapterHandlerEntry* AdapterHandlerLibrary::_int_arg_handler = NULL;
 AdapterHandlerEntry* AdapterHandlerLibrary::_obj_arg_handler = NULL;
 AdapterHandlerEntry* AdapterHandlerLibrary::_obj_int_arg_handler = NULL;
 AdapterHandlerEntry* AdapterHandlerLibrary::_obj_obj_arg_handler = NULL;
-const int AdapterHandlerLibrary_size = 32*K;
+const int AdapterHandlerLibrary_size = 48*K;
 BufferBlob* AdapterHandlerLibrary::_buffer = NULL;
 
 BufferBlob* AdapterHandlerLibrary::buffer_blob() {


### PR DESCRIPTION
Due to verification code added by [JDK-8292694](https://bugs.openjdk.org/browse/JDK-8292694), more space is required for the c2i and i2c adapters to support the scalarized calling convention. The issue is intermittent and only reproduces on a specific platform, but I verified that the fix works.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293934](https://bugs.openjdk.org/browse/JDK-8293934): [lworld] TestCallingConvention triggers "code buffer not large enough" assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/760/head:pull/760` \
`$ git checkout pull/760`

Update a local copy of the PR: \
`$ git checkout pull/760` \
`$ git pull https://git.openjdk.org/valhalla pull/760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 760`

View PR using the GUI difftool: \
`$ git pr show -t 760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/760.diff">https://git.openjdk.org/valhalla/pull/760.diff</a>

</details>
