### PR TITLE
8293994: [lworld] Deoptimization from nmethod entry barrier breaks scalarized calling convention

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1775,28 +1775,13 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   }
 
   __ verified_entry(C, 0);
-  __ bind(*_verified_entry);
 
   if (C->stub_function() == NULL) {
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
-      // Dummy labels for just measuring the code size
-      Label dummy_slow_path;
-      Label dummy_continuation;
-      Label dummy_guard;
-      Label* slow_path = &dummy_slow_path;
-      Label* continuation = &dummy_continuation;
-      Label* guard = &dummy_guard;
-      if (!Compile::current()->output()->in_scratch_emit_size()) {
-        // Use real labels from actual stub when not emitting code for the purpose of measuring its size
-        C2EntryBarrierStub* stub = Compile::current()->output()->entry_barrier_table()->add_entry_barrier();
-        slow_path = &stub->slow_path();
-        continuation = &stub->continuation();
-        guard = &stub->guard();
-      }
-      // In the C2 code, we move the non-hot part of nmethod entry barriers out-of-line to a stub.
-      bs->nmethod_entry_barrier(&_masm, slow_path, continuation, guard);
-    }
+    __ entry_barrier();
+  }
+
+  if (!Compile::current()->output()->in_scratch_emit_size()) {
+    __ bind(*_verified_entry);
   }
 
   if (VerifyStackAtCalls) {
@@ -2193,7 +2178,7 @@ void MachVEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 
 void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
 {
-  MacroAssembler _masm(&cbuf);
+  C2_MacroAssembler _masm(&cbuf);
 
   if (!_verified) {
     Label skip;
@@ -2203,12 +2188,24 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     __ bind(skip);
 
   } else {
+    // TODO 8284443 Avoid creation of temporary frame
+    if (ra_->C->stub_function() == NULL) {
+      __ verified_entry(ra_->C, 0);
+      __ entry_barrier();
+      int framesize = ra_->C->output()->frame_slots() << LogBytesPerInt;
+      __ remove_frame(framesize, false);
+    }
     // Unpack inline type args passed as oop and then jump to
     // the verified entry point (skipping the unverified entry).
     int sp_inc = __ unpack_inline_args(ra_->C, _receiver_only);
     // Emit code for verified entry and save increment for stack repair on return
     __ verified_entry(ra_->C, sp_inc);
-    __ b(*_verified_entry);
+    if (Compile::current()->output()->in_scratch_emit_size()) {
+      Label dummy_verified_entry;
+      __ b(dummy_verified_entry);
+    } else {
+      __ b(*_verified_entry);
+    }
   }
 }
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1770,10 +1770,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ bind(L_skip_barrier);
   }
 
