### PR TITLE
8294678: [lworld] Update AccessFlags tests to include ACC_IDENTITY and ACC_VALUE

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1512,13 +1512,15 @@ public final class Class<T> implements java.io.Serializable,
         // INNER_CLASS forbids. INNER_CLASS allows PRIVATE, PROTECTED,
         // and STATIC, which are not allowed on Location.CLASS.
         // Use getClassAccessFlagsRaw to expose SUPER status.
+        // Arrays are identity classes but not reflected in modifiers
         var location = (isMemberClass() || isLocalClass() ||
                         isAnonymousClass() || isArray()) ?
             AccessFlag.Location.INNER_CLASS :
             AccessFlag.Location.CLASS;
-        return AccessFlag.maskToAccessFlags((location == AccessFlag.Location.CLASS) ?
-                                            getClassAccessFlagsRaw() :
-                                            getModifiers(),
+        final int mask = ((location == AccessFlag.Location.CLASS) ?
+                getClassAccessFlagsRaw() : getModifiers()) |
+                (isArray() ? Modifier.IDENTITY : 0);
+        return AccessFlag.maskToAccessFlags(mask & (~0x800),  // suppress unspecified bit
                                             location);
     }
 

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1512,15 +1512,13 @@ public final class Class<T> implements java.io.Serializable,
         // INNER_CLASS forbids. INNER_CLASS allows PRIVATE, PROTECTED,
         // and STATIC, which are not allowed on Location.CLASS.
         // Use getClassAccessFlagsRaw to expose SUPER status.
-        // Arrays are identity classes but not reflected in modifiers
         var location = (isMemberClass() || isLocalClass() ||
                         isAnonymousClass() || isArray()) ?
             AccessFlag.Location.INNER_CLASS :
             AccessFlag.Location.CLASS;
-        final int mask = ((location == AccessFlag.Location.CLASS) ?
-                getClassAccessFlagsRaw() : getModifiers()) |
-                (isArray() ? Modifier.IDENTITY : 0);
-        return AccessFlag.maskToAccessFlags(mask & (~0x800),  // suppress unspecified bit
+        return AccessFlag.maskToAccessFlags((location == AccessFlag.Location.CLASS) ?
+                                            getClassAccessFlagsRaw() & (~0x800) :
+                                            getModifiers() & (~0x800), // suppress unspecified bit
                                             location);
     }
 

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
@@ -54,6 +54,8 @@ public final class ClassAccessFlagTest {
         Class<?>[] testClasses = {
             ClassAccessFlagTest.class,
             TestInterface.class,
+            TestIdentityInterface.class,
+            TestValueInterface.class,
             ExpectedClassFlags.class,
             TestOuterEnum.class
         };
@@ -161,7 +163,7 @@ public final class ClassAccessFlagTest {
                                                arrayClass);
                 }
             }
-            // Verify IDENTITY, ABSTRACT, and FINAL access flags
+            // Verify IDENTITY, ABSTRACT, FINAL, and access mode
             Set<AccessFlag> expected = new HashSet<>(4);
             expected.add(AccessFlag.ABSTRACT);
             expected.add(AccessFlag.FINAL);
@@ -181,21 +183,45 @@ public final class ClassAccessFlagTest {
     // locations:
     // PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, INTERFACE, ABSTRACT,
     // SYNTHETIC, ANNOTATION, ENUM.
+    // Include cases for classes with identity, value modifier, or no modifier.
 
     @ExpectedClassFlags("[PUBLIC, STATIC, INTERFACE, ABSTRACT]")
     public      interface PublicInterface {}
+    @ExpectedClassFlags("[PUBLIC, STATIC, IDENTITY, INTERFACE, ABSTRACT]")
+    public      identity interface PublicIdentityInterface {}
+    @ExpectedClassFlags("[PUBLIC, STATIC, VALUE, INTERFACE, ABSTRACT]")
+    public      value interface PublicValueInterface {}
+
     @ExpectedClassFlags("[PROTECTED, STATIC, INTERFACE, ABSTRACT]")
     protected   interface ProtectedInterface {}
+    @ExpectedClassFlags("[PROTECTED, STATIC, IDENTITY, INTERFACE, ABSTRACT]")
+    protected   identity interface ProtectedIdentityInterface {}
+    @ExpectedClassFlags("[PROTECTED, STATIC, VALUE, INTERFACE, ABSTRACT]")
+    protected   value interface ProtectedValueInterface {}
+
     @ExpectedClassFlags("[PRIVATE, STATIC, INTERFACE, ABSTRACT]")
     private     interface PrivateInterface {}
+    @ExpectedClassFlags("[PRIVATE, STATIC, IDENTITY, INTERFACE, ABSTRACT]")
+    private     identity interface PrivateIdentityInterface {}
+    @ExpectedClassFlags("[PRIVATE, STATIC, VALUE, INTERFACE, ABSTRACT]")
+    private     value interface PrivateValueInterface {}
+
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT]")
     /*package*/ interface PackageInterface {}
