### PR TITLE
8280979: [lworld] Rename PrimitiveObjectMethods to ValueObjectMethods

### DIFF
--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -521,7 +521,7 @@ JRT_ENTRY(int, Runtime1::substitutability_check(JavaThread* current, oopDesc* le
   args.push_oop(Handle(THREAD, right));
   JavaValue result(T_BOOLEAN);
   JavaCalls::call_static(&result,
-                         vmClasses::PrimitiveObjectMethods_klass(),
+                         vmClasses::ValueObjectMethods_klass(),
                          vmSymbols::isSubstitutable_name(),
                          vmSymbols::object_object_boolean_signature(),
                          &args, CHECK_0);

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -131,7 +131,7 @@
   do_klass(Context_klass,                               java_lang_invoke_MethodHandleNatives_CallSiteContext  ) \
   do_klass(ConstantCallSite_klass,                      java_lang_invoke_ConstantCallSite                     ) \
   do_klass(MutableCallSite_klass,                       java_lang_invoke_MutableCallSite                      ) \
-  do_klass(PrimitiveObjectMethods_klass,                java_lang_runtime_PrimitiveObjectMethods              ) \
+  do_klass(ValueObjectMethods_klass,                    java_lang_runtime_ValueObjectMethods                  ) \
   do_klass(VolatileCallSite_klass,                      java_lang_invoke_VolatileCallSite                     ) \
                                                                                                                 \
   do_klass(AssertionStatusDirectives_klass,             java_lang_AssertionStatusDirectives                   ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -780,9 +780,9 @@
   template(url_void_signature,                              "(Ljava/net/URL;)V")                                  \
   template(url_array_classloader_void_signature,            "([Ljava/net/URL;Ljava/lang/ClassLoader;)V")          \
                                                                                                                   \
-  template(java_lang_runtime_PrimitiveObjectMethods,        "java/lang/runtime/PrimitiveObjectMethods")           \
+  template(java_lang_runtime_ValueObjectMethods,            "java/lang/runtime/ValueObjectMethods")               \
   template(isSubstitutable_name,                            "isSubstitutable")                                    \
-  template(primitiveObjectHashCode_name,                    "primitiveObjectHashCode")                            \
+  template(valueObjectHashCode_name,                        "valueObjectHashCode")                                \
   template(jdk_internal_value_PrimitiveClass,               "jdk/internal/value/PrimitiveClass")                  \
                                                                                                                   \
   /* Thread.dump_to_file jcmd */                                                                                  \

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -132,7 +132,7 @@ LatestMethodCache* Universe::_throw_illegal_access_error_cache = NULL;
 LatestMethodCache* Universe::_throw_no_such_method_error_cache = NULL;
 LatestMethodCache* Universe::_do_stack_walk_cache     = NULL;
 LatestMethodCache* Universe::_is_substitutable_cache  = NULL;
-LatestMethodCache* Universe::_primitive_type_hash_code_cache = NULL;
+LatestMethodCache* Universe::_value_object_hash_code_cache = NULL;
 
 long Universe::verify_flags                           = Universe::Verify_All;
 
@@ -237,7 +237,7 @@ void Universe::metaspace_pointers_do(MetaspaceClosure* it) {
   _throw_no_such_method_error_cache->metaspace_pointers_do(it);
   _do_stack_walk_cache->metaspace_pointers_do(it);
   _is_substitutable_cache->metaspace_pointers_do(it);
-  _primitive_type_hash_code_cache->metaspace_pointers_do(it);
+  _value_object_hash_code_cache->metaspace_pointers_do(it);
 }
 
 // Serialize metadata and pointers to primitive type mirrors in and out of CDS archive
@@ -287,7 +287,7 @@ void Universe::serialize(SerializeClosure* f) {
   _throw_no_such_method_error_cache->serialize(f);
   _do_stack_walk_cache->serialize(f);
   _is_substitutable_cache->serialize(f);
-  _primitive_type_hash_code_cache->serialize(f);
+  _value_object_hash_code_cache->serialize(f);
 }
 
 
@@ -803,7 +803,7 @@ jint universe_init() {
   Universe::_throw_no_such_method_error_cache = new LatestMethodCache();
   Universe::_do_stack_walk_cache = new LatestMethodCache();
   Universe::_is_substitutable_cache = new LatestMethodCache();
-  Universe::_primitive_type_hash_code_cache = new LatestMethodCache();
+  Universe::_value_object_hash_code_cache = new LatestMethodCache();
 
 #if INCLUDE_CDS
   DynamicArchive::check_for_dynamic_dump();
@@ -975,12 +975,12 @@ void Universe::initialize_known_methods(TRAPS) {
   // Set up substitutability testing
   ResourceMark rm;
   initialize_known_method(_is_substitutable_cache,
-                          vmClasses::PrimitiveObjectMethods_klass(),
+                          vmClasses::ValueObjectMethods_klass(),
                           vmSymbols::isSubstitutable_name()->as_C_string(),
                           vmSymbols::object_object_boolean_signature(), true, CHECK);
-  initialize_known_method(_primitive_type_hash_code_cache,
-                          vmClasses::PrimitiveObjectMethods_klass(),
-                          vmSymbols::primitiveObjectHashCode_name()->as_C_string(),
+  initialize_known_method(_value_object_hash_code_cache,
+                          vmClasses::ValueObjectMethods_klass(),
+                          vmSymbols::valueObjectHashCode_name()->as_C_string(),
                           vmSymbols::object_int_signature(), true, CHECK);
 }
 

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -120,8 +120,8 @@ class Universe: AllStatic {
   static LatestMethodCache* _throw_illegal_access_error_cache; // Unsafe.throwIllegalAccessError() method
   static LatestMethodCache* _throw_no_such_method_error_cache; // Unsafe.throwNoSuchMethodError() method
   static LatestMethodCache* _do_stack_walk_cache;      // method for stack walker callback
-  static LatestMethodCache* _is_substitutable_cache;   // PrimitiveObjectMethods.isSubstitutable() method
-  static LatestMethodCache* _primitive_type_hash_code_cache;  // PrimitiveObjectMethods.primitiveObjectHashCode() method
+  static LatestMethodCache* _is_substitutable_cache;   // ValueObjectMethods.isSubstitutable() method
+  static LatestMethodCache* _value_object_hash_code_cache;  // ValueObjectMethods.valueObjectHashCode() method
 
   static Array<int>*            _the_empty_int_array;            // Canonicalized int array
   static Array<u2>*             _the_empty_short_array;          // Canonicalized short array
@@ -267,7 +267,7 @@ class Universe: AllStatic {
   static Method*      do_stack_walk_method()          { return _do_stack_walk_cache->get_method(); }
 
   static Method*      is_substitutable_method()       { return _is_substitutable_cache->get_method(); }
-  static Method*      primitive_type_hash_code_method()  { return _primitive_type_hash_code_cache->get_method(); }
+  static Method*      value_object_hash_code_method() { return _value_object_hash_code_cache->get_method(); }
 
   static oop          the_null_sentinel();
   static address      the_null_sentinel_addr()        { return (address) &_the_null_sentinel;  }

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2220,7 +2220,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   }
 
   // Both operands are values types of the same class, we need to perform a
-  // substitutability test. Delegate to PrimitiveObjectMethods::isSubstitutable().
+  // substitutability test. Delegate to ValueObjectMethods::isSubstitutable().
   Node* ne_io_phi = PhiNode::make(ne_region, i_o());
   Node* mem = reset_memory();
   Node* ne_mem_phi = PhiNode::make(ne_region, mem);
@@ -2235,7 +2235,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   set_all_memory(mem);
 
   kill_dead_locals();
-  ciMethod* subst_method = ciEnv::current()->PrimitiveObjectMethods_klass()->find_method(ciSymbols::isSubstitutable_name(), ciSymbols::object_object_boolean_signature());
+  ciMethod* subst_method = ciEnv::current()->ValueObjectMethods_klass()->find_method(ciSymbols::isSubstitutable_name(), ciSymbols::object_object_boolean_signature());
   CallStaticJavaNode *call = new CallStaticJavaNode(C, TypeFunc::make(subst_method), SharedRuntime::get_resolve_static_call_stub(), subst_method);
   call->set_override_symbolic_info(true);
   call->init_req(TypeFunc::Parms, not_null_left);
@@ -2245,7 +2245,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   Node* ret = set_results_for_java_call(call, false, true);
   dec_sp(2);
 
-  // Test the return value of PrimitiveObjectMethods::isSubstitutable()
+  // Test the return value of ValueObjectMethods::isSubstitutable()
   Node* subst_cmp = _gvn.transform(new CmpINode(ret, intcon(1)));
   Node* ctl = C->top();
   if (btest == BoolTest::eq) {

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -623,7 +623,7 @@ JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
       JavaCallArguments args;
       Handle ho(THREAD, obj);
       args.push_oop(ho);
-      methodHandle method(THREAD, Universe::primitive_type_hash_code_method());
+      methodHandle method(THREAD, Universe::value_object_hash_code_method());
       JavaCalls::call(&result, method, &args, THREAD);
       if (HAS_PENDING_EXCEPTION) {
         if (!PENDING_EXCEPTION->is_a(vmClasses::Error_klass())) {

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -308,7 +308,7 @@ bool JNIHandles::is_same_object(jobject handle1, jobject handle2) {
   if (EnableValhalla) {
     if (!ret && obj1 != NULL && obj2 != NULL && obj1->klass() == obj2->klass() && obj1->klass()->is_inline_klass()) {
       // The two references are different, they are not null and they are both inline types,
-      // a full substitutability test is required, calling PrimitiveObjectMethods.isSubstitutable()
+      // a full substitutability test is required, calling ValueObjectMethods.isSubstitutable()
       // (similarly to InterpreterRuntime::is_substitutable)
       JavaThread* THREAD = JavaThread::current();
       Handle ha(THREAD, obj1);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1114,10 +1114,10 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     bc = Bytecodes::_invokestatic;
     methodHandle attached_method(THREAD, extract_attached_method(vfst));
     assert(attached_method.not_null(), "must have attached method");
-    vmClasses::PrimitiveObjectMethods_klass()->initialize(CHECK_NH);
+    vmClasses::ValueObjectMethods_klass()->initialize(CHECK_NH);
     LinkResolver::resolve_invoke(callinfo, receiver, attached_method, bc, false, CHECK_NH);
 #ifdef ASSERT
-    Method* is_subst = vmClasses::PrimitiveObjectMethods_klass()->find_method(vmSymbols::isSubstitutable_name(), vmSymbols::object_object_boolean_signature());
+    Method* is_subst = vmClasses::ValueObjectMethods_klass()->find_method(vmSymbols::isSubstitutable_name(), vmSymbols::object_object_boolean_signature());
     assert(callinfo.selected_method() == is_subst, "must be isSubstitutable method");
 #endif
     return receiver;

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -50,13 +50,13 @@ import static java.lang.invoke.MethodType.methodType;
 import static java.lang.runtime.ObjectMethods.primitiveEquals;
 
 /**
- * Implementation for Object::equals and Object::hashCode for primitive classes.
+ * Implementation for Object::equals and Object::hashCode for value objects.
  *
- * PrimitiveObjectMethods::isSubstitutable and primitiveObjectHashCode are
+ * ValueObjectMethods::isSubstitutable and valueObjectHashCode are
  * private entry points called by VM.
  */
-final class PrimitiveObjectMethods {
-    private PrimitiveObjectMethods() {}
+final class ValueObjectMethods {
+    private ValueObjectMethods() {}
     private static final boolean VERBOSE =
         GetPropertyAction.privilegedGetProperty("value.bsm.debug") != null;
     private static final JavaLangInvokeAccess JLIA = SharedSecrets.getJavaLangInvokeAccess();
@@ -92,8 +92,8 @@ final class PrimitiveObjectMethods {
             }
         }
 
-        static MethodHandle primitiveEquals(Class<?> primitiveType) {
-            return primitiveEquals.get(primitiveType);
+        static MethodHandle basicPrimitiveEquals(Class<?> valueType) {
+            return primitiveEquals.get(valueType);
         }
 
         /*
@@ -105,7 +105,7 @@ final class PrimitiveObjectMethods {
          * 2. if o1 and o2 are both values then o1 v== o2
          *
          * At invocation time, it needs a dynamic check on the objects and
-         * do the substitutability test if they are of a primitive type.
+         * do the substitutability test if they are of a value type.
          */
         static MethodHandle referenceTypeEquals(Class<?> type) {
             return OBJECT_EQUALS.asType(methodType(boolean.class, type, type));
@@ -117,12 +117,11 @@ final class PrimitiveObjectMethods {
         }
 
         /*
-         * Produces a MethodHandle that returns boolean if two value instances
-         * of the given primitive class are substitutable.
+         * Produces a MethodHandle that returns boolean if two value objects
+         * of the given value class are substitutable.
          */
-        static MethodHandle primitiveTypeEquals(Class<?> type) {
-            assert PrimitiveClass.isPrimitiveValueType(type) ||
-                    (type.isValue() && !PrimitiveClass.isPrimitiveClass(type));
+        static MethodHandle valueTypeEquals(Class<?> type) {
+            assert isValueType(type);
             MethodType mt = methodType(boolean.class, type, type);
             MethodHandle[] getters = getters(type, TYPE_SORTER);
             MethodHandle instanceTrue = dropArguments(TRUE, 0, type, Object.class).asType(mt);
@@ -143,9 +142,8 @@ final class PrimitiveObjectMethods {
                                                instanceFalse));
         }
 
-        static MethodHandle primitiveTypeHashCode(Class<?> type) {
-            assert PrimitiveClass.isPrimitiveValueType(type) ||
-                    (type.isValue() && !PrimitiveClass.isPrimitiveClass(type));
+        static MethodHandle valueTypeHashCode(Class<?> type) {
+            assert isValueType(type);
             MethodHandle target = dropArguments(constant(int.class, SALT), 0, type);
             MethodHandle cls = dropArguments(constant(Class.class, type),0, type);
             MethodHandle classHashCode = filterReturnValue(cls, hashCodeForType(Class.class));
@@ -159,9 +157,9 @@ final class PrimitiveObjectMethods {
                 MethodHandle getter = getters[i];
                 Class<?> ftype = fieldType(getter);
 
-                // For primitive type or reference type, this calls Objects::hashCode.
-                // If the instance is of primitive type and the hashCode method is not
-                // overridden, VM will call primitiveObjectHashCode to compute the
+                // For basic primitive types or reference types, this calls Objects::hashCode.
+                // If the instance is of value type and the hashCode method is not
+                // overridden, VM will call valueObjectHashCode to compute the
                 // hash code.
                 MethodHandle hasher = hashCodeForType(ftype);
                 hashers[i] = filterReturnValue(getter, hasher);
@@ -180,13 +178,13 @@ final class PrimitiveObjectMethods {
             if (a == null && b == null) return true;
             if (a == null || b == null) return false;
             if (a.getClass() != b.getClass()) return false;
-            return a.getClass().isValue() ? valueEq(a, b) : (a == b);
+            return a.getClass().isValue() ? valueEqual(a, b) : (a == b);
         }
 
         /*
-         * Returns true if two values are substitutable.
+         * Returns true if two value objects are substitutable.
          */
-        private static boolean valueEq(Object a, Object b) {
+        private static boolean valueEqual(Object a, Object b) {
             assert a != null && b != null && isSameValueClass(a, b);
             try {
                 Class<?> type = a.getClass();
@@ -209,11 +207,11 @@ final class PrimitiveObjectMethods {
         }
 
         /*
-         * Returns true if the given objects are of the same primitive class.
+         * Returns true if the given objects are of the same value class.
          *
-         * Two objects are of the same primitive class iff:
+         * Two objects are of the same value class iff:
          * 1. a != null and b != null
-         * 2. the declaring class of a and b is the same primitive class
+         * 2. the declaring class of a and b is the same value class
          */
         private static boolean isSameValueClass(Object a, Object b) {
             if (a == null || b == null) return false;
@@ -238,7 +236,8 @@ final class PrimitiveObjectMethods {
 
         private static final MethodHandle FALSE = constant(boolean.class, false);
         private static final MethodHandle TRUE = constant(boolean.class, true);
-        private static final MethodHandle OBJECT_EQUALS = findStatic("eq", methodType(boolean.class, Object.class, Object.class));
+        private static final MethodHandle OBJECT_EQUALS =
+            findStatic("eq", methodType(boolean.class, Object.class, Object.class));
         private static final MethodHandle IS_SAME_VALUE_CLASS =
             findStatic("isSameValueClass", methodType(boolean.class, Object.class, Object.class));
         private static final MethodHandle IS_NULL =
@@ -298,10 +297,10 @@ final class PrimitiveObjectMethods {
      * <ul>
      * <li>If {@code a} and {@code b} are both {@code null}, this method returns
      *     {@code true}.
-     * <li>If {@code a} and {@code b} are both value instances of the same class
+     * <li>If {@code a} and {@code b} are both instances of the same value class
      *     {@code V}, this method returns {@code true} if, for all fields {@code f}
      *      declared in {@code V}, {@code a.f} and {@code b.f} are substitutable.
-     * <li>If {@code a} and {@code b} are both primitives of the same type,
+     * <li>If {@code a} and {@code b} are both values of the same basic primitive type,
      *     this method returns {@code a == b} with the following exception:
      *     <ul>
      *     <li> If {@code a} and {@code b} both represent {@code NaN},
@@ -417,10 +416,9 @@ final class PrimitiveObjectMethods {
      */
     private static <T> MethodHandle substitutableInvoker(Class<T> type) {
         if (type.isPrimitive())
-            return MethodHandleBuilder.primitiveEquals(type);
+            return MethodHandleBuilder.basicPrimitiveEquals(type);
 
-        if (PrimitiveClass.isPrimitiveValueType(type) ||
-                (type.isValue() && !PrimitiveClass.isPrimitiveClass(type))) {
+        if (isValueType(type)) {
             return SUBST_TEST_METHOD_HANDLES.get(type);
         }
         return MethodHandleBuilder.referenceTypeEquals(type);
@@ -429,22 +427,23 @@ final class PrimitiveObjectMethods {
     // store the method handle for value types in ClassValue
     private static ClassValue<MethodHandle> SUBST_TEST_METHOD_HANDLES = new ClassValue<>() {
         @Override protected MethodHandle computeValue(Class<?> type) {
-            return MethodHandleBuilder.primitiveTypeEquals(type);
+            return MethodHandleBuilder.valueTypeEquals(type);
         }
     };
 
     /**
-     * Invoke the bootstrap methods hashCode for the given primitive class object.
+     * Invoke the hashCode method for the given value object.
      * @param o the instance to hash.
-     * @return the hash code of the given primitive class object.
+     * @return the hash code of the given value object.
      */
-    private static int primitiveObjectHashCode(Object o) {
+    private static int valueObjectHashCode(Object o) {
         Class<?> c = o.getClass();
         try {
             // Note: javac disallows user to call super.hashCode if user implemented
             // risk for recursion for experts crafting byte-code
             if (!c.isValue())
                 throw new InternalError("must be value or primitive class: " + c.getName());
+
             Class<?> type = PrimitiveClass.isPrimitiveClass(c) ? PrimitiveClass.asValueType(c) : c;
             return (int) HASHCODE_METHOD_HANDLES.get(type).invoke(o);
         } catch (Error|RuntimeException e) {
@@ -455,9 +454,25 @@ final class PrimitiveObjectMethods {
         }
     }
 
+    /**
+     * Returns true if the given type is a value type.
+     *
+     * If the given type represents a primitive class, this method returns
+     * true if the given type is a primitive type.  If the given type
+     * is a primitive class reference type, this method returns false.
+     *
+     * If the given type represents a basic primitive type, this method
+     * returns false.
+     */
+    private static boolean isValueType(Class<?> type) {
+        if (!type.isValue()) return false;
+
+        return !PrimitiveClass.isPrimitiveClass(type) || PrimitiveClass.isPrimitiveValueType(type);
+    }
+
     private static ClassValue<MethodHandle> HASHCODE_METHOD_HANDLES = new ClassValue<>() {
         @Override protected MethodHandle computeValue(Class<?> type) {
-            return MethodHandleBuilder.primitiveTypeHashCode(type);
+            return MethodHandleBuilder.valueTypeHashCode(type);
         }
     };
 

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -178,13 +178,13 @@ final class ValueObjectMethods {
             if (a == null && b == null) return true;
             if (a == null || b == null) return false;
             if (a.getClass() != b.getClass()) return false;
-            return a.getClass().isValue() ? valueEqual(a, b) : (a == b);
+            return a.getClass().isValue() ? valueEquals(a, b) : (a == b);
         }
 
         /*
          * Returns true if two value objects are substitutable.
          */
-        private static boolean valueEqual(Object a, Object b) {
+        private static boolean valueEquals(Object a, Object b) {
             assert a != null && b != null && isSameValueClass(a, b);
             try {
                 Class<?> type = a.getClass();

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -92,7 +92,7 @@ final class ValueObjectMethods {
             }
         }
 
-        static MethodHandle basicPrimitiveEquals(Class<?> type) {
+        static MethodHandle builtinPrimitiveEquals(Class<?> type) {
             return primitiveEquals.get(type);
         }
 
@@ -306,7 +306,7 @@ final class ValueObjectMethods {
      * <li>If {@code a} and {@code b} are both instances of the same value class
      *     {@code V}, this method returns {@code true} if, for all fields {@code f}
      *      declared in {@code V}, {@code a.f} and {@code b.f} are substitutable.
-     * <li>If {@code a} and {@code b} are both values of the same basic primitive type,
+     * <li>If {@code a} and {@code b} are both values of the same builtin primitive type,
      *     this method returns {@code a == b} with the following exception:
      *     <ul>
      *     <li> If {@code a} and {@code b} both represent {@code NaN},
@@ -422,7 +422,7 @@ final class ValueObjectMethods {
      */
     private static <T> MethodHandle substitutableInvoker(Class<T> type) {
         if (type.isPrimitive())
-            return MethodHandleBuilder.basicPrimitiveEquals(type);
+            return MethodHandleBuilder.builtinPrimitiveEquals(type);
 
         if (isValueClass(type) || PrimitiveClass.isPrimitiveValueType(type)) {
             return SUBST_TEST_METHOD_HANDLES.get(type);

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -92,8 +92,8 @@ final class ValueObjectMethods {
             }
         }
 
-        static MethodHandle basicPrimitiveEquals(Class<?> valueType) {
-            return primitiveEquals.get(valueType);
+        static MethodHandle basicPrimitiveEquals(Class<?> type) {
+            return primitiveEquals.get(type);
         }
 
         /*

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -165,7 +165,7 @@ public class InlineTypes {
         protected static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
         protected static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
         protected static final String FIELD_ACCESS = "(.*Field: *" + END;
-        protected static final String SUBSTITUTABILITY_TEST = START + "CallStaticJava" + MID + "java.lang.runtime.PrimitiveObjectMethods::isSubstitutable" + END;
+        protected static final String SUBSTITUTABILITY_TEST = START + "CallStaticJava" + MID + "java.lang.runtime.ValueObjectMethods::isSubstitutable" + END;
         protected static final String CMPP = START + "(CmpP|CmpN)" + MID + "" + END;
     }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsSubstitutableReresolution.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIsSubstitutableReresolution.java
@@ -28,7 +28,7 @@ import jdk.test.lib.Asserts;
  * @test
  * @bug 8234108
  * @library /testlibrary /test/lib
- * @summary Verify that call reresolution works for C2 compiled calls to java.lang.runtime.PrimitiveObjectMethods::isSubstitutable0.
+ * @summary Verify that call reresolution works for C2 compiled calls to java.lang.runtime.ValueObjectMethods::isSubstitutable0.
  * @compile -XDenablePrimitiveClasses TestIsSubstitutableReresolution.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestIsSubstitutableReresolution::test

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -188,7 +188,7 @@ public class SubstitutabilityTest {
      * isSubstitutable method handle invoker requires both parameters are
      * non-null and of the same primitive class.
      *
-     * This verifies PrimitiveObjectMethods::isSubstitutable that does not
+     * This verifies ValueObjectMethods::isSubstitutable that does not
      * throw an exception if any one of parameter is null or if
      * the parameters are of different types.
      */
@@ -210,7 +210,7 @@ public class SubstitutabilityTest {
     static {
         Method m = null;
         try {
-            Class<?> c = Class.forName("java.lang.runtime.PrimitiveObjectMethods");
+            Class<?> c = Class.forName("java.lang.runtime.ValueObjectMethods");
             m = c.getDeclaredMethod("isSubstitutable", Object.class, Object.class);
             m.setAccessible(true);
         } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
This PR does the renaming to match the Value Objects JEP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8280979](https://bugs.openjdk.org/browse/JDK-8280979): [lworld] Rename PrimitiveObjectMethods to ValueObjectMethods


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/787/head:pull/787` \
`$ git checkout pull/787`

Update a local copy of the PR: \
`$ git checkout pull/787` \
`$ git pull https://git.openjdk.org/valhalla pull/787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 787`

View PR using the GUI difftool: \
`$ git pr show -t 787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/787.diff">https://git.openjdk.org/valhalla/pull/787.diff</a>

</details>