-  if (C->max_vector_size() > 0) {
-    __ reinitialize_ptrue();
-  }
-
   __ verified_entry(C, 0);
 
   if (C->stub_function() == NULL) {
@@ -2188,6 +2184,10 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     __ bind(skip);
 
   } else {
+    // insert a nop at the start of the prolog so we can patch in a
+    // branch if we need to invalidate the method later
+    __ nop();
+
     // TODO 8284443 Avoid creation of temporary frame
     if (ra_->C->stub_function() == NULL) {
       __ verified_entry(ra_->C, 0);

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -312,18 +312,15 @@ void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_inc, 
 }
 
 void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, bool needs_stack_repair, bool has_scalarized_args, Label* verified_inline_entry_label) {
-  if (has_scalarized_args) {
-    // Initialize orig_pc to detect deoptimization during buffering in the entry points
-    str(zr, Address(sp, sp_offset_for_orig_pc - frame_size_in_bytes));
-  }
-  if (!needs_stack_repair && verified_inline_entry_label != NULL) {
-    bind(*verified_inline_entry_label);
-  }
-
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before creating a frame.
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   generate_stack_overflow_check(bang_size_in_bytes);
+
+  if (has_scalarized_args) {
+    // Initialize orig_pc to detect deoptimization during buffering in the entry points
+    str(zr, Address(sp, sp_offset_for_orig_pc - frame_size_in_bytes));
+  }
 
   build_frame_helper(frame_size_in_bytes, 0, needs_stack_repair);
 
@@ -331,9 +328,8 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->nmethod_entry_barrier(this, NULL /* slow_path */, NULL /* continuation */, NULL /* guard */);
 
-  if (needs_stack_repair && verified_inline_entry_label != NULL) {
-    // Jump here from the scalarized entry points that require additional stack space
-    // for packing scalarized arguments and therefore already created the frame.
+  if (verified_inline_entry_label != NULL) {
+    // Jump here from the scalarized entry points that already created the frame.
     bind(*verified_inline_entry_label);
   }
 }
@@ -365,20 +361,15 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   int args_passed = sig->length();
   int args_passed_cc = SigEntry::fill_sig_bt(sig_cc, sig_bt);
 
-  // Check if we need to extend the stack for packing
-  int sp_inc = 0;
-  if (args_on_stack > args_on_stack_cc) {
-    sp_inc = extend_stack_for_inline_args(args_on_stack);
-  }
-
-  // Create a temp frame so we can call into the runtime. It must be properly set up to accommodate GC.
-  build_frame_helper(frame_size_in_bytes, sp_inc, ces->c1_needs_stack_repair());
-
   // Initialize orig_pc to detect deoptimization during buffering in below runtime call
   str(zr, Address(sp, sp_offset_for_orig_pc));
 
+  // Create a temp frame so we can call into the runtime. It must be properly set up to accommodate GC.
+  build_frame_helper(frame_size_in_bytes, 0, ces->c1_needs_stack_repair());
+
   // The runtime call might safepoint, make sure nmethod entry barrier is executed
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  // C1 code is not hot enough to micro optimize the nmethod entry barrier with an out-of-line stub
   bs->nmethod_entry_barrier(this, NULL /* slow_path */, NULL /* continuation */, NULL /* guard */);
 
   // FIXME -- call runtime only if we cannot in-line allocate all the incoming inline type args.
@@ -397,16 +388,20 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   // Remove the temp frame
   MacroAssembler::remove_frame(frame_size_in_bytes);
 
+  // Check if we need to extend the stack for packing
+  int sp_inc = 0;
+  if (args_on_stack > args_on_stack_cc) {
+    sp_inc = extend_stack_for_inline_args(args_on_stack);
+  }
+
   shuffle_inline_args(true, is_inline_ro_entry, sig_cc,
                       args_passed_cc, args_on_stack_cc, regs_cc, // from
                       args_passed, args_on_stack, regs,          // to
                       sp_inc, val_array);
 
-  if (ces->c1_needs_stack_repair()) {
-    // Create the real frame. Below jump will then skip over the stack banging and frame
-    // setup code in the verified_inline_entry (which has a different real_frame_size).
-    build_frame_helper(frame_size_in_bytes, sp_inc, true);
-  }
+  // Create the real frame. Below jump will then skip over the stack banging and frame
+  // setup code in the verified_inline_entry (which has a different real_frame_size).
+  build_frame_helper(frame_size_in_bytes, sp_inc, ces->c1_needs_stack_repair());
 
   b(verified_inline_entry_label);
   return rt_call_offset;

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -35,6 +35,7 @@
                                   enum shift_kind kind = Assembler::LSL, unsigned shift = 0);
 
  public:
+  void entry_barrier();
   void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
   static int entry_barrier_stub_size();
 

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -163,6 +163,31 @@ static NativeNMethodBarrier* native_nmethod_barrier(nmethod* nm) {
   return barrier;
 }
 
