### PR TITLE
8295731: [lworld] C1's linear register allocator spill map is incorrect

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1261,9 +1261,9 @@ void GraphBuilder::stack_op(Bytecodes::Code code) {
           s.next();
           if (s.cur_bc() != Bytecodes::_pop) {
             w1->as_NewInlineTypeInstance()->set_not_larva_anymore();
-          }  else {
+          } else {
             w1->as_NewInlineTypeInstance()->increment_on_stack_count();
-           }
+          }
         }
         state()->raw_push(w1);
         state()->raw_push(w3);

--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -63,9 +63,9 @@
 
 // Map BasicType to spill size in 32-bit words, matching VMReg's notion of words
 #ifdef _LP64
-static int type2spill_size[T_CONFLICT+1]={ -1, 0, 0, 0, 1, 1, 1, 2, 1, 1, 1, 2, 2, 2, 0, 2,  1, 2, 1, 2, -1};
+static int type2spill_size[T_CONFLICT+1]={ -1, 0, 0, 0, 1, 1, 1, 2, 1, 1, 1, 2, 2, 2, 2, 0, 2,  1, 2, 1, -1};
 #else
-static int type2spill_size[T_CONFLICT+1]={ -1, 0, 0, 0, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 0, 1, -1, 1, 1, 1, -1};
+static int type2spill_size[T_CONFLICT+1]={ -1, 0, 0, 0, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0, 1, -1, 1, 1, -1};
 #endif
 
 


### PR DESCRIPTION
We spuriously assert on AArch64 because the spill location on stack for an 8-byte value is not properly aligned. After some hours of debugging and staring at the Valhalla specific changes, I finally noticed that when moving around the `T_VALUE`/`T_INLINE_TYPE`/`T_PRIMITIVE_OBJECT` basic type definitions, we forgot to adjust the spill map of C1's register allocator accordingly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8295731](https://bugs.openjdk.org/browse/JDK-8295731): [lworld] C1's linear register allocator spill map is incorrect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/797/head:pull/797` \
`$ git checkout pull/797`

Update a local copy of the PR: \
`$ git checkout pull/797` \
`$ git pull https://git.openjdk.org/valhalla pull/797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 797`

View PR using the GUI difftool: \
`$ git pr show -t 797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/797.diff">https://git.openjdk.org/valhalla/pull/797.diff</a>

</details>
