### PR TITLE
8295735: [lworld] Missing membar after buffer initialization in method handle return

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2612,45 +2612,45 @@ void PhaseMacroExpand::expand_mh_intrinsic_return(CallStaticJavaNode* call) {
     transform_later(fast_mem);
   }
 
-  ctl = new RegionNode(alloc_in_place ? 4 : 3);
-  mem = new PhiNode(ctl, Type::MEMORY, TypePtr::BOTTOM);
-  io = new PhiNode(ctl, Type::ABIO);
-  res = new PhiNode(ctl, TypeInstPtr::BOTTOM);
-  ctl->init_req(1, no_allocation_ctl);
-  mem->init_req(1, mem);
-  io->init_req(1, io);
-  res->init_req(1, no_allocation_res);
-  ctl->init_req(2, slow_norm);
-  mem->init_req(2, slow_mem);
-  io->init_req(2, slow_io);
-  res->init_req(2, slow_res);
+  Node* r = new RegionNode(alloc_in_place ? 4 : 3);
+  Node* mem_phi = new PhiNode(r, Type::MEMORY, TypePtr::BOTTOM);
+  Node* io_phi = new PhiNode(r, Type::ABIO);
+  Node* res_phi = new PhiNode(r, TypeInstPtr::BOTTOM);
+  r->init_req(1, no_allocation_ctl);
+  mem_phi->init_req(1, mem);
+  io_phi->init_req(1, io);
+  res_phi->init_req(1, no_allocation_res);
+  r->init_req(2, slow_norm);
+  mem_phi->init_req(2, slow_mem);
+  io_phi->init_req(2, slow_io);
+  res_phi->init_req(2, slow_res);
   if (alloc_in_place) {
-    ctl->init_req(3, fast_ctl);
-    mem->init_req(3, fast_mem);
-    io->init_req(3, io);
-    res->init_req(3, fast_res);
+    r->init_req(3, fast_ctl);
+    mem_phi->init_req(3, fast_mem);
+    io_phi->init_req(3, io);
+    res_phi->init_req(3, fast_res);
   }
-  transform_later(ctl);
-  transform_later(mem);
-  transform_later(io);
-  transform_later(res);
+  transform_later(r);
+  transform_later(mem_phi);
+  transform_later(io_phi);
+  transform_later(res_phi);
 
   // Do not let stores that initialize this buffer be reordered with a subsequent
   // store that would make this buffer accessible by other threads.
   MemBarNode* mb = MemBarNode::make(C, Op_MemBarStoreStore, Compile::AliasIdxBot);
   transform_later(mb);
-  mb->init_req(TypeFunc::Memory, mem);
-  mb->init_req(TypeFunc::Control, ctl);
-  ctl = new ProjNode(mb, TypeFunc::Control);
-  transform_later(ctl);
-  mem = new ProjNode(mb, TypeFunc::Memory);
-  transform_later(mem);
+  mb->init_req(TypeFunc::Memory, mem_phi);
+  mb->init_req(TypeFunc::Control, r);
+  r = new ProjNode(mb, TypeFunc::Control);
+  transform_later(r);
+  mem_phi = new ProjNode(mb, TypeFunc::Memory);
+  transform_later(mem_phi);
 
   assert(projs->nb_resproj == 1, "unexpected number of results");
-  _igvn.replace_in_uses(projs->fallthrough_catchproj, ctl);
-  _igvn.replace_in_uses(projs->fallthrough_memproj, mem);
-  _igvn.replace_in_uses(projs->fallthrough_ioproj, io);
-  _igvn.replace_in_uses(projs->resproj[0], res);
+  _igvn.replace_in_uses(projs->fallthrough_catchproj, r);
+  _igvn.replace_in_uses(projs->fallthrough_memproj, mem_phi);
+  _igvn.replace_in_uses(projs->fallthrough_ioproj, io_phi);
+  _igvn.replace_in_uses(projs->resproj[0], res_phi);
   _igvn.replace_in_uses(projs->catchall_catchproj, ex_r);
   _igvn.replace_in_uses(projs->catchall_memproj, ex_mem_phi);
   _igvn.replace_in_uses(projs->catchall_ioproj, ex_io_phi);


### PR DESCRIPTION
A missing membar after buffer initialization in C2's handling of scalarized returns from method handle intrinsics leads to incorrect execution and crashes with compiler/valhalla/inlinetypes/TestBufferTearing.java on aarch64.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8295735](https://bugs.openjdk.org/browse/JDK-8295735): [lworld] Missing membar after buffer initialization in method handle return


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/799/head:pull/799` \
`$ git checkout pull/799`

Update a local copy of the PR: \
`$ git checkout pull/799` \
`$ git pull https://git.openjdk.org/valhalla pull/799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 799`

View PR using the GUI difftool: \
`$ git pr show -t 799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/799.diff">https://git.openjdk.org/valhalla/pull/799.diff</a>

</details>
