### PR TITLE
8296423: [lworld] add VarHandle tests for value classes

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -31,8 +31,6 @@ import java.lang.invoke.VarHandle.VarHandleDesc;
 import java.util.Objects;
 import java.util.Optional;
 
-import jdk.internal.value.PrimitiveClass;
-
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 #warn
@@ -150,8 +148,6 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object checkCast(FieldInstanceReadWrite handle, $type$ value) {
-            if (PrimitiveClass.isPrimitiveValueType(handle.fieldType))
-                Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
 #end[Object]
@@ -503,8 +499,6 @@ final class VarHandle$Type$s {
 
 #if[Object]
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
-            if (PrimitiveClass.isPrimitiveValueType(handle.fieldType))
-                Objects.requireNonNull(value);
             return handle.fieldType.cast(value);
         }
 #end[Object]
@@ -746,7 +740,7 @@ final class VarHandle$Type$s {
 #if[Reference]
     static VarHandle makeVarHandleValuesArray(Class<?> arrayClass) {
         Class<?> componentType = arrayClass.getComponentType();
-        assert PrimitiveClass.isPrimitiveValueType(componentType) && UNSAFE.isFlattenedArray(arrayClass);
+        assert UNSAFE.isFlattenedArray(arrayClass);
         // should cache these VarHandle for performance
         return VarHandles.makeArrayElementHandle(arrayClass);
     }
@@ -805,9 +799,6 @@ final class VarHandle$Type$s {
 #if[Object]
         @ForceInline
         static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
-            if (PrimitiveClass.isPrimitiveValueType(handle.componentType))
-                 Objects.requireNonNull(value);
-
             if (handle.arrayType == oarray.getClass()) {
                 // Fast path: static array type same as argument array type
                 return handle.componentType.cast(value);

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -26,6 +26,7 @@
 package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
+import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -262,15 +263,16 @@ public final class Unsafe {
 
     /**
      * Fetches a reference value of the given type from a given Java variable.
-     * This method can return a reference to a value or a null reference
-     * for a nullable reference of a primitive type.
+     * This method can return a reference to a value if it is non-null.
+     * If the value is null, this method returns a default value for
+     * primitive value types or null for identity classes and value classes.
      *
      * @param type type
      */
     public Object getReference(Object o, long offset, Class<?> type) {
         Object ref = getReference(o, offset);
-        if (ref == null && type.isValue()) {
-            // If the type of the returned reference is a regular primitive type
+        if (ref == null && PrimitiveClass.isPrimitiveValueType(type)) {
+            // If the type of the returned reference is a primitive value type,
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(type);
         }
@@ -279,8 +281,8 @@ public final class Unsafe {
 
     public Object getReferenceVolatile(Object o, long offset, Class<?> type) {
         Object ref = getReferenceVolatile(o, offset);
-        if (ref == null && type.isValue()) {
-            // If the type of the returned reference is a regular primitive type
+        if (ref == null && PrimitiveClass.isPrimitiveValueType(type)) {
+            // If the type of the returned reference is a primitive value type,
             // return an uninitialized default value if null
             ref = uninitializedDefaultValue(type);
         }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -26,7 +26,6 @@
 package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
-import jdk.internal.value.PrimitiveClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -232,14 +231,14 @@ public final class Unsafe {
      * @param offset indication of where the variable resides in a Java heap
      *        object, if any, else a memory address locating the variable
      *        statically
-     * @param pc primitive class
+     * @param valueType value type
      * @param <V> the type of a value
      * @return the value fetched from the indicated Java variable
      * @throws RuntimeException No defined exceptions are thrown, not even
      *         {@link NullPointerException}
      */
     @IntrinsicCandidate
-    public native <V> V getValue(Object o, long offset, Class<?> pc);
+    public native <V> V getValue(Object o, long offset, Class<?> valueType);
 
     /**
      * Stores the given value into a given Java variable.
@@ -252,46 +251,46 @@ public final class Unsafe {
      * @param offset indication of where the variable resides in a Java heap
      *        object, if any, else a memory address locating the variable
      *        statically
-     * @param pc primitive class
+     * @param valueType value type
      * @param v the value to store into the indicated Java variable
      * @param <V> the type of a value
      * @throws RuntimeException No defined exceptions are thrown, not even
      *         {@link NullPointerException}
      */
     @IntrinsicCandidate
-    public native <V> void putValue(Object o, long offset, Class<?> pc, V v);
+    public native <V> void putValue(Object o, long offset, Class<?> valueType, V v);
 
     /**
-     * Fetches a reference value of type {@code pc} from a given Java variable.
+     * Fetches a reference value of the given type from a given Java variable.
      * This method can return a reference to a value or a null reference
      * for a nullable reference of a primitive type.
      *
-     * @param pc primitive class
+     * @param type type
      */
-    public Object getReference(Object o, long offset, Class<?> pc) {
+    public Object getReference(Object o, long offset, Class<?> type) {
         Object ref = getReference(o, offset);
-        if (ref == null && PrimitiveClass.isPrimitiveValueType(pc)) {
+        if (ref == null && type.isValue()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
-            ref = uninitializedDefaultValue(pc);
+            ref = uninitializedDefaultValue(type);
         }
         return ref;
     }
 
-    public Object getReferenceVolatile(Object o, long offset, Class<?> pc) {
+    public Object getReferenceVolatile(Object o, long offset, Class<?> type) {
         Object ref = getReferenceVolatile(o, offset);
-        if (ref == null && PrimitiveClass.isPrimitiveValueType(pc)) {
+        if (ref == null && type.isValue()) {
             // If the type of the returned reference is a regular primitive type
             // return an uninitialized default value if null
-            ref = uninitializedDefaultValue(pc);
+            ref = uninitializedDefaultValue(type);
         }
         return ref;
     }
 
     /**
-     * Returns an uninitialized default value of the given primitive class.
+     * Returns an uninitialized default value of the given value type.
      */
-    public native <V> V uninitializedDefaultValue(Class<?> pc);
+    public native <V> V uninitializedDefaultValue(Class<?> type);
 
     /**
      * Returns an object instance with a private buffered value whose layout
@@ -314,13 +313,12 @@ public final class Unsafe {
     public native <V> V finishPrivateBuffer(V value);
 
     /**
-     * Returns the header size of the given primitive class.
+     * Returns the header size of the given value type.
      *
-     * @param pc primitive class
-     * @param <V> value clas
-     * @return the header size of the primitive class
+     * @param valueType value type
+     * @return the header size of the value type
      */
-    public native <V> long valueHeaderSize(Class<V> pc);
+    public native <V> long valueHeaderSize(Class<V> valueType);
 
     /** @see #getInt(Object, long) */
     @IntrinsicCandidate
@@ -1548,8 +1546,8 @@ public final class Unsafe {
                                                        Object expected,
                                                        Object x);
 
-    private final boolean isInlineType(Object o) {
-        return o != null && PrimitiveClass.isPrimitiveClass(o.getClass());
+    private final boolean isValueObject(Object o) {
+        return o != null && o.getClass().isValue();
     }
 
     /*
@@ -1560,10 +1558,10 @@ public final class Unsafe {
      * change the JDK 13 xxxReference method signature freely.
      */
     public final <V> boolean compareAndSetReference(Object o, long offset,
-                                                    Class<?> valueType,
+                                                    Class<?> type,
                                                     V expected,
                                                     V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (type.isValue() || isValueObject(expected)) {
             synchronized (valueLock) {
                 Object witness = getReference(o, offset);
                 if (witness == expected) {
@@ -1604,7 +1602,7 @@ public final class Unsafe {
                                                         Class<?> valueType,
                                                         V expected,
                                                         V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (valueType.isValue() || isValueObject(expected)) {
             synchronized (valueLock) {
                 Object witness = getReference(o, offset);
                 if (witness == expected) {
@@ -1686,7 +1684,7 @@ public final class Unsafe {
                                                              Class<?> valueType,
                                                              V expected,
                                                              V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (valueType.isValue() || isValueObject(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1712,7 +1710,7 @@ public final class Unsafe {
                                                                Class<?> valueType,
                                                                V expected,
                                                                V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (valueType.isValue() || isValueObject(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1738,7 +1736,7 @@ public final class Unsafe {
                                                                Class<?> valueType,
                                                                V expected,
                                                                V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (valueType.isValue() || isValueObject(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -1764,7 +1762,7 @@ public final class Unsafe {
                                                         Class<?> valueType,
                                                         V expected,
                                                         V x) {
-        if (PrimitiveClass.isPrimitiveClass(valueType) || isInlineType(expected)) {
+        if (valueType.isValue() || isValueObject(expected)) {
             return compareAndSetReference(o, offset, valueType, expected, x);
         } else {
             return weakCompareAndSetReferencePlain(o, offset, expected, x);
@@ -2396,8 +2394,8 @@ public final class Unsafe {
 
     /**
      * Global lock for atomic and volatile strength access to any value of
-     * a primitive type.  This is a temporary workaround until better localized
-     * atomic access mechanisms are supported for primitive types.
+     * a value type.  This is a temporary workaround until better localized
+     * atomic access mechanisms are supported for value class and primitive class.
      */
     private static final Object valueLock = new Object();
 

--- a/test/jdk/java/lang/invoke/VarHandles/Value.java
+++ b/test/jdk/java/lang/invoke/VarHandles/Value.java
@@ -21,42 +21,14 @@
  * questions.
  */
 
-final primitive class Value {
-    final char char_v;
-    final byte byte_v;
-    final boolean boolean_v;
-    final int int_v;
-    final short short_v;
-    final long long_v;
-    final double double_v;
-    final float float_v;
-    final Point point_v;
-    Value() {
-        char_v = 'z';
-        boolean_v = true;
-        byte_v = 0;
-        int_v = 1;
-        short_v = 2;
-        long_v = 3;
-        float_v = 0.1f;
-        double_v = 0.2d;
-        point_v = new Point(1, 1);
-    }
-    public Value(char c, boolean z, byte b, int x, short y, long l, float f, double d, Point p) {
-        this.char_v = c;
-        this.byte_v = b;
-        this.boolean_v = z;
-        this.int_v = x;
-        this.short_v = y;
-        this.long_v = l;
-        this.float_v = f;
-        this.double_v = d;
-        this.point_v = p;
+value class Value {
+    Point p;
+    public Value(Point p) {
+        this.p = p;
     }
 
-    static Value getInstance() {
-        return new Value('\u0123', true, (byte)0x01, 0x01234567, (short)0x0123,
-                         0x0123456789ABCDEFL, 1.0f, 1.0d, new Point(1, 1));
+    static Value getInstance(Point p) {
+        return new Value(p);
     }
 
 }

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessBoolean.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessBoolean.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessBoolean
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessBoolean
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessBoolean
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessBoolean
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessBoolean
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessBoolean
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessBoolean
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessBoolean
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             VarHandleTestAccessBoolean.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(boolean[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "boolean_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessBoolean::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -363,20 +353,6 @@ public class VarHandleTestAccessBoolean extends VarHandleBaseTest {
             boolean o = (boolean) vh.getAndAddRelease(recv, true);
         });
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            boolean x = (boolean) vh.get(recv);
-            assertEquals(x, true, "get boolean value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, false);
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessByte.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessByte.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessByte
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessByte
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessByte
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessByte
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessByte
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessByte
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessByte
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessByte
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
             VarHandleTestAccessByte.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(byte[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "byte_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessByte::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -352,20 +342,6 @@ public class VarHandleTestAccessByte extends VarHandleBaseTest {
 
 
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            byte x = (byte) vh.get(recv);
-            assertEquals(x, (byte)0x01, "get byte value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, (byte)0x23);
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessChar.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessChar.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessChar
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessChar
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessChar
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessChar
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessChar
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessChar
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessChar
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessChar
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
             VarHandleTestAccessChar.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(char[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "char_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessChar::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -352,20 +342,6 @@ public class VarHandleTestAccessChar extends VarHandleBaseTest {
 
 
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            char x = (char) vh.get(recv);
-            assertEquals(x, '\u0123', "get char value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, '\u4567');
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessDouble.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessDouble.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessDouble
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessDouble
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessDouble
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessDouble
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessDouble
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessDouble
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessDouble
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessDouble
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
             VarHandleTestAccessDouble.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(double[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "double_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessDouble::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -386,20 +376,6 @@ public class VarHandleTestAccessDouble extends VarHandleBaseTest {
 
         checkUOE(() -> {
             double o = (double) vh.getAndBitwiseXorRelease(recv, 1.0d);
-        });
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            double x = (double) vh.get(recv);
-            assertEquals(x, 1.0d, "get double value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, 2.0d);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessFloat.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessFloat.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessFloat
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessFloat
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessFloat
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessFloat
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessFloat
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessFloat
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessFloat
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessFloat
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
             VarHandleTestAccessFloat.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(float[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "float_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessFloat::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -386,20 +376,6 @@ public class VarHandleTestAccessFloat extends VarHandleBaseTest {
 
         checkUOE(() -> {
             float o = (float) vh.getAndBitwiseXorRelease(recv, 1.0f);
-        });
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            float x = (float) vh.get(recv);
-            assertEquals(x, 1.0f, "get float value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, 2.0f);
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessInt.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessInt.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessInt
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessInt
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessInt
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessInt
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessInt
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessInt
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessInt
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessInt
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
             VarHandleTestAccessInt.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(int[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "int_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessInt::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -352,20 +342,6 @@ public class VarHandleTestAccessInt extends VarHandleBaseTest {
 
 
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            int x = (int) vh.get(recv);
-            assertEquals(x, 0x01234567, "get int value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, 0x89ABCDEF);
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessLong.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessLong.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessLong
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessLong
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessLong
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessLong
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessLong
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessLong
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessLong
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessLong
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
             VarHandleTestAccessLong.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(long[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "long_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessLong::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -352,20 +342,6 @@ public class VarHandleTestAccessLong extends VarHandleBaseTest {
 
 
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            long x = (long) vh.get(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "get long value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, 0xCAFEBABECAFEBABEL);
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessPoint.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import jdk.internal.value.PrimitiveClass;
-
 import static org.testng.Assert.*;
 
 public class VarHandleTestAccessPoint extends VarHandleBaseTest {
@@ -76,7 +75,6 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
     VarHandle vhArray;
 
     VarHandle vhArrayObject;
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -129,9 +127,6 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
 
         vhArray = MethodHandles.arrayElementVarHandle(Point[].class);
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "point_v", type);
     }
 
 
@@ -292,11 +287,6 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array store exception",
                                               vhArrayObject, VarHandleTestAccessPoint::testArrayStoreException,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -406,20 +396,6 @@ public class VarHandleTestAccessPoint extends VarHandleBaseTest {
 
         checkUOE(() -> {
             Point o = (Point) vh.getAndBitwiseXorRelease(recv, Point.getInstance(1,1));
-        });
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            Point x = (Point) vh.get(recv);
-            assertEquals(x, Point.getInstance(1,1), "get Point value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, Point.getInstance(2,2));
         });
     }
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessShort.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessShort.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessShort
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessShort
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessShort
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessShort
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessShort
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessShort
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessShort
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessShort
  */
 
 import org.testng.annotations.BeforeClass;
@@ -73,7 +72,6 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
 
     VarHandle vhArray;
 
-    VarHandle vhValueTypeField;
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -125,9 +123,6 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
             VarHandleTestAccessShort.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(short[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "short_v", type);
     }
 
 
@@ -283,11 +278,6 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
         cases.add(new VarHandleAccessTestCase("Array index out of bounds",
                                               vhArray, VarHandleTestAccessShort::testArrayIndexOutOfBounds,
                                               false));
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -352,20 +342,6 @@ public class VarHandleTestAccessShort extends VarHandleBaseTest {
 
 
 
-    }
-
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            short x = (short) vh.get(recv);
-            assertEquals(x, (short)0x0123, "get short value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, (short)0x4567);
-        });
     }
 
     static void testStaticFinalField(VarHandle vh) {

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessString.java
@@ -25,11 +25,10 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessString.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessString
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessString
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessString
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessString
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccessString
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessString
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccessString
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessString
  */
 
 import org.testng.annotations.BeforeClass;
@@ -126,7 +125,6 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
 
         vhArray = MethodHandles.arrayElementVarHandle(String[].class);
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
-
     }
 
 
@@ -398,7 +396,6 @@ public class VarHandleTestAccessString extends VarHandleBaseTest {
             String o = (String) vh.getAndBitwiseXorRelease(recv, "foo");
         });
     }
-
 
     static void testStaticFinalField(VarHandle vh) {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
@@ -1,0 +1,1401 @@
+/*
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccessValue.java
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccessValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccessValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccessValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccessValue
+ */
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class VarHandleTestAccessValue extends VarHandleBaseTest {
+    static final Class<?> type = Value.class;
+
+    static final Value static_final_v = Value.getInstance(Point.getInstance(1,1));
+
+    static Value static_v;
+
+    final Value final_v = Value.getInstance(Point.getInstance(1,1));
+
+    Value v;
+
+    static final Value static_final_v2 = Value.getInstance(Point.getInstance(1,1));
+
+    static Value static_v2;
+
+    final Value final_v2 = Value.getInstance(Point.getInstance(1,1));
+
+    Value v2;
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    VarHandle vhArrayObject;
+
+    VarHandle[] allocate(boolean same) {
+        List<VarHandle> vhs = new ArrayList<>();
+
+        String postfix = same ? "" : "2";
+        VarHandle vh;
+        try {
+            vh = MethodHandles.lookup().findVarHandle(
+                    VarHandleTestAccessValue.class, "final_v" + postfix, type);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findVarHandle(
+                    VarHandleTestAccessValue.class, "v" + postfix, type);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findStaticVarHandle(
+                VarHandleTestAccessValue.class, "static_final_v" + postfix, type);
+            vhs.add(vh);
+
+            vh = MethodHandles.lookup().findStaticVarHandle(
+                VarHandleTestAccessValue.class, "static_v" + postfix, type);
+            vhs.add(vh);
+
+            if (same) {
+                vh = MethodHandles.arrayElementVarHandle(Value[].class);
+            }
+            else {
+                vh = MethodHandles.arrayElementVarHandle(String[].class);
+            }
+            vhs.add(vh);
+        } catch (Exception e) {
+            throw new InternalError(e);
+        }
+        return vhs.toArray(new VarHandle[0]);
+    }
+
+    @BeforeClass
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessValue.class, "final_v", type);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessValue.class, "v", type);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestAccessValue.class, "static_final_v", type);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestAccessValue.class, "static_v", type);
+
+        vhArray = MethodHandles.arrayElementVarHandle(Value[].class);
+        vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
+    }
+
+
+    @DataProvider
+    public Object[][] varHandlesProvider() throws Exception {
+        List<VarHandle> vhs = new ArrayList<>();
+        vhs.add(vhField);
+        vhs.add(vhStaticField);
+        vhs.add(vhArray);
+
+        return vhs.stream().map(tc -> new Object[]{tc}).toArray(Object[][]::new);
+    }
+
+    @Test
+    public void testEquals() {
+        VarHandle[] vhs1 = allocate(true);
+        VarHandle[] vhs2 = allocate(true);
+
+        for (int i = 0; i < vhs1.length; i++) {
+            for (int j = 0; j < vhs1.length; j++) {
+                if (i != j) {
+                    assertNotEquals(vhs1[i], vhs1[j]);
+                    assertNotEquals(vhs1[i], vhs2[j]);
+                }
+            }
+        }
+
+        VarHandle[] vhs3 = allocate(false);
+        for (int i = 0; i < vhs1.length; i++) {
+            assertNotEquals(vhs1[i], vhs3[i]);
+        }
+    }
+
+    @Test(dataProvider = "varHandlesProvider")
+    public void testIsAccessModeSupported(VarHandle vh) {
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_VOLATILE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_VOLATILE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_OPAQUE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.SET_OPAQUE));
+
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.COMPARE_AND_EXCHANGE_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_PLAIN));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.WEAK_COMPARE_AND_SET_RELEASE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET_ACQUIRE));
+        assertTrue(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_SET_RELEASE));
+
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_ADD_RELEASE));
+
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_OR_RELEASE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_AND_RELEASE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR_ACQUIRE));
+        assertFalse(vh.isAccessModeSupported(VarHandle.AccessMode.GET_AND_BITWISE_XOR_RELEASE));
+    }
+
+
+    @DataProvider
+    public Object[][] typesProvider() throws Exception {
+        List<Object[]> types = new ArrayList<>();
+        types.add(new Object[] {vhField, Arrays.asList(VarHandleTestAccessValue.class)});
+        types.add(new Object[] {vhStaticField, Arrays.asList()});
+        types.add(new Object[] {vhArray, Arrays.asList(Value[].class, int.class)});
+
+        return types.stream().toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "typesProvider")
+    public void testTypes(VarHandle vh, List<Class<?>> pts) {
+        assertEquals(vh.varType(), type);
+
+        assertEquals(vh.coordinateTypes(), pts);
+
+        testTypes(vh);
+    }
+
+
+    @Test
+    public void testLookupInstanceToStatic() {
+        checkIAE("Lookup of static final field to instance final field", () -> {
+            MethodHandles.lookup().findStaticVarHandle(
+                    VarHandleTestAccessValue.class, "final_v", type);
+        });
+
+        checkIAE("Lookup of static field to instance field", () -> {
+            MethodHandles.lookup().findStaticVarHandle(
+                    VarHandleTestAccessValue.class, "v", type);
+        });
+    }
+
+    @Test
+    public void testLookupStaticToInstance() {
+        checkIAE("Lookup of instance final field to static final field", () -> {
+            MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessValue.class, "static_final_v", type);
+        });
+
+        checkIAE("Lookup of instance field to static field", () -> {
+            vhStaticField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestAccessValue.class, "static_v", type);
+        });
+    }
+
+
+    @DataProvider
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        cases.add(new VarHandleAccessTestCase("Instance final field",
+                                              vhFinalField, vh -> testInstanceFinalField(this, vh)));
+        cases.add(new VarHandleAccessTestCase("Instance final field unsupported",
+                                              vhFinalField, vh -> testInstanceFinalFieldUnsupported(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static final field",
+                                              vhStaticFinalField, VarHandleTestAccessValue::testStaticFinalField));
+        cases.add(new VarHandleAccessTestCase("Static final field unsupported",
+                                              vhStaticFinalField, VarHandleTestAccessValue::testStaticFinalFieldUnsupported,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Instance field",
+                                              vhField, vh -> testInstanceField(this, vh)));
+        cases.add(new VarHandleAccessTestCase("Instance field unsupported",
+                                              vhField, vh -> testInstanceFieldUnsupported(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static field",
+                                              vhStaticField, VarHandleTestAccessValue::testStaticField));
+        cases.add(new VarHandleAccessTestCase("Static field unsupported",
+                                              vhStaticField, VarHandleTestAccessValue::testStaticFieldUnsupported,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Array",
+                                              vhArray, VarHandleTestAccessValue::testArray));
+        cases.add(new VarHandleAccessTestCase("Array Object[]",
+                                              vhArrayObject, VarHandleTestAccessValue::testArray));
+        cases.add(new VarHandleAccessTestCase("Array unsupported",
+                                              vhArray, VarHandleTestAccessValue::testArrayUnsupported,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Array index out of bounds",
+                                              vhArray, VarHandleTestAccessValue::testArrayIndexOutOfBounds,
+                                              false));
+        cases.add(new VarHandleAccessTestCase("Array store exception",
+                                              vhArrayObject, VarHandleTestAccessValue::testArrayStoreException,
+                                              false));
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+
+
+
+    static void testInstanceFinalField(VarHandleTestAccessValue recv, VarHandle vh) {
+        // Plain
+        {
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "get Value value");
+        }
+
+
+        // Volatile
+        {
+            Value x = (Value) vh.getVolatile(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getVolatile Value value");
+        }
+
+        // Lazy
+        {
+            Value x = (Value) vh.getAcquire(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getRelease Value value");
+        }
+
+        // Opaque
+        {
+            Value x = (Value) vh.getOpaque(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getOpaque Value value");
+        }
+    }
+
+    static void testInstanceFinalFieldUnsupported(VarHandleTestAccessValue recv, VarHandle vh) {
+        checkUOE(() -> {
+            vh.set(recv, Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setVolatile(recv, Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setRelease(recv, Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setOpaque(recv, Value.getInstance(Point.getInstance(2,2)));
+        });
+
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAdd(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOr(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAnd(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXor(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+    }
+
+    static void testStaticFinalField(VarHandle vh) {
+        // Plain
+        {
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "get Value value");
+        }
+
+
+        // Volatile
+        {
+            Value x = (Value) vh.getVolatile();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getVolatile Value value");
+        }
+
+        // Lazy
+        {
+            Value x = (Value) vh.getAcquire();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getRelease Value value");
+        }
+
+        // Opaque
+        {
+            Value x = (Value) vh.getOpaque();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "getOpaque Value value");
+        }
+    }
+
+    static void testStaticFinalFieldUnsupported(VarHandle vh) {
+        checkUOE(() -> {
+            vh.set(Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setVolatile(Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setRelease(Value.getInstance(Point.getInstance(2,2)));
+        });
+
+        checkUOE(() -> {
+            vh.setOpaque(Value.getInstance(Point.getInstance(2,2)));
+        });
+
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAdd(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOr(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAnd(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXor(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+    }
+
+
+    static void testInstanceField(VarHandleTestAccessValue recv, VarHandle vh) {
+        // Plain
+        {
+            vh.set(recv, Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "set Value value");
+        }
+
+
+        // Volatile
+        {
+            vh.setVolatile(recv, Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) vh.getVolatile(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+        }
+
+        // Lazy
+        {
+            vh.setRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) vh.getAcquire(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+        }
+
+        // Opaque
+        {
+            vh.setOpaque(recv, Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) vh.getOpaque(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+        }
+
+        vh.set(recv, Value.getInstance(Point.getInstance(1,1)));
+
+        // Compare
+        {
+            boolean r = vh.compareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, true, "success compareAndSet Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+        }
+
+        {
+            boolean r = vh.compareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, false, "failing compareAndSet Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetPlain(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetAcquire(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetRelease Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetRelease Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSet(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSet Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSet Value value");
+        }
+
+        // Compare set and get
+        {
+            vh.set(recv, Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSet(recv, Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+        }
+
+        {
+            vh.set(recv, Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSetAcquire(recv, Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetAcquire Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetAcquire Value value");
+        }
+
+        {
+            vh.set(recv, Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSetRelease(recv, Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetRelease Value");
+            Value x = (Value) vh.get(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetRelease Value value");
+        }
+
+
+    }
+
+    static void testInstanceFieldUnsupported(VarHandleTestAccessValue recv, VarHandle vh) {
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAdd(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOr(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAnd(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXor(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+    }
+
+
+    static void testStaticField(VarHandle vh) {
+        // Plain
+        {
+            vh.set(Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "set Value value");
+        }
+
+
+        // Volatile
+        {
+            vh.setVolatile(Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) vh.getVolatile();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+        }
+
+        // Lazy
+        {
+            vh.setRelease(Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) vh.getAcquire();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+        }
+
+        // Opaque
+        {
+            vh.setOpaque(Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) vh.getOpaque();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+        }
+
+        vh.set(Value.getInstance(Point.getInstance(1,1)));
+
+        // Compare
+        {
+            boolean r = vh.compareAndSet(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, true, "success compareAndSet Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+        }
+
+        {
+            boolean r = vh.compareAndSet(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, false, "failing compareAndSet Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchange(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchange(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+        }
+
+        {
+            Value r = (Value) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetPlain(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetPlain(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetAcquire(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetAcquire(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSetRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSetRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetRelease Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetRelease Value value");
+        }
+
+        {
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = vh.weakCompareAndSet(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value");
+        }
+
+        {
+            boolean success = vh.weakCompareAndSet(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSet Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSet Value value");
+        }
+
+        // Compare set and get
+        {
+            vh.set(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSet(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+        }
+
+        {
+            vh.set(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSetAcquire(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetAcquire Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetAcquire Value value");
+        }
+
+        {
+            vh.set(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) vh.getAndSetRelease(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetRelease Value");
+            Value x = (Value) vh.get();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetRelease Value value");
+        }
+
+
+    }
+
+    static void testStaticFieldUnsupported(VarHandle vh) {
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAdd(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOr(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAnd(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXor(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+    }
+
+
+    static void testArray(VarHandle vh) {
+        Value[] array = new Value[10];
+
+        for (int i = 0; i < array.length; i++) {
+            // Plain
+            {
+                vh.set(array, i, Value.getInstance(Point.getInstance(1,1)));
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "get Value value");
+            }
+
+
+            // Volatile
+            {
+                vh.setVolatile(array, i, Value.getInstance(Point.getInstance(2,2)));
+                Value x = (Value) vh.getVolatile(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+            }
+
+            // Lazy
+            {
+                vh.setRelease(array, i, Value.getInstance(Point.getInstance(1,1)));
+                Value x = (Value) vh.getAcquire(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+            }
+
+            // Opaque
+            {
+                vh.setOpaque(array, i, Value.getInstance(Point.getInstance(2,2)));
+                Value x = (Value) vh.getOpaque(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+            }
+
+            vh.set(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+            // Compare
+            {
+                boolean r = vh.compareAndSet(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(r, true, "success compareAndSet Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+            }
+
+            {
+                boolean r = vh.compareAndSet(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, false, "failing compareAndSet Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchange(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchange(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchangeAcquire(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchangeAcquire(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchangeRelease(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+            }
+
+            {
+                Value r = (Value) vh.compareAndExchangeRelease(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetPlain(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetPlain Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetPlain(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetAcquire(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetAcquire(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSetRelease(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetRelease Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSetRelease(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetRelease Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetRelease Value value");
+            }
+
+            {
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = vh.weakCompareAndSet(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSet Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value");
+            }
+
+            {
+                boolean success = vh.weakCompareAndSet(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSet Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSet Value value");
+            }
+
+            // Compare set and get
+            {
+                vh.set(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) vh.getAndSet(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+            }
+
+            {
+                vh.set(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) vh.getAndSetAcquire(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetAcquire Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetAcquire Value value");
+            }
+
+            {
+                vh.set(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) vh.getAndSetRelease(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetRelease Value");
+                Value x = (Value) vh.get(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetRelease Value value");
+            }
+
+
+        }
+    }
+
+    static void testArrayUnsupported(VarHandle vh) {
+        Value[] array = new Value[10];
+
+        int i = 0;
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAdd(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddAcquire(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndAddRelease(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOr(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrAcquire(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseOrRelease(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAnd(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndAcquire(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseAndRelease(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXor(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorAcquire(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+
+        checkUOE(() -> {
+            Value o = (Value) vh.getAndBitwiseXorRelease(array, i, Value.getInstance(Point.getInstance(1,1)));
+        });
+    }
+
+    static void testArrayIndexOutOfBounds(VarHandle vh) throws Throwable {
+        Value[] array = new Value[10];
+
+        for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
+            final int ci = i;
+
+            checkAIOOBE(() -> {
+                Value x = (Value) vh.get(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.set(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value x = (Value) vh.getVolatile(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setVolatile(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value x = (Value) vh.getAcquire(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setRelease(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value x = (Value) vh.getOpaque(array, ci);
+            });
+
+            checkAIOOBE(() -> {
+                vh.setOpaque(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.compareAndSet(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            });
+
+            checkAIOOBE(() -> {
+                Value r = (Value) vh.compareAndExchange(array, ci, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value r = (Value) vh.compareAndExchangeAcquire(array, ci, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value r = (Value) vh.compareAndExchangeRelease(array, ci, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetPlain(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSet(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetAcquire(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            });
+
+            checkAIOOBE(() -> {
+                boolean r = vh.weakCompareAndSetRelease(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            });
+
+            checkAIOOBE(() -> {
+                Value o = (Value) vh.getAndSet(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value o = (Value) vh.getAndSetAcquire(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+            checkAIOOBE(() -> {
+                Value o = (Value) vh.getAndSetRelease(array, ci, Value.getInstance(Point.getInstance(1,1)));
+            });
+
+
+        }
+    }
+
+    static void testArrayStoreException(VarHandle vh) throws Throwable {
+        Object[] array = new Value[10];
+        Arrays.fill(array, Value.getInstance(Point.getInstance(1,1)));
+        Object value = new Object();
+
+        // Set
+        checkASE(() -> {
+            vh.set(array, 0, value);
+        });
+
+        // SetVolatile
+        checkASE(() -> {
+            vh.setVolatile(array, 0, value);
+        });
+
+        // SetOpaque
+        checkASE(() -> {
+            vh.setOpaque(array, 0, value);
+        });
+
+        // SetRelease
+        checkASE(() -> {
+            vh.setRelease(array, 0, value);
+        });
+
+        // CompareAndSet
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // WeakCompareAndSet
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // WeakCompareAndSetVolatile
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // WeakCompareAndSetAcquire
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // WeakCompareAndSetRelease
+        checkASE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // CompareAndExchange
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchange(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // CompareAndExchangeAcquire
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // CompareAndExchangeRelease
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchangeRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), value);
+        });
+
+        // GetAndSet
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSet(array, 0, value);
+        });
+
+        // GetAndSetAcquire
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSetAcquire(array, 0, value);
+        });
+
+        // GetAndSetRelease
+        checkASE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSetRelease(array, 0, value);
+        });
+    }
+}
+

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessBoolean.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessBoolean.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessBoolean
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessBoolean
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
 
     static final boolean static_final_v = true;
 
-    static boolean static_v;
+    static boolean static_v = true;
 
     final boolean final_v = true;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessBoolean.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(boolean[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "boolean_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessBoolean::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -403,29 +392,6 @@ public class VarHandleTestMethodHandleAccessBoolean extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            boolean x = (boolean) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, true, "get boolean value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, true);
-            });
-        }
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
-            checkUOE(am, () -> {
-                boolean r = (boolean) hs.get(am).invokeExact(recv, true);
-            });
-        }
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessByte.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessByte.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessByte
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessByte
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
 
     static final byte static_final_v = (byte)0x01;
 
-    static byte static_v;
+    static byte static_v = (byte)0x01;
 
     final byte final_v = (byte)0x01;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessByte.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(byte[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "byte_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessByte::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -425,24 +414,6 @@ public class VarHandleTestMethodHandleAccessByte extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            byte x = (byte) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (byte)0x01, "get byte value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, (byte)0x01);
-            });
-        }
-
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessChar.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessChar.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessChar
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessChar
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
 
     static final char static_final_v = '\u0123';
 
-    static char static_v;
+    static char static_v = '\u0123';
 
     final char final_v = '\u0123';
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessChar.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(char[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "char_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessChar::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -425,24 +414,6 @@ public class VarHandleTestMethodHandleAccessChar extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            char x = (char) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, '\u0123', "get char value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, '\u0123');
-            });
-        }
-
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessFloat.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessFloat.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessFloat
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessFloat
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
 
     static final float static_final_v = 1.0f;
 
-    static float static_v;
+    static float static_v = 1.0f;
 
     final float final_v = 1.0f;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessFloat.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(float[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "float_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessFloat::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -347,29 +336,6 @@ public class VarHandleTestMethodHandleAccessFloat extends VarHandleBaseTest {
         }
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            float x = (float) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 1.0f, "get float value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, 1.0f);
-            });
-        }
-
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
-            checkUOE(am, () -> {
-                float r = (float) hs.get(am).invokeExact(recv, 1.0f);
-            });
-        }
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessInt.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessInt.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessInt
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessInt
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
 
     static final int static_final_v = 0x01234567;
 
-    static int static_v;
+    static int static_v = 0x01234567;
 
     final int final_v = 0x01234567;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessInt.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(int[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "int_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessInt::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -425,24 +414,6 @@ public class VarHandleTestMethodHandleAccessInt extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            int x = (int) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x01234567, "get int value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, 0x01234567);
-            });
-        }
-
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessLong.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessLong.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessLong
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessLong
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
 
     static final long static_final_v = 0x0123456789ABCDEFL;
 
-    static long static_v;
+    static long static_v = 0x0123456789ABCDEFL;
 
     final long final_v = 0x0123456789ABCDEFL;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessLong.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(long[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "long_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessLong::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -425,24 +414,6 @@ public class VarHandleTestMethodHandleAccessLong extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            long x = (long) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, 0x0123456789ABCDEFL, "get long value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, 0x0123456789ABCDEFL);
-            });
-        }
-
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessPoint.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import jdk.internal.value.PrimitiveClass;
-
 import static org.testng.Assert.*;
 
 public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
@@ -49,7 +48,7 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
 
     static final Point static_final_v = Point.getInstance(1,1);
 
-    static Point static_v;
+    static Point static_v = Point.getInstance(1,1);
 
     final Point final_v = Point.getInstance(1,1);
 
@@ -64,8 +63,6 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -82,9 +79,6 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessPoint.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(Point[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "point_v", type);
     }
 
 
@@ -113,11 +107,6 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessPoint::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -327,34 +316,6 @@ public class VarHandleTestMethodHandleAccessPoint extends VarHandleBaseTest {
         }
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            Point x = (Point) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, Point.getInstance(1,1), "get Point value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, Point.getInstance(1,1));
-            });
-        }
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
-            checkUOE(am, () -> {
-                Point r = (Point) hs.get(am).invokeExact(recv, Point.getInstance(1,1));
-            });
-        }
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
-            checkUOE(am, () -> {
-                Point r = (Point) hs.get(am).invokeExact(recv, Point.getInstance(1,1));
-            });
-        }
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessShort.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessShort.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessShort
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessShort
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
 
     static final short static_final_v = (short)0x0123;
 
-    static short static_v;
+    static short static_v = (short)0x0123;
 
     final short final_v = (short)0x0123;
 
@@ -62,8 +61,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-    VarHandle vhValueTypeField;
 
     @BeforeClass
     public void setup() throws Exception {
@@ -80,9 +77,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessShort.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(short[].class);
-
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "short_v", type);
     }
 
 
@@ -111,11 +105,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccessShort::testArrayIndexOutOfBounds,
                                                      false));
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -425,24 +414,6 @@ public class VarHandleTestMethodHandleAccessShort extends VarHandleBaseTest {
 
     }
 
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            short x = (short) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, (short)0x0123, "get short value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, (short)0x0123);
-            });
-        }
-
-
-    }
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
@@ -25,8 +25,7 @@
 
 /*
  * @test
- * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessString.java
- * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessString
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccessString
  */
 
 import org.testng.annotations.BeforeClass;
@@ -47,7 +46,7 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
 
     static final String static_final_v = "foo";
 
-    static String static_v;
+    static String static_v = "foo";
 
     final String final_v = "foo";
 
@@ -62,7 +61,6 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
 
     @BeforeClass
     public void setup() throws Exception {
@@ -79,7 +77,6 @@ public class VarHandleTestMethodHandleAccessString extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccessString.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle(String[].class);
-
     }
 
 

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
@@ -1,0 +1,792 @@
+/*
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccessValue.java
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccessValue
+ */
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class VarHandleTestMethodHandleAccessValue extends VarHandleBaseTest {
+    static final Class<?> type = Value.class;
+
+    static final Value static_final_v = Value.getInstance(Point.getInstance(1,1));
+
+    static Value static_v = Value.getInstance(Point.getInstance(1,1));
+
+    final Value final_v = Value.getInstance(Point.getInstance(1,1));
+
+    Value v;
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodHandleAccessValue.class, "final_v", type);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodHandleAccessValue.class, "v", type);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodHandleAccessValue.class, "static_final_v", type);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodHandleAccessValue.class, "static_v", type);
+
+        vhArray = MethodHandles.arrayElementVarHandle(Value[].class);
+    }
+
+
+    @DataProvider
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        for (VarHandleToMethodHandle f : VarHandleToMethodHandle.values()) {
+            cases.add(new MethodHandleAccessTestCase("Instance field",
+                                                     vhField, f, hs -> testInstanceField(this, hs)));
+            cases.add(new MethodHandleAccessTestCase("Instance field unsupported",
+                                                     vhField, f, hs -> testInstanceFieldUnsupported(this, hs),
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Static field",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccessValue::testStaticField));
+            cases.add(new MethodHandleAccessTestCase("Static field unsupported",
+                                                     vhStaticField, f, VarHandleTestMethodHandleAccessValue::testStaticFieldUnsupported,
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Array",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessValue::testArray));
+            cases.add(new MethodHandleAccessTestCase("Array unsupported",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessValue::testArrayUnsupported,
+                                                     false));
+            cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
+                                                     vhArray, f, VarHandleTestMethodHandleAccessValue::testArrayIndexOutOfBounds,
+                                                     false));
+        }
+
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+
+    static void testInstanceField(VarHandleTestMethodHandleAccessValue recv, Handles hs) throws Throwable {
+        // Plain
+        {
+            hs.get(TestAccessMode.SET).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "set Value value");
+        }
+
+
+        // Volatile
+        {
+            hs.get(TestAccessMode.SET_VOLATILE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) hs.get(TestAccessMode.GET_VOLATILE).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+        }
+
+        // Lazy
+        {
+            hs.get(TestAccessMode.SET_RELEASE).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+        }
+
+        // Opaque
+        {
+            hs.get(TestAccessMode.SET_OPAQUE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) hs.get(TestAccessMode.GET_OPAQUE).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+        }
+
+        hs.get(TestAccessMode.SET).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+
+        // Compare
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, true, "success compareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+        }
+
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, false, "failing compareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetRelease Value value");
+        }
+
+        {
+            boolean success = false;
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSet Value value");
+        }
+
+        // Compare set and get
+        {
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET).invokeExact(recv, Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(recv);
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+        }
+
+
+    }
+
+    static void testInstanceFieldUnsupported(VarHandleTestMethodHandleAccessValue recv, Handles hs) throws Throwable {
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                Value r = (Value) hs.get(am).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                Value r = (Value) hs.get(am).invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+    }
+
+
+    static void testStaticField(Handles hs) throws Throwable {
+        // Plain
+        {
+            hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "set Value value");
+        }
+
+
+        // Volatile
+        {
+            hs.get(TestAccessMode.SET_VOLATILE).invokeExact(Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) hs.get(TestAccessMode.GET_VOLATILE).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+        }
+
+        // Lazy
+        {
+            hs.get(TestAccessMode.SET_RELEASE).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            Value x = (Value) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+        }
+
+        // Opaque
+        {
+            hs.get(TestAccessMode.SET_OPAQUE).invokeExact(Value.getInstance(Point.getInstance(2,2)));
+            Value x = (Value) hs.get(TestAccessMode.GET_OPAQUE).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+        }
+
+        hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+
+        // Compare
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, true, "success compareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+        }
+
+        {
+            boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, false, "failing compareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+            assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+        }
+
+        {
+            Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetPlain Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+            boolean success = (boolean) mh.invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE).invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetRelease Value value");
+        }
+
+        {
+            MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+            boolean success = false;
+            for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                success = (boolean) mh.invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                if (!success) weakDelay();
+            }
+            assertEquals(success, true, "success weakCompareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value");
+        }
+
+        {
+            boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+            assertEquals(success, false, "failing weakCompareAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetRe Value value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET).invokeExact(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetAcquire Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetAcquire Value value");
+        }
+
+        // Compare set and get
+        {
+            hs.get(TestAccessMode.SET).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+
+            Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(Value.getInstance(Point.getInstance(2,2)));
+            assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetRelease Value");
+            Value x = (Value) hs.get(TestAccessMode.GET).invokeExact();
+            assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetRelease Value value");
+        }
+
+
+    }
+
+    static void testStaticFieldUnsupported(Handles hs) throws Throwable {
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                Value r = (Value) hs.get(am).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                Value r = (Value) hs.get(am).invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+    }
+
+
+    static void testArray(Handles hs) throws Throwable {
+        Value[] array = new Value[10];
+
+        for (int i = 0; i < array.length; i++) {
+            // Plain
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "get Value value");
+            }
+
+
+            // Volatile
+            {
+                hs.get(TestAccessMode.SET_VOLATILE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)));
+                Value x = (Value) hs.get(TestAccessMode.GET_VOLATILE).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setVolatile Value value");
+            }
+
+            // Lazy
+            {
+                hs.get(TestAccessMode.SET_RELEASE).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+                Value x = (Value) hs.get(TestAccessMode.GET_ACQUIRE).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "setRelease Value value");
+            }
+
+            // Opaque
+            {
+                hs.get(TestAccessMode.SET_OPAQUE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)));
+                Value x = (Value) hs.get(TestAccessMode.GET_OPAQUE).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "setOpaque Value value");
+            }
+
+            hs.get(TestAccessMode.SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+            // Compare
+            {
+                boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(r, true, "success compareAndSet Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndSet Value value");
+            }
+
+            {
+                boolean r = (boolean) hs.get(TestAccessMode.COMPARE_AND_SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, false, "failing compareAndSet Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndSet Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchange Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchange Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchange Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeAcquire Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_ACQUIRE).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing compareAndExchangeAcquire Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                assertEquals(r, Value.getInstance(Point.getInstance(2,2)), "success compareAndExchangeRelease Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success compareAndExchangeRelease Value value");
+            }
+
+            {
+                Value r = (Value) hs.get(TestAccessMode.COMPARE_AND_EXCHANGE_RELEASE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(r, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing compareAndExchangeRelease Value value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetPlain Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetPlain Value value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_PLAIN).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetPlain Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetPlain Value value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSetAcquire Value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSetAcquire Value value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_RELEASE);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSetRelease Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "success weakCompareAndSetRelease Value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET_ACQUIRE).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSetAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "failing weakCompareAndSetAcquire Value value");
+            }
+
+            {
+                MethodHandle mh = hs.get(TestAccessMode.WEAK_COMPARE_AND_SET);
+                boolean success = false;
+                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+                    success = (boolean) mh.invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                    if (!success) weakDelay();
+                }
+                assertEquals(success, true, "success weakCompareAndSet Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "success weakCompareAndSet Value");
+            }
+
+            {
+                boolean success = (boolean) hs.get(TestAccessMode.WEAK_COMPARE_AND_SET).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(3,3)));
+                assertEquals(success, false, "failing weakCompareAndSet Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(1,1)), "failing weakCompareAndSet Value value");
+            }
+
+            // Compare set and get
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) hs.get(TestAccessMode.GET_AND_SET).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSet Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSet Value value");
+            }
+
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_ACQUIRE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetAcquire Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetAcquire Value value");
+            }
+
+            {
+                hs.get(TestAccessMode.SET).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+
+                Value o = (Value) hs.get(TestAccessMode.GET_AND_SET_RELEASE).invokeExact(array, i, Value.getInstance(Point.getInstance(2,2)));
+                assertEquals(o, Value.getInstance(Point.getInstance(1,1)), "getAndSetRelease Value");
+                Value x = (Value) hs.get(TestAccessMode.GET).invokeExact(array, i);
+                assertEquals(x, Value.getInstance(Point.getInstance(2,2)), "getAndSetRelease Value value");
+            }
+
+
+        }
+    }
+
+    static void testArrayUnsupported(Handles hs) throws Throwable {
+        Value[] array = new Value[10];
+
+        final int i = 0;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
+            checkUOE(am, () -> {
+                Value o = (Value) hs.get(am).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
+            checkUOE(am, () -> {
+                Value o = (Value) hs.get(am).invokeExact(array, i, Value.getInstance(Point.getInstance(1,1)));
+            });
+        }
+    }
+
+    static void testArrayIndexOutOfBounds(Handles hs) throws Throwable {
+        Value[] array = new Value[10];
+
+        for (int i : new int[]{-1, Integer.MIN_VALUE, 10, 11, Integer.MAX_VALUE}) {
+            final int ci = i;
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+                checkAIOOBE(am, () -> {
+                    Value x = (Value) hs.get(am).invokeExact(array, ci);
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+                checkAIOOBE(am, () -> {
+                    hs.get(am).invokeExact(array, ci, Value.getInstance(Point.getInstance(1,1)));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+                checkAIOOBE(am, () -> {
+                    boolean r = (boolean) hs.get(am).invokeExact(array, ci, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(2,2)));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+                checkAIOOBE(am, () -> {
+                    Value r = (Value) hs.get(am).invokeExact(array, ci, Value.getInstance(Point.getInstance(2,2)), Value.getInstance(Point.getInstance(1,1)));
+                });
+            }
+
+            for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+                checkAIOOBE(am, () -> {
+                    Value o = (Value) hs.get(am).invokeExact(array, ci, Value.getInstance(Point.getInstance(1,1)));
+                });
+            }
+
+
+        }
+    }
+}
+

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypePoint.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import jdk.internal.value.PrimitiveClass;
-
 import static org.testng.Assert.*;
 
 import static java.lang.invoke.MethodType.*;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
@@ -1,0 +1,2063 @@
+/*
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+/*
+ * @test
+ * @bug 8156486
+ * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodTypeValue.java
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses VarHandleTestMethodTypeValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodTypeValue
+ * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeValue
+*/
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+import static java.lang.invoke.MethodType.*;
+
+public class VarHandleTestMethodTypeValue extends VarHandleBaseTest {
+    static final Class<?> type = Value.class;
+
+    static final Value static_final_v = Value.getInstance(Point.getInstance(1,1));
+
+    static Value static_v = Value.getInstance(Point.getInstance(1,1));
+
+    final Value final_v = Value.getInstance(Point.getInstance(1,1));
+
+    Value v = Value.getInstance(Point.getInstance(1,1));
+
+    VarHandle vhFinalField;
+
+    VarHandle vhField;
+
+    VarHandle vhStaticField;
+
+    VarHandle vhStaticFinalField;
+
+    VarHandle vhArray;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        vhFinalField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodTypeValue.class, "final_v", type);
+
+        vhField = MethodHandles.lookup().findVarHandle(
+                VarHandleTestMethodTypeValue.class, "v", type);
+
+        vhStaticFinalField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodTypeValue.class, "static_final_v", type);
+
+        vhStaticField = MethodHandles.lookup().findStaticVarHandle(
+            VarHandleTestMethodTypeValue.class, "static_v", type);
+
+        vhArray = MethodHandles.arrayElementVarHandle(Value[].class);
+    }
+
+    @DataProvider
+    public Object[][] accessTestCaseProvider() throws Exception {
+        List<AccessTestCase<?>> cases = new ArrayList<>();
+
+        cases.add(new VarHandleAccessTestCase("Instance field",
+                                              vhField, vh -> testInstanceFieldWrongMethodType(this, vh),
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Static field",
+                                              vhStaticField, VarHandleTestMethodTypeValue::testStaticFieldWrongMethodType,
+                                              false));
+
+        cases.add(new VarHandleAccessTestCase("Array",
+                                              vhArray, VarHandleTestMethodTypeValue::testArrayWrongMethodType,
+                                              false));
+
+        for (VarHandleToMethodHandle f : VarHandleToMethodHandle.values()) {
+            cases.add(new MethodHandleAccessTestCase("Instance field",
+                                                     vhField, f, hs -> testInstanceFieldWrongMethodType(this, hs),
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Static field",
+                                                     vhStaticField, f, VarHandleTestMethodTypeValue::testStaticFieldWrongMethodType,
+                                                     false));
+
+            cases.add(new MethodHandleAccessTestCase("Array",
+                                                     vhArray, f, VarHandleTestMethodTypeValue::testArrayWrongMethodType,
+                                                     false));
+        }
+        // Work around issue with jtreg summary reporting which truncates
+        // the String result of Object.toString to 30 characters, hence
+        // the first dummy argument
+        return cases.stream().map(tc -> new Object[]{tc.toString(), tc}).toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "accessTestCaseProvider")
+    public <T> void testAccess(String desc, AccessTestCase<T> atc) throws Throwable {
+        T t = atc.get();
+        int iters = atc.requiresLoop() ? ITERS : 1;
+        for (int c = 0; c < iters; c++) {
+            atc.testAccess(t);
+        }
+    }
+
+
+    static void testInstanceFieldWrongMethodType(VarHandleTestMethodTypeValue recv, VarHandle vh) throws Throwable {
+        // Get
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.get(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.get(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            Value x = (Value) vh.get(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.get();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.get(recv, Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.set(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.set(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.set(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.set(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getVolatile(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getVolatile(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            Value x = (Value) vh.getVolatile(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getVolatile(recv, Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setVolatile(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setVolatile(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setVolatile(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getOpaque(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getOpaque(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            Value x = (Value) vh.getOpaque(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getOpaque(recv, Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setOpaque(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setOpaque(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setOpaque(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getAcquire(null);
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getAcquire(Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            Value x = (Value) vh.getAcquire(0);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire(recv);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire(recv);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAcquire(recv, Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            vh.setRelease(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            vh.setRelease(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setRelease(recv, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setRelease(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.compareAndSet(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.compareAndSet(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetPlain(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetPlain(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSet(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSet(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetAcquire(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetAcquire(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetRelease(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetRelease(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchange(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchange(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchange(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.compareAndExchange(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchange(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchangeAcquire(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.compareAndExchangeAcquire(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchangeRelease(null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.compareAndExchangeRelease(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeRelease(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.compareAndExchangeRelease(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeRelease(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getAndSet(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSet(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSet(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.getAndSet(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSet(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getAndSetAcquire(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSetAcquire(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetAcquire(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.getAndSetAcquire(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetAcquire(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.getAndSetRelease(null, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            Value x = (Value) vh.getAndSetRelease(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetRelease(recv, Void.class);
+        });
+        checkWMTE(() -> { // reciever primitive class
+            Value x = (Value) vh.getAndSetRelease(0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetRelease(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+    }
+
+    static void testInstanceFieldWrongMethodType(VarHandleTestMethodTypeValue recv, Handles hs) throws Throwable {
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class)).
+                    invokeExact((VarHandleTestMethodTypeValue) null);
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class)).
+                    invokeExact(Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class)).
+                    invokeExact(0);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeValue.class)).
+                    invokeExact(recv);
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class)).
+                    invokeExact(recv);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeValue.class, type)).
+                    invokeExact((VarHandleTestMethodTypeValue) null, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                hs.get(am, methodType(void.class, Class.class, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                hs.get(am, methodType(void.class, int.class, type)).
+                    invokeExact(0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, VarHandleTestMethodTypeValue.class, type, Class.class)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class, type, type)).
+                    invokeExact((VarHandleTestMethodTypeValue) null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class, Class.class, type)).
+                    invokeExact(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class, type, Class.class)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class , type, type)).
+                    invokeExact(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class, type, type, Class.class)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            checkNPE(() -> { // null receiver
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, type, type)).
+                    invokeExact((VarHandleTestMethodTypeValue) null, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, type, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, Class.class, type)).
+                    invokeExact(recv, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, type, Class.class)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            checkWMTE(() -> { // reciever primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class , type, type)).
+                    invokeExact(0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeValue.class , type, type)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class , type, type)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, type, type, Class.class)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            checkNPE(() -> { // null receiver
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, type)).
+                    invokeExact((VarHandleTestMethodTypeValue) null, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, Class.class)).
+                    invokeExact(recv, Void.class);
+            });
+            checkWMTE(() -> { // reciever primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class, type)).
+                    invokeExact(0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, VarHandleTestMethodTypeValue.class, type)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, VarHandleTestMethodTypeValue.class, type)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, VarHandleTestMethodTypeValue.class, type)).
+                    invokeExact(recv, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+
+    }
+
+
+    static void testStaticFieldWrongMethodType(VarHandle vh) throws Throwable {
+        // Get
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get();
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.get(Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.set(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getVolatile(Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getOpaque(Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire();
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAcquire(Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            vh.setRelease(Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchange(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchange(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchange(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeAcquire(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeRelease(Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeRelease(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSet(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSet(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetAcquire(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetAcquire(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetRelease(Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetRelease(Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+    }
+
+    static void testStaticFieldWrongMethodType(Handles hs) throws Throwable {
+        int i = 0;
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(Class.class)).
+                    invokeExact(Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, Class.class)).
+                    invokeExact(Void.class);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, type, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, type)).
+                    invokeExact(Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                Value x = (Value) hs.get(am, methodType(type, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, type, type)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type, type)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, type, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            // Incorrect argument types
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class)).
+                    invokeExact(Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, type)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, type)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, type, Class.class)).
+                    invokeExact(Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+
+    }
+
+
+    static void testArrayWrongMethodType(VarHandle vh) throws Throwable {
+        Value[] array = new Value[10];
+        Arrays.fill(array, Value.getInstance(Point.getInstance(1,1)));
+
+        // Get
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.get(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.get(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.get(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.get(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.get(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.get(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.get();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.get(array, 0, Void.class);
+        });
+
+
+        // Set
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.set(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            vh.set(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.set(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.set(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.set(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.set();
+        });
+        checkWMTE(() -> { // >
+            vh.set(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getVolatile(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getVolatile(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.getVolatile(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getVolatile(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getVolatile(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getVolatile(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getVolatile();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getVolatile(array, 0, Void.class);
+        });
+
+
+        // SetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setVolatile(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setVolatile(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setVolatile(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setVolatile(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setVolatile(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setVolatile();
+        });
+        checkWMTE(() -> { // >
+            vh.setVolatile(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getOpaque(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getOpaque(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.getOpaque(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getOpaque(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getOpaque(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getOpaque(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getOpaque();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getOpaque(array, 0, Void.class);
+        });
+
+
+        // SetOpaque
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setOpaque(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setOpaque(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setOpaque(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setOpaque(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setOpaque(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setOpaque();
+        });
+        checkWMTE(() -> { // >
+            vh.setOpaque(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getAcquire(null, 0);
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getAcquire(Void.class, 0);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.getAcquire(0, 0);
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getAcquire(array, Void.class);
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void x = (Void) vh.getAcquire(array, 0);
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAcquire(array, 0);
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAcquire(array, 0, Void.class);
+        });
+
+
+        // SetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            vh.setRelease(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            vh.setRelease(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            vh.setRelease(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            vh.setRelease(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            vh.setRelease(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            vh.setRelease();
+        });
+        checkWMTE(() -> { // >
+            vh.setRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.compareAndSet(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.compareAndSet(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.compareAndSet(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.compareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.compareAndSet(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.compareAndSet(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.compareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.compareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetPlain(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetPlain(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetPlain(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetPlain(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetPlain(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetPlain();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetPlain(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetVolatile
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSet(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSet(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSet(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSet(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSet(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSet();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetAcquire(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetAcquire(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetAcquire(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetAcquire(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // WeakCompareAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            boolean r = vh.weakCompareAndSetRelease(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // receiver reference class
+            boolean r = vh.weakCompareAndSetRelease(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            boolean r = vh.weakCompareAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // receiver primitive class
+            boolean r = vh.weakCompareAndSetRelease(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            boolean r = vh.weakCompareAndSetRelease(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            boolean r = vh.weakCompareAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            boolean r = vh.weakCompareAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchange
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchange(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.compareAndExchange(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchange(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchange(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.compareAndExchange(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.compareAndExchange(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchange(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchange(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchange();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchange(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchangeAcquire(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.compareAndExchangeAcquire(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.compareAndExchangeAcquire(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // CompareAndExchangeRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null receiver
+            Value x = (Value) vh.compareAndExchangeRelease(null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.compareAndExchangeRelease(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // expected reference class
+            Value x = (Value) vh.compareAndExchangeRelease(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // actual reference class
+            Value x = (Value) vh.compareAndExchangeRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+        checkWMTE(() -> { // array primitive class
+            Value x = (Value) vh.compareAndExchangeRelease(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.compareAndExchangeRelease(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.compareAndExchangeRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.compareAndExchangeRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.compareAndExchangeRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.compareAndExchangeRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSet
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getAndSet(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getAndSet(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSet(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            Value x = (Value) vh.getAndSet(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getAndSet(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSet();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSet(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSetAcquire
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getAndSetAcquire(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getAndSetAcquire(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetAcquire(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            Value x = (Value) vh.getAndSetAcquire(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getAndSetAcquire(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetAcquire();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetAcquire(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+        // GetAndSetRelease
+        // Incorrect argument types
+        checkNPE(() -> { // null array
+            Value x = (Value) vh.getAndSetRelease(null, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // array reference class
+            Value x = (Value) vh.getAndSetRelease(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkCCE(() -> { // value reference class
+            Value x = (Value) vh.getAndSetRelease(array, 0, Void.class);
+        });
+        checkWMTE(() -> { // reciarrayever primitive class
+            Value x = (Value) vh.getAndSetRelease(0, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // index reference class
+            Value x = (Value) vh.getAndSetRelease(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect return type
+        checkCCE(() -> { // reference class
+            Void r = (Void) vh.getAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        checkWMTE(() -> { // primitive class
+            boolean x = (boolean) vh.getAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)));
+        });
+        // Incorrect arity
+        checkWMTE(() -> { // 0
+            Value x = (Value) vh.getAndSetRelease();
+        });
+        checkWMTE(() -> { // >
+            Value x = (Value) vh.getAndSetRelease(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+        });
+
+
+    }
+
+    static void testArrayWrongMethodType(Handles hs) throws Throwable {
+        Value[] array = new Value[10];
+        Arrays.fill(array, Value.getInstance(Point.getInstance(1,1)));
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class)).
+                    invokeExact((Value[]) null, 0);
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, int.class)).
+                    invokeExact(Void.class, 0);
+            });
+            checkWMTE(() -> { // array primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class, int.class)).
+                    invokeExact(0, 0);
+            });
+            checkWMTE(() -> { // index reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, Class.class)).
+                    invokeExact(array, Void.class);
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void x = (Void) hs.get(am, methodType(Void.class, Value[].class, int.class)).
+                    invokeExact(array, 0);
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class)).
+                    invokeExact(array, 0);
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                hs.get(am, methodType(void.class, Value[].class, int.class, type)).
+                    invokeExact((Value[]) null, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                hs.get(am, methodType(void.class, Class.class, int.class, type)).
+                    invokeExact(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                hs.get(am, methodType(void.class, Value[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                hs.get(am, methodType(void.class, int.class, int.class, type)).
+                    invokeExact(0, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // index reference class
+                hs.get(am, methodType(void.class, Value[].class, Class.class, type)).
+                    invokeExact(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                hs.get(am, methodType(void.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                hs.get(am, methodType(void.class, Value[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, type, type)).
+                    invokeExact((Value[]) null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // receiver reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Class.class, int.class, type, type)).
+                    invokeExact(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, Class.class, type)).
+                    invokeExact(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, type, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            checkWMTE(() -> { // receiver primitive class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, int.class, int.class, type, type)).
+                    invokeExact(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // index reference class
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Value[].class, Class.class, type, type)).
+                    invokeExact(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                boolean r = (boolean) hs.get(am, methodType(boolean.class)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                boolean r = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, type, type, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null receiver
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, type, type)).
+                    invokeExact((Value[]) null, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, int.class, type, type)).
+                    invokeExact(Void.class, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // expected reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, Class.class, type)).
+                    invokeExact(array, 0, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // actual reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, type, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+            checkWMTE(() -> { // array primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class, int.class, type, type)).
+                    invokeExact(0, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // index reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, Class.class, type, type)).
+                    invokeExact(array, Void.class, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, Value[].class, int.class, type, type)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, type, type)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, type, type, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
+            // Incorrect argument types
+            checkNPE(() -> { // null array
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, type)).
+                    invokeExact((Value[]) null, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // array reference class
+                Value x = (Value) hs.get(am, methodType(type, Class.class, int.class, type)).
+                    invokeExact(Void.class, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            hs.checkWMTEOrCCE(() -> { // value reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, Class.class)).
+                    invokeExact(array, 0, Void.class);
+            });
+            checkWMTE(() -> { // array primitive class
+                Value x = (Value) hs.get(am, methodType(type, int.class, int.class, type)).
+                    invokeExact(0, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // index reference class
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, Class.class, type)).
+                    invokeExact(array, Void.class, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect return type
+            hs.checkWMTEOrCCE(() -> { // reference class
+                Void r = (Void) hs.get(am, methodType(Void.class, Value[].class, int.class, type)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            checkWMTE(() -> { // primitive class
+                boolean x = (boolean) hs.get(am, methodType(boolean.class, Value[].class, int.class, type)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)));
+            });
+            // Incorrect arity
+            checkWMTE(() -> { // 0
+                Value x = (Value) hs.get(am, methodType(type)).
+                    invokeExact();
+            });
+            checkWMTE(() -> { // >
+                Value x = (Value) hs.get(am, methodType(type, Value[].class, int.class, type, Class.class)).
+                    invokeExact(array, 0, Value.getInstance(Point.getInstance(1,1)), Void.class);
+            });
+        }
+
+
+    }
+}

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -25,11 +25,18 @@
 
 /*
  * @test
+#if[Value]
  * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestAccess$Type$.java
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=10    -Xint                   VarHandleTestAccess$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccess$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000                         VarHandleTestAccess$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccess$Type$
+#else[Value]
+ * @run testng/othervm -Diters=10    -Xint                   VarHandleTestAccess$Type$
+ * @run testng/othervm -Diters=20000 -XX:TieredStopAtLevel=1 VarHandleTestAccess$Type$
+ * @run testng/othervm -Diters=20000                         VarHandleTestAccess$Type$
+ * @run testng/othervm -Diters=20000 -XX:-TieredCompilation  VarHandleTestAccess$Type$
+#end[Value]
  */
 
 import org.testng.annotations.BeforeClass;
@@ -44,7 +51,6 @@ import java.util.List;
 
 #if[Point]
 import jdk.internal.value.PrimitiveClass;
-
 #end[Point]
 import static org.testng.Assert.*;
 
@@ -84,9 +90,6 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 #if[Object]
     VarHandle vhArrayObject;
 #end[Object]
-#if[Value]
-    VarHandle vhValueTypeField;
-#end[Value]
 
     VarHandle[] allocate(boolean same) {
         List<VarHandle> vhs = new ArrayList<>();
@@ -145,11 +148,6 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
 #if[Object]
         vhArrayObject = MethodHandles.arrayElementVarHandle(Object[].class);
 #end[Object]
-
-#if[Value]
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "$varType$_v", type);
-#end[Value]
     }
 
 
@@ -346,13 +344,6 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
                                               vhArrayObject, VarHandleTestAccess$Type$::testArrayStoreException,
                                               false));
 #end[Object]
-#if[Value]
-        cases.add(new VarHandleAccessTestCase("Value type field",
-                                              vhValueTypeField, vh -> testValueTypeField(Value.getInstance(), vh)));
-        cases.add(new VarHandleAccessTestCase("Value type field unsupported",
-                                              vhValueTypeField, vh -> testValueTypeFieldUnsupported(Value.getInstance(), vh),
-                                              false));
-#end[Value]
         // Work around issue with jtreg summary reporting which truncates
         // the String result of Object.toString to 30 characters, hence
         // the first dummy argument
@@ -513,22 +504,6 @@ public class VarHandleTestAccess$Type$ extends VarHandleBaseTest {
         });
 #end[Bitwise]
     }
-
-#if[Value]
-    static void testValueTypeField(Value recv, VarHandle vh) {
-        // Plain
-        {
-            $type$ x = ($type$) vh.get(recv);
-            assertEquals(x, $value1$, "get $type$ value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, VarHandle vh) {
-        checkUOE(() -> {
-            vh.set(recv, $value2$);
-        });
-    }
-#end[Value]
 
     static void testStaticFinalField(VarHandle vh) {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -25,8 +25,12 @@
 
 /*
  * @test
+#if[Value]
  * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodHandleAccess$Type$.java
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Diters=2000 VarHandleTestMethodHandleAccess$Type$
+#else[Value]
+ * @run testng/othervm -Diters=20000 VarHandleTestMethodHandleAccess$Type$
+#end[Value]
  */
 
 import org.testng.annotations.BeforeClass;
@@ -42,7 +46,6 @@ import java.util.List;
 
 #if[Point]
 import jdk.internal.value.PrimitiveClass;
-
 #end[Point]
 import static org.testng.Assert.*;
 
@@ -55,7 +58,7 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
 
     static final $type$ static_final_v = $value1$;
 
-    static $type$ static_v;
+    static $type$ static_v = $value1$;
 
     final $type$ final_v = $value1$;
 
@@ -70,10 +73,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
     VarHandle vhStaticFinalField;
 
     VarHandle vhArray;
-
-#if[Value]
-    VarHandle vhValueTypeField;
-#end[Value]
 
     @BeforeClass
     public void setup() throws Exception {
@@ -90,11 +89,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             VarHandleTestMethodHandleAccess$Type$.class, "static_v", type);
 
         vhArray = MethodHandles.arrayElementVarHandle($type$[].class);
-
-#if[Value]
-        vhValueTypeField = MethodHandles.lookup().findVarHandle(
-                    Value.class, "$varType$_v", type);
-#end[Value]
     }
 
 
@@ -123,13 +117,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
             cases.add(new MethodHandleAccessTestCase("Array index out of bounds",
                                                      vhArray, f, VarHandleTestMethodHandleAccess$Type$::testArrayIndexOutOfBounds,
                                                      false));
-#if[Value]
-        cases.add(new MethodHandleAccessTestCase("Value type field",
-                                                 vhValueTypeField, f, hs -> testValueTypeField(Value.getInstance(), hs)));
-        cases.add(new MethodHandleAccessTestCase("Value type field unsupported",
-                                                 vhValueTypeField, f, hs -> testValueTypeFieldUnsupported(Value.getInstance(), hs),
-                                                 false));
-#end[Value]
         }
 
         // Work around issue with jtreg summary reporting which truncates
@@ -478,59 +465,6 @@ public class VarHandleTestMethodHandleAccess$Type$ extends VarHandleBaseTest {
 #end[Bitwise]
     }
 
-#if[Value]
-    static void testValueTypeField(Value recv, Handles hs) throws Throwable {
-        // Plain
-        {
-            $type$ x = ($type$) hs.get(TestAccessMode.GET).invokeExact(recv);
-            assertEquals(x, $value1$, "get $type$ value");
-        }
-    }
-
-    static void testValueTypeFieldUnsupported(Value recv, Handles hs) throws Throwable {
-        // Plain
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.SET)) {
-            checkUOE(am, () -> {
-                hs.get(am).invokeExact(recv, $value1$);
-            });
-        }
-#if[!CAS]
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_SET)) {
-            checkUOE(am, () -> {
-                boolean r = (boolean) hs.get(am).invokeExact(recv, $value1$, $value2$);
-            });
-        }
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.COMPARE_AND_EXCHANGE)) {
-            checkUOE(am, () -> {
-                $type$ r = ($type$) hs.get(am).invokeExact(recv, $value1$, $value2$);
-            });
-        }
-
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_SET)) {
-            checkUOE(am, () -> {
-                $type$ r = ($type$) hs.get(am).invokeExact(recv, $value1$);
-            });
-        }
-#end[CAS]
-
-#if[!AtomicAdd]
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_ADD)) {
-            checkUOE(am, () -> {
-                $type$ r = ($type$) hs.get(am).invokeExact(recv, $value1$);
-            });
-        }
-#end[AtomicAdd]
-
-#if[!Bitwise]
-        for (TestAccessMode am : testAccessModesOfType(TestAccessType.GET_AND_BITWISE)) {
-            checkUOE(am, () -> {
-                $type$ r = ($type$) hs.get(am).invokeExact(recv, $value1$);
-            });
-        }
-#end[Bitwise]
-    }
-#end[Value]
 
     static void testStaticField(Handles hs) throws Throwable {
         // Plain

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -27,17 +27,17 @@
  * @test
  * @bug 8156486
  * @compile -XDenablePrimitiveClasses Point.java Value.java VarHandleTestMethodType$Type$.java
-#if[Point]
+#if[Value]
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses VarHandleTestMethodType$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodType$Type$
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
-#else[Point]
+#else[Value]
  * @run testng/othervm VarHandleTestMethodType$Type$
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false VarHandleTestMethodType$Type$
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodType$Type$
-#end[Point]
+#end[Value]
 */
 
 import org.testng.annotations.BeforeClass;
@@ -52,7 +52,6 @@ import java.util.List;
 
 #if[Point]
 import jdk.internal.value.PrimitiveClass;
-
 #end[Point]
 import static org.testng.Assert.*;
 

--- a/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
+++ b/test/jdk/java/lang/invoke/VarHandles/generate-vh-tests.sh
@@ -9,11 +9,10 @@ SPP=build.tools.spp.Spp
 # desirable to generate code using ASM which will allow more flexibility
 # in the kinds of tests that are generated.
 
-for type in boolean byte short char int long float double String Point
+for type in boolean byte short char int long float double String Point Value
 do
   Type="$(tr '[:lower:]' '[:upper:]' <<< ${type:0:1})${type:1}"
-  varType="$(tr '[:upper:]' '[:lower:]' <<< ${type:0:1})${type:1}"
-  args="-K$type -Dtype=$type -DType=$Type -DvarType=$varType"
+  args="-K$type -Dtype=$type -DType=$Type"
 
   args="$args -KCAS"
 
@@ -29,15 +28,14 @@ do
       ;;
   esac
 
+# Object = object of identity class or value class
+# Value = value class or primitive class
   case $type in
-    boolean|byte|short|char|int|long|float|double|Point)
-      args="$args -KValue"
-      ;;
-  esac
-
-  case $type in
-    String|Point)
+    String)
       args="$args -KObject"
+      ;;
+    Point|Value)
+      args="$args -KObject -KValue"
       ;;
   esac
 
@@ -89,11 +87,16 @@ do
       value1=\"foo\"
       value2=\"bar\"
       value3=\"baz\"
-       ;;
+      ;;
     Point)
       value1="Point.getInstance(1,1)"
       value2="Point.getInstance(2,2)"
       value3="Point.getInstance(3,3)"
+      ;;
+    Value)
+      value1="Value.getInstance(Point.getInstance(1,1))"
+      value2="Value.getInstance(Point.getInstance(2,2))"
+      value3="Value.getInstance(Point.getInstance(3,3))"
       ;;
   esac
 

--- a/test/jdk/valhalla/valuetypes/InlinableValue.java
+++ b/test/jdk/valhalla/valuetypes/InlinableValue.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-public primitive class Value {
+public primitive class InlinableValue {
     char char_v;
     byte byte_v;
     boolean boolean_v;
@@ -35,7 +35,7 @@ public primitive class Value {
     Point.ref point_ref;
     Object ref_v;
 
-    Value(char c, boolean z, byte b, int x, short y, long l, float f, double d, Number number, Point p, Object o) {
+    InlinableValue(char c, boolean z, byte b, int x, short y, long l, float f, double d, Number number, Point p, Object o) {
         char_v = c;
         byte_v = b;
         boolean_v = z;
@@ -49,7 +49,7 @@ public primitive class Value {
         point_ref = null;
         ref_v = o;
     }
-    Value(char c, boolean z, byte b, int x, short y, long l, float f, double d, Number number, Point p, Point.ref pref, Object o) {
+    InlinableValue(char c, boolean z, byte b, int x, short y, long l, float f, double d, Number number, Point p, Point.ref pref, Object o) {
         char_v = c;
         byte_v = b;
         boolean_v = z;
@@ -126,8 +126,8 @@ public primitive class Value {
             this.ref = o;
             return this;
         }
-        Value build() {
-            return new Value(c, z, b, i, s, l, f, d, n, p, pref, ref);
+        InlinableValue build() {
+            return new InlinableValue(c, z, b, i, s, l, f, d, n, p, pref, ref);
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @summary test MethodHandle/VarHandle o primitive classes
+ * @summary test MethodHandle/VarHandle of value classes and primitive classes
  * @compile -XDenablePrimitiveClasses MethodHandleTest.java
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses MethodHandleTest
  */
@@ -45,6 +45,7 @@ public class MethodHandleTest {
     private static final Point P = Point.makePoint(10, 20);
     private static final Line L = Line.makeLine(10, 20, 30, 40);
     private static final MutablePath PATH = MutablePath.makePath(10, 20, 30, 40);
+    private static final Value V = new Value(P, new ValueOptional(L));
 
     @DataProvider(name="fields")
     static Object[][] fields() {
@@ -62,6 +63,7 @@ public class MethodHandleTest {
                 // identity class whose non-final fields are of primitive value type,
                 // primitive reference type, reference type and value class
                 new Object[] { "MixedValues", mv, new String[] {"p", "l", "mutablePath", "list", "nfp", "voptional"} },
+                new Object[] { "MethodHandleTest$Value", V, new String[] {"p", "vo"} },
         };
     }
 
@@ -110,7 +112,7 @@ public class MethodHandleTest {
         MixedValues mv = new MixedValues(P, L, PATH, "mixed", "types");
         Point p = Point.makePoint(100, 200);
         Line l = Line.makeLine(100, 200, 300, 400);
-        ValueOptional v = new ValueOptional(P);
+        ValueOptional vo = new ValueOptional(P);
 
         setValueField(MutablePath.class, "p1", path, p);
         setValueField(MutablePath.class, "p2", path, p);
@@ -119,11 +121,11 @@ public class MethodHandleTest {
         setValueField(MixedValues.class, "staticPoint", null, p);
         // the following are nullable fields
         setField(MixedValues.class, "nfp", mv, p, false);
-        setField(MixedValues.class, "voptional", mv, v, false);
+        setField(MixedValues.class, "voptional", mv, vo, false);
         // static fields of reference type
         setField(MixedValues.class, "staticLine", null, l, false);
         setField(MixedValues.class, "staticLine", null, null, false);
-        setField(MixedValues.class, "staticValue", null, v, false);
+        setField(MixedValues.class, "staticValue", null, vo, false);
     }
 
     @DataProvider(name="arrays")
@@ -133,6 +135,7 @@ public class MethodHandleTest {
                 new Object[] { Point.ref[].class, P },
                 new Object[] { Line[].class, L },
                 new Object[] { MutablePath[].class, PATH },
+                new Object[] { Value[].class, V },
         };
     }
 
@@ -155,7 +158,7 @@ public class MethodHandleTest {
         try {
             Object v = (Object)setter.invoke(array, 1, null);
             assertFalse(PrimitiveClass.isPrimitiveValueType(elementType), "should fail to set a primitive class array element to null");
-            assertNull((Object)getter.invoke(array, 1));
+            assertNull((Object) getter.invoke(array, 1));
         } catch (NullPointerException e) {
             assertTrue(PrimitiveClass.isPrimitiveValueType(elementType), "should only fail to set a primitive class array element to null");
         }
@@ -324,6 +327,15 @@ public class MethodHandleTest {
             assertEquals(f.get(null), value);
         } finally {
             f.set(null, v);
+        }
+    }
+
+    static value class Value {
+        Point p;
+        ValueOptional vo;
+        Value(Point p, ValueOptional vo) {
+            this.p = p;
+            this.vo = vo;
         }
     }
 }

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -24,14 +24,12 @@
 
 /*
  * @test
- * @summary test Object methods on primitive classes
+ * @summary test Object methods on value classes and primitive classes
  * @modules java.base/jdk.internal.value
  * @compile -XDenablePrimitiveClasses ObjectMethods.java
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Dvalue.bsm.salt=1 ObjectMethods
- * @compile -XDenablePrimitiveClasses ObjectMethods.java
  * @run testng/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Dvalue.bsm.salt=1 -XX:InlineFieldMaxFlatSize=0 ObjectMethods
  */
-import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
@@ -53,24 +51,24 @@ public class ObjectMethods {
     static final Line LINE2 = Line.makeLine(10, 20, 3, 4);
     static final MutablePath MUTABLE_PATH = MutablePath.makePath(10, 20, 30, 40);
     static final MixedValues MIXED_VALUES = new MixedValues(P1, LINE1, MUTABLE_PATH, "value");
-    static final Value VALUE = new Value.Builder()
-                                        .setChar('z')
-                                        .setBoolean(false)
-                                        .setByte((byte)0x1)
-                                        .setShort((short)3)
-                                        .setLong(4L)
-                                        .setPoint(Point.makePoint(200, 200))
-                                        .setNumber(Value.Number.intValue(10)).build();
-    static final Value VALUE1 = new Value.Builder()
-                                        .setChar('z')
-                                        .setBoolean(false)
-                                        .setByte((byte)0x1)
-                                        .setShort((short)3)
-                                        .setLong(4L)
-                                        .setPoint(Point.makePoint(100, 100))
-                                        .setPointRef(Point.makePoint(200, 200))
-                                        .setReference(Point.makePoint(300, 300))
-                                        .setNumber(Value.Number.intValue(20)).build();
+    static final InlinableValue VALUE = new InlinableValue.Builder()
+                                                .setChar('z')
+                                                .setBoolean(false)
+                                                .setByte((byte)0x1)
+                                                .setShort((short)3)
+                                                .setLong(4L)
+                                                .setPoint(Point.makePoint(200, 200))
+                                                .setNumber(InlinableValue.Number.intValue(10)).build();
+    static final InlinableValue VALUE1 = new InlinableValue.Builder()
+                                                .setChar('z')
+                                                .setBoolean(false)
+                                                .setByte((byte)0x1)
+                                                .setShort((short)3)
+                                                .setLong(4L)
+                                                .setPoint(Point.makePoint(100, 100))
+                                                .setPointRef(Point.makePoint(200, 200))
+                                                .setReference(Point.makePoint(300, 300))
+                                                .setNumber(InlinableValue.Number.intValue(20)).build();
 
     @DataProvider(name="Identities")
     Object[][] identitiesData() {
@@ -124,16 +122,16 @@ public class ObjectMethods {
             { LINE1, Line.makeLine(1, 2, 3, 4), true},
             { LINE1, LINE2, false},
             { LINE1, LINE1, true},
-            { VALUE, new Value.Builder()
+            { VALUE, new InlinableValue.Builder()
                               .setChar('z')
                               .setBoolean(false)
                               .setByte((byte)0x1)
                               .setShort((short)3)
                               .setLong(4L)
                               .setPoint(Point.makePoint(200, 200))
-                              .setNumber(Value.Number.intValue(10)).build(), true},
-            { new Value.Builder().setNumber(new Value.IntNumber(10)).build(),
-              new Value.Builder().setNumber(new Value.IntNumber(10)).build(), false},
+                              .setNumber(InlinableValue.Number.intValue(10)).build(), true},
+            { new InlinableValue.Builder().setNumber(new InlinableValue.IntNumber(10)).build(),
+              new InlinableValue.Builder().setNumber(new InlinableValue.IntNumber(10)).build(), false},
             // reference classes containing fields of primitive class
             { MUTABLE_PATH, MutablePath.makePath(10, 20, 30, 40), false},
             { MIXED_VALUES, MIXED_VALUES, true},
@@ -174,13 +172,11 @@ public class ObjectMethods {
         };
     }
 
-
     @Test(dataProvider="interfaceEqualsTests")
     public void testNumber(Number n1, Number n2, boolean isSubstitutable, boolean isEquals) {
         assertTrue((n1 == n2) == isSubstitutable);
         assertTrue(n1.equals(n2) == isEquals);
     }
-
 
     @DataProvider(name="toStringTests")
     Object[][] toStringTests() {
@@ -189,9 +185,9 @@ public class ObjectMethods {
             { Line.makeLine(1, 2, 3, 4) },
             { VALUE },
             { VALUE1 },
-            { new Value.Builder()
+            { new InlinableValue.Builder()
                         .setReference(List.of("ref"))
-                        .setNumber(new Value.IntNumber(99)).build() },
+                        .setNumber(new InlinableValue.IntNumber(99)).build() },
             // enclosing instance field `this$0` should be filtered
             { MyValue1.default },
             { new MyValue1(0,0, null) },

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @summary test MethodHandle/VarHandle on primitive classes
  * @modules java.base/java.lang.runtime:open
  *          java.base/jdk.internal.org.objectweb.asm
  * @compile -XDenablePrimitiveClasses SubstitutabilityTest.java
@@ -48,7 +47,7 @@ public class SubstitutabilityTest {
         Line l1 = Line.makeLine(p1, p2);
         var mpath = MutablePath.makePath(10, 20, 30, 40);
         var mixedValues = new MixedValues(p1, l1, mpath, "value");
-        var number = Value.Number.intValue(99);
+        var number = InlinableValue.Number.intValue(99);
         var list = List.of("list");
         return new Object[][] {
             new Object[] { p1, Point.makePoint(10, 10) },
@@ -65,11 +64,11 @@ public class SubstitutabilityTest {
             new Object[] { valueBuilder().setFloat(Float.NaN).setDouble(Double.NaN).setPoint(p1).build(),
                            valueBuilder().setFloat(Float.NaN).setDouble(Double.NaN).setPoint(l1.p1).build() },
             new Object[] { valueBuilder().setFloat(Float.NaN).setDouble(Double.NaN).setNumber(number).build(),
-                           valueBuilder().setFloat(Float.NaN).setDouble(Double.NaN).setNumber(Value.Number.intValue(99)).build() },
+                           valueBuilder().setFloat(Float.NaN).setDouble(Double.NaN).setNumber(InlinableValue.Number.intValue(99)).build() },
             new Object[] { valueBuilder().setFloat(+0.0f).setDouble(+0.0).setReference(list).build(),
                            valueBuilder().setFloat(+0.0f).setDouble(+0.0).setReference(list).build() },
-            new Object[] { valueBuilder().setNumber(Value.Number.intValue(100)).build(),
-                           valueBuilder().setNumber(Value.Number.intValue(100)).build() },
+            new Object[] { valueBuilder().setNumber(InlinableValue.Number.intValue(100)).build(),
+                           valueBuilder().setNumber(InlinableValue.Number.intValue(100)).build() },
             new Object[] { valueBuilder().setReference(list).build(),
                            valueBuilder().setReference(list).build() },
             new Object[] { new ValueOptional(p1), new ValueOptional(p1)},
@@ -88,7 +87,7 @@ public class SubstitutabilityTest {
     Object[][] notSubstitutableCases() {
         var point = Point.makePoint(10, 10);
         var mpath = MutablePath.makePath(10, 20, 30, 40);
-        var number = Value.Number.intValue(99);
+        var number = InlinableValue.Number.intValue(99);
         return new Object[][] {
             new Object[] { Point.makePoint(10, 10), Point.makePoint(10, 20)},
             new Object[] { mpath, MutablePath.makePath(10, 20, 30, 40)},
@@ -102,23 +101,23 @@ public class SubstitutabilityTest {
             new Object[] { valueBuilder().setPointRef(point).build(),
                            valueBuilder().setPointRef(Point.makePoint(20, 20)).build() },
             new Object[] { valueBuilder().setNumber(number).build(),
-                           valueBuilder().setNumber(new Value.IntNumber(99)).build() },
-            new Object[] { valueBuilder().setNumber(Value.Number.intValue(1)).build(),
-                           valueBuilder().setNumber(Value.Number.shortValue((short)1)).build() },
-            new Object[] { valueBuilder().setNumber(new Value.IntNumber(99)).build(),
-                           valueBuilder().setNumber(new Value.IntNumber(99)).build() },
+                           valueBuilder().setNumber(new InlinableValue.IntNumber(99)).build() },
+            new Object[] { valueBuilder().setNumber(InlinableValue.Number.intValue(1)).build(),
+                           valueBuilder().setNumber(InlinableValue.Number.shortValue((short)1)).build() },
+            new Object[] { valueBuilder().setNumber(new InlinableValue.IntNumber(99)).build(),
+                           valueBuilder().setNumber(new InlinableValue.IntNumber(99)).build() },
             new Object[] { valueBuilder().setReference(List.of("list")).build(),
                            valueBuilder().setReference(List.of("list")).build() },
             new Object[] { new ValueOptional(point), new ValueOptional(mpath)},
-            new Object[] { new ValueOptional(Value.Number.intValue(1)), new ValueOptional(Value.Number.shortValue((short)1))},
+            new Object[] { new ValueOptional(InlinableValue.Number.intValue(1)), new ValueOptional(InlinableValue.Number.shortValue((short)1))},
         };
     }
     @Test(dataProvider="notSubstitutable")
     public void notSubstitutableTest(Object a, Object b) {
         assertFalse(isSubstitutable(a, b));
     }
-    private static Value.Builder valueBuilder() {
-        Value.Builder builder = new Value.Builder();
+    private static InlinableValue.Builder valueBuilder() {
+        InlinableValue.Builder builder = new InlinableValue.Builder();
         return builder.setChar('a')
                        .setBoolean(true)
                        .setByte((byte)0x1)


### PR DESCRIPTION
Add VarHandle tests for value class.   This fixes a bug in Unsafe::compareAndSet support.   This also cleans up test/jdk/java/lang/invoke/VarHandles tests such that it only extends the tests for value class and primitive class.  The test cases  for accessing fields declared in a value class or a primitive class are covered by tests in test/jdk/valhalla/valuetypes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8296423](https://bugs.openjdk.org/browse/JDK-8296423): [lworld]  add VarHandle tests for value classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/804/head:pull/804` \
`$ git checkout pull/804`

Update a local copy of the PR: \
`$ git checkout pull/804` \
`$ git pull https://git.openjdk.org/valhalla pull/804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 804`

View PR using the GUI difftool: \
`$ git pr show -t 804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/804.diff">https://git.openjdk.org/valhalla/pull/804.diff</a>

</details>
