### PR TITLE
8294462: [lworld] Add jdk.internal.misc.ValhallaFeatures to reflect -XX:+EnableValhalla

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -156,6 +156,7 @@ JVM_IsFinalizationEnabled
 JVM_IsHiddenClass
 JVM_IsInterface
 JVM_IsPreviewEnabled
+JVM_IsValhallaEnabled
 JVM_IsContinuationsSupported
 JVM_IsPrimitiveClass
 JVM_IsRecord

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -172,6 +172,9 @@ JNIEXPORT jboolean JNICALL
 JVM_IsPreviewEnabled(void);
 
 JNIEXPORT jboolean JNICALL
+JVM_IsValhallaEnabled(void);
+
+JNIEXPORT jboolean JNICALL
 JVM_IsContinuationsSupported(void);
 
 JNIEXPORT void JNICALL

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3562,6 +3562,10 @@ JVM_LEAF(jboolean, JVM_IsPreviewEnabled(void))
   return Arguments::enable_preview() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
+JVM_LEAF(jboolean, JVM_IsValhallaEnabled(void))
+  return EnableValhalla ? JNI_TRUE : JNI_FALSE;
+JVM_END
+
 JVM_LEAF(jboolean, JVM_IsContinuationsSupported(void))
   return VMContinuations ? JNI_TRUE : JNI_FALSE;
 JVM_END

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3243,24 +3243,6 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   }
 #endif
 
-  if (EnableValhalla) {
-    // create_property("valhalla.enableValhalla", "true", InternalProperty)
-    const char* prop_name = "valhalla.enableValhalla";
-    const char* prop_value = "true";
-    const size_t prop_len = strlen(prop_name) + strlen(prop_value) + 2;
-    char* property = AllocateHeap(prop_len, mtArguments);
-    int ret = jio_snprintf(property, prop_len, "%s=%s", prop_name, prop_value);
-    if (ret < 0 || ret >= (int)prop_len) {
-      FreeHeap(property);
-      return JNI_ENOMEM;
-    }
-    bool added = add_property(property, UnwriteableProperty, InternalProperty);
-    FreeHeap(property);
-    if (!added) {
-      return JNI_ENOMEM;
-    }
-  }
-
 #ifndef CAN_SHOW_REGISTERS_ON_ASSERT
   UNSUPPORTED_OPTION(ShowRegistersOnAssert);
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT

--- a/src/java.base/share/classes/jdk/internal/misc/ValhallaFeatures.java
+++ b/src/java.base/share/classes/jdk/internal/misc/ValhallaFeatures.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.misc;
+
+/**
+ * Defines static methods to test if Valhalla features are enabled at run-time.
+ */
+public class ValhallaFeatures {
+    private static final boolean ENABLED = isValhallaEnabled();
+
+    private ValhallaFeatures() {
+    }
+
+    /**
+     * {@return true if Valhalla features are enabled, otherwise false}
+     */
+    public static boolean isEnabled() {
+        return ENABLED;
+    }
+
+    /**
+     * Ensures that EnableValhalla features are enabled.
+     * @throws UnsupportedOperationException if EnableValhalla features are not enabled
+     */
+    public static void ensureValhallaEnabled() {
+        if (!ENABLED) {
+            throw new UnsupportedOperationException(
+                    "ValhallaFeatures Features not enabled, need to run with -XX:+EnableValhalla");
+        }
+    }
+
+    private static native boolean isValhallaEnabled();
+}

--- a/src/java.base/share/native/libjava/ValhallaFeatures.c
+++ b/src/java.base/share/native/libjava/ValhallaFeatures.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jvm.h"
+
+#include "jdk_internal_misc_ValhallaFeatures.h"
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_misc_ValhallaFeatures_isValhallaEnabled(JNIEnv *env, jclass cls) {
+    return JVM_IsValhallaEnabled();
+}

--- a/test/jdk/valhalla/valuetypes/ValhallaFeaturesTest.java
+++ b/test/jdk/valhalla/valuetypes/ValhallaFeaturesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.misc.ValhallaFeatures;
+
+/*
+ * @test
+ * @modules java.base/jdk.internal.misc
+ * @summary Test feature flags reflect command line flags
+ * @run main/othervm ValhallaFeaturesTest true
+ * @run main/othervm -XX:+EnableValhalla ValhallaFeaturesTest true
+ * @run main/othervm -XX:-EnableValhalla ValhallaFeaturesTest false
+ */
+
+public class ValhallaFeaturesTest {
+
+    public static void main(String[] args) {
+        boolean expected = args.length > 0 ? args[0].equalsIgnoreCase("true") : false;
+        boolean enabled = ValhallaFeatures.isEnabled();
+        System.out.println("EnableValhalla: " + enabled);
+        if (expected != enabled) {
+            throw new RuntimeException("expected: " + expected + ", actual: " + enabled);
+        }
+
+        try {
+            ValhallaFeatures.ensureValhallaEnabled();
+            if (!enabled) {
+                throw new RuntimeException("ensureValhallaEnabled should have thrown UOE");
+            }
+        } catch (UnsupportedOperationException uoe) {
+            if (enabled) {
+                throw new RuntimeException("UnsupportedOperationException not expected", uoe);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Updated to set the system property after all of the option setting locations have been processed.
Verified via -XshowSettings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294462](https://bugs.openjdk.org/browse/JDK-8294462): [lworld] Add jdk.internal.misc.ValhallaFeatures to reflect -XX:+EnableValhalla


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/769/head:pull/769` \
`$ git checkout pull/769`

Update a local copy of the PR: \
`$ git checkout pull/769` \
`$ git pull https://git.openjdk.org/valhalla pull/769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 769`

View PR using the GUI difftool: \
`$ git pr show -t 769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/769.diff">https://git.openjdk.org/valhalla/pull/769.diff</a>

</details>
