### PR TITLE
8295234: [lworld] inner class of older classfile versions is not recognized as identity class

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -154,6 +154,7 @@ JVM_IsConstructorIx
 JVM_IsDumpingClassList
 JVM_IsFinalizationEnabled
 JVM_IsHiddenClass
+JVM_IsIdentityClass
 JVM_IsInterface
 JVM_IsPreviewEnabled
 JVM_IsValhallaEnabled

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -571,6 +571,9 @@ JVM_IsPrimitiveClass(JNIEnv *env, jclass cls);
 JNIEXPORT jboolean JNICALL
 JVM_IsHiddenClass(JNIEnv *env, jclass cls);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsIdentityClass(JNIEnv *env, jclass cls);
+
 JNIEXPORT jint JNICALL
 JVM_GetClassModifiers(JNIEnv *env, jclass cls);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -1251,6 +1251,19 @@ JVM_ENTRY(jboolean, JVM_IsHiddenClass(JNIEnv *env, jclass cls))
   return k->is_hidden();
 JVM_END
 
+JVM_ENTRY(jboolean, JVM_IsIdentityClass(JNIEnv *env, jclass cls))
+  oop mirror = JNIHandles::resolve_non_null(cls);
+  if (java_lang_Class::is_primitive(mirror)) {
+    return JNI_FALSE;
+  }
+  Klass* k = java_lang_Class::as_Klass(mirror);
+  if (EnableValhalla) {
+    return k->is_array_klass() || k->is_identity_class();
+  } else {
+    return k->is_interface() ? JNI_FALSE : JNI_TRUE;
+  }
+JVM_END
+
 JVM_ENTRY(jobjectArray, JVM_GetClassSigners(JNIEnv *env, jclass cls))
   JvmtiVMObjectAllocEventCollector oam;
   oop mirror = JNIHandles::resolve_non_null(cls);

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -648,13 +648,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since Valhalla
      */
-    public boolean isIdentity() {
-        if (!ValhallaFeatures.isEnabled()) {
-            // by default interfaces are not an identity interface
-            return !isInterface();
-        }
-        return (this.getModifiers() & Modifier.IDENTITY) != 0 || isArray();
-    }
+    public native boolean isIdentity();
 
     /**
      * {@return {@code true} if this {@code Class} object represents a value

--- a/src/java.base/share/native/libjava/Class.c
+++ b/src/java.base/share/native/libjava/Class.c
@@ -62,6 +62,7 @@ static JNINativeMethod methods[] = {
     {"setSigners",       "([" OBJ ")V",     (void *)&JVM_SetClassSigners},
     {"isArray",          "()Z",             (void *)&JVM_IsArrayClass},
     {"isHidden",         "()Z",             (void *)&JVM_IsHiddenClass},
+    {"isIdentity",       "()Z",             (void *)&JVM_IsIdentityClass},
     {"isPrimitive",      "()Z",             (void *)&JVM_IsPrimitiveClass},
     {"getModifiers",     "()I",             (void *)&JVM_GetClassModifiers},
     {"getDeclaredFields0","(Z)[" FLD,       (void *)&JVM_GetClassDeclaredFields},


### PR DESCRIPTION
The modifiers of an inner class uses the access flags in the `InnerClasses`  attribute.   An inner class with an older class file version does not have `ACC_IDENTITY` flag set.   Instead of having `Class::isIdentity`  to depend on `getModifiers()`, this PR proposes to make `Class::isIdentity` a native method implemented by the VM. In addition, `Class::isIdentity` can be made as intrinsics.

I leave `Class::isValue` as is.   A value class must have `ACC_VALUE` flag set.   `Class::getModifiers` is already intrinsified.   We can revisit this in the future when there is a need to make it as a native VM method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8295234](https://bugs.openjdk.org/browse/JDK-8295234): [lworld] inner class of older classfile versions is not recognized as identity class


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/794/head:pull/794` \
`$ git checkout pull/794`

Update a local copy of the PR: \
`$ git checkout pull/794` \
`$ git pull https://git.openjdk.org/valhalla pull/794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 794`

View PR using the GUI difftool: \
`$ git pr show -t 794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/794.diff">https://git.openjdk.org/valhalla/pull/794.diff</a>

</details>
