### PR TITLE
8224057: [lworld] a hidden value class can't have <vnew> static factory method

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -700,9 +700,8 @@ final class MemberName implements Member, Cloneable {
         this.name = this.clazz.isValue() ? VALUE_FACTORY_NAME : CONSTRUCTOR_NAME;
         if (this.type == null) {
             Class<?> rtype = void.class;
-            if (isStatic()) {  // a static init factory, not a true constructor
+            if (isStatic()) {  // a value class static factory, not a true constructor
                 rtype = getDeclaringClass();
-                // FIXME: If it's a hidden class, this sig won't work.
             }
             this.type = new Object[] { rtype, ctor.getParameterTypes() };
         }

--- a/test/jdk/java/lang/invoke/defineHiddenClass/HiddenValueClass.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/HiddenValueClass.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @compile ValueImpl.jcod
+ * @run testng/othervm HiddenValueClass
+ * @summary a hidden value class can only be defined without "<vnew>" static
+ *          factory method.  It will have to provide a different instance creation.
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import static java.lang.invoke.MethodType.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.test.lib.Utils;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class HiddenValueClass {
+
+    value class Impl implements Runnable {
+        public void run() {}
+    }
+
+    private static final Path CLASSES_DIR = Paths.get(Utils.TEST_CLASSES);
+
+    /*
+     * ClassFormatError when defining HiddenValueClass$Impl as a hidden class
+     * as it defines "<vnew>()LHiddenValueClass$Impl;" which is illegal.
+     *
+     * A hidden class cannot have "<vnew>" factory method since it cannot
+     * be named.
+     */
+    @Test
+    public void illegalHiddenValueClass() throws Throwable {
+        byte[] bytes = Files.readAllBytes(CLASSES_DIR.resolve("HiddenValueClass$Impl.class"));
+        assertThrows(ClassFormatError.class, () -> MethodHandles.lookup().defineHiddenClass(bytes, false));
+    }
+
+    /*
+     * ValueImpl is a value class without "<vnew>" method but instead
+     * a special factory method named "$make" (no bracket) with
+     * "()java/lang/Runnable;" descriptor defined.
+     */
+    @Test
+    public void hiddenValueClassWithMakeFactory() throws Throwable {
+        byte[] bytes = Files.readAllBytes(CLASSES_DIR.resolve("ValueImpl.class"));
+        Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, false);
+        MethodHandle mh = lookup.findStatic(lookup.lookupClass(), "$make", methodType(Runnable.class));
+        Runnable r = (Runnable)mh.invokeExact();
+        r.run();
+    }
+}

--- a/test/jdk/java/lang/invoke/defineHiddenClass/ValueImpl.jcod
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/ValueImpl.jcod
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+// Generated from this source:
+//
+// value class ValueImpl implements Runnable {
+//     public void run() {
+//         System.out.println("ValueImpl::run");
+//     }
+// }
+//
+// then modified "<vnew>()LValueImpl;" to "$make()Ljava/lang/Runnable;"
+
+class ValueImpl {
+  0xCAFEBABE;
+  0; // minor version
+  64; // version
+  [29] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1     at 0x0A
+    Utf8 "ValueImpl"; // #2     at 0x0D
+    Field #4 #5; // #3     at 0x19
+    class #6; // #4     at 0x1E
+    NameAndType #7 #8; // #5     at 0x21
+    Utf8 "java/lang/System"; // #6     at 0x26
+    Utf8 "out"; // #7     at 0x39
+    Utf8 "Ljava/io/PrintStream;"; // #8     at 0x3F
+    String #10; // #9     at 0x57
+    Utf8 "ValueImpl::run"; // #10     at 0x5A
+    Method #12 #13; // #11     at 0x6B
+    class #14; // #12     at 0x70
+    NameAndType #15 #16; // #13     at 0x73
+    Utf8 "java/io/PrintStream"; // #14     at 0x78
+    Utf8 "println"; // #15     at 0x8E
+    Utf8 "(Ljava/lang/String;)V"; // #16     at 0x98
+    class #18; // #17     at 0xB0
+    Utf8 "java/lang/Object"; // #18     at 0xB3
+    class #20; // #19     at 0xC6
+    Utf8 "java/lang/Runnable"; // #20     at 0xC9
+    Utf8 "run"; // #21     at 0xDE
+    Utf8 "()V"; // #22     at 0xE4
+    Utf8 "Code"; // #23     at 0xEA
+    Utf8 "LineNumberTable"; // #24     at 0xF1
+    Utf8 "$make"; // #25     at 0x0103
+    Utf8 "()Ljava/lang/Runnable;"; // #26     at 0x010C
+    Utf8 "SourceFile"; // #27     at 0x011C
+    Utf8 "ValueImpl.java"; // #28     at 0x0129
+  } // Constant Pool
+
+  0x0050; // access [ ACC_FINAL ]
+  #1;// this_cpx
+  #17;// super_cpx
+
+  [1] { // Interfaces
+    #19;
+  } // Interfaces
+
+  [0] { // fields
+  } // fields
+
+  [2] { // methods
+    { // Member at 0x0148
+      0x0001; // access
+      #21; // name_cpx
+      #22; // sig_cpx
+      [1] { // Attributes
+        Attr(#23, 37) { // Code at 0x0150
+          2; // max_stack
+          1; // max_locals
+          Bytes[9]{
+            0xB200031209B6000B;
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#24, 10) { // LineNumberTable at 0x016B
+              [2] { // LineNumberTable
+                0  3; //  at 0x0177
+                8  4; //  at 0x017B
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+    ;
+    { // Member at 0x017B
+      0x0008; // access
+      #25; // name_cpx
+      #26; // sig_cpx
+      [1] { // Attributes
+        Attr(#23, 30) { // Code at 0x0183
+          1; // max_stack
+          1; // max_locals
+          Bytes[6]{
+            0xCB00014B2AB0;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#24, 6) { // LineNumberTable at 0x019B
+              [1] { // LineNumberTable
+                0  1; //  at 0x01A7
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    } // Member
+  } // methods
+
+  [1] { // Attributes
+    Attr(#27, 2) { // SourceFile at 0x01A9
+      #28;
+    } // end SourceFile
+  } // Attributes
+} // end class ValueImpl


### PR DESCRIPTION
A hidden class has no name.  Rather than declaring a "<vnew>" method, a hidden value class will have to provide a different mechanism to create value instances.

This PR adds a test to verify that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8224057](https://bugs.openjdk.org/browse/JDK-8224057): [lworld] a hidden value class can't have <vnew> static factory method


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/798/head:pull/798` \
`$ git checkout pull/798`

Update a local copy of the PR: \
`$ git checkout pull/798` \
`$ git pull https://git.openjdk.org/valhalla pull/798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 798`

View PR using the GUI difftool: \
`$ git pr show -t 798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/798.diff">https://git.openjdk.org/valhalla/pull/798.diff</a>

</details>
