### PR TITLE
8303137: [lworld] Fix ArchivedEnumTest fail caused by changed Enum static field

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,14 +191,13 @@ public enum AccessFlag {
      * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
-    SUPER(0x0000_0020, false, Location.SET_CLASS_SUPER_VALHALLA,
+    SUPER(0x0000_0020, false,
+            ValhallaFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS,
             new Function<ClassFileFormatVersion, Set<Location>>() {
             @Override
             public Set<Location> apply(ClassFileFormatVersion cffv) {
                 return (cffv.compareTo(ClassFileFormatVersion.RELEASE_21) >= 0 &&
-                        ValhallaFeatures.isEnabled()) ?
-                        Location.SET_CLASS_SUPER_VALHALLA :
-                        Location.SET_CLASS;}
+                        ValhallaFeatures.isEnabled()) ? Location.EMPTY_SET : Location.SET_CLASS;}
         }),
 
     /**
@@ -667,8 +666,6 @@ public enum AccessFlag {
         private static final Set<Location> SET_CLASS = Set.of(CLASS);
         private static final Set<Location> SET_CLASS_INNER_CLASS =
             Set.of(CLASS, INNER_CLASS);
-        private static final Set<Location> SET_CLASS_SUPER_VALHALLA =
-                ValhallaFeatures.isEnabled() ? EMPTY_SET : SET_CLASS_INNER_CLASS;
         private static final Set<Location> SET_CLASS_IDENTITY_VALHALLA =
                 ValhallaFeatures.isEnabled() ? SET_CLASS_INNER_CLASS : EMPTY_SET;
         private static final Set<Location> SET_MODULE_REQUIRES =

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -665,8 +665,6 @@ public enum AccessFlag {
         private static final Set<Location> SET_CLASS = Set.of(CLASS);
         private static final Set<Location> SET_CLASS_INNER_CLASS =
             Set.of(CLASS, INNER_CLASS);
-        private static final Set<Location> SET_CLASS_IDENTITY_VALHALLA =
-                ValhallaFeatures.isEnabled() ? SET_CLASS_INNER_CLASS : EMPTY_SET;
         private static final Set<Location> SET_MODULE_REQUIRES =
             Set.of(MODULE_REQUIRES);
         private static final Set<Location> SET_PUBLIC_1 =

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -206,14 +206,13 @@ public enum AccessFlag {
      * value of <code>{@value "0x%04x" Modifier#IDENTITY}</code>.
      * @jvms 4.1 -B. Class access and property modifiers
      */
-    IDENTITY(Modifier.IDENTITY, true, Location.SET_CLASS_IDENTITY_VALHALLA,
+    IDENTITY(Modifier.IDENTITY, true,
+            ValhallaFeatures.isEnabled() ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET,
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
                     return (cffv.compareTo(ClassFileFormatVersion.RELEASE_21) >= 0 &&
-                            ValhallaFeatures.isEnabled()) ?
-                            Location.SET_CLASS_IDENTITY_VALHALLA :
-                            Location.EMPTY_SET;}
+                            ValhallaFeatures.isEnabled()) ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;}
             }),
 
     /**


### PR DESCRIPTION
Removed private static field in j.l.reflect.AccesFlag that CDS could not archive.
Replaced with inline expression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8303137](https://bugs.openjdk.org/browse/JDK-8303137): [lworld] Fix ArchivedEnumTest fail caused by changed Enum static field


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/827/head:pull/827` \
`$ git checkout pull/827`

Update a local copy of the PR: \
`$ git checkout pull/827` \
`$ git pull https://git.openjdk.org/valhalla pull/827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 827`

View PR using the GUI difftool: \
`$ git pr show -t 827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/827.diff">https://git.openjdk.org/valhalla/pull/827.diff</a>

</details>