+    @ExpectedClassFlags("[STATIC, IDENTITY, INTERFACE, ABSTRACT]")
+    /*package*/ identity interface PackageIdentityInterface {}
+    @ExpectedClassFlags("[STATIC, VALUE, INTERFACE, ABSTRACT]")
+    /*package*/ value interface PackageValueInterface {}
 
     @ExpectedClassFlags("[FINAL, IDENTITY]")
     /*package*/ final class TestFinalClass {}
+    @ExpectedClassFlags("[FINAL, IDENTITY]")
+    /*package*/ final identity class TestFinalIdentityClass {}
 
     @ExpectedClassFlags("[IDENTITY, ABSTRACT]")
     /*package*/ abstract class TestAbstractClass {}
+    @ExpectedClassFlags("[IDENTITY, ABSTRACT]")
+    /*package*/ abstract identity class TestAbstractIdentityClass {}
 
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT, ANNOTATION]")
     /*package*/ @interface TestMarkerAnnotation {}
@@ -218,9 +244,15 @@ public final class ClassAccessFlagTest {
 
     @ExpectedClassFlags("[PRIVATE, IDENTITY, ABSTRACT]")
     private abstract class Foo {}
+    @ExpectedClassFlags("[PRIVATE, IDENTITY, ABSTRACT]")
+    private abstract identity class IdentityFoo {}
 
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT]")
     interface StaticTestInterface {}
+    @ExpectedClassFlags("[STATIC, IDENTITY, INTERFACE, ABSTRACT]")
+    identity interface StaticTestIdentityInterface {}
+    @ExpectedClassFlags("[STATIC, VALUE, INTERFACE, ABSTRACT]")
+    value interface StaticTestValueInterface {}
 }
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -231,6 +263,10 @@ public final class ClassAccessFlagTest {
 
 @ExpectedClassFlags("[INTERFACE, ABSTRACT]")
 interface TestInterface {}
+@ExpectedClassFlags("[SUPER, IDENTITY, INTERFACE, ABSTRACT]")
+identity interface TestIdentityInterface {}
+@ExpectedClassFlags("[VALUE, INTERFACE, ABSTRACT]")
+value interface TestValueInterface {}
 
 
 @ExpectedClassFlags("[FINAL, SUPER, IDENTITY, ENUM]")

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
@@ -161,6 +161,18 @@ public final class ClassAccessFlagTest {
                                                arrayClass);
                 }
             }
