### PR TITLE
8304084: [lworld] Fix copyright text in GensrcValueClasses.gmk

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -19,6 +19,8 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
 #
 
 ################################################################################


### PR DESCRIPTION
Correct incomplete copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8304084](https://bugs.openjdk.org/browse/JDK-8304084): [lworld] Fix copyright text in GensrcValueClasses.gmk


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla pull/830/head:pull/830` \
`$ git checkout pull/830`

Update a local copy of the PR: \
`$ git checkout pull/830` \
`$ git pull https://git.openjdk.org/valhalla pull/830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 830`

View PR using the GUI difftool: \
`$ git pr show -t 830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/830.diff">https://git.openjdk.org/valhalla/pull/830.diff</a>

</details>
