### PR TITLE
8294312: [lworld] Add java.util.Objects.isIdentityObject

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -639,23 +639,29 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * {@return {@code true} if this class is an identity class, otherwise {@code false}}
+     * When value classes are enabled, classes with the {@linkplain Modifier#IDENTITY IDENTITY}
+     * {@link #getModifiers() modifier} are identified as identity classes;
+     * when not enabled, all classes are identity classes.
+     * Array classes are always identity classes.
      *
      * @since Valhalla
      */
     public boolean isIdentity() {
         return !ValhallaFeatures.isEnabled() ||  // Before Valhalla all classes are identity classes
-                isArray() ||
-                (this.getModifiers() & Modifier.IDENTITY) != 0;
+                (this.getModifiers() & Modifier.IDENTITY) != 0 ||
+                isArray();
     }
 
     /**
      * {@return {@code true} if this class is a value class, otherwise {@code false}}
+     * When value classes are enabled, classes with the {@linkplain Modifier#VALUE VALUE}
+     * {@link #getModifiers() modifier} are identified as value classes;
+     * when not enabled, no classes are value classes.
      *
      * @since Valhalla
      */
     public boolean isValue() {
         return ValhallaFeatures.isEnabled() &&  // Before Valhalla no classes are value classes
-                !isArray() &&
                 (this.getModifiers() & Modifier.VALUE) != 0;
     }
 

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -72,6 +72,7 @@ import java.util.stream.Collectors;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.misc.ValhallaFeatures;
 import jdk.internal.module.Resources;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.CallerSensitiveAdapter;
@@ -642,7 +643,9 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isIdentity() {
-        return isArray() || (this.getModifiers() & Modifier.IDENTITY) != 0;
+        return !ValhallaFeatures.isEnabled() ||  // Before Valhalla all classes are identity classes
+                isArray() ||
+                (this.getModifiers() & Modifier.IDENTITY) != 0;
     }
 
     /**
@@ -651,7 +654,9 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isValue() {
-        return !isArray() && (this.getModifiers() & Modifier.VALUE) != 0;
+        return ValhallaFeatures.isEnabled() &&  // Before Valhalla no classes are value classes
+                !isArray() &&
+                (this.getModifiers() & Modifier.VALUE) != 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -639,10 +639,9 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * {@return {@code true} if this class is an identity class, otherwise {@code false}}
-     * When value classes are enabled, classes with the {@linkplain Modifier#IDENTITY IDENTITY}
-     * {@link #getModifiers() modifier} are identified as identity classes;
-     * when not enabled, all classes are identity classes.
-     * Array classes are always identity classes.
+     * If this {@code Class} object represents an array type, then this method returns {@code true}.
+     * If this {@code Class} object represents a primitive type, or {@code void},
+     * then this method returns {@code false}.
      *
      * @since Valhalla
      */
@@ -654,15 +653,13 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * {@return {@code true} if this class is a value class, otherwise {@code false}}
-     * When value classes are enabled, classes with the {@linkplain Modifier#VALUE VALUE}
-     * {@link #getModifiers() modifier} are identified as value classes;
-     * when not enabled, no classes are value classes.
+     * If this {@code Class} object represents an array type, a primitive type, or
+     * {@code void}, then this method returns {@code false}.
      *
      * @since Valhalla
      */
     public boolean isValue() {
-        return ValhallaFeatures.isEnabled() &&  // Before Valhalla no classes are value classes
-                (this.getModifiers() & Modifier.VALUE) != 0;
+        return (this.getModifiers() & Modifier.VALUE) != 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -642,7 +642,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isIdentity() {
-        return (this.getModifiers() & Modifier.IDENTITY) != 0;
+        return isArray() || (this.getModifiers() & Modifier.IDENTITY) != 0;
     }
 
     /**
@@ -651,7 +651,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since Valhalla
      */
     public boolean isValue() {
-        return (this.getModifiers() & Modifier.VALUE) != 0;
+        return !isArray() && (this.getModifiers() & Modifier.VALUE) != 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * Subclasses of {@code java.lang.Object} can be either identity classes or value classes.
  * The class {@code Object} itself is neither an identity class nor a value class.
  * See {@jls The Java Language Specification  8.1.1.5 identity and value Classes}.
- * An Instance can be created with {@code new Object()}, those instances are
+ * An instance can be created with {@code new Object()}, those instances are
  * {@link Objects#isIdentityObject(Object) an identity object}.
  *
  * @see     java.lang.Class

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -35,6 +35,12 @@ import java.util.Objects;
  * Class {@code Object} is the root of the class hierarchy.
  * Every class has {@code Object} as a superclass. All objects,
  * including arrays, implement the methods of this class.
+ * <p>
+ * Subclasses of {@code java.lang.Object} can be either identity classes or value classes.
+ * The class {@code Object} itself is neither an identity class nor a value class.
+ * See {@jls The Java Language Specification  8.1.1.5 identity and value Classes}.
+ * An Instance can be created with {@code new Object()}, those instances are
+ * {@link Objects#isIdentityObject(Object) an identity object}.
  *
  * @see     java.lang.Class
  * @since   1.0

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -36,7 +36,8 @@ import java.util.Objects;
  * Every class has {@code Object} as a superclass. All objects,
  * including arrays, implement the methods of this class.
  * <p>
- * Subclasses of {@code java.lang.Object} can be either identity classes or value classes.
+ * Subclasses of {@code java.lang.Object} can be either {@linkplain Class#isIdentity() identity classes}
+ * or {@linkplain Class#isValue value classes}.
  * The class {@code Object} itself is neither an identity class nor a value class.
  * See {@jls The Java Language Specification  8.1.1.5 identity and value Classes}.
  * An instance can be created with {@code new Object()}, those instances are

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -25,6 +25,7 @@
 
 package java.util;
 
+import jdk.internal.misc.ValhallaFeatures;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.misc.Unsafe;
@@ -189,6 +190,17 @@ public final class Objects {
         return o.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(o));
     }
 
+   /**
+     * {@return {@code true} if the object is an identity object, otherwise {@code false}}
+     * @param o an object
+     */
+//    @IntrinsicCandidate
+    public static boolean isIdentityObject(Object o) {
+        return o.getClass().isIdentity() ||
+                o.getClass() == Object.class ||
+                !ValhallaFeatures.isEnabled(); // Before Valhalla all objects are identity objects.
+    }
+
     /**
      * Checks that the specified object reference is an identity object.
      *
@@ -202,9 +214,8 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);
-        var cl = obj.getClass();
-        if (cl.isValue())
-            throw new IdentityException(cl);
+        if (!isIdentityObject(obj))
+            throw new IdentityException(obj.getClass());
         return obj;
     }
 
@@ -223,7 +234,7 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj, String message) {
         Objects.requireNonNull(obj);
-        if (obj.getClass().isValue())
+        if (!isIdentityObject(obj))
             throw new IdentityException(message);
         return obj;
     }
@@ -243,7 +254,7 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj, Supplier<String> messageSupplier) {
         Objects.requireNonNull(obj);
-        if (obj.getClass().isValue())
+        if (!isIdentityObject(obj))
             throw new IdentityException(messageSupplier == null ?
                     null : messageSupplier.get());
         return obj;

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -191,14 +191,16 @@ public final class Objects {
     }
 
    /**
-     * {@return {@code true} if the object is an identity object, otherwise {@code false}}
-     * @param o an object
-     */
+    * {@return {@code true} if the object is an identity object, otherwise {@code false}}
+    *
+    * @param obj an object
+    * @throws NullPointerException if {@code obj} is {@code null}
+    */
 //    @IntrinsicCandidate
-    public static boolean isIdentityObject(Object o) {
-        return o.getClass().isIdentity() ||
-                o.getClass() == Object.class ||
-                !ValhallaFeatures.isEnabled(); // Before Valhalla all objects are identity objects.
+    public static boolean isIdentityObject(Object obj) {
+        requireNonNull(obj);
+        return obj.getClass().isIdentity() ||  // Before Valhalla all classes are identity classes
+                obj.getClass() == Object.class;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -191,7 +191,7 @@ public final class Objects {
     }
 
    /**
-    * {@return {@code true} if the object is an identity object, otherwise {@code false}}
+    * {@return {@code true} if the specified object reference is an identity object, otherwise {@code false}}
     *
     * @param obj an object
     * @throws NullPointerException if {@code obj} is {@code null}

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -34,6 +34,7 @@
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.testng.annotations.BeforeTest;
@@ -69,6 +70,31 @@ public class ObjectMethods {
                                         .setPointRef(Point.makePoint(200, 200))
                                         .setReference(Point.makePoint(300, 300))
                                         .setNumber(Value.Number.intValue(20)).build();
+
+    @DataProvider(name="Identities")
+    Object[][] identitiesData() {
+        return new Object[][]{
+                {new Object(), true},
+                {"String", true},
+                {String.class, true},
+                {Object.class, true},
+                {new ValueType1(1), false},
+                {new ValueType2(2), false},
+                {new PrimitiveRecord(1, "A"), false},
+                {new ValueRecord(1,"B"), false},
+                {new int[0], true},  // arrays of primitives classes are identity objects
+                {new Object[0], true},  // arrays of identity classes are identity objects
+                {new String[0], true},  // arrays of identity classes are identity objects
+                {new ValueType1[0], true},  // arrays of value classes are identity objects
+        };
+    }
+
+    @Test(dataProvider="Identities")
+    void identityTests(Object obj, boolean expected) {
+        var actual = Objects.isIdentityObject(obj);
+        assertEquals(expected, actual, "Objects.isIdentityObject unexpected");
+    }
+
     @DataProvider(name="equalsTests")
     Object[][] equalsTests() {
         return new Object[][]{

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -82,7 +82,7 @@ public class ObjectMethods {
                 {new ValueType2(2), false},
                 {new PrimitiveRecord(1, "A"), false},
                 {new ValueRecord(1,"B"), false},
-                {new int[0], true},  // arrays of primitives classes are identity objects
+                {new int[0], true},  // arrays of primitive classes are identity objects
                 {new Object[0], true},  // arrays of identity classes are identity objects
                 {new String[0], true},  // arrays of identity classes are identity objects
                 {new ValueType1[0], true},  // arrays of value classes are identity objects

--- a/test/jdk/valhalla/valuetypes/ValhallaFeaturesTest.java
+++ b/test/jdk/valhalla/valuetypes/ValhallaFeaturesTest.java
@@ -25,34 +25,38 @@
 
 import jdk.internal.misc.ValhallaFeatures;
 
+import org.junit.*;
+import static org.junit.Assert.*;
+
 /*
  * @test
  * @modules java.base/jdk.internal.misc
  * @summary Test feature flags reflect command line flags
- * @run main/othervm ValhallaFeaturesTest true
- * @run main/othervm -XX:+EnableValhalla ValhallaFeaturesTest true
- * @run main/othervm -XX:-EnableValhalla ValhallaFeaturesTest false
+ * @run junit/othervm -Dexpected=true ValhallaFeaturesTest
+ * @run junit/othervm -XX:+EnableValhalla -Dexpected=true ValhallaFeaturesTest
+ * @run junit/othervm -XX:-EnableValhalla -Dexpected=false ValhallaFeaturesTest
  */
 
 public class ValhallaFeaturesTest {
 
-    public static void main(String[] args) {
-        boolean expected = args.length > 0 ? args[0].equalsIgnoreCase("true") : false;
+    // Save the expected enable from the command line -Dexpected
+    private static boolean expected = Boolean.getBoolean("expected");
+
+    @Test
+    public void checkEnable() {
         boolean enabled = ValhallaFeatures.isEnabled();
         System.out.println("EnableValhalla: " + enabled);
-        if (expected != enabled) {
-            throw new RuntimeException("expected: " + expected + ", actual: " + enabled);
-        }
+        assertEquals("EnableValhalla Flag", expected, enabled);
+    }
 
-        try {
+    @Test
+    public void checkEnsure() {
+        if (expected) {
+            // Throwing an exception is an error
             ValhallaFeatures.ensureValhallaEnabled();
-            if (!enabled) {
-                throw new RuntimeException("ensureValhallaEnabled should have thrown UOE");
-            }
-        } catch (UnsupportedOperationException uoe) {
-            if (enabled) {
-                throw new RuntimeException("UnsupportedOperationException not expected", uoe);
-            }
+        } else {
+            assertThrows("EnableValhalla Flag", UnsupportedOperationException.class,
+                    () -> ValhallaFeatures.ensureValhallaEnabled());
         }
     }
 }


### PR DESCRIPTION
Add `java.util.Objects.isIdentityObject(obj)` and update tests.

Correct j.l.Class.isIdentity() and .isValue() to correctly identify all arrays as identity objects.
(The modifiers for array classes do have not reliable ACC_IDENTITY or ACC_VALUE bits).

Updated ValhallaFeaturesTest to use junit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294312](https://bugs.openjdk.org/browse/JDK-8294312): [lworld] Add java.util.Objects.isIdentityObject


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/770/head:pull/770` \
`$ git checkout pull/770`

Update a local copy of the PR: \
`$ git checkout pull/770` \
`$ git pull https://git.openjdk.org/valhalla pull/770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 770`

View PR using the GUI difftool: \
`$ git pr show -t 770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/770.diff">https://git.openjdk.org/valhalla/pull/770.diff</a>

</details>