+static void set_value(nmethod* nm, jint val) {
+  NativeNMethodBarrier* cmp1 = native_nmethod_barrier(nm);
+  cmp1->set_value(nm, val);
+
+  if (!nm->is_osr_method() && nm->method()->has_scalarized_args()) {
+    // nmethods with scalarized arguments have multiple entry points that each have an own nmethod entry barrier
+    assert(nm->verified_entry_point() != nm->verified_inline_entry_point(), "scalarized entry point not found");
+    address method_body = nm->is_compiled_by_c1() ? nm->verified_inline_entry_point() : nm->verified_entry_point();
+    address entry_point2 = nm->is_compiled_by_c1() ? nm->verified_entry_point() : nm->verified_inline_entry_point();
+
+    int barrier_offset = reinterpret_cast<address>(cmp1) - method_body;
+    NativeNMethodBarrier* cmp2 = reinterpret_cast<NativeNMethodBarrier*>(entry_point2 + barrier_offset);
+    assert(cmp1 != cmp2, "sanity");
+    debug_only(cmp2->verify());
+    cmp2->set_value(nm, val);
+
+    if (method_body != nm->verified_inline_ro_entry_point() && entry_point2 != nm->verified_inline_ro_entry_point()) {
+      NativeNMethodBarrier* cmp3 = reinterpret_cast<NativeNMethodBarrier*>(nm->verified_inline_ro_entry_point() + barrier_offset);
+      assert(cmp1 != cmp3 && cmp2 != cmp3, "sanity");
+      debug_only(cmp3->verify());
+      cmp3->set_value(nm, val);
+    }
+  }
+}
+
 void BarrierSetNMethod::disarm(nmethod* nm) {
   if (!supports_entry_barrier(nm)) {
     return;
@@ -179,8 +204,7 @@ void BarrierSetNMethod::disarm(nmethod* nm) {
 
   // Disarms the nmethod guard emitted by BarrierSetAssembler::nmethod_entry_barrier.
   // Symmetric "LDR; DMB ISHLD" is in the nmethod barrier.
-  NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
-  barrier->set_value(nm, disarmed_value());
+  set_value(nm, disarmed_value());
 }
 
 void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
@@ -199,8 +223,7 @@ void BarrierSetNMethod::arm(nmethod* nm, int arm_value) {
     bs_asm->increment_patching_epoch();
   }
 
-  NativeNMethodBarrier* barrier = native_nmethod_barrier(nm);
-  barrier->set_value(nm, arm_value);
+  set_value(nm, arm_value);
 }
 
 bool BarrierSetNMethod::is_armed(nmethod* nm) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5951,18 +5951,16 @@ void MacroAssembler::get_thread(Register dst) {
 // C2 compiled method's prolog code
 // Moved here from aarch64.ad to support Valhalla code belows
 void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
-
-  // n.b. frame size includes space for return pc and rfp
-  const long framesize = C->output()->frame_size_in_bytes();
-
-  // insert a nop at the start of the prolog so we can patch in a
-  // branch if we need to invalidate the method later
-  nop();
+  if (C->max_vector_size() > 0) {
+    reinitialize_ptrue();
+  }
 
   int bangsize = C->output()->bang_size_in_bytes();
   if (C->output()->need_stack_bang(bangsize))
     generate_stack_overflow_check(bangsize);
 
+  // n.b. frame size includes space for return pc and rfp
+  const long framesize = C->output()->frame_size_in_bytes();
   build_frame(framesize);
 
   if (C->needs_stack_repair()) {

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -615,6 +615,8 @@ static void gen_c2i_adapter(MacroAssembler *masm,
                             int& frame_complete,
                             int& frame_size_in_words,
                             bool alloc_inline_receiver) {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->c2i_entry_barrier(masm);
 
   // Before we get into the guts of the C2I adapter, see if we should be here
   // at all.  We've come from compiled code and are attempting to jump to the
@@ -1062,9 +1064,6 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
     __ bind(L_skip_barrier);
     c2i_no_clinit_check_entry = __ pc();
   }
-
-  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->c2i_entry_barrier(masm);
 
   gen_c2i_adapter(masm, sig_cc, regs_cc, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, true);
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1077,6 +1077,8 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
     gen_inline_cache_check(masm, inline_entry_skip_fixup);
 
     c2i_inline_entry = __ pc();
+    // TODO 8294013 Fix this and add tests
+    c2i_no_clinit_check_entry = __ pc();
     gen_c2i_adapter(masm, sig, regs, inline_entry_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
   }
 

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -312,7 +312,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
   assert(UseCompressedClassPointers || offset() - start_offset == ic_cmp_size, "check alignment in emit_method_entry");
 }
 
-void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_inc, bool needs_stack_repair) {
+void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool has_scalarized_args, bool needs_stack_repair) {
   push(rbp);
   if (PreserveFramePointer) {
     mov(rbp, rsp);
@@ -331,6 +331,10 @@ void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_inc, 
     int real_frame_size = sp_inc + frame_size_in_bytes + wordSize;
     movptr(Address(rsp, frame_size_in_bytes - wordSize), real_frame_size);
   }
+  if (has_scalarized_args) {
+    // Initialize orig_pc to detect deoptimization during buffering in the entry points
+    movptr(Address(rsp, sp_offset_for_orig_pc), 0);
+  }
 }
 
 void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, bool needs_stack_repair, bool has_scalarized_args, Label* verified_inline_entry_label) {
@@ -342,12 +346,7 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   generate_stack_overflow_check(bang_size_in_bytes);
 
-  if (has_scalarized_args) {
-    // Initialize orig_pc to detect deoptimization during buffering in the entry points
-    movptr(Address(rsp, sp_offset_for_orig_pc - frame_size_in_bytes - wordSize), 0);
-  }
-
-  build_frame_helper(frame_size_in_bytes, 0, needs_stack_repair);
+  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, 0, has_scalarized_args, needs_stack_repair);
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   // C1 code is not hot enough to micro optimize the nmethod entry barrier with an out-of-line stub
@@ -393,11 +392,8 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
   int args_passed = sig->length();
   int args_passed_cc = SigEntry::fill_sig_bt(sig_cc, sig_bt);
 
