### PR TITLE
8294013: [lworld] Missing class init barriers in c2i adapter

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1759,17 +1759,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   // branch if we need to invalidate the method later
   __ nop();
 
-  if (C->clinit_barrier_on_entry()) {
-    assert(!C->method()->holder()->is_not_initialized(), "initialization should have been started");
-
-    Label L_skip_barrier;
-
-    __ mov_metadata(rscratch2, C->method()->holder()->constant_encoding());
-    __ clinit_barrier(rscratch2, rscratch1, &L_skip_barrier);
-    __ far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
-    __ bind(L_skip_barrier);
-  }
-
   __ verified_entry(C, 0);
 
   if (C->stub_function() == NULL) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5951,6 +5951,17 @@ void MacroAssembler::get_thread(Register dst) {
 // C2 compiled method's prolog code
 // Moved here from aarch64.ad to support Valhalla code belows
 void MacroAssembler::verified_entry(Compile* C, int sp_inc) {
+  if (C->clinit_barrier_on_entry()) {
+    assert(!C->method()->holder()->is_not_initialized(), "initialization should have been started");
+
+    Label L_skip_barrier;
+
+    mov_metadata(rscratch2, C->method()->holder()->constant_encoding());
+    clinit_barrier(rscratch2, rscratch1, &L_skip_barrier);
+    far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
+    bind(L_skip_barrier);
+  }
+
   if (C->max_vector_size() > 0) {
     reinitialize_ptrue();
   }

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -793,12 +793,35 @@ static void gen_c2i_adapter_helper(MacroAssembler* masm,
 static void gen_c2i_adapter(MacroAssembler *masm,
                             const GrowableArray<SigEntry>* sig_extended,
                             const VMRegPair *regs,
+                            bool requires_clinit_barrier,
+                            address& c2i_no_clinit_check_entry,
                             Label& skip_fixup,
                             address start,
                             OopMapSet* oop_maps,
                             int& frame_complete,
                             int& frame_size_in_words,
                             bool alloc_inline_receiver) {
+  if (requires_clinit_barrier && VM_Version::supports_fast_class_init_checks()) {
+    Label L_skip_barrier;
+    Register method = rbx;
+
+    { // Bypass the barrier for non-static methods
+      Register flags = rscratch1;
+      __ movl(flags, Address(method, Method::access_flags_offset()));
+      __ testl(flags, JVM_ACC_STATIC);
+      __ jcc(Assembler::zero, L_skip_barrier); // non-static
+    }
+
+    Register klass = rscratch1;
+    __ load_method_holder(klass, method);
+    __ clinit_barrier(klass, r15_thread, &L_skip_barrier /*L_fast_path*/);
+
+    __ jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub())); // slow path
+
+    __ bind(L_skip_barrier);
+    c2i_no_clinit_check_entry = __ pc();
+  }
+
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   bs->c2i_entry_barrier(masm);
 
@@ -1251,7 +1274,8 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
   // On exit from the interpreter, the interpreter will restore our SP (lest the
   // compiled code, which relies solely on SP and not RBP, get sick).
 
-  address c2i_unverified_entry = __ pc();
+  address c2i_unverified_entry        = __ pc();
+  address c2i_unverified_inline_entry = __ pc();
   Label skip_fixup;
 
   gen_inline_cache_check(masm, skip_fixup);
@@ -1261,53 +1285,30 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
   int frame_size_in_words = 0;
 
   // Scalarized c2i adapter with non-scalarized receiver (i.e., don't pack receiver)
+  address c2i_no_clinit_check_entry = NULL;
   address c2i_inline_ro_entry = __ pc();
   if (regs_cc != regs_cc_ro) {
-    gen_c2i_adapter(masm, sig_cc_ro, regs_cc_ro, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
+    // No class init barrier needed because method is guaranteed to be non-static
+    gen_c2i_adapter(masm, sig_cc_ro, regs_cc_ro, /* requires_clinit_barrier = */ false, c2i_no_clinit_check_entry,
+                    skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, /* requires_clinit_barrier = */ false);
     skip_fixup.reset();
   }
 
   // Scalarized c2i adapter
-  address c2i_entry = __ pc();
-
-  // Class initialization barrier for static methods
-  address c2i_no_clinit_check_entry = NULL;
-  if (VM_Version::supports_fast_class_init_checks()) {
-    Label L_skip_barrier;
-    Register method = rbx;
-
-    { // Bypass the barrier for non-static methods
-      Register flags = rscratch1;
-      __ movl(flags, Address(method, Method::access_flags_offset()));
-      __ testl(flags, JVM_ACC_STATIC);
-      __ jcc(Assembler::zero, L_skip_barrier); // non-static
-    }
-
-    Register klass = rscratch1;
-    __ load_method_holder(klass, method);
-    __ clinit_barrier(klass, r15_thread, &L_skip_barrier /*L_fast_path*/);
-
-    __ jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub())); // slow path
-
-    __ bind(L_skip_barrier);
-    c2i_no_clinit_check_entry = __ pc();
-  }
-
-  gen_c2i_adapter(masm, sig_cc, regs_cc, skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, true);
-
-  address c2i_unverified_inline_entry = c2i_unverified_entry;
+  address c2i_entry        = __ pc();
+  address c2i_inline_entry = __ pc();
+  gen_c2i_adapter(masm, sig_cc, regs_cc, /* requires_clinit_barrier = */ true, c2i_no_clinit_check_entry,
+                  skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, /* requires_clinit_barrier = */ true);
 
   // Non-scalarized c2i adapter
-  address c2i_inline_entry = c2i_entry;
   if (regs != regs_cc) {
-    Label inline_entry_skip_fixup;
     c2i_unverified_inline_entry = __ pc();
+    Label inline_entry_skip_fixup;
     gen_inline_cache_check(masm, inline_entry_skip_fixup);
 
     c2i_inline_entry = __ pc();
-    // TODO 8294013 Fix this and add tests
-    c2i_no_clinit_check_entry = __ pc();
-    gen_c2i_adapter(masm, sig, regs, inline_entry_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, false);
+    gen_c2i_adapter(masm, sig, regs, /* requires_clinit_barrier = */ true, c2i_no_clinit_check_entry,
+                    inline_entry_skip_fixup, i2c_entry, oop_maps, frame_complete, frame_size_in_words, /* requires_clinit_barrier = */ false);
   }
 
   __ flush();

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -901,21 +901,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
 
-  if (C->clinit_barrier_on_entry()) {
-    assert(VM_Version::supports_fast_class_init_checks(), "sanity");
-    assert(!C->method()->holder()->is_not_initialized(), "initialization should have been started");
-
-    Label L_skip_barrier;
-    Register klass = rscratch1;
-
-    __ mov_metadata(klass, C->method()->holder()->constant_encoding());
-    __ clinit_barrier(klass, r15_thread, &L_skip_barrier /*L_fast_path*/);
-
-    __ jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub())); // slow path
-
-    __ bind(L_skip_barrier);
-  }
-
   __ verified_entry(C);
 
   if (ra_->C->stub_function() == NULL) {

--- a/test/hotspot/jtreg/runtime/clinit/ClassInitBarrier.java
+++ b/test/hotspot/jtreg/runtime/clinit/ClassInitBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,16 @@ public class ClassInitBarrier {
 
     static final boolean THROW = Boolean.getBoolean("THROW");
 
+    static value class MyValue {
+        int x = 42;
+
+        void verify() {
+            Asserts.assertEquals(x, 42);
+        }
+    }
+
     static class Test {
+
         static class A {
             static {
                 if (!init(B.class)) {
@@ -85,9 +94,9 @@ public class ClassInitBarrier {
                 changePhase(Phase.FINISHED);
             }
 
-            static              void staticM(Runnable action) { action.run(); }
-            static synchronized void staticS(Runnable action) { action.run(); }
-            static native       void staticN(Runnable action);
+            static              void staticM(Runnable action, MyValue val) { action.run(); val.verify(); }
+            static synchronized void staticS(Runnable action, MyValue val) { action.run(); val.verify(); }
+            static native       void staticN(Runnable action, MyValue val);
 
             static int staticF;
 
@@ -99,31 +108,31 @@ public class ClassInitBarrier {
 
         static class B extends A {}
 
-        static void testInvokeStatic(Runnable action)       { A.staticM(action); }
-        static void testInvokeStaticSync(Runnable action)   { A.staticS(action); }
-        static void testInvokeStaticNative(Runnable action) { A.staticN(action); }
+        static void testInvokeStatic(Runnable action, MyValue val)       { A.staticM(action, val); }
+        static void testInvokeStaticSync(Runnable action, MyValue val)   { A.staticS(action, val); }
+        static void testInvokeStaticNative(Runnable action, MyValue val) { A.staticN(action, val); }
 
-        static int  testGetStatic(Runnable action)    { int v = A.staticF; action.run(); return v;   }
-        static void testPutStatic(Runnable action)    { A.staticF = 1;     action.run(); }
-        static A    testNewInstanceA(Runnable action) { A obj = new A();   action.run(); return obj; }
-        static B    testNewInstanceB(Runnable action) { B obj = new B();   action.run(); return obj; }
+        static int  testGetStatic(Runnable action, MyValue val)    { int v = A.staticF; action.run(); val.verify(); return v;   }
+        static void testPutStatic(Runnable action, MyValue val)    { A.staticF = 1;     action.run(); val.verify(); }
+        static A    testNewInstanceA(Runnable action, MyValue val) { A obj = new A();   action.run(); val.verify(); return obj; }
+        static B    testNewInstanceB(Runnable action, MyValue val) { B obj = new B();   action.run(); val.verify(); return obj; }
 
-        static int  testGetField(A recv, Runnable action)      { int v = recv.f; action.run(); return v; }
-        static void testPutField(A recv, Runnable action)      { recv.f = 1;     action.run(); }
-        static void testInvokeVirtual(A recv, Runnable action) { recv.m();       action.run(); }
+        static int  testGetField(A recv, Runnable action, MyValue val)      { int v = recv.f; action.run(); val.verify(); return v; }
+        static void testPutField(A recv, Runnable action, MyValue val)      { recv.f = 1;     action.run(); val.verify(); }
+        static void testInvokeVirtual(A recv, Runnable action, MyValue val) { recv.m();       action.run(); val.verify(); }
 
-        static native void testInvokeStaticJNI(Runnable action);
-        static native void testInvokeStaticSyncJNI(Runnable action);
-        static native void testInvokeStaticNativeJNI(Runnable action);
+        static native void testInvokeStaticJNI(Runnable action, MyValue val);
+        static native void testInvokeStaticSyncJNI(Runnable action, MyValue val);
+        static native void testInvokeStaticNativeJNI(Runnable action, MyValue val);
 
-        static native int  testGetStaticJNI(Runnable action);
-        static native void testPutStaticJNI(Runnable action);
-        static native A    testNewInstanceAJNI(Runnable action);
-        static native B    testNewInstanceBJNI(Runnable action);
+        static native int  testGetStaticJNI(Runnable action, MyValue val);
+        static native void testPutStaticJNI(Runnable action, MyValue val);
+        static native A    testNewInstanceAJNI(Runnable action, MyValue val);
+        static native B    testNewInstanceBJNI(Runnable action, MyValue val);
 
-        static native int  testGetFieldJNI(A recv, Runnable action);
-        static native void testPutFieldJNI(A recv, Runnable action);
-        static native void testInvokeVirtualJNI(A recv, Runnable action);
+        static native int  testGetFieldJNI(A recv, Runnable action, MyValue val);
+        static native void testPutFieldJNI(A recv, Runnable action, MyValue val);
+        static native void testInvokeVirtualJNI(A recv, Runnable action, MyValue val);
 
         static void runTests() {
             checkBlockingAction(Test::testInvokeStatic);       // invokestatic
@@ -140,7 +149,7 @@ public class ClassInitBarrier {
             checkNonBlockingAction(Test::testPutStaticJNI);          // putstatic
             checkBlockingAction(Test::testNewInstanceAJNI);          // new
 
-            A recv = testNewInstanceB(NON_BLOCKING.get());  // trigger B initialization
+            A recv = testNewInstanceB(NON_BLOCKING.get(), new MyValue());  // trigger B initialization
             checkNonBlockingAction(Test::testNewInstanceB); // new: NO BLOCKING: same thread: A being initialized, B fully initialized
 
             checkNonBlockingAction(recv, Test::testGetField);      // getfield
@@ -154,18 +163,19 @@ public class ClassInitBarrier {
         }
 
         static void warmup() {
+            MyValue val = new MyValue();
             for (int i = 0; i < 20_000; i++) {
-                testInvokeStatic(      NON_BLOCKING_WARMUP);
-                testInvokeStaticNative(NON_BLOCKING_WARMUP);
-                testInvokeStaticSync(  NON_BLOCKING_WARMUP);
-                testGetStatic(         NON_BLOCKING_WARMUP);
-                testPutStatic(         NON_BLOCKING_WARMUP);
-                testNewInstanceA(      NON_BLOCKING_WARMUP);
-                testNewInstanceB(      NON_BLOCKING_WARMUP);
+                testInvokeStatic(      NON_BLOCKING_WARMUP, val);
+                testInvokeStaticNative(NON_BLOCKING_WARMUP, val);
+                testInvokeStaticSync(  NON_BLOCKING_WARMUP, val);
+                testGetStatic(         NON_BLOCKING_WARMUP, val);
+                testPutStatic(         NON_BLOCKING_WARMUP, val);
+                testNewInstanceA(      NON_BLOCKING_WARMUP, val);
+                testNewInstanceB(      NON_BLOCKING_WARMUP, val);
 
-                testGetField(new B(),      NON_BLOCKING_WARMUP);
-                testPutField(new B(),      NON_BLOCKING_WARMUP);
-                testInvokeVirtual(new B(), NON_BLOCKING_WARMUP);
+                testGetField(new B(),      NON_BLOCKING_WARMUP, val);
+                testPutField(new B(),      NON_BLOCKING_WARMUP, val);
+                testInvokeVirtual(new B(), NON_BLOCKING_WARMUP, val);
             }
         }
 
@@ -265,11 +275,11 @@ public class ClassInitBarrier {
     }
 
     interface TestCase0 {
-        void run(Runnable runnable);
+        void run(Runnable runnable, MyValue val);
     }
 
     interface TestCase1<T> {
-        void run(T arg, Runnable runnable);
+        void run(T arg, Runnable runnable, MyValue val);
     }
 
     enum Phase { BEFORE_INIT, IN_PROGRESS, FINISHED, INIT_FAILURE }
@@ -339,24 +349,25 @@ public class ClassInitBarrier {
     static final Factory<Runnable> BLOCKING     = () -> disposableAction(Phase.FINISHED, BLOCKING_COUNTER, BLOCKING_ACTIONS);
 
     static void checkBlockingAction(TestCase0 r) {
+        MyValue val = new MyValue();
         switch (phase) {
             case IN_PROGRESS: {
                 // Barrier during class initalization.
-                r.run(NON_BLOCKING.get());             // initializing thread
+                r.run(NON_BLOCKING.get(), val);             // initializing thread
                 checkBlocked(ON_BLOCK, ON_FAILURE, r); // different thread
                 break;
             }
             case FINISHED: {
                 // No barrier after class initalization is over.
-                r.run(NON_BLOCKING.get()); // initializing thread
+                r.run(NON_BLOCKING.get(), val); // initializing thread
                 checkNotBlocked(r);        // different thread
                 break;
             }
             case INIT_FAILURE: {
                 // Exception is thrown after class initialization failed.
-                TestCase0 test = action -> execute(NoClassDefFoundError.class, () -> r.run(action));
+                TestCase0 test = (action, valarg) -> execute(NoClassDefFoundError.class, () -> r.run(action, valarg));
 
-                test.run(NON_BLOCKING.get()); // initializing thread
+                test.run(NON_BLOCKING.get(), val); // initializing thread
                 checkNotBlocked(test);        // different thread
                 break;
             }
@@ -365,17 +376,17 @@ public class ClassInitBarrier {
     }
 
     static void checkNonBlockingAction(TestCase0 r) {
-        r.run(NON_BLOCKING.get()); // initializing thread
+        r.run(NON_BLOCKING.get(), new MyValue()); // initializing thread
         checkNotBlocked(r);        // different thread
     }
 
     static <T> void checkNonBlockingAction(T recv, TestCase1<T> r) {
-        r.run(recv, NON_BLOCKING.get());                  // initializing thread
-        checkNotBlocked((action) -> r.run(recv, action)); // different thread
+        r.run(recv, NON_BLOCKING.get(), new MyValue());                  // initializing thread
+        checkNotBlocked((action, val) -> r.run(recv, action, val)); // different thread
     }
 
     static void checkFailingAction(TestCase0 r) {
-        r.run(NON_BLOCKING.get()); // initializing thread
+        r.run(NON_BLOCKING.get(), new MyValue()); // initializing thread
         checkNotBlocked(r);        // different thread
     }
 
@@ -393,7 +404,7 @@ public class ClassInitBarrier {
     static void checkBlocked(Consumer<Thread> onBlockHandler, Thread.UncaughtExceptionHandler onException, TestCase0 r) {
         Thread thr = new Thread(() -> {
             try {
-                r.run(BLOCKING.get());
+                r.run(BLOCKING.get(), new MyValue());
                 System.out.println("Thread " + Thread.currentThread() + ": Finished successfully");
             } catch(Throwable e) {
                 System.out.println("Thread " + Thread.currentThread() + ": Exception thrown: " + e);
@@ -421,7 +432,7 @@ public class ClassInitBarrier {
     }
 
     static void checkNotBlocked(TestCase0 r) {
-        final Thread thr = new Thread(() -> r.run(NON_BLOCKING.get()));
+        final Thread thr = new Thread(() -> r.run(NON_BLOCKING.get(), new MyValue()));
         final Throwable[] ex = new Throwable[1];
         thr.setUncaughtExceptionHandler((t, e) -> {
             if (thr != t) {

--- a/test/hotspot/jtreg/runtime/clinit/libClassInitBarrier.cpp
+++ b/test/hotspot/jtreg/runtime/clinit/libClassInitBarrier.cpp
@@ -54,13 +54,13 @@ extern "C" {
         test_class_B = (jclass)env->NewGlobalRef(arg1);
         if (test_class_B == NULL)  return JNI_FALSE;
 
-        test_staticM_id = env->GetStaticMethodID(test_class_A, "staticM", "(Ljava/lang/Runnable;)V");
+        test_staticM_id = env->GetStaticMethodID(test_class_A, "staticM", "(Ljava/lang/Runnable;LClassInitBarrier$MyValue;)V");
         if (test_staticM_id == NULL)  return JNI_FALSE;
 
-        test_staticS_id = env->GetStaticMethodID(test_class_A, "staticS", "(Ljava/lang/Runnable;)V");
+        test_staticS_id = env->GetStaticMethodID(test_class_A, "staticS", "(Ljava/lang/Runnable;LClassInitBarrier$MyValue;)V");
         if (test_staticS_id == NULL)  return JNI_FALSE;
 
-        test_staticN_id = env->GetStaticMethodID(test_class_A, "staticN", "(Ljava/lang/Runnable;)V");
+        test_staticN_id = env->GetStaticMethodID(test_class_A, "staticN", "(Ljava/lang/Runnable;LClassInitBarrier$MyValue;)V");
         if (test_staticN_id == NULL)  return JNI_FALSE;
 
         test_A_m_id = env->GetMethodID(test_class_A, "m", "()V");
@@ -79,16 +79,16 @@ extern "C" {
         env->CallVoidMethod(action, methodId);
     }
 
-    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticJNI(JNIEnv* env, jclass cls, jobject action) {
-        env->CallStaticVoidMethod(test_class_A, test_staticM_id, action);
+    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticJNI(JNIEnv* env, jclass cls, jobject action, jobject val) {
+        env->CallStaticVoidMethod(test_class_A, test_staticM_id, action, val);
     }
 
-    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticSyncJNI(JNIEnv* env, jclass cls, jobject action) {
-        env->CallStaticVoidMethod(test_class_A, test_staticS_id, action);
+    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticSyncJNI(JNIEnv* env, jclass cls, jobject action, jobject val) {
+        env->CallStaticVoidMethod(test_class_A, test_staticS_id, action, val);
     }
 
-    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticNativeJNI(JNIEnv* env, jclass cls, jobject action) {
-        env->CallStaticVoidMethod(test_class_A, test_staticN_id, action);
+    JNIEXPORT void JNICALL Java_ClassInitBarrier_00024Test_testInvokeStaticNativeJNI(JNIEnv* env, jclass cls, jobject action, jobject val) {
+        env->CallStaticVoidMethod(test_class_A, test_staticN_id, action, val);
     }
 
     JNIEXPORT jint JNICALL Java_ClassInitBarrier_00024Test_testGetStaticJNI(JNIEnv* env, jclass cls, jobject action) {


### PR DESCRIPTION
Class initialization barriers for static methods are missing in the non-scalarized entry points of nmethods and c2i adapters. I extended the corresponding test to cover this case.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294013](https://bugs.openjdk.org/browse/JDK-8294013): [lworld] Missing class init barriers in c2i adapter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/778/head:pull/778` \
`$ git checkout pull/778`

Update a local copy of the PR: \
`$ git checkout pull/778` \
`$ git pull https://git.openjdk.org/valhalla pull/778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 778`

View PR using the GUI difftool: \
`$ git pr show -t 778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/778.diff">https://git.openjdk.org/valhalla/pull/778.diff</a>

</details>
