### PR TITLE
[lworld+vector] Borrowing MultiFields initial implementation from https://github.com/fparain/valhalla/tree/multifields.

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -148,6 +148,7 @@ class ClassFileParser {
   Array<InlineKlass*>* _inline_type_field_klasses;
   const intArray* _method_ordering;
   GrowableArray<Method*>* _all_mirandas;
+  Array<MultiFieldInfo>* _multifield_info;
 
   enum { fixed_buffer_size = 128 };
   u_char _linenumbertable_buffer[fixed_buffer_size];

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1257,7 +1257,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
 
 
   if (ik->has_inline_type_fields()) {
-    for (AllFieldStream fs(ik->fields(), ik->constants()); !fs.done(); fs.next()) {
+    for (AllFieldStream fs(ik); !fs.done(); fs.next()) {
       if (Signature::basic_type(fs.signature()) == T_PRIMITIVE_OBJECT) {
         if (!fs.access_flags().is_static()) {
           // Pre-load inline class

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -262,6 +262,7 @@
   template(java_util_concurrent_atomic_AtomicReferenceFieldUpdater_Impl,     "java/util/concurrent/atomic/AtomicReferenceFieldUpdater$AtomicReferenceFieldUpdaterImpl") \
   template(jdk_internal_vm_annotation_Contended_signature,                   "Ljdk/internal/vm/annotation/Contended;")    \
   template(jdk_internal_vm_annotation_ReservedStackAccess_signature,         "Ljdk/internal/vm/annotation/ReservedStackAccess;") \
+  template(jdk_internal_vm_annotation_MultiField_signature,                  "Ljdk/internal/vm/annotation/MultiField;") \
   template(jdk_internal_ValueBased_signature,                                "Ljdk/internal/ValueBased;") \
                                                                                                   \
   /* class symbols needed by intrinsics */                                                        \

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -308,7 +308,8 @@ class MetaspaceObj {
   f(ConstantPoolCache) \
   f(Annotations) \
   f(MethodCounters) \
-  f(RecordComponent)
+  f(RecordComponent) \
+  f(MultiFieldInfo)
 
 #define METASPACE_OBJ_TYPE_DECLARE(name) name ## Type,
 #define METASPACE_OBJ_TYPE_NAME_CASE(name) case name ## Type: return #name;

--- a/src/hotspot/share/memory/metaspaceClosure.hpp
+++ b/src/hotspot/share/memory/metaspaceClosure.hpp
@@ -42,6 +42,7 @@
   class   ConstantPoolCache; // no C++ vtable
   class   ConstMethod;       // no C++ vtable
   class   MethodCounters;    // no C++ vtable
+  class   MultiFieldInfo;    // no C++ vtable
   class   Symbol;            // no C++ vtable
   class   Metadata;          // has C++ vtable (so do all subclasses)
   class     ConstantPool;

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -434,7 +434,7 @@ class ConstantPool : public Metadata {
     unresolved_klass_at_put(which, name_index, CPKlassSlot::_temp_resolved_klass_index);
   }
 
-  jint int_at(int which) {
+  jint int_at(int which) const {
     assert(tag_at(which).is_int(), "Corrupted constant pool");
     return *int_at_addr(which);
   }

--- a/src/hotspot/share/oops/fieldInfo.cpp
+++ b/src/hotspot/share/oops/fieldInfo.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "oops/fieldInfo.hpp"
+#include "oops/instanceKlass.hpp"
+
+Symbol* FieldInfo::get_multifield_name(Array<MultiFieldInfo>* multifield_info) const {
+  assert(is_multifield(), "Sanity check");
+  return multifield_info->at(secondary_index()).name();
+}
+
+u2 FieldInfo::multifield_base(Array<MultiFieldInfo>* multifield_info) const {
+  assert(is_multifield(), "Sanity check");
+  return multifield_info->at(secondary_index()).base_index();
+}
+
+jbyte FieldInfo::multifield_index(Array<MultiFieldInfo>* multifield_info) const {
+  assert(is_multifield(), "Sanity check");
+  return multifield_info->at(secondary_index()).multifield_index();
+}

--- a/src/hotspot/share/oops/fieldStreams.inline.hpp
+++ b/src/hotspot/share/oops/fieldStreams.inline.hpp
@@ -29,8 +29,8 @@
 
 #include "runtime/javaThread.hpp"
 
-FieldStreamBase::FieldStreamBase(Array<u2>* fields, ConstantPool* constants, int start, int limit) : _fields(fields),
-         _constants(constantPoolHandle(Thread::current(), constants)), _index(start) {
+FieldStreamBase::FieldStreamBase(Array<u2>* fields, ConstantPool* constants, Array<MultiFieldInfo>* multifield_info, int start, int limit) : _fields(fields),
+         _constants(constantPoolHandle(Thread::current(), constants)), _multifield_info(multifield_info), _index(start) {
   _index = start;
   int num_fields = init_generic_signature_start_slot();
   if (limit < start) {
@@ -40,13 +40,13 @@ FieldStreamBase::FieldStreamBase(Array<u2>* fields, ConstantPool* constants, int
   }
 }
 
-FieldStreamBase::FieldStreamBase(Array<u2>* fields, ConstantPool* constants) : _fields(fields),
-         _constants(constantPoolHandle(Thread::current(), constants)), _index(0) {
+FieldStreamBase::FieldStreamBase(Array<u2>* fields, ConstantPool* constants, Array<MultiFieldInfo>* multifield_info) : _fields(fields),
+         _constants(constantPoolHandle(Thread::current(), constants)), _multifield_info(multifield_info), _index(0) {
   _limit = init_generic_signature_start_slot();
 }
 
 FieldStreamBase::FieldStreamBase(InstanceKlass* klass) : _fields(klass->fields()),
-         _constants(constantPoolHandle(Thread::current(), klass->constants())), _index(0),
+         _constants(constantPoolHandle(Thread::current(), klass->constants())), _multifield_info(klass->multifield_info()),_index(0),
          _limit(klass->java_fields_count()) {
   init_generic_signature_start_slot();
   assert(klass == field_holder(), "");

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -112,7 +112,8 @@ void fieldDescriptor::reinitialize(InstanceKlass* ik, int index) {
   }
   FieldInfo* f = ik->field(index);
   _access_flags = accessFlags_from(f->access_flags());
-  guarantee(f->name_index() != 0 && f->signature_index() != 0, "bad constant pool index for fieldDescriptor");
+  // assert to be extended to allow multifield names
+  guarantee(/*f->name_index() != 0 &&*/ f->signature_index() != 0, "bad constant pool index for fieldDescriptor");
   _index = index;
   verify();
 }

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -95,6 +95,9 @@ class fieldDescriptor {
   bool is_transient()             const    { return access_flags().is_transient(); }
   inline bool is_inlined() const;
   inline bool is_inline_type()    const;
+  inline bool is_multifield()            const;
+  inline u2   multifield_base()          const;
+  inline jbyte multifield_index()        const;
 
   bool is_synthetic()             const    { return access_flags().is_synthetic(); }
 

--- a/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.inline.hpp
@@ -34,7 +34,7 @@
 // must be put in this file, as they require runtime/handles.inline.hpp.
 
 inline Symbol* fieldDescriptor::name() const {
-  return field()->name(_cp());
+  return field()->name(field_holder()->multifield_info(),  _cp());
 }
 
 inline Symbol* fieldDescriptor::signature() const {
@@ -84,5 +84,9 @@ inline BasicType fieldDescriptor::field_type() const {
 
 inline bool fieldDescriptor::is_inlined()  const  { return field()->is_inlined(); }
 inline bool fieldDescriptor::is_inline_type() const { return Signature::basic_type(field()->signature(_cp())) == T_PRIMITIVE_OBJECT; }
+
+inline bool fieldDescriptor::is_multifield() const { return field()->is_multifield(); };
+inline u2   fieldDescriptor::multifield_base() const { return field_holder()->multifield_info(field()->secondary_index()).base_index(); }
+inline jbyte fieldDescriptor::multifield_index() const { return  field_holder()->multifield_info(field()->secondary_index()).multifield_index(); }
 
 #endif // SHARE_RUNTIME_FIELDDESCRIPTOR_INLINE_HPP

--- a/src/java.base/share/classes/java/lang/MultiField.java
+++ b/src/java.base/share/classes/java/lang/MultiField.java
@@ -1,0 +1,52 @@
+/*
+* Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.  Oracle designates this
+* particular file as subject to the "Classpath" exception as provided
+* by Oracle in the LICENSE file that accompanied this code.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+* <p>An annotation expressing that the field has to be
+* replicated several times and all replication must be
+* layed out contiguously in memory. The annotation is
+* ignored if the type of the field is not one of the
+* eight Java basic primitive types: boolean, byte, short,
+* char, int, long, float, double.
+*/
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface MultiField {
+
+   /**
+    * The total number of fields (initial plus replicated).
+    * This tag is only meaningful for field level annotations.
+    *
+    * @return total number of fields to layout.
+    */
+   byte value() default 0;
+}


### PR DESCRIPTION
Merging initial Multifields support added by @fparain in his local repository https://github.com/fparain/valhalla/tree/multifields.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Contributors
 * Frederic Parain `<fparain@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/792/head:pull/792` \
`$ git checkout pull/792`

Update a local copy of the PR: \
`$ git checkout pull/792` \
`$ git pull https://git.openjdk.org/valhalla pull/792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 792`

View PR using the GUI difftool: \
`$ git pr show -t 792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/792.diff">https://git.openjdk.org/valhalla/pull/792.diff</a>

</details>
