### PR TITLE
8293800: [lworld] Remove TypeInlineType and related code

### DIFF
--- a/src/hotspot/share/opto/arraycopynode.cpp
+++ b/src/hotspot/share/opto/arraycopynode.cpp
@@ -290,7 +290,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     if ((!ary_dest->is_flat() && bs->array_copy_requires_gc_barriers(is_alloc_tightly_coupled(), dest_elem, false, false, BarrierSetC2::Optimization)) ||
-        (ary_dest->is_flat() && ary_src->elem()->make_ptr()->inline_klass()->contains_oops() &&
+        (ary_dest->is_flat() && ary_src->elem()->inline_klass()->contains_oops() &&
          bs->array_copy_requires_gc_barriers(is_alloc_tightly_coupled(), T_OBJECT, false, false, BarrierSetC2::Optimization))) {
       // It's an object array copy but we can't emit the card marking that is needed
       return false;
@@ -353,7 +353,7 @@ bool ArrayCopyNode::prepare_array_copy(PhaseGVN *phase, bool can_reshape,
 
     BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
     if ((!ary_src->is_flat() && bs->array_copy_requires_gc_barriers(true, elem, true, is_clone_inst(), BarrierSetC2::Optimization)) ||
-        (ary_src->is_flat() && ary_src->elem()->make_ptr()->inline_klass()->contains_oops() &&
+        (ary_src->is_flat() && ary_src->elem()->inline_klass()->contains_oops() &&
          bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, is_clone_inst(), BarrierSetC2::Optimization))) {
       // It's an object array copy but we can't emit the card marking that is needed
       return false;
@@ -418,7 +418,7 @@ void ArrayCopyNode::copy(GraphKit& kit,
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   Node* ctl = kit.control();
   if (atp_dest->is_flat()) {
-    ciInlineKlass* vk = atp_src->elem()->make_ptr()->inline_klass();
+    ciInlineKlass* vk = atp_src->elem()->inline_klass();
     for (int j = 0; j < vk->nof_nonstatic_fields(); j++) {
       ciField* field = vk->nonstatic_field_at(j);
       int off_in_vt = field->offset() - vk->first_field_offset();

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -414,6 +414,7 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   const TypePtr *my_type = _type->isa_ptr();
   const Type *result = _type;
   if (in_type != NULL && my_type != NULL) {
+    // TODO Check if this is still needed/executed now that we call ConstraintCastNode::Value above
     if (!StressReflectiveCode && my_type->isa_aryptr() && in_type->isa_aryptr()) {
       // Propagate array properties (not flat/null-free)
       // Don't do this when StressReflectiveCode is enabled because it might lead to
@@ -427,7 +428,7 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
     if (in_ptr == TypePtr::Null) {
       result = in_type;
     } else if (in_ptr != TypePtr::Constant) {
-      result =  my_type->cast_to_ptr_type(my_type->join_ptr(in_ptr));
+      result = my_type->cast_to_ptr_type(my_type->join_ptr(in_ptr));
     }
   }
 

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -414,7 +414,7 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   const TypePtr *my_type = _type->isa_ptr();
   const Type *result = _type;
   if (in_type != NULL && my_type != NULL) {
-    // TODO Check if this is still needed/executed now that we call ConstraintCastNode::Value above
+    // TODO 8251442
     if (!StressReflectiveCode && my_type->isa_aryptr() && in_type->isa_aryptr()) {
       // Propagate array properties (not flat/null-free)
       // Don't do this when StressReflectiveCode is enabled because it might lead to

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -414,7 +414,7 @@ const Type* CheckCastPPNode::Value(PhaseGVN* phase) const {
   const TypePtr *my_type = _type->isa_ptr();
   const Type *result = _type;
   if (in_type != NULL && my_type != NULL) {
-    // TODO 8251442
+    // TODO 8302672
     if (!StressReflectiveCode && my_type->isa_aryptr() && in_type->isa_aryptr()) {
       // Propagate array properties (not flat/null-free)
       // Don't do this when StressReflectiveCode is enabled because it might lead to

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2481,7 +2481,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // Check recursively if inputs are either an inline type, constant null
   // or another Phi (including self references through data loops). If so,
   // push the inline types down through the phis to enable folding of loads.
-  if (EnableValhalla && (_type->isa_ptr() || _type->isa_inlinetype()) && req() > 2) {
+  if (EnableValhalla && _type->isa_ptr() && req() > 2) {
     ResourceMark rm;
     Unique_Node_List worklist;
     worklist.push(this);
@@ -2529,7 +2529,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           if (phase->find_int_con(n->as_InlineType()->get_is_init(), 0) != 1) {
             is_init = false;
           }
-        } else if (n->is_Phi() && can_reshape && (n->bottom_type()->isa_ptr() || n->bottom_type()->isa_inlinetype())) {
+        } else if (n->is_Phi() && can_reshape && n->bottom_type()->isa_ptr()) {
           worklist.push(n);
         } else if (t->is_zero_type()) {
           is_init = false;

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1412,8 +1412,9 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
       tj = ta = TypeAryPtr::make(ptr,ta->const_oop(),tary,NULL,false,Type::Offset(offset), ta->field_offset());
     }
     // Initially all flattened array accesses share a single slice
-    if (ta->is_flat() && ta->elem() != TypeInlineType::BOTTOM && _flattened_accesses_share_alias) {
-      const TypeAry *tary = TypeAry::make(TypeInlineType::BOTTOM, ta->size());
+    if (ta->is_flat() && ta->elem() != TypeInstPtr::BOTTOM && _flattened_accesses_share_alias) {
+      // TODO should be flat, right?
+      const TypeAry *tary = TypeAry::make(TypeInstPtr::BOTTOM, ta->size());
       tj = ta = TypeAryPtr::make(ptr,ta->const_oop(),tary,NULL,false,Type::Offset(offset), Type::Offset(Type::OffsetBot));
     }
     // Arrays of bytes and of booleans both use 'bastore' and 'baload' so

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1716,9 +1716,9 @@ Compile::AliasType* Compile::find_alias_type(const TypePtr* adr_type, bool no_cr
         alias_type(idx)->set_element(elemtype);
       }
       int field_offset = flat->is_aryptr()->field_offset().get();
-      if (elemtype->isa_inlinetype() &&
+      if (flat->is_aryptr()->is_flat() &&
           field_offset != Type::OffsetBot) {
-        ciInlineKlass* vk = elemtype->inline_klass();
+        ciInlineKlass* vk = elemtype->make_ptr()->inline_klass();
         field_offset += vk->first_field_offset();
         field = vk->get_field_by_offset(field_offset, false);
       }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1413,8 +1413,7 @@ const TypePtr *Compile::flatten_alias_type( const TypePtr *tj ) const {
     }
     // Initially all flattened array accesses share a single slice
     if (ta->is_flat() && ta->elem() != TypeInstPtr::BOTTOM && _flattened_accesses_share_alias) {
-      // TODO should be flat, right?
-      const TypeAry *tary = TypeAry::make(TypeInstPtr::BOTTOM, ta->size());
+      const TypeAry* tary = TypeAry::make(TypeInstPtr::BOTTOM, ta->size(), /* stable= */ false, /* flat= */ true);
       tj = ta = TypeAryPtr::make(ptr,ta->const_oop(),tary,NULL,false,Type::Offset(offset), Type::Offset(Type::OffsetBot));
     }
     // Arrays of bytes and of booleans both use 'bastore' and 'baload' so

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1717,9 +1717,9 @@ Compile::AliasType* Compile::find_alias_type(const TypePtr* adr_type, bool no_cr
         alias_type(idx)->set_element(elemtype);
       }
       int field_offset = flat->is_aryptr()->field_offset().get();
-      if (flat->is_aryptr()->is_flat() &&
+      if (flat->is_flat() &&
           field_offset != Type::OffsetBot) {
-        ciInlineKlass* vk = elemtype->make_ptr()->inline_klass();
+        ciInlineKlass* vk = elemtype->inline_klass();
         field_offset += vk->first_field_offset();
         field = vk->get_field_by_offset(field_offset, false);
       }
@@ -1770,7 +1770,7 @@ Compile::AliasType* Compile::find_alias_type(const TypePtr* adr_type, bool no_cr
       alias_type(idx)->set_field(field);
       if (flat->isa_aryptr()) {
         // Fields of flat arrays are rewritable although they are declared final
-        assert(flat->is_aryptr()->is_flat(), "must be a flat array");
+        assert(flat->is_flat(), "must be a flat array");
         alias_type(idx)->set_rewritable(true);
       }
     }
@@ -2094,8 +2094,7 @@ void Compile::adjust_flattened_array_access_aliases(PhaseIterGVN& igvn) {
     for (uint i = 0; i < AliasCacheSize; i++) {
       AliasCacheEntry* ace = &_alias_cache[i];
       if (ace->_adr_type != NULL &&
-          ace->_adr_type->isa_aryptr() &&
-          ace->_adr_type->is_aryptr()->is_flat()) {
+          ace->_adr_type->is_flat()) {
         ace->_adr_type = NULL;
         ace->_index = (i != 0) ? 0 : AliasIdxTop; // Make sure the NULL adr_type resolves to AliasIdxTop
       }
@@ -2220,8 +2219,8 @@ void Compile::adjust_flattened_array_access_aliases(PhaseIterGVN& igvn) {
               if (idx == m->req()-1) {
                 Node* r = m->in(0);
                 for (uint j = (uint)start_alias; j <= (uint)stop_alias; j++) {
-                  const Type* adr_type = get_adr_type(j);
-                  if (!adr_type->isa_aryptr() || !adr_type->is_aryptr()->is_flat() || j == (uint)index) {
+                  const TypePtr* adr_type = get_adr_type(j);
+                  if (!adr_type->isa_aryptr() || !adr_type->is_flat() || j == (uint)index) {
                     continue;
                   }
                   Node* phi = new PhiNode(r, Type::MEMORY, get_adr_type(j));
@@ -2250,8 +2249,8 @@ void Compile::adjust_flattened_array_access_aliases(PhaseIterGVN& igvn) {
               Node* ctrl = m->in(0)->in(TypeFunc::Control);
               igvn.replace_input_of(m->in(0), TypeFunc::Control, top());
               for (uint j = (uint)start_alias; j <= (uint)stop_alias; j++) {
-                const Type* adr_type = get_adr_type(j);
-                if (!adr_type->isa_aryptr() || !adr_type->is_aryptr()->is_flat() || j == (uint)index) {
+                const TypePtr* adr_type = get_adr_type(j);
+                if (!adr_type->isa_aryptr() || !adr_type->is_flat() || j == (uint)index) {
                   continue;
                 }
                 MemBarNode* mb = new MemBarCPUOrderNode(this, j, NULL);
@@ -2293,8 +2292,8 @@ void Compile::adjust_flattened_array_access_aliases(PhaseIterGVN& igvn) {
       // Fix the memory state at the MergeMem we started from
       igvn.rehash_node_delayed(current);
       for (uint j = (uint)start_alias; j <= (uint)stop_alias; j++) {
-        const Type* adr_type = get_adr_type(j);
-        if (!adr_type->isa_aryptr() || !adr_type->is_aryptr()->is_flat()) {
+        const TypePtr* adr_type = get_adr_type(j);
+        if (!adr_type->isa_aryptr() || !adr_type->is_flat()) {
           continue;
         }
         current->set_memory_at(j, mm);
@@ -3711,8 +3710,8 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
         MergeMemNode* mm = prec->as_MergeMem();
         Node* base = mm->base_memory();
         for (int i = AliasIdxRaw + 1; i < num_alias_types(); i++) {
-          const Type* adr_type = get_adr_type(i);
-          if (adr_type->isa_aryptr() && adr_type->is_aryptr()->is_flat()) {
+          const TypePtr* adr_type = get_adr_type(i);
+          if (adr_type->is_flat()) {
             Node* m = mm->memory_at(i);
             n->add_prec(m);
           }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1167,7 +1167,7 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
                                (aat->isa_aryptr() && (aat->isa_aryptr()->elem() == Type::BOTTOM || aat->isa_aryptr()->elem()->make_oopptr() != NULL)) ||
                                (aat->isa_aryptr() && aat->isa_aryptr()->elem() != NULL &&
                                                                aat->isa_aryptr()->is_flat() &&
-                                                               aat->isa_aryptr()->elem()->make_ptr()->inline_klass()->contains_oops()));
+                                                               aat->isa_aryptr()->elem()->inline_klass()->contains_oops()));
           if (i == TypeFunc::Parms) {
             src_has_oops = arg_has_oops;
           }
@@ -2373,9 +2373,9 @@ bool ConnectionGraph::is_oop_field(Node* n, int offset, bool* unsafe) {
       } else if (find_second_addp(n, n->in(AddPNode::Base)) != NULL) {
         // Ignore first AddP.
       } else {
-        const Type* elemtype = adr_type->isa_aryptr()->elem();
-        if (adr_type->isa_aryptr()->is_flat() && field_offset != Type::OffsetBot) {
-          ciInlineKlass* vk = elemtype->make_ptr()->inline_klass();
+        const Type* elemtype = adr_type->is_aryptr()->elem();
+        if (adr_type->is_aryptr()->is_flat() && field_offset != Type::OffsetBot) {
+          ciInlineKlass* vk = elemtype->inline_klass();
           field_offset += vk->first_field_offset();
           bt = vk->get_field_by_offset(field_offset, false)->layout_type();
         } else {

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1167,7 +1167,7 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
                                (aat->isa_aryptr() && (aat->isa_aryptr()->elem() == Type::BOTTOM || aat->isa_aryptr()->elem()->make_oopptr() != NULL)) ||
                                (aat->isa_aryptr() && aat->isa_aryptr()->elem() != NULL &&
                                                                aat->isa_aryptr()->is_flat() &&
-                                                               aat->isa_aryptr()->elem()->inline_klass()->contains_oops()));
+                                                               aat->isa_aryptr()->elem()->make_ptr()->inline_klass()->contains_oops()));
           if (i == TypeFunc::Parms) {
             src_has_oops = arg_has_oops;
           }
@@ -2374,8 +2374,8 @@ bool ConnectionGraph::is_oop_field(Node* n, int offset, bool* unsafe) {
         // Ignore first AddP.
       } else {
         const Type* elemtype = adr_type->isa_aryptr()->elem();
-        if (elemtype->isa_inlinetype() && field_offset != Type::OffsetBot) {
-          ciInlineKlass* vk = elemtype->inline_klass();
+        if (adr_type->isa_aryptr()->is_flat() && field_offset != Type::OffsetBot) {
+          ciInlineKlass* vk = elemtype->make_ptr()->inline_klass();
           field_offset += vk->first_field_offset();
           bt = vk->get_field_by_offset(field_offset, false)->layout_type();
         } else {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3929,7 +3929,7 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
         // don't share a single slice.
         assert(C->flattened_accesses_share_alias(), "should be set at parse time");
         C->set_flattened_accesses_share_alias(false);
-        ciInlineKlass* vk = arytype->elem()->make_ptr()->inline_klass();
+        ciInlineKlass* vk = arytype->elem()->inline_klass();
         for (int i = 0, len = vk->nof_nonstatic_fields(); i < len; i++) {
           ciField* field = vk->nonstatic_field_at(i);
           if (field->offset() >= TrackedInitializationLimit * HeapWordSize)
@@ -4242,7 +4242,7 @@ Node* GraphKit::new_array(Node* klass_node,     // array klass (maybe variable)
   if (ary_ptr != NULL && ary_ptr->klass_is_exact()) {
     // Array type is known
     if (ary_ptr->is_null_free() && !ary_ptr->is_flat()) {
-      ciInlineKlass* vk = ary_ptr->elem()->make_oopptr()->inline_klass();
+      ciInlineKlass* vk = ary_ptr->elem()->inline_klass();
       default_value = InlineTypeNode::default_oop(gvn(), vk);
     }
   } else if (ary_type->can_be_inline_array()) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3929,7 +3929,7 @@ Node* GraphKit::set_output_for_allocation(AllocateNode* alloc,
         // don't share a single slice.
         assert(C->flattened_accesses_share_alias(), "should be set at parse time");
         C->set_flattened_accesses_share_alias(false);
-        ciInlineKlass* vk = arytype->elem()->inline_klass();
+        ciInlineKlass* vk = arytype->elem()->make_ptr()->inline_klass();
         for (int i = 0, len = vk->nof_nonstatic_fields(); i < len; i++) {
           ciField* field = vk->nonstatic_field_at(i);
           if (field->offset() >= TrackedInitializationLimit * HeapWordSize)
@@ -4459,7 +4459,7 @@ Node* GraphKit::load_String_value(Node* str, bool set_ctrl) {
                                                      false, NULL, Type::Offset(0));
   const TypePtr* value_field_type = string_type->add_offset(value_offset);
   const TypeAryPtr* value_type = TypeAryPtr::make(TypePtr::NotNull,
-                                                  TypeAry::make(TypeInt::BYTE, TypeInt::POS, false, true, true),
+                                                  TypeAry::make(TypeInt::BYTE, TypeInt::POS, false, false, true, true),
                                                   ciTypeArrayKlass::make(T_BYTE), true, Type::Offset(0));
   Node* p = basic_plus_adr(str, str, value_offset);
   Node* load = access_load_at(str, p, value_field_type, value_type, T_OBJECT,

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2467,7 +2467,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     }
     if (is_store) {
       const Type* val_t = _gvn.type(val);
-      if (!(val_t->isa_inlinetype() || val_t->is_inlinetypeptr()) || val_t->inline_klass() != inline_klass) {
+      if (!val_t->is_inlinetypeptr() || val_t->inline_klass() != inline_klass) {
         set_map(old_map);
         set_sp(old_sp);
         return false;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2427,6 +2427,9 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
 
   if (bt != T_ILLEGAL) {
     assert(alias_type->adr_type()->is_oopptr(), "should be on-heap access");
+    if (adr_type->isa_aryptr() && adr_type->isa_aryptr()->is_flat()) {
+      bt = T_PRIMITIVE_OBJECT;
+    }
     if (bt == T_BYTE && adr_type->isa_aryptr()) {
       // Alias type doesn't differentiate between byte[] and boolean[]).
       // Use address type to get the element type.
@@ -2454,9 +2457,9 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
       }
     } else if (adr_type->isa_aryptr()) {
       const Type* elem = adr_type->is_aryptr()->elem();
-      if (!elem->isa_inlinetype()) {
+      if (!adr_type->is_aryptr()->is_flat()) {
         mismatched = true;
-      } else if (elem->inline_klass() != inline_klass) {
+      } else if (elem->make_ptr()->inline_klass() != inline_klass) {
         mismatched = true;
       }
     } else {
@@ -4324,7 +4327,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
     const TypeKlassPtr* tklass = _gvn.type(klass_node)->is_klassptr();
     bool exclude_flat = UseFlatArray && bs->array_copy_requires_gc_barriers(true, T_OBJECT, false, false, BarrierSetC2::Parsing) &&
                         // Can src array be flat and contain oops?
-                        (orig_t == NULL || (!orig_t->is_not_flat() && (!orig_t->is_flat() || orig_t->elem()->inline_klass()->contains_oops()))) &&
+                        (orig_t == NULL || (!orig_t->is_not_flat() && (!orig_t->is_flat() || orig_t->elem()->make_ptr()->inline_klass()->contains_oops()))) &&
                         // Can dest array be flat and contain oops?
                         tklass->can_be_inline_array() && (!tklass->is_flat() || tklass->is_aryklassptr()->elem()->is_instklassptr()->instance_klass()->as_inline_klass()->contains_oops());
     Node* not_objArray = exclude_flat ? generate_non_objArray_guard(klass_node, bailout) : generate_typeArray_guard(klass_node, bailout);
@@ -5117,7 +5120,8 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
       const TypeAryPtr* ary_ptr = obj_type->isa_aryptr();
       if (UseFlatArray && bs->array_copy_requires_gc_barriers(true, T_OBJECT, true, false, BarrierSetC2::Expansion) &&
           obj_type->can_be_inline_array() &&
-          (ary_ptr == NULL || (!ary_ptr->is_not_flat() && (!ary_ptr->is_flat() || ary_ptr->elem()->inline_klass()->contains_oops())))) {
+          // TODO can we move the make_ptr into the check??
+          (ary_ptr == NULL || (!ary_ptr->is_not_flat() && (!ary_ptr->is_flat() || ary_ptr->elem()->make_ptr()->inline_klass()->contains_oops())))) {
         // Flattened inline type array may have object field that would require a
         // write barrier. Conservatively, go to slow path.
         generate_fair_guard(flat_array_test(obj_klass), slow_region);
@@ -5520,7 +5524,13 @@ bool LibraryCallKit::inline_arraycopy() {
 
   if (has_src && has_dest && can_emit_guards) {
     BasicType src_elem = top_src->isa_aryptr()->elem()->array_element_basic_type();
+    if (top_src->is_flat()) {
+      src_elem = T_PRIMITIVE_OBJECT;
+    }
     BasicType dest_elem = top_dest->isa_aryptr()->elem()->array_element_basic_type();
+    if (top_dest->is_flat()) {
+      dest_elem = T_PRIMITIVE_OBJECT;
+    }
     if (is_reference_type(src_elem, true)) src_elem = T_OBJECT;
     if (is_reference_type(dest_elem, true)) dest_elem = T_OBJECT;
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -787,12 +787,6 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       nfields = alloc->in(AllocateNode::ALength)->find_int_con(-1);
       assert(nfields >= 0, "must be an array klass.");
       basic_elem_type = res_type->is_aryptr()->elem()->array_element_basic_type();
-      if (res_type->is_flat()) {
-        basic_elem_type = T_PRIMITIVE_OBJECT;
-      }
-      if (basic_elem_type == T_PRIMITIVE_OBJECT && !res_type->is_aryptr()->is_flat()) {
-        basic_elem_type = T_OBJECT;
-      }
       array_base = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
       element_size = type2aelembytes(basic_elem_type);
       field_type = res_type->is_aryptr()->elem();

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -787,6 +787,9 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       nfields = alloc->in(AllocateNode::ALength)->find_int_con(-1);
       assert(nfields >= 0, "must be an array klass.");
       basic_elem_type = res_type->is_aryptr()->elem()->array_element_basic_type();
+      if (res_type->is_flat()) {
+        basic_elem_type = T_PRIMITIVE_OBJECT;
+      }
       if (basic_elem_type == T_PRIMITIVE_OBJECT && !res_type->is_aryptr()->is_flat()) {
         basic_elem_type = T_OBJECT;
       }
@@ -858,8 +861,9 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
 
       Node* field_val = NULL;
       const TypeOopPtr* field_addr_type = res_type->add_offset(offset)->isa_oopptr();
+      // TODO refactor check(s)
       if (res_type->isa_aryptr() && res_type->is_aryptr()->is_flat()) {
-        ciInlineKlass* vk = res_type->is_aryptr()->elem()->inline_klass();
+        ciInlineKlass* vk = res_type->is_aryptr()->elem()->make_ptr()->inline_klass();
         assert(vk->flatten_array(), "must be flattened");
         field_val = inline_type_from_mem(mem, ctl, vk, field_addr_type->isa_aryptr(), 0, alloc);
       } else {

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -293,7 +293,7 @@ Node* PhaseMacroExpand::make_arraycopy_load(ArrayCopyNode* ac, intptr_t offset, 
       Node* adr = NULL;
       Node* base = ac->in(ArrayCopyNode::Src);
       const TypeAryPtr* adr_type = _igvn.type(base)->is_aryptr();
-      if (adr_type->is_aryptr()->is_flat()) {
+      if (adr_type->is_flat()) {
         shift = adr_type->flat_log_elem_size();
       }
       if (src_pos_t->is_con() && dest_pos_t->is_con()) {
@@ -790,7 +790,7 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
       array_base = arrayOopDesc::base_offset_in_bytes(basic_elem_type);
       element_size = type2aelembytes(basic_elem_type);
       field_type = res_type->is_aryptr()->elem();
-      if (res_type->is_aryptr()->is_flat()) {
+      if (res_type->is_flat()) {
         // Flattened inline type array
         element_size = res_type->is_aryptr()->flat_elem_size();
       }
@@ -855,9 +855,8 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
 
       Node* field_val = NULL;
       const TypeOopPtr* field_addr_type = res_type->add_offset(offset)->isa_oopptr();
-      // TODO refactor check(s)
-      if (res_type->isa_aryptr() && res_type->is_aryptr()->is_flat()) {
-        ciInlineKlass* vk = res_type->is_aryptr()->elem()->make_ptr()->inline_klass();
+      if (res_type->is_flat()) {
+        ciInlineKlass* vk = res_type->is_aryptr()->elem()->inline_klass();
         assert(vk->flatten_array(), "must be flattened");
         field_val = inline_type_from_mem(mem, ctl, vk, field_addr_type->isa_aryptr(), 0, alloc);
       } else {
@@ -948,7 +947,7 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
   // Scalarize inline types that were added to the safepoint.
   // Don't allow linking a constant oop (if available) for flat array elements
   // because Deoptimization::reassign_flat_array_elements needs field values.
-  bool allow_oop = res_type != NULL && (!res_type->isa_aryptr() || !res_type->is_aryptr()->is_flat());
+  bool allow_oop = (res_type != NULL) && !res_type->is_flat();
   for (uint i = 0; i < value_worklist.size(); ++i) {
     InlineTypeNode* vt = value_worklist.at(i)->as_InlineType();
     vt->make_scalar_in_safepoints(&_igvn, allow_oop);

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1339,16 +1339,11 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     BasicType dest_elem = T_OBJECT;
     if (top_dest != NULL && top_dest->elem() != Type::BOTTOM) {
       dest_elem = top_dest->elem()->array_element_basic_type();
-      if (top_dest->is_flat()) {
-        dest_elem = T_PRIMITIVE_OBJECT;
-      }
     }
-    if (dest_elem == T_ARRAY || dest_elem == T_NARROWOOP || (dest_elem == T_PRIMITIVE_OBJECT && !top_dest->is_flat())) {
-      dest_elem = T_OBJECT;
-    }
+    if (is_reference_type(dest_elem, true)) dest_elem = T_OBJECT;
+
     if (top_src != NULL && top_src->is_flat()) {
       // If src is flat, dest is guaranteed to be flat as well
-      dest_elem = T_PRIMITIVE_OBJECT;
       top_dest = top_src;
     }
 
@@ -1362,7 +1357,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
     Node* mem = ac->in(TypeFunc::Memory);
     const TypePtr* adr_type = NULL;
-    if (dest_elem == T_PRIMITIVE_OBJECT) {
+    if (top_dest->is_flat()) {
       assert(dest_length != NULL || StressReflectiveCode, "must be tightly coupled");
       // Copy to a flat array modifies multiple memory slices. Conservatively insert a barrier
       // on all slices to prevent writes into the source from floating below the arraycopy.
@@ -1411,22 +1406,12 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
 
   if (top_src != NULL && top_src->elem() != Type::BOTTOM) {
     src_elem = top_src->elem()->array_element_basic_type();
-    if (top_src->is_flat()) {
-      src_elem = T_PRIMITIVE_OBJECT;
-    }
   }
   if (top_dest != NULL && top_dest->elem() != Type::BOTTOM) {
     dest_elem = top_dest->elem()->array_element_basic_type();
-    if (top_dest->is_flat()) {
-      dest_elem = T_PRIMITIVE_OBJECT;
-    }
   }
-  if (src_elem == T_ARRAY || src_elem == T_NARROWOOP || (src_elem == T_PRIMITIVE_OBJECT && !top_src->is_flat())) {
-    src_elem = T_OBJECT;
-  }
-  if (dest_elem == T_ARRAY || dest_elem == T_NARROWOOP || (dest_elem == T_PRIMITIVE_OBJECT && !top_dest->is_flat())) {
-    dest_elem = T_OBJECT;
-  }
+  if (is_reference_type(src_elem, true)) src_elem = T_OBJECT;
+  if (is_reference_type(dest_elem, true)) dest_elem = T_OBJECT;
 
   if (ac->is_arraycopy_validated() && dest_elem != T_CONFLICT && src_elem == T_CONFLICT) {
     src_elem = dest_elem;
@@ -1454,8 +1439,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     return;
   }
 
-  assert(!ac->is_arraycopy_validated() || (src_elem == dest_elem && dest_elem != T_VOID) ||
-         (src_elem == T_PRIMITIVE_OBJECT && StressReflectiveCode), "validated but different basic types");
+  assert(!ac->is_arraycopy_validated() || (src_elem == dest_elem && dest_elem != T_VOID), "validated but different basic types");
 
   // (2) src and dest arrays must have elements of the same BasicType
   // Figure out the size and type of the elements we will be copying.
@@ -1464,8 +1448,8 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // fields if we need to emit write barriers.
   //
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  if (src_elem != dest_elem || dest_elem == T_VOID ||
-      (dest_elem == T_PRIMITIVE_OBJECT && top_dest->elem()->make_ptr()->inline_klass()->contains_oops() &&
+  if (src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID ||
+      (top_src->is_flat() && top_dest->elem()->make_ptr()->inline_klass()->contains_oops() &&
        bs->array_copy_requires_gc_barriers(alloc != NULL, T_OBJECT, false, false, BarrierSetC2::Optimization))) {
     // The component types are not the same or are not recognized.  Punt.
     // (But, avoid the native method wrapper to JVM_ArrayCopy.)
@@ -1496,7 +1480,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   // (9) each element of an oop array must be assignable
 
   Node* mem = ac->in(TypeFunc::Memory);
-  if (dest_elem == T_PRIMITIVE_OBJECT) {
+  if (top_dest->is_flat()) {
     // Copy to a flat array modifies multiple memory slices. Conservatively insert a barrier
     // on all slices to prevent writes into the source from floating below the arraycopy.
     insert_mem_bar(&ctrl, &mem, Op_MemBarCPUOrder);
@@ -1564,7 +1548,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   const TypePtr* adr_type = NULL;
   Node* dest_length = (alloc != NULL) ? alloc->in(AllocateNode::ALength) : NULL;
 
-  if (dest_elem == T_PRIMITIVE_OBJECT) {
+  if (top_dest->is_flat()) {
     adr_type = adjust_for_flat_array(top_dest, src_offset, dest_offset, length, dest_elem, dest_length);
   } else if (ac->_dest_type != TypeOopPtr::BOTTOM) {
     adr_type = ac->_dest_type->add_offset(Type::OffsetBot)->is_ptr();

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1284,7 +1284,7 @@ const TypePtr* PhaseMacroExpand::adjust_for_flat_array(const TypeAryPtr* top_des
                                                        Node*& dest_length) {
 #ifdef ASSERT
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  bool needs_barriers = top_dest->elem()->make_ptr()->inline_klass()->contains_oops() &&
+  bool needs_barriers = top_dest->elem()->inline_klass()->contains_oops() &&
     bs->array_copy_requires_gc_barriers(dest_length != NULL, T_OBJECT, false, false, BarrierSetC2::Optimization);
   assert(!needs_barriers || StressReflectiveCode, "Flat arracopy would require GC barriers");
 #endif
@@ -1449,7 +1449,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
   //
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   if (src_elem != dest_elem || top_src->is_flat() != top_dest->is_flat() || dest_elem == T_VOID ||
-      (top_src->is_flat() && top_dest->elem()->make_ptr()->inline_klass()->contains_oops() &&
+      (top_src->is_flat() && top_dest->elem()->inline_klass()->contains_oops() &&
        bs->array_copy_requires_gc_barriers(alloc != NULL, T_OBJECT, false, false, BarrierSetC2::Optimization))) {
     // The component types are not the same or are not recognized.  Punt.
     // (But, avoid the native method wrapper to JVM_ArrayCopy.)

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2831,7 +2831,6 @@ Node* StoreNode::Identity(PhaseGVN* phase) {
     // a newly allocated object is already all-zeroes everywhere
     if (mem->is_Proj() && mem->in(0)->is_Allocate() &&
         (phase->type(val)->is_zero_type() || mem->in(0)->in(AllocateNode::DefaultValue) == val)) {
-      assert(!phase->type(val)->is_zero_type() || mem->in(0)->in(AllocateNode::DefaultValue) == NULL, "storing null to inline type array is forbidden");
       result = mem;
     }
 

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1975,7 +1975,7 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     // expression (LShiftL quux 3) independently optimized to the constant 8.
     if ((t->isa_int() == NULL) && (t->isa_long() == NULL)
         && (_type->isa_vect() == NULL)
-        && t->isa_inlinetype() == NULL
+        && !ary->is_flat()
         && Opcode() != Op_LoadKlass && Opcode() != Op_LoadNKlass) {
       // t might actually be lower than _type, if _type is a unique
       // concrete subclass of abstract class t.

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -609,8 +609,8 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
       // Create InlineTypeNode from the oop and replace the parameter
       Node* vt = InlineTypeNode::make_from_oop(this, parm, t->inline_klass(), !t->maybe_null());
       set_local(i, vt);
-    } else if (UseTypeSpeculation && (i == (arg_size - 1)) && !is_osr_parse() &&
-               method()->has_vararg() && t->isa_aryptr() != NULL && !t->is_aryptr()->is_not_null_free()) {
+    } else if (UseTypeSpeculation && (i == (arg_size - 1)) && !is_osr_parse() && method()->has_vararg() &&
+               t->isa_aryptr() != NULL && !t->is_aryptr()->is_null_free() && !t->is_aryptr()->is_not_null_free()) {
       // Speculate on varargs Object array being not null-free (and therefore also not flattened)
       const TypePtr* spec_type = t->speculative();
       spec_type = (spec_type != NULL && spec_type->isa_aryptr() != NULL) ? spec_type : t->is_aryptr();

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -84,7 +84,7 @@ void Parse::array_load(BasicType bt) {
   const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
   if (ary_t->is_flat()) {
     // Load from flattened inline type array
-    Node* vt = InlineTypeNode::make_from_flattened(this, elemtype->inline_klass(), ary, adr);
+    Node* vt = InlineTypeNode::make_from_flattened(this, elemtype->make_ptr()->inline_klass(), ary, adr);
     push(vt);
     return;
   } else if (ary_t->is_null_free()) {
@@ -209,6 +209,7 @@ void Parse::array_store(BasicType bt) {
     const Type* tval = _gvn.type(cast_val);
     // We may have lost type information for 'val' here due to the casts
     // emitted by the array_store_check code (see JDK-6312651)
+    // TODO remove it now
     // TODO Remove this code once JDK-6312651 is in.
     const Type* tval_init = _gvn.type(val);
     // Based on the value to be stored, try to determine if the array is not null-free and/or not flat.

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -215,10 +215,9 @@ void Parse::array_store(BasicType bt) {
     // Based on the value to be stored, try to determine if the array is not null-free and/or not flat.
     // This is only legal for non-null stores because the array_store_check always passes for null, even
     // if the array is null-free. Null stores are handled in GraphKit::gen_inline_array_null_guard().
-    bool not_inline = !tval->isa_inlinetype() &&
-                      ((!tval_init->maybe_null() && !tval_init->is_oopptr()->can_be_inline_type()) ||
-                       (!tval->maybe_null() && !tval->is_oopptr()->can_be_inline_type()));
-    bool not_flattened = not_inline || ((tval_init->is_inlinetypeptr() || tval_init->isa_inlinetype()) && !tval_init->inline_klass()->flatten_array());
+    bool not_inline = (!tval_init->maybe_null() && !tval_init->is_oopptr()->can_be_inline_type()) ||
+                      (!tval->maybe_null() && !tval->is_oopptr()->can_be_inline_type());
+    bool not_flattened = not_inline || (tval_init->is_inlinetypeptr() && !tval_init->inline_klass()->flatten_array());
     if (!ary_t->is_not_null_free() && not_inline) {
       // Storing a non-inline type, mark array as not null-free (-> not flat).
       ary_t = ary_t->cast_to_not_null_free();
@@ -277,9 +276,9 @@ void Parse::array_store(BasicType bt) {
         }
         // Try to determine the inline klass
         ciInlineKlass* vk = NULL;
-        if (tval->isa_inlinetype() || tval->is_inlinetypeptr()) {
+        if (tval->is_inlinetypeptr()) {
           vk = tval->inline_klass();
-        } else if (tval_init->isa_inlinetype() || tval_init->is_inlinetypeptr()) {
+        } else if (tval_init->is_inlinetypeptr()) {
           vk = tval_init->inline_klass();
         } else if (elemtype->is_inlinetypeptr()) {
           vk = elemtype->inline_klass();

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -84,7 +84,7 @@ void Parse::array_load(BasicType bt) {
   const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
   if (ary_t->is_flat()) {
     // Load from flattened inline type array
-    Node* vt = InlineTypeNode::make_from_flattened(this, elemtype->make_ptr()->inline_klass(), ary, adr);
+    Node* vt = InlineTypeNode::make_from_flattened(this, elemtype->inline_klass(), ary, adr);
     push(vt);
     return;
   } else if (ary_t->is_null_free()) {
@@ -207,18 +207,12 @@ void Parse::array_store(BasicType bt) {
   } else if (bt == T_OBJECT) {
     elemtype = elemtype->make_oopptr();
     const Type* tval = _gvn.type(cast_val);
-    // We may have lost type information for 'val' here due to the casts
-    // emitted by the array_store_check code (see JDK-6312651)
-    // TODO remove it now
-    // TODO Remove this code once JDK-6312651 is in.
-    const Type* tval_init = _gvn.type(val);
     // Based on the value to be stored, try to determine if the array is not null-free and/or not flat.
     // This is only legal for non-null stores because the array_store_check always passes for null, even
     // if the array is null-free. Null stores are handled in GraphKit::gen_inline_array_null_guard().
-    bool not_inline = (!tval_init->maybe_null() && !tval_init->is_oopptr()->can_be_inline_type()) ||
-                      (!tval->maybe_null() && !tval->is_oopptr()->can_be_inline_type());
-    bool not_flattened = not_inline || (tval_init->is_inlinetypeptr() && !tval_init->inline_klass()->flatten_array());
-    if (!ary_t->is_not_null_free() && not_inline) {
+    bool not_null_free = !tval->maybe_null() && !tval->is_oopptr()->can_be_inline_type();
+    bool not_flattened = not_null_free || (tval->is_inlinetypeptr() && !tval->inline_klass()->flatten_array());
+    if (!ary_t->is_not_null_free() && not_null_free) {
       // Storing a non-inline type, mark array as not null-free (-> not flat).
       ary_t = ary_t->cast_to_not_null_free();
       Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, ary_t));
@@ -278,8 +272,6 @@ void Parse::array_store(BasicType bt) {
         ciInlineKlass* vk = NULL;
         if (tval->is_inlinetypeptr()) {
           vk = tval->inline_klass();
-        } else if (tval_init->is_inlinetypeptr()) {
-          vk = tval_init->inline_klass();
         } else if (elemtype->is_inlinetypeptr()) {
           vk = elemtype->inline_klass();
         }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -263,14 +263,12 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
                                                        immutable_memory(), p2, tak));
 
   // If we statically know that this is an inline type array, use precise element klass for checkcast
-  if (!elemtype->isa_inlinetype()) {
-    elemtype = elemtype->make_oopptr();
-  }
+  const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
   bool null_free = false;
-  if (elemtype->isa_inlinetype() != NULL || elemtype->is_inlinetypeptr()) {
+  if (elemtype->make_ptr()->is_inlinetypeptr()) {
     // We statically know that this is an inline type array, use precise klass ptr
-    null_free = elemtype->isa_inlinetype() || !elemtype->maybe_null();
-    a_e_klass = makecon(TypeKlassPtr::make(elemtype->inline_klass()));
+    null_free = arytype->is_flat() || !elemtype->make_ptr()->maybe_null();
+    a_e_klass = makecon(TypeKlassPtr::make(elemtype->make_ptr()->inline_klass()));
   }
 
   // Check (the hard way) and throw if not a subklass.

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -268,7 +268,7 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
   if (elemtype->make_ptr()->is_inlinetypeptr()) {
     // We statically know that this is an inline type array, use precise klass ptr
     null_free = arytype->is_flat() || !elemtype->make_ptr()->maybe_null();
-    a_e_klass = makecon(TypeKlassPtr::make(elemtype->make_ptr()->inline_klass()));
+    a_e_klass = makecon(TypeKlassPtr::make(elemtype->inline_klass()));
   }
 
   // Check (the hard way) and throw if not a subklass.

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5066,6 +5066,9 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
         // Result is non-flattened
         off = Offset(flattened_offset()).meet(Offset(tap->flattened_offset()));
         field_off = Offset::bottom;
+      } else if (flattened_offset() == tap->flattened_offset()) {
+        off = Offset(!is_flat() ? offset() : tap->offset());
+        field_off = !is_flat() ? field_offset() : tap->field_offset();
       }
     }
 
@@ -6639,6 +6642,8 @@ const Type    *TypeAryKlassPtr::xmeet( const Type *t ) const {
         null_free = _null_free;
       } else if (above_centerline(this->ptr()) && !above_centerline(tap->ptr())) {
         null_free = tap->_null_free;
+      } else if (above_centerline(this->ptr()) && above_centerline(tap->ptr())) {
+        null_free = _null_free || tap->_null_free;
       }
     }
     return make(ptr, elem, res_klass, off, res_not_flat, res_not_null_free, null_free);

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6384,10 +6384,9 @@ ciKlass* TypeAryPtr::compute_klass(DEBUG_ONLY(bool verify)) const {
   }
 
   // Get element klass
-  if (is_flat()) {
-    // TODO this comment does not make sense anymore
-    // If element type is TypeInlineType::BOTTOM, inline_klass() will be null.
-    if (el->is_inlinetypeptr() && el->inline_klass() != NULL) {
+  if (is_flat() && el->is_inlinetypeptr()) {
+    // TODO can we remove this?
+    if (el->inline_klass() != NULL) {
       k_ary = ciArrayKlass::make(el->inline_klass(), /* null_free */ true);
     }
   } else if ((tinst = el->isa_instptr()) != NULL) {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6388,7 +6388,7 @@ ciKlass* TypeAryPtr::compute_klass(DEBUG_ONLY(bool verify)) const {
     // TODO this comment does not make sense anymore
     // If element type is TypeInlineType::BOTTOM, inline_klass() will be null.
     if (el->is_inlinetypeptr() && el->inline_klass() != NULL) {
-      k_ary = ciArrayKlass::make(el->make_ptr()->inline_klass(), /* null_free */ true);
+      k_ary = ciArrayKlass::make(el->inline_klass(), /* null_free */ true);
     }
   } else if ((tinst = el->isa_instptr()) != NULL) {
     // Leave k_ary at NULL.

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -2453,7 +2453,6 @@ bool TypeAry::ary_must_be_exact() const {
   if (tinst) {
     if (tinst->instance_klass()->is_final()) {
       // Even if MyValue is exact, [LMyValue is not exact due to [QMyValue <: [LMyValue.
-      // TODO double check this
       if (tinst->is_inlinetypeptr() && (tinst->ptr() == TypePtr::BotPTR || tinst->ptr() == TypePtr::TopPTR)) {
         return false;
       }
@@ -3740,7 +3739,6 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
     const TypeAryPtr* arr = TypeAryPtr::make(TypePtr::BotPTR, arr0, klass, true, Offset(0));
     return arr;
   } else if (klass->is_flat_array_klass()) {
-    // TODO check this
     const TypeOopPtr* etype = TypeOopPtr::make_from_klass_raw(klass->as_array_klass()->element_klass(), trust_interfaces);
     etype = etype->join_speculative(TypePtr::NOTNULL)->is_oopptr();
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::POS, /* stable= */ false, /* flat= */ true);
@@ -5056,7 +5054,6 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
 
     ciKlass* res_klass = NULL;
     bool res_xk = false;
-    // TODO Should be use tary->_flat instead?
     bool res_flat = false;
     bool res_not_flat = false;
     bool res_not_null_free = false;

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6873,11 +6873,11 @@ void TypeAryKlassPtr::dump2( Dict & d, uint depth, outputStream *st ) const {
   default:
     break;
   }
+  if (is_flat()) st->print(":flat");
+  if (_null_free) st->print(":null free");
   if (Verbose) {
-    if (is_flat()) st->print(":flat");
     if (_not_flat) st->print(":not flat");
     if (_not_null_free) st->print(":not null free");
-    if (_null_free) st->print(":null free");
   }
 
   _offset.dump2(st);

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -2318,8 +2318,7 @@ inline bool Type::is_inlinetypeptr() const {
 }
 
 inline ciInlineKlass* Type::inline_klass() const {
-  assert(is_inlinetypeptr(), "must be an inline type ptr");
-  return is_instptr()->instance_klass()->as_inline_klass();
+  return make_ptr()->is_instptr()->instance_klass()->as_inline_klass();
 }
 
 

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -781,8 +781,8 @@ public:
 //------------------------------TypeAry----------------------------------------
 // Class of Array Types
 class TypeAry : public Type {
-  TypeAry(const Type* elem, const TypeInt* size, bool stable, bool not_flat, bool not_null_free) : Type(Array),
-      _elem(elem), _size(size), _stable(stable), _not_flat(not_flat), _not_null_free(not_null_free) {}
+  TypeAry(const Type* elem, const TypeInt* size, bool stable, bool flat, bool not_flat, bool not_null_free) : Type(Array),
+      _elem(elem), _size(size), _stable(stable), _flat(flat), _not_flat(not_flat), _not_null_free(not_null_free) {}
 public:
   virtual bool eq( const Type *t ) const;
   virtual int  hash() const;             // Type specific hashing
@@ -795,6 +795,7 @@ private:
   const bool _stable;           // Are elements @Stable?
 
   // Inline type array properties
+  const bool _flat;             // Array is flattened
   const bool _not_flat;         // Array is never flattened
   const bool _not_null_free;    // Array is never null-free
 
@@ -802,7 +803,7 @@ private:
 
 public:
   static const TypeAry* make(const Type* elem, const TypeInt* size, bool stable = false,
-                             bool not_flat = false, bool not_null_free = false);
+                             bool flat = false, bool not_flat = false, bool not_null_free = false);
 
   virtual const Type *xmeet( const Type *t ) const;
   virtual const Type *xdual() const;    // Compute dual right now.
@@ -1023,7 +1024,7 @@ protected:
                                                             ciKlass*& res_klass, bool& res_xk, bool& res_flatten_array);
 
   template<class T> static MeetResult meet_aryptr(PTR& ptr, const Type*& elem, const T* this_ary, const T* other_ary,
-                                                  ciKlass*& res_klass, bool& res_xk, bool &res_not_flat, bool &res_not_null_free);
+                                                  ciKlass*& res_klass, bool& res_xk, bool &res_flat, bool &res_not_flat, bool &res_not_null_free);
 
   template <class T1, class T2> static bool is_java_subtype_of_helper_for_instance(const T1* this_one, const T2* other, bool this_exact, bool other_exact);
   template <class T1, class T2> static bool is_same_java_type_as_helper_for_instance(const T1* this_one, const T2* other);
@@ -1504,7 +1505,7 @@ public:
   bool      is_stable() const { return _ary->_stable; }
 
   // Inline type array properties
-  bool is_flat()          const { return _ary->_elem->isa_inlinetype() != NULL; }
+  bool is_flat()          const { return _ary->_flat; }
   bool is_not_flat()      const { return _ary->_not_flat; }
   bool is_null_free()     const { return is_flat() || (_ary->_elem->make_ptr() != NULL && _ary->_elem->make_ptr()->is_inlinetypeptr() && (_ary->_elem->make_ptr()->ptr() == NotNull || _ary->_elem->make_ptr()->ptr() == AnyNull)); }
   bool is_not_null_free() const { return _ary->_not_null_free; }


### PR DESCRIPTION
After [JDK-8293542](https://bugs.openjdk.org/browse/JDK-8293542), we only use `TypeInlineType` for flat arrays and for the calling convention. This large cleanup removes it and uses a pointer type instead, which significantly reduces the complexity of the implementation.

Thanks to Roland, for helping with fixing some C2 type system issues!

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293800](https://bugs.openjdk.org/browse/JDK-8293800): [lworld] Remove TypeInlineType and related code


### Contributors
 * Roland Westrelin `<roland@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/829/head:pull/829` \
`$ git checkout pull/829`

Update a local copy of the PR: \
`$ git checkout pull/829` \
`$ git pull https://git.openjdk.org/valhalla pull/829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 829`

View PR using the GUI difftool: \
`$ git pr show -t 829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/829.diff">https://git.openjdk.org/valhalla/pull/829.diff</a>

</details>
