### PR TITLE
8301867: [lworld] BlackholeTest triggers assert "Should have been buffered"

### DIFF
--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -623,6 +623,7 @@ class BlackholeNode : public MultiNode {
 public:
   BlackholeNode(Node* ctrl) : MultiNode(1) {
     init_req(TypeFunc::Control, ctrl);
+    init_class_id(Class_Blackhole);
   }
   virtual int   Opcode() const;
   virtual uint ideal_reg() const { return 0; } // not matched in the AD file


### PR DESCRIPTION
The recent merge accidentally removed a Valhalla specific line from the `BlackholeNode` constructor because the class was moved when JDK-8296545 was merged in. This led to the `is_Blackhole()` check in `Compile::process_inline_types` to incorrectly return false.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8301867](https://bugs.openjdk.org/browse/JDK-8301867): [lworld] BlackholeTest triggers assert "Should have been buffered"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/820/head:pull/820` \
`$ git checkout pull/820`

Update a local copy of the PR: \
`$ git checkout pull/820` \
`$ git pull https://git.openjdk.org/valhalla pull/820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 820`

View PR using the GUI difftool: \
`$ git pr show -t 820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/820.diff">https://git.openjdk.org/valhalla/pull/820.diff</a>

</details>
