### PR TITLE
8293702: [lworld] C1 does not properly handle unloaded inline type field loads

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2186,6 +2186,7 @@ void LIRGenerator::do_LoadField(LoadField* x) {
       __ branch_destination(L_end->label());
       set_in_conditional_code(false);
     } else {
+      info = state_for(x, x->state_before());
       __ cmp(lir_cond_equal, result, LIR_OprFact::oopConst(NULL));
       __ branch(lir_cond_equal, new DeoptimizeStub(info, Deoptimization::Reason_uninitialized,
                                                          Deoptimization::Action_make_not_entrant));

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1097,5 +1097,28 @@ public class TestUnloadedInlineTypeField {
         } catch (NoClassDefFoundError e) {
             // Expected
         }
+    }
+
+    static final primitive class MyValue27 {
+        final int foo = rI;
+    }
+
+    static class MyValue27Holder {
+        MyValue27 v;
+    }
+
+    // Make sure MyValue27Holder is loaded but MyValue27 is not
+    Class test27Class = MyValue27Holder.class;
+
+    // Test unloaded inline type field load from loaded holder
+    @Test
+    public static int test27() {
+        MyValue27Holder holder = new MyValue27Holder();
+        return holder.v.foo;
+    }
+
+    @Run(test = "test27")
+    public void test27_verifier() {
+        Asserts.assertEQ(test27(), 0);
     }
 }


### PR DESCRIPTION
We crash in C1 when emitting a `DeoptimizeStub` for handling a null field load from a non-flattened, unloaded inline type field because the state for re-execution after deopt is not initialized.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293702](https://bugs.openjdk.org/browse/JDK-8293702): [lworld] C1 does not properly handle unloaded inline type field loads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/825/head:pull/825` \
`$ git checkout pull/825`

Update a local copy of the PR: \
`$ git checkout pull/825` \
`$ git pull https://git.openjdk.org/valhalla pull/825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 825`

View PR using the GUI difftool: \
`$ git pr show -t 825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/825.diff">https://git.openjdk.org/valhalla/pull/825.diff</a>

</details>
