### PR TITLE
8303416: [lworld] Fix JVM crash at Unsafe_FinishPrivateBuffer

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -64,6 +64,9 @@ protected:
   // Checks if the inline type fields are all set to default values
   bool is_default(PhaseGVN* gvn) const;
 
+  // Checks if the inline type oop is an allocated buffer with larval state
+  bool is_larval(PhaseGVN* gvn) const;
+
   // Checks if the inline type is loaded from memory and if so returns the oop
   Node* is_loaded(PhaseGVN* phase, ciInlineKlass* vk = NULL, Node* base = NULL, int holder_offset = 0);
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLarvalState.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLarvalState.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8303416
+ * @summary Fix JVM crash at Unsafe_FinishPrivateBuffer
+ * @library /test/lib
+ * @compile -XDenablePrimitiveClasses
+ *          --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+ *          TestLarvalState.java
+ * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses
+ *                   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+ *                   compiler.valhalla.inlinetypes.TestLarvalState
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.lang.reflect.*;
+import java.util.Random;
+
+import jdk.internal.misc.Unsafe;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+public class TestLarvalState {
+    private static int LENGTH = 10000;
+
+    private static final Random RD = Utils.getRandomInstance();
+
+    static byte[] arr = new byte[LENGTH];
+
+    static {
+        for (int i = 0; i < LENGTH; i++) {
+            arr[i] = (byte) RD.nextInt(127);
+        }
+    }
+
+    public static byte test(byte b) {
+        Value obj = new Value();
+        obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
+        Unsafe.getUnsafe().putByte(obj, obj.offset, b);
+        obj = Unsafe.getUnsafe().finishPrivateBuffer(obj);
+        return Unsafe.getUnsafe().getByte(obj, obj.offset);
+    }
+
+    public static void main(String[] args) {
+        byte actual = 0;
+        for (int i = 0; i < LENGTH; i++) {
+            actual += test(arr[i]);
+        }
+
+        byte expected = 0;
+        for (int i = 0; i < LENGTH; i++) {
+            expected += arr[i];
+        }
+        Asserts.assertEquals(expected, actual);
+    }
+
+    primitive static class Value {
+        byte field = 0;
+
+        static long offset = fieldOffset();
+
+        private static long fieldOffset() {
+            try {
+                var f = Value.class.getDeclaredField("field");
+                return Unsafe.getUnsafe().objectFieldOffset(f);
+            } catch (Exception e) {
+                System.out.println(e);
+            }
+            return -1L;
+        }
+    }
+}
+


### PR DESCRIPTION
When calling Unsafe.finishPrivateBuffer(), JVM crashes with following
 assertion failure:

```
 Internal Error (/mnt/local/code/valhalla/src/hotspot/share/prims/unsafe.cpp:388), pid=29517, tid=29518
  assert(v->mark().is_larval_state()) failed: must be a larval value

 JRE version: OpenJDK Runtime Environment (21.0) (fastdebug build 21-internal-git-05e4d0dba)
 Java VM: OpenJDK 64-Bit Server VM (fastdebug 21-internal-git-05e4d0dba, mixed mode, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
 Problematic frame:
 V  [[libjvm.so](http://libjvm.so/)+0x1a92a64]  Unsafe_FinishPrivateBuffer+0xc0
```
The assertion is used to check whether the input value is in larval
 state. Usually this method is called after `Unsafe.makePrivateBuffer()`,
 which will create a new oop and set it to larval state. If everything
 works fine, the above assertion won't fail. But the issue happens if
 all the fields of the input value object of `Unsafe.makePrivateBuffer()`
 are the relative java default values (i.e. `0`). The root cause is the
 C2 compiler will optimize the new buffered oop to the default oop for
 such value object, and the larval state is missed during the optimization.
 Marking the larval bit of the optimized oop can fix the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8303416](https://bugs.openjdk.org/browse/JDK-8303416): [lworld] Fix JVM crash at Unsafe_FinishPrivateBuffer


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/828/head:pull/828` \
`$ git checkout pull/828`

Update a local copy of the PR: \
`$ git checkout pull/828` \
`$ git pull https://git.openjdk.org/valhalla pull/828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 828`

View PR using the GUI difftool: \
`$ git pr show -t 828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/828.diff">https://git.openjdk.org/valhalla/pull/828.diff</a>

</details>
