### PR TITLE
8304168: CDS tests fail with --enable-preview patched value classes

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -19,6 +19,8 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
 #
 
 ################################################################################

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -61,7 +61,8 @@ public class RedefineRunningMethods_Shared {
         TestCommon.testDump(appJar, shared_classes,
                             // command-line arguments ...
                             use_whitebox_jar,
-                            "--enable-preview");
+                            "--enable-preview",
+                            "-XX:-EnableValhalla");
 
         // RedefineRunningMethods.java contained this:
         // @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace RedefineRunningMethods
@@ -71,6 +72,7 @@ public class RedefineRunningMethods_Shared {
                                  "-XX:+UnlockDiagnosticVMOptions",
                                  "-XX:+WhiteBoxAPI",
                                  "--enable-preview",
+                                 "-XX:-EnableValhalla",
                                  // These arguments are expected by RedefineRunningMethods
                                  "-javaagent:redefineagent.jar",
                                  "-Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace",

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -465,7 +465,7 @@ abstract public class TestScaffold extends TargetAdapter {
         String mainWrapper = System.getProperty("main.wrapper");
         if ("Virtual".equals(mainWrapper)) {
             argInfo.targetAppCommandLine = TestScaffold.class.getName() + " " + mainWrapper + " ";
-            argInfo.targetVMArgs += "--enable-preview ";
+            argInfo.targetVMArgs += "--enable-preview " + "-XX:-EnableValhalla ";
         } else if ("true".equals(System.getProperty("test.enable.preview"))) {
             // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";


### PR DESCRIPTION
When --enable-preview is true, the patching of some java.base classes as value classes disables CDS. 
Subsequently the CDS tests fail.

Disable the patching of the classes by disabling Valhalla when used with --enable-preview for a couple of tests.