### PR TITLE
8294054: [lworld] asPrimaryType/asValueType intrinsics broken after JDK-8287692

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -247,7 +247,9 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
 
   switch (id) {
   case vmIntrinsics::_asPrimaryType:
+  case vmIntrinsics::_asPrimaryTypeArg:
   case vmIntrinsics::_asValueType:
+  case vmIntrinsics::_asValueTypeArg:
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_isAssignableFrom:
   case vmIntrinsics::_getModifiers:

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -288,8 +288,10 @@ class methodHandle;
                                                                                                                         \
   /* reflective intrinsics, for java/lang/Class, etc. */                                                                \
   do_intrinsic(_asPrimaryType,            java_lang_Class,        asPrimaryType_name, void_class_signature,      F_R)   \
+  do_intrinsic(_asPrimaryTypeArg,         jdk_internal_value_PrimitiveClass, asPrimaryType_name, class_class_signature, F_S) \
    do_name(     asPrimaryType_name,                              "asPrimaryType")                                       \
   do_intrinsic(_asValueType,              java_lang_Class,        asValueType_name, void_class_signature,        F_R)   \
+  do_intrinsic(_asValueTypeArg,           jdk_internal_value_PrimitiveClass, asValueType_name,   class_class_signature, F_S) \
    do_name(     asValueType_name,                                "asValueType")                                         \
   do_intrinsic(_isAssignableFrom,         java_lang_Class,        isAssignableFrom_name, class_boolean_signature, F_RN) \
    do_name(     isAssignableFrom_name,                           "isAssignableFrom")                                    \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -605,6 +605,7 @@
   template(class_int_signature,                       "(Ljava/lang/Class;)I")                     \
   template(class_long_signature,                      "(Ljava/lang/Class;)J")                     \
   template(class_boolean_signature,                   "(Ljava/lang/Class;)Z")                     \
+  template(class_class_signature,                     "(Ljava/lang/Class;)Ljava/lang/Class;")     \
   template(throwable_throwable_signature,             "(Ljava/lang/Throwable;)Ljava/lang/Throwable;")             \
   template(throwable_string_void_signature,           "(Ljava/lang/Throwable;Ljava/lang/String;)V")               \
   template(string_array_void_signature,               "([Ljava/lang/String;)V")                                   \
@@ -785,6 +786,7 @@
   template(java_lang_runtime_PrimitiveObjectMethods,        "java/lang/runtime/PrimitiveObjectMethods")           \
   template(isSubstitutable_name,                            "isSubstitutable")                                    \
   template(primitiveObjectHashCode_name,                    "primitiveObjectHashCode")                            \
+  template(jdk_internal_value_PrimitiveClass,               "jdk/internal/value/PrimitiveClass")                  \
                                                                                                                   \
   /* Thread.dump_to_file jcmd */                                                                                  \
   template(jdk_internal_vm_ThreadDumper,           "jdk/internal/vm/ThreadDumper")                                \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -688,7 +688,9 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_copyOfRange:
   case vmIntrinsics::_clone:
   case vmIntrinsics::_asPrimaryType:
+  case vmIntrinsics::_asPrimaryTypeArg:
   case vmIntrinsics::_asValueType:
+  case vmIntrinsics::_asValueTypeArg:
   case vmIntrinsics::_isAssignableFrom:
   case vmIntrinsics::_isInstance:
   case vmIntrinsics::_getModifiers:

--- a/src/java.base/share/classes/jdk/internal/value/PrimitiveClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/PrimitiveClass.java
@@ -27,6 +27,7 @@ package jdk.internal.value;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 /**
  * Utilities to access Primitive Classes as described in JEP 401.
@@ -60,6 +61,7 @@ public class PrimitiveClass {
      *         this class or interface
      * @since Valhalla
      */
+    @IntrinsicCandidate
     public static Class<?> asPrimaryType(Class<?> aClass) {
         return javaLangAccess.asPrimaryType(aClass);
     }
@@ -79,6 +81,7 @@ public class PrimitiveClass {
      * @since Valhalla
      */
     @SuppressWarnings("unchecked")
+    @IntrinsicCandidate
     public static Class<?> asValueType(Class<?> aClass) {
         return javaLangAccess.asValueType(aClass);
     }


### PR DESCRIPTION
[JDK-8287692](https://bugs.openjdk.org/browse/JDK-8287692) made the `asPrimaryType`/`asValueType` methods in `java.lang.Class` package private and added public versions to `jdk.internal.value.PrimitiveClass`. This change adds the required VM code to intrinsify the new methods.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294054](https://bugs.openjdk.org/browse/JDK-8294054): [lworld] asPrimaryType/asValueType intrinsics broken after JDK-8287692


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/762/head:pull/762` \
`$ git checkout pull/762`

Update a local copy of the PR: \
`$ git checkout pull/762` \
`$ git pull https://git.openjdk.org/valhalla pull/762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 762`

View PR using the GUI difftool: \
`$ git pr show -t 762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/762.diff">https://git.openjdk.org/valhalla/pull/762.diff</a>

</details>
