### PR TITLE
8304168: [lworld] CDS tests fail with --enable-preview patched value classes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -61,7 +61,8 @@ public class RedefineRunningMethods_Shared {
         TestCommon.testDump(appJar, shared_classes,
                             // command-line arguments ...
                             use_whitebox_jar,
-                            "--enable-preview");
+                            "--enable-preview",
+                            "-XX:-EnableValhalla");
 
         // RedefineRunningMethods.java contained this:
         // @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace RedefineRunningMethods
@@ -71,6 +72,7 @@ public class RedefineRunningMethods_Shared {
                                  "-XX:+UnlockDiagnosticVMOptions",
                                  "-XX:+WhiteBoxAPI",
                                  "--enable-preview",
+                                 "-XX:-EnableValhalla",
                                  // These arguments are expected by RedefineRunningMethods
                                  "-javaagent:redefineagent.jar",
                                  "-Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace",

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -465,7 +465,7 @@ abstract public class TestScaffold extends TargetAdapter {
         String mainWrapper = System.getProperty("main.wrapper");
         if ("Virtual".equals(mainWrapper)) {
             argInfo.targetAppCommandLine = TestScaffold.class.getName() + " " + mainWrapper + " ";
-            argInfo.targetVMArgs += "--enable-preview " + "-XX:-EnableValhalla ";
+            argInfo.targetVMArgs += "--enable-preview ";
         } else if ("true".equals(System.getProperty("test.enable.preview"))) {
             // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -465,7 +465,7 @@ abstract public class TestScaffold extends TargetAdapter {
         String mainWrapper = System.getProperty("main.wrapper");
         if ("Virtual".equals(mainWrapper)) {
             argInfo.targetAppCommandLine = TestScaffold.class.getName() + " " + mainWrapper + " ";
-            argInfo.targetVMArgs += "--enable-preview ";
+            argInfo.targetVMArgs += "--enable-preview " + "-XX:-EnableValhalla ";
         } else if ("true".equals(System.getProperty("test.enable.preview"))) {
             // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";


### PR DESCRIPTION
When --enable-preview is true, the patching of some java.base classes as value classes disables CDS. 
Subsequently the CDS tests fail.

For a CDS, disable Valhalla when --enable-preview is set so java.base is not patched with value classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8304168](https://bugs.openjdk.org/browse/JDK-8304168): [lworld] CDS tests fail with --enable-preview patched value classes (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/832/head:pull/832` \
`$ git checkout pull/832`

Update a local copy of the PR: \
`$ git checkout pull/832` \
`$ git pull https://git.openjdk.org/valhalla.git pull/832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 832`

View PR using the GUI difftool: \
`$ git pr show -t 832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/832.diff">https://git.openjdk.org/valhalla/pull/832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/832#issuecomment-1468658996)