### PR TITLE
8294229: [lworld] sun.jvm.hotspot.interpreter.Bytecodes refers to "defaultvalue" (not aconst_init)

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecodes.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/Bytecodes.java
@@ -241,7 +241,7 @@ public class Bytecodes {
   public static final int _goto_w               = 200; // 0xc8
   public static final int _jsr_w                = 201; // 0xc9
   public static final int _breakpoint           = 202; // 0xca
-  public static final int _defaultvalue         = 203; // 0xcb
+  public static final int _aconst_init          = 203; // 0xcb
   public static final int _withfield            = 204; // 0xcc
 
   public static final int number_of_java_codes  = 205;


### PR DESCRIPTION
Renamed to aconst_init

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294229](https://bugs.openjdk.org/browse/JDK-8294229): [lworld] sun.jvm.hotspot.interpreter.Bytecodes refers to "defaultvalue" (not aconst_init)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/767/head:pull/767` \
`$ git checkout pull/767`

Update a local copy of the PR: \
`$ git checkout pull/767` \
`$ git pull https://git.openjdk.org/valhalla pull/767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 767`

View PR using the GUI difftool: \
`$ git pr show -t 767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/767.diff">https://git.openjdk.org/valhalla/pull/767.diff</a>

</details>