-  // Initialize orig_pc to detect deoptimization during buffering in below runtime call
-  movptr(Address(rsp, sp_offset_for_orig_pc - frame_size_in_bytes - wordSize), 0);
-
   // Create a temp frame so we can call into the runtime. It must be properly set up to accommodate GC.
-  build_frame_helper(frame_size_in_bytes, 0, ces->c1_needs_stack_repair());
+  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, 0, true, ces->c1_needs_stack_repair());
 
   // The runtime call might safepoint, make sure nmethod entry barrier is executed
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
@@ -430,7 +426,7 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
 
   // Create the real frame. Below jump will then skip over the stack banging and frame
   // setup code in the verified_inline_entry (which has a different real_frame_size).
-  build_frame_helper(frame_size_in_bytes, sp_inc, ces->c1_needs_stack_repair());
+  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, sp_inc, true, ces->c1_needs_stack_repair());
 
   jmp(verified_inline_entry_label);
   return rt_call_offset;

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -138,6 +138,29 @@ void C2_MacroAssembler::verified_entry(Compile* C, int sp_inc) {
 #endif
 }
 
+void C2_MacroAssembler::entry_barrier() {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+#ifdef _LP64
+  if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+    // We put the non-hot code of the nmethod entry barrier out-of-line in a stub.
+    Label dummy_slow_path;
+    Label dummy_continuation;
+    Label* slow_path = &dummy_slow_path;
+    Label* continuation = &dummy_continuation;
+    if (!Compile::current()->output()->in_scratch_emit_size()) {
+      // Use real labels from actual stub when not emitting code for the purpose of measuring its size
+      C2EntryBarrierStub* stub = Compile::current()->output()->entry_barrier_table()->add_entry_barrier();
+      slow_path = &stub->slow_path();
+      continuation = &stub->continuation();
+    }
+    bs->nmethod_entry_barrier(this, slow_path, continuation);
+  }
+#else
+  // Don't bother with out-of-line nmethod entry barrier stub for x86_32.
+  bs->nmethod_entry_barrier(this, NULL /* slow_path */, NULL /* continuation */);
+#endif
+}
+
 void C2_MacroAssembler::emit_entry_barrier_stub(C2EntryBarrierStub* stub) {
   bind(stub->slow_path());
   call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -31,6 +31,7 @@ public:
   // C2 compiled method's prolog code.
   void verified_entry(Compile* C, int sp_inc = 0);
 
+  void entry_barrier();
   void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
   static int entry_barrier_stub_size();
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -799,6 +799,9 @@ static void gen_c2i_adapter(MacroAssembler *masm,
                             int& frame_complete,
                             int& frame_size_in_words,
                             bool alloc_inline_receiver) {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->c2i_entry_barrier(masm);
+
   // Before we get into the guts of the C2I adapter, see if we should be here
   // at all.  We've come from compiled code and are attempting to jump to the
   // interpreter, which means the caller made a static call to get here
@@ -1289,9 +1292,6 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
     __ bind(L_skip_barrier);
     c2i_no_clinit_check_entry = __ pc();
   }
-
-  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  bs->c2i_entry_barrier(masm);
 
   gen_c2i_adapter(masm, sig_cc, regs_cc, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, true);
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -1305,6 +1305,8 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
     gen_inline_cache_check(masm, inline_entry_skip_fixup);
 
     c2i_inline_entry = __ pc();
+    // TODO 8294013 Fix this and add tests
+    c2i_no_clinit_check_entry = __ pc();
     gen_c2i_adapter(masm, sig, regs, inline_entry_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
   }
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -917,29 +917,13 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   }
 
   __ verified_entry(C);
-  __ bind(*_verified_entry);
 
-  if (C->stub_function() == NULL) {
-    BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
- #ifdef _LP64
-    if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
-      // We put the non-hot code of the nmethod entry barrier out-of-line in a stub.
-      Label dummy_slow_path;
-      Label dummy_continuation;
-      Label* slow_path = &dummy_slow_path;
-      Label* continuation = &dummy_continuation;
-      if (!Compile::current()->output()->in_scratch_emit_size()) {
-        // Use real labels from actual stub when not emitting code for the purpose of measuring its size
-        C2EntryBarrierStub* stub = Compile::current()->output()->entry_barrier_table()->add_entry_barrier();
-        slow_path = &stub->slow_path();
-        continuation = &stub->continuation();
-      }
-      bs->nmethod_entry_barrier(&_masm, slow_path, continuation);
-    }
-#else
-    // Don't bother with out-of-line nmethod entry barrier stub for x86_32.
-    bs->nmethod_entry_barrier(&_masm, NULL /* slow_path */, NULL /* continuation */);
-#endif
+  if (ra_->C->stub_function() == NULL) {
+    __ entry_barrier();
+  }
+
+  if (!Compile::current()->output()->in_scratch_emit_size()) {
+    __ bind(*_verified_entry);
   }
 
   C->output()->set_frame_complete(cbuf.insts_size());
