### PR TITLE
8294860: [lworld] Add java.util.Objects.isValueObject

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -264,7 +264,7 @@ public final class Objects {
     }
 
    /**
-    * {@return {@code true} if the specified object reference is a value object,
+    * {@return {@code true} if the specified object is a {@linkplain Class#isValue value object},
     * otherwise {@code false}}
     *
     * @param obj an object

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -263,6 +263,19 @@ public final class Objects {
         return obj;
     }
 
+   /**
+    * {@return {@code true} if the specified object reference is a value object,
+    * otherwise {@code false}}
+    *
+    * @param obj an object
+    * @throws NullPointerException if {@code obj} is {@code null}
+    */
+//    @IntrinsicCandidate
+    public static boolean isValueObject(Object obj) {
+        requireNonNull(obj, "obj");
+        return obj.getClass().isValue();
+    }
+
     /**
      * Returns 0 if the arguments are identical and {@code
      * c.compare(a, b)} otherwise.

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -100,6 +100,8 @@ public class ObjectMethods {
             assertEquals(Objects.isIdentityObject(obj), identityClass, "Objects.isIdentityObject()");
         }
 
+        assertEquals(Objects.isValueObject(obj), valueClass, "Objects.isValueObject()");
+
         assertEquals(clazz.isIdentity(), identityClass, "Class.isIdentity()");
 
         assertEquals(clazz.isValue(), valueClass, "Class.isValue()");


### PR DESCRIPTION
Add method `java.util.Objects.isValueObject(Object obj)`.

The complement to `Objects.isIdentityObject(Object obj)` this method return true if the object is a value object.

Add the cases to the existing ObjectMethods test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294860](https://bugs.openjdk.org/browse/JDK-8294860): [lworld] Add java.util.Objects.isValueObject


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer) ⚠️ Review applies to [80c6914b](https://git.openjdk.org/valhalla/pull/786/files/80c6914bbe76988470773fd93986f1559dcc9ad1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/786/head:pull/786` \
`$ git checkout pull/786`

Update a local copy of the PR: \
`$ git checkout pull/786` \
`$ git pull https://git.openjdk.org/valhalla pull/786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 786`

View PR using the GUI difftool: \
`$ git pr show -t 786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/786.diff">https://git.openjdk.org/valhalla/pull/786.diff</a>

</details>
