### PR TITLE
8295455: [lworld] find_callee_info_helper hits "must have non-abstract attached method" assert

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -303,14 +303,14 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
   cmp_klass(receiver, iCache, rscratch1);
 }
 
-void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool has_scalarized_args, bool needs_stack_repair) {
+void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool reset_orig_pc, bool needs_stack_repair) {
   MacroAssembler::build_frame(frame_size_in_bytes);
 
   if (needs_stack_repair) {
     save_stack_increment(sp_inc, frame_size_in_bytes);
   }
-  if (has_scalarized_args) {
-    // Initialize orig_pc to detect deoptimization during buffering in the entry points
+  if (reset_orig_pc) {
+    // Zero orig_pc to detect deoptimization during buffering in the entry points
     str(zr, Address(sp, sp_offset_for_orig_pc));
   }
 }
@@ -397,7 +397,7 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
 
   // Create the real frame. Below jump will then skip over the stack banging and frame
   // setup code in the verified_inline_entry (which has a different real_frame_size).
-  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, sp_inc, true, ces->c1_needs_stack_repair());
+  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, sp_inc, false, ces->c1_needs_stack_repair());
 
   b(verified_inline_entry_label);
   return rt_call_offset;

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -312,7 +312,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
   assert(UseCompressedClassPointers || offset() - start_offset == ic_cmp_size, "check alignment in emit_method_entry");
 }
 
-void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool has_scalarized_args, bool needs_stack_repair) {
+void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool reset_orig_pc, bool needs_stack_repair) {
   push(rbp);
   if (PreserveFramePointer) {
     mov(rbp, rsp);
@@ -331,8 +331,8 @@ void C1_MacroAssembler::build_frame_helper(int frame_size_in_bytes, int sp_offse
     int real_frame_size = sp_inc + frame_size_in_bytes + wordSize;
     movptr(Address(rsp, frame_size_in_bytes - wordSize), real_frame_size);
   }
-  if (has_scalarized_args) {
-    // Initialize orig_pc to detect deoptimization during buffering in the entry points
+  if (reset_orig_pc) {
+    // Zero orig_pc to detect deoptimization during buffering in the entry points
     movptr(Address(rsp, sp_offset_for_orig_pc), 0);
   }
 }
@@ -426,7 +426,7 @@ int C1_MacroAssembler::scalarized_entry(const CompiledEntrySignature* ces, int f
 
   // Create the real frame. Below jump will then skip over the stack banging and frame
   // setup code in the verified_inline_entry (which has a different real_frame_size).
-  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, sp_inc, true, ces->c1_needs_stack_repair());
+  build_frame_helper(frame_size_in_bytes, sp_offset_for_orig_pc, sp_inc, false, ces->c1_needs_stack_repair());
 
   jmp(verified_inline_entry_label);
   return rt_call_offset;

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -33,7 +33,7 @@ class CompiledEntrySignature;
 class C1_MacroAssembler: public MacroAssembler {
  private:
   int scalarized_entry(const CompiledEntrySignature* ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_inline_entry_label, bool is_inline_ro_entry);
-  void build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool has_scalarized_args, bool needs_stack_repair);
+  void build_frame_helper(int frame_size_in_bytes, int sp_offset_for_orig_pc, int sp_inc, bool reset_orig_pc, bool needs_stack_repair);
  public:
   // creation
   C1_MacroAssembler(CodeBuffer* code) : MacroAssembler(code) { pd_init(); }

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1187,7 +1187,7 @@ Handle SharedRuntime::find_callee_info_helper(vframeStream& vfst, Bytecodes::Cod
     frame callerFrame = stubFrame.sender(&reg_map2);
     bool caller_is_c1 = false;
 
-    if (callerFrame.is_compiled_frame() && !callerFrame.is_deoptimized_frame()) {
+    if (callerFrame.is_compiled_frame()) {
       caller_is_c1 = callerFrame.cb()->is_compiled_by_c1();
     }
 
@@ -1909,6 +1909,9 @@ methodHandle SharedRuntime::reresolve_call_site(bool& is_static_call, bool& is_o
   frame stub_frame = current->last_frame();
   assert(stub_frame.is_runtime_frame(), "must be a runtimeStub");
   frame caller = stub_frame.sender(&reg_map);
+  if (caller.is_compiled_frame()) {
+    caller_is_c1 = caller.cb()->is_compiled_by_c1();
+  }
 
   // Do nothing if the frame isn't a live compiled frame.
   // nmethod could be deoptimized by the time we get here
@@ -1920,7 +1923,6 @@ methodHandle SharedRuntime::reresolve_call_site(bool& is_static_call, bool& is_o
 
     // Check for static or virtual call
     CompiledMethod* caller_nm = CodeCache::find_compiled(pc);
-    caller_is_c1 = caller_nm->is_compiled_by_c1();
 
     // Default call_addr is the location of the "basic" call.
     // Determine the address of the call we a reresolving. With


### PR DESCRIPTION
I was finally able to reproduce this intermittent issue. The root cause is that the call (re-)resolution code does not correctly detect a C1 caller frame if that one got deoptimized and therefore either hits an assert or uses the wrong callee entry point, leading to incorrect execution.

I also fixed an unrelated issue in the scalarized entry point of a C1 compiled method, that leads to the orig_pc not being zeroed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8295455](https://bugs.openjdk.org/browse/JDK-8295455): [lworld] find_callee_info_helper hits "must have non-abstract attached method" assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/795/head:pull/795` \
`$ git checkout pull/795`

Update a local copy of the PR: \
`$ git checkout pull/795` \
`$ git pull https://git.openjdk.org/valhalla pull/795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 795`

View PR using the GUI difftool: \
`$ git pr show -t 795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/795.diff">https://git.openjdk.org/valhalla/pull/795.diff</a>

</details>
