### PR TITLE
8270852: [lworld] bytecodes spinned at runtime should set minor_version to 65535 if preview feature enabled

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -26,7 +26,6 @@
 package java.lang.invoke;
 
 import jdk.internal.misc.PreviewFeatures;
-import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.CDS;
 import jdk.internal.org.objectweb.asm.*;
 import sun.invoke.util.BytecodeDescriptor;

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -25,6 +25,7 @@
 
 package java.lang.invoke;
 
+import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.value.PrimitiveClass;
 import jdk.internal.misc.CDS;
 import jdk.internal.org.objectweb.asm.*;
@@ -321,7 +322,8 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             interfaceNames = itfs.toArray(new String[itfs.size()]);
         }
 
-        cw.visit(CLASSFILE_VERSION, ACC_SUPER + ACC_FINAL + ACC_SYNTHETIC,
+        int version = CLASSFILE_VERSION | (PreviewFeatures.isEnabled() ? Opcodes.V_PREVIEW : 0);
+        cw.visit(version, ACC_SUPER + ACC_FINAL + ACC_SYNTHETIC,
                  lambdaClassName, null,
                  JAVA_LANG_OBJECT, interfaceNames);
 
@@ -642,7 +644,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             while (c.isArray()) {
                 c = c.getComponentType();
             }
-            return (c.isValue() && !PrimitiveClass.isPrimitiveClass(c)) || PrimitiveClass.isPrimitiveValueType(c);
+            return c.isValue();
         }
 
         boolean isEmpty() {


### PR DESCRIPTION
This patch prepares for lworld to switch to a preview feature.  Also fix the generation of lambda classes and proxy classes to have `Preload` attribute for value classes (not only primitive classes).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8270852](https://bugs.openjdk.org/browse/JDK-8270852): [lworld] bytecodes spinned at runtime should set minor_version to 65535 if preview feature enabled


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/779/head:pull/779` \
`$ git checkout pull/779`

Update a local copy of the PR: \
`$ git checkout pull/779` \
`$ git pull https://git.openjdk.org/valhalla pull/779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 779`

View PR using the GUI difftool: \
`$ git pr show -t 779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/779.diff">https://git.openjdk.org/valhalla/pull/779.diff</a>

</details>
