### PR TITLE
8301899: [lworld] Value class APIs should have annotation for PreviewFeature

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -69,10 +69,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.misc.Unsafe;
-import jdk.internal.misc.ValhallaFeatures;
 import jdk.internal.module.Resources;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.CallerSensitiveAdapter;
@@ -648,6 +648,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public native boolean isIdentity();
 
     /**
@@ -659,6 +660,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public boolean isValue() {
         return (this.getModifiers() & Modifier.VALUE) != 0;
     }

--- a/src/java.base/share/classes/java/lang/IdentityException.java
+++ b/src/java.base/share/classes/java/lang/IdentityException.java
@@ -23,6 +23,8 @@
 package java.lang;
 
 
+import jdk.internal.javac.PreviewFeature;
+
 /**
  * Thrown when an identity object is required but a value object is supplied.
  * <p>
@@ -32,6 +34,7 @@ package java.lang;
  *
  * @since Valhalla
  */
+@PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 public class IdentityException extends RuntimeException {
     @java.io.Serial
     private static final long serialVersionUID = 1L;

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -25,7 +25,7 @@
 
 package java.util;
 
-import jdk.internal.misc.ValhallaFeatures;
+import jdk.internal.javac.PreviewFeature;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.misc.Unsafe;
@@ -197,6 +197,7 @@ public final class Objects {
     * @param obj an object
     * @throws NullPointerException if {@code obj} is {@code null}
     */
+   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 //    @IntrinsicCandidate
     public static boolean isIdentityObject(Object obj) {
         requireNonNull(obj);
@@ -214,6 +215,7 @@ public final class Objects {
      * @throws IdentityException if {@code obj} is not an identity object
      * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);
@@ -234,6 +236,7 @@ public final class Objects {
      * @throws IdentityException if {@code obj} is not an identity object
      * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
     public static <T> T requireIdentity(T obj, String message) {
         Objects.requireNonNull(obj);
@@ -254,6 +257,7 @@ public final class Objects {
      * @throws IdentityException if {@code obj} is not an identity object
      * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     @ForceInline
     public static <T> T requireIdentity(T obj, Supplier<String> messageSupplier) {
         Objects.requireNonNull(obj);
@@ -270,6 +274,7 @@ public final class Objects {
     * @param obj an object
     * @throws NullPointerException if {@code obj} is {@code null}
     */
+   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 //    @IntrinsicCandidate
     public static boolean isValueObject(Object obj) {
         requireNonNull(obj, "obj");

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -72,6 +72,8 @@ public @interface PreviewFeature {
         VIRTUAL_THREADS,
         @JEP(number=434, title="Foreign Function & Memory API", status="Second Preview")
         FOREIGN,
+        @JEP(number=8277163, title="Value Objects")
+        VALUE_OBJECTS,
         /**
          * A key for testing.
          */

--- a/test/jdk/valhalla/valuetypes/TEST.properties
+++ b/test/jdk/valhalla/valuetypes/TEST.properties
@@ -1,2 +1,3 @@
 # Reflection methods for primitive classes are in PrimitiveClass instead of java.lang.class
 modules = java.base/jdk.internal.value
+enablePreview = true


### PR DESCRIPTION
Add the PreviewFeature for value objects and annotate new APIs.

Update tests to EnablePreview (all tests in test/jdk/valhalla/...)

Tier1-3 tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8301899](https://bugs.openjdk.org/browse/JDK-8301899): [lworld] Value class APIs should have annotation for PreviewFeature


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/823/head:pull/823` \
`$ git checkout pull/823`

Update a local copy of the PR: \
`$ git checkout pull/823` \
`$ git pull https://git.openjdk.org/valhalla pull/823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 823`

View PR using the GUI difftool: \
`$ git pr show -t 823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/823.diff">https://git.openjdk.org/valhalla/pull/823.diff</a>

</details>
