### PR TITLE
8294272: improve error messages issued by javac if primitive classes are not supported

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -287,6 +287,9 @@ public enum Source {
 
         public Error error(String sourceName) {
             Assert.checkNonNull(optFragment);
+            if (this == PRIMITIVE_CLASSES) {
+                return Errors.PrimitiveClassesNotSupported(minLevel.name);
+            }
             return optKind == DiagKind.NORMAL ?
                     Errors.FeatureNotSupportedInSource(optFragment, sourceName, minLevel.name) :
                     Errors.FeatureNotSupportedInSourcePlural(optFragment, sourceName, minLevel.name);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -5152,6 +5152,7 @@ public class JavacParser implements Parser {
 
     protected void checkSourceLevel(int pos, Feature feature) {
         if (feature == Feature.PRIMITIVE_CLASSES && !allowPrimitiveClasses) {
+            // primitive classes are special
             log.error(DiagnosticFlag.SOURCE_LEVEL, pos, feature.error(source.name));
         } else if (preview.isPreview(feature) && !preview.isEnabled()) {
             //preview feature without --preview flag, error

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3915,6 +3915,11 @@ compiler.misc.feature.value.classes=\
 compiler.err.cyclic.primitive.class.membership=\
     cyclic primitive class membership involving {0}
 
+# 0: string (expected version)
+compiler.err.primitive.classes.not.supported=\
+    primitive classes are not supported\n\
+     (use -source {0} or higher to enable primitive classes and pass compiler option: -XDenablePrimitiveClasses)
+
 compiler.warn.get.class.compared.with.interface=\
     return value of getClass() can never equal the class literal of an interface
 

--- a/test/langtools/tools/javac/diags/examples/PrimitiveClassesNotSupported.java
+++ b/test/langtools/tools/javac/diags/examples/PrimitiveClassesNotSupported.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.primitive.classes.not.supported
+
+public primitive class PrimitiveClassesNotSupported {
+}

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate1.out
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate1.out
@@ -1,2 +1,2 @@
-CheckFeatureGate1.java:10:12: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 13, 19
+CheckFeatureGate1.java:10:12: compiler.err.primitive.classes.not.supported: 19
 1 error

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate2.out
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate2.out
@@ -1,2 +1,2 @@
-CheckFeatureGate2.java:11:17: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 13, 19
+CheckFeatureGate2.java:11:17: compiler.err.primitive.classes.not.supported: 19
 1 error

--- a/test/langtools/tools/javac/valhalla/primitive-classes/PrimitiveAsTypeName.out
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/PrimitiveAsTypeName.out
@@ -1,4 +1,4 @@
 - compiler.warn.source.no.system.modules.path: 16
-PrimitiveAsTypeName.java:12:24: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.primitive.classes), 16, 19
+PrimitiveAsTypeName.java:12:24: compiler.err.primitive.classes.not.supported: 19
 1 error
 1 warning


### PR DESCRIPTION
improve the error message issued by javac is the `-XDenablePrimitiveClasses` is not passed by the user

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294272](https://bugs.openjdk.org/browse/JDK-8294272): improve error messages issued by javac if primitive classes are not supported


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/768/head:pull/768` \
`$ git checkout pull/768`

Update a local copy of the PR: \
`$ git checkout pull/768` \
`$ git pull https://git.openjdk.org/valhalla pull/768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 768`

View PR using the GUI difftool: \
`$ git pr show -t 768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/768.diff">https://git.openjdk.org/valhalla/pull/768.diff</a>

</details>
