### PR TITLE
8284164: [lworld] Inline type elements of autobox cache should be casted to non-null

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5096,12 +5096,8 @@ const TypeAryPtr* TypeAryPtr::cast_to_autobox_cache() const {
   if (is_autobox_cache())  return this;
   const TypeOopPtr* etype = elem()->make_oopptr();
   if (etype == NULL)  return this;
-  // TODO fix with JDK-8284164
-  // Ignore inline types to not confuse logic in TypeAryPtr::compute_klass
-  if (!etype->is_inlinetypeptr()) {
-    // The pointers in the autobox arrays are always non-null.
-    etype = etype->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
-  }
+  // The pointers in the autobox arrays are always non-null.
+  etype = etype->cast_to_ptr_type(TypePtr::NotNull)->is_oopptr();
   const TypeAry* new_ary = TypeAry::make(etype, size(), is_stable(), is_not_flat(), is_not_null_free());
   return make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset, _instance_id, _speculative, _inline_depth, /*is_autobox_cache=*/true);
 }


### PR DESCRIPTION
The problematic logic in `TypeAryPtr::compute_klass` was removed with the integration of [JDK-8297933](https://bugs.openjdk.org/browse/JDK-8297933):

https://github.com/openjdk/valhalla/blob/8ac816b8642b1994a21b5b1476aca93ba4a1096a/src/hotspot/share/opto/type.cpp#L6047-L6050

We therefore no longer need the workaround.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8284164](https://bugs.openjdk.org/browse/JDK-8284164): [lworld] Inline type elements of autobox cache should be casted to non-null


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/826/head:pull/826` \
`$ git checkout pull/826`

Update a local copy of the PR: \
`$ git checkout pull/826` \
`$ git pull https://git.openjdk.org/valhalla pull/826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 826`

View PR using the GUI difftool: \
`$ git pr show -t 826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/826.diff">https://git.openjdk.org/valhalla/pull/826.diff</a>

</details>