@@ -1662,8 +1646,8 @@ void MachVEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
 {
   C2_MacroAssembler _masm(&cbuf);
+  uint insts_size = cbuf.insts_size();
   if (!_verified) {
-    uint insts_size = cbuf.insts_size();
     if (UseCompressedClassPointers) {
       __ load_klass(rscratch1, j_rarg0, rscratch2);
       __ cmpptr(rax, rscratch1);
@@ -1672,12 +1656,31 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     }
     __ jump_cc(Assembler::notEqual, RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
   } else {
+    // TODO 8284443 Avoid creation of temporary frame
+    if (ra_->C->stub_function() == NULL) {
+      __ verified_entry(ra_->C, 0);
+      __ entry_barrier();
+      int initial_framesize = ra_->C->output()->frame_size_in_bytes() - 2*wordSize;
+      __ remove_frame(initial_framesize, false);
+    }
     // Unpack inline type args passed as oop and then jump to
     // the verified entry point (skipping the unverified entry).
     int sp_inc = __ unpack_inline_args(ra_->C, _receiver_only);
     // Emit code for verified entry and save increment for stack repair on return
     __ verified_entry(ra_->C, sp_inc);
-    __ jmp(*_verified_entry);
+    if (Compile::current()->output()->in_scratch_emit_size()) {
+      Label dummy_verified_entry;
+      __ jmp(dummy_verified_entry);
+    } else {
+      __ jmp(*_verified_entry);
+    }
+  }
+  /* WARNING these NOPs are critical so that verified entry point is properly
+     4 bytes aligned for patching by NativeJump::patch_verified_entry() */
+  int nops_cnt = 4 - ((cbuf.insts_size() - insts_size) & 0x3);
+  nops_cnt &= 0x3; // Do not add nops if code is aligned.
+  if (nops_cnt > 0) {
+    __ nop(nops_cnt);
   }
 }
 

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -33,7 +33,7 @@ class CompiledEntrySignature;
 class C1_MacroAssembler: public MacroAssembler {
  private:
   int scalarized_entry(const CompiledEntrySignature* ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_inline_entry_label, bool is_inline_ro_entry);
-  void build_frame_helper(int frame_size_in_bytes, int sp_inc, bool needs_stack_repair);
+  void build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool has_scalarized_args, bool needs_stack_repair);
  public:
   // creation
   C1_MacroAssembler(CodeBuffer* code) : MacroAssembler(code) { pd_init(); }

--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -654,7 +654,7 @@ void CompiledStaticCall::compute_entry(const methodHandle& m, CompiledMethod* ca
       // C1 -> interp: values passed as oops
       info._entry = m()->get_c2i_inline_entry();
     } else {
-      // C2 -> interp: values passed fields
+      // C2 -> interp: values passed as fields
       info._entry = m()->get_c2i_entry();
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -56,7 +56,7 @@ bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
 
     // We can end up calling nmethods that are unloading
     // since we clear compiled ICs lazily. Returning false
-    // will re-resovle the call and update the compiled IC.
+    // will re-resolve the call and update the compiled IC.
     return false;
   }
 

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -51,7 +51,7 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
 
     // We can end up calling nmethods that are unloading
     // since we clear compiled ICs lazily. Returning false
-    // will re-resovle the call and update the compiled IC.
+    // will re-resolve the call and update the compiled IC.
     return false;
   }
 

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -133,10 +133,10 @@ public:
 };
 
 class C2EntryBarrierStubTable {
-  C2EntryBarrierStub* _stub;
+  GrowableArray<C2EntryBarrierStub*> _stubs;
 
 public:
-  C2EntryBarrierStubTable() : _stub(NULL) {}
+  C2EntryBarrierStubTable() {}
   C2EntryBarrierStub* add_entry_barrier();
   int estimate_stub_size() const;
   void emit(CodeBuffer& cb);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -359,7 +359,7 @@ void frame::deoptimize(JavaThread* thread) {
     // type args. We can't deoptimize at that point because the buffers have not yet been initialized.
     // Also, if the method is synchronized, we first need to acquire the lock.
     // Don't patch the return pc to delay deoptimization until we enter the method body (the check
-    // addedin LIRGenerator::do_Base will detect the pending deoptimization by checking the original_pc).
+    // added in LIRGenerator::do_Base will detect the pending deoptimization by checking the original_pc).
 #if defined ASSERT && !defined AARCH64   // Stub call site does not look like NativeCall on AArch64
     NativeCall* call = nativeCall_before(this->pc());
     address dest = call->destination();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1569,7 +1569,11 @@ JRT_BLOCK_ENTRY(address, SharedRuntime::handle_wrong_method(JavaThread* current)
       // so bypassing it in c2i adapter is benign.
       return callee->get_c2i_no_clinit_check_entry();
     } else {
-      return callee->get_c2i_entry();
+      if (caller_frame.is_interpreted_frame()) {
+        return callee->get_c2i_inline_entry();
+      } else {
+        return callee->get_c2i_entry();
+      }
     }
   }
 


### PR DESCRIPTION
The recent sweeper removal ([JDK-8290025](https://bugs.openjdk.org/browse/JDK-8290025)) always enabled nmethod entry barriers. This revealed an issue where deoptimization from the slow path (`-XX:+DeoptimizeNMethodBarriersALot`) breaks the scalarized calling convention because once deoptimization is triggered at nmethod entry via `BarrierSetNMethod::deoptimize`, we already converted the calling convention and can't easily go back. Also with method handle invocation logic, we can not tell in `SharedRuntime::handle_wrong_method` which calling convention the callee nmethod converted to.

After evaluating several ideas, I found that the cleanest solution is to have an own nmethod entry barrier per entry point right before converting calling conventions.

While debugging, I discovered similar issues with the class init barriers, that I'll address in a follow-up fix ([JDK-8294013](https://bugs.openjdk.org/browse/JDK-8294013)).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293994](https://bugs.openjdk.org/browse/JDK-8293994): [lworld] Deoptimization from nmethod entry barrier breaks scalarized calling convention


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/773/head:pull/773` \
`$ git checkout pull/773`

Update a local copy of the PR: \
`$ git checkout pull/773` \
`$ git pull https://git.openjdk.org/valhalla pull/773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 773`

View PR using the GUI difftool: \
`$ git pr show -t 773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/773.diff">https://git.openjdk.org/valhalla/pull/773.diff</a>

</details>