+            // Verify IDENTITY, ABSTRACT, and FINAL access flags
+            Set<AccessFlag> expected = new HashSet<>(4);
+            expected.add(AccessFlag.ABSTRACT);
+            expected.add(AccessFlag.FINAL);
+            expected.add(AccessFlag.IDENTITY);
+            if (accessLevel != null)
+                expected.add(accessLevel);
+            if (!expected.equals(arrayClass.accessFlags())) {
+                throw new RuntimeException("Unexpected access flags for array: " + accessClass +
+                        ": actual: " + arrayClass.accessFlags() +
+                        ", expected: " + expected);
+            }
         }
 
     }

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagTest.java
@@ -167,7 +167,7 @@ public final class ClassAccessFlagTest {
             Set<AccessFlag> expected = new HashSet<>(4);
             expected.add(AccessFlag.ABSTRACT);
             expected.add(AccessFlag.FINAL);
-            expected.add(AccessFlag.IDENTITY);
+//            expected.add(AccessFlag.IDENTITY);  // NYI Pending: JDK-8294866
             if (accessLevel != null)
                 expected.add(accessLevel);
             if (!expected.equals(arrayClass.accessFlags())) {

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -104,11 +104,12 @@ public class ObjectMethods {
 
         assertEquals(clazz.isValue(), valueClass, "Class.isValue()");
 
-        assertEquals(clazz.accessFlags().contains(AccessFlag.IDENTITY),
-                identityClass, "AccessFlag.IDENTITY");
-
-        assertEquals(clazz.accessFlags().contains(AccessFlag.VALUE),
-                valueClass, "AccessFlag.VALUE");
+        // JDK-8294866: Not yet implemented checks of AccessFlags for the array class
+//        assertEquals(clazz.accessFlags().contains(AccessFlag.IDENTITY),
+//                identityClass, "AccessFlag.IDENTITY");
+//
+//        assertEquals(clazz.accessFlags().contains(AccessFlag.VALUE),
+//                valueClass, "AccessFlag.VALUE");
     }
 
     @DataProvider(name="equalsTests")

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -91,24 +91,24 @@ public class ObjectMethods {
     }
 
     @Test(dataProvider="Identities")
-    void identityTests(Object obj, boolean classIdentity, boolean classValue) {
+    void identityTests(Object obj, boolean identityClass, boolean valueClass) {
         Class<?> clazz = obj.getClass();
 
         if (clazz == Object.class) {
-            assertEquals(Objects.isIdentityObject(obj), true, "Objects.isIdentityObject()");
+            assertTrue(Objects.isIdentityObject(obj), "Objects.isIdentityObject()");
         } else {
-            assertEquals(Objects.isIdentityObject(obj), expectedIdentity, "Objects.isIdentityObject()");
+            assertEquals(Objects.isIdentityObject(obj), identityClass, "Objects.isIdentityObject()");
         }
 
-        assertEquals(clazz.isIdentity(), classIdentity, "Class.isIdentity()");
+        assertEquals(clazz.isIdentity(), identityClass, "Class.isIdentity()");
 
-        assertEquals(clazz.isValue(), classValue, "Class.isValue()");
+        assertEquals(clazz.isValue(), valueClass, "Class.isValue()");
 
         assertEquals(clazz.accessFlags().contains(AccessFlag.IDENTITY),
-                classIdentity, "AccessFlag.IDENTITY");
+                identityClass, "AccessFlag.IDENTITY");
 
         assertEquals(clazz.accessFlags().contains(AccessFlag.VALUE),
-                classValue, "AccessFlag.VALUE");
+                valueClass, "AccessFlag.VALUE");
     }
 
     @DataProvider(name="equalsTests")

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -31,6 +31,7 @@
  * @compile -XDenablePrimitiveClasses ObjectMethods.java
  * @run testng/othervm -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
  */
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
@@ -74,25 +75,40 @@ public class ObjectMethods {
     @DataProvider(name="Identities")
     Object[][] identitiesData() {
         return new Object[][]{
-                {new Object(), true},
-                {"String", true},
-                {String.class, true},
-                {Object.class, true},
-                {new ValueType1(1), false},
-                {new ValueType2(2), false},
-                {new PrimitiveRecord(1, "A"), false},
-                {new ValueRecord(1,"B"), false},
-                {new int[0], true},  // arrays of primitive classes are identity objects
-                {new Object[0], true},  // arrays of identity classes are identity objects
-                {new String[0], true},  // arrays of identity classes are identity objects
-                {new ValueType1[0], true},  // arrays of value classes are identity objects
+                {new Object(), false, false},
+                {"String", true, false},
+                {String.class, true, false},
+                {Object.class, true, false},
+                {new ValueType1(1), false, true},
+                {new ValueType2(2), false, true},
+                {new PrimitiveRecord(1, "A"), false, true},
+                {new ValueRecord(1,"B"), false, true},
+                {new int[0], true, false},  // arrays of primitive classes are identity objects
+                {new Object[0], true, false},  // arrays of identity classes are identity objects
+                {new String[0], true, false},  // arrays of identity classes are identity objects
+                {new ValueType1[0], true, false},  // arrays of value classes are identity objects
         };
     }
 
     @Test(dataProvider="Identities")
-    void identityTests(Object obj, boolean expected) {
-        var actual = Objects.isIdentityObject(obj);
-        assertEquals(expected, actual, "Objects.isIdentityObject unexpected");
+    void identityTests(Object obj, boolean classIdentity, boolean classValue) {
+        Class<?> clazz = obj.getClass();
+
+        if (clazz == Object.class) {
+            assertEquals(Objects.isIdentityObject(obj), true, "Objects.isIdentityObject()");
+        } else {
+            assertEquals(Objects.isIdentityObject(obj), expectedIdentity, "Objects.isIdentityObject()");
+        }
+
+        assertEquals(clazz.isIdentity(), classIdentity, "Class.isIdentity()");
+
+        assertEquals(clazz.isValue(), classValue, "Class.isValue()");
+
+        assertEquals(clazz.accessFlags().contains(AccessFlag.IDENTITY),
+                classIdentity, "AccessFlag.IDENTITY");
+
+        assertEquals(clazz.accessFlags().contains(AccessFlag.VALUE),
+                classValue, "AccessFlag.VALUE");
     }
 
     @DataProvider(name="equalsTests")


### PR DESCRIPTION
The tests for Class.accessFlags should be updated to check ACC_IDENTITY and ACC_VALUE. 
Update ClassAccessFlagTest and ObjectMethods test to check consistency between
Class.isIdentity() and Class.isValue() methods with the Class accessFlags().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294678](https://bugs.openjdk.org/browse/JDK-8294678): [lworld] Update AccessFlags tests to include ACC_IDENTITY and ACC_VALUE


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/775/head:pull/775` \
`$ git checkout pull/775`

Update a local copy of the PR: \
`$ git checkout pull/775` \
`$ git pull https://git.openjdk.org/valhalla pull/775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 775`

View PR using the GUI difftool: \
`$ git pr show -t 775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/775.diff">https://git.openjdk.org/valhalla/pull/775.diff</a>

</details>
