### PR TITLE
8301664: [lworld] Inconsistent CastPP type leads to infinite loop in PhaseIterGVN::optimize

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1434,9 +1434,9 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
       cast_clone->set_req(0, ctrl);
       cast_clone->set_req(1, in);
       register_new_node(cast_clone, ctrl);
-      const Type* tclone = cast_clone->Value(&_igvn);
-      _igvn.set_type(cast_clone, tclone);
-      cast_clone->as_Type()->set_type(tclone);
+      const Type* tcast = cast_clone->Value(&_igvn);
+      _igvn.set_type(cast_clone, tcast);
+      cast_clone->as_Type()->set_type(tcast);
       in = cast_clone;
     }
     Node* addr_clone = addr->clone();

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1434,7 +1434,9 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
       cast_clone->set_req(0, ctrl);
       cast_clone->set_req(1, in);
       register_new_node(cast_clone, ctrl);
-      _igvn.set_type(cast_clone, cast_clone->Value(&_igvn));
+      const Type* tclone = cast_clone->Value(&_igvn);
+      _igvn.set_type(cast_clone, tclone);
+      cast_clone->as_Type()->set_type(tclone);
       in = cast_clone;
     }
     Node* addr_clone = addr->clone();

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -66,10 +66,6 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
-# Valhalla
-compiler/valhalla/inlinetypes/TestDeoptimizationWhenBuffering.java 8294624 generic-aarch64
-compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaType.java 8301665 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Cloning of CastPPs in `PhaseIdealLoop::flatten_array_element_type_check` does not update the bottom type of the CastPP, leading to a mismatch of `type()` and `adr_type()` of a `LoadNKlass` -> `AddP` -> `CastPP` user. As a result, the node is re-added to the IGVN worklist infinitely, assuming that type of the AddP will be updated:
https://github.com/openjdk/valhalla/blob/256f488b64846e4af2bfa90d436139bda8d0e7aa/src/hotspot/share/opto/memnode.cpp#L372-L374

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8301664](https://bugs.openjdk.org/browse/JDK-8301664): [lworld] Inconsistent CastPP type leads to infinite loop in PhaseIterGVN::optimize


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/822/head:pull/822` \
`$ git checkout pull/822`

Update a local copy of the PR: \
`$ git checkout pull/822` \
`$ git pull https://git.openjdk.org/valhalla pull/822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 822`

View PR using the GUI difftool: \
`$ git pr show -t 822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/822.diff">https://git.openjdk.org/valhalla/pull/822.diff</a>

</details>
