### PR TITLE
8296711: [lworld] identity/value javadoc cleanup

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -25,6 +25,7 @@
 
 package java.lang.ref;
 
+import java.util.Objects;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 /**
@@ -32,9 +33,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * determines that their referents may otherwise be reclaimed.  Phantom
  * references are most often used to schedule post-mortem cleanup actions.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValue()
- * value class}; such a value can never have another reference to it
- * and cannot be held in a reference type.
+ * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
  *
  * <p> Suppose the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -40,8 +40,8 @@ import java.util.Objects;
  * implemented in close cooperation with the garbage collector, this class may
  * not be subclassed directly.
  * <p>
- * References can only refer to identity objects.
- * Attempts to create a reference to a {@linkplain Class#isValue() value object}
+ * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
+ * Attempts to create a reference to a {@linkplain Objects#isValueObject value object}
  * results in an {@link IdentityException}.
  * @param <T> the type of the referent
  *

--- a/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -26,14 +26,14 @@
 package java.lang.ref;
 
 
+import java.util.Objects;
+
 /**
  * Soft reference objects, which are cleared at the discretion of the garbage
  * collector in response to memory demand.  Soft references are most often used
  * to implement memory-sensitive caches.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValue()
- * value class}; such a value can never have another reference to it
- * and cannot be held in a reference type.
+ * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">softly

--- a/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -26,14 +26,14 @@
 package java.lang.ref;
 
 
+import java.util.Objects;
+
 /**
  * Weak reference objects, which do not prevent their referents from being
  * made finalizable, finalized, and then reclaimed.  Weak references are most
  * often used to implement canonicalizing mappings.
  * <p>
- * The referent must not be an instance of a {@linkplain Class#isValue()
- * value class}; such a value can never have another reference to it
- * and cannot be held in a reference type.
+ * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">weakly


### PR DESCRIPTION
Clarify the java doc descriptions in java.lang.ref classes to say that References can only be created to identity objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8296711](https://bugs.openjdk.org/browse/JDK-8296711): [lworld] identity/value javadoc cleanup


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/807/head:pull/807` \
`$ git checkout pull/807`

Update a local copy of the PR: \
`$ git checkout pull/807` \
`$ git pull https://git.openjdk.org/valhalla pull/807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 807`

View PR using the GUI difftool: \
`$ git pr show -t 807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/807.diff">https://git.openjdk.org/valhalla/pull/807.diff</a>

</details>
