### PR TITLE
8296172: [lworld] vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007/TestDescription.java fails with "primitive" keyword

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007.java
@@ -43,7 +43,7 @@ public class objmonusage007 {
     native static int getResult();
     native static void check(Object o, Thread owner, int ec, int wc);
 
-    static primitive class LocalValue {
+    static value class LocalValue {
         int i = 0;
     }
 


### PR DESCRIPTION
Use "value object"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8296172](https://bugs.openjdk.org/browse/JDK-8296172): [lworld] vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007/TestDescription.java fails with "primitive" keyword


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/803/head:pull/803` \
`$ git checkout pull/803`

Update a local copy of the PR: \
`$ git checkout pull/803` \
`$ git pull https://git.openjdk.org/valhalla pull/803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 803`

View PR using the GUI difftool: \
`$ git pr show -t 803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/803.diff">https://git.openjdk.org/valhalla/pull/803.diff</a>

</details>
