### PR TITLE
8306301: [lworld] Circular dependency when unpacking

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6371,7 +6371,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
 }
 
 VMReg MacroAssembler::spill_reg_for(VMReg reg) {
-  return (reg->is_FloatRegister()) ? v0->as_VMReg() : r14->as_VMReg();
+  return (reg->is_FloatRegister()) ? v8->as_VMReg() : r14->as_VMReg();
 }
 
 void MacroAssembler::cache_wb(Address line) {

--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -212,7 +212,7 @@ bool MacroAssembler::shuffle_inline_args_spill(bool is_packing, const GrowableAr
   if (!is_packing || SigEntry::skip_value_delimiters(sig, sig_index)) {
     reg = regs_from[from_index].first();
     if (!reg->is_valid() || reg_state[reg->value()] != reg_readonly) {
-      // Spilling this won't break circles
+      // Spilling this won't break cycles
       return true;
     }
   } else {
@@ -229,7 +229,7 @@ bool MacroAssembler::shuffle_inline_args_spill(bool is_packing, const GrowableAr
       }
     }
     if (!found) {
-      // Spilling fields in this inline type arg won't break circles
+      // Spilling fields in this inline type arg won't break cycles
       return true;
     }
   }


### PR DESCRIPTION
The enhanced `StressCallingConvention` option from [JDK-8301007](https://bugs.openjdk.org/browse/JDK-8301007) triggered a spurious assert due to an unresolvable circular dependency between register/stack slots when emitting code for unpacking. The root cause is that `v0` is used as spill register on aarch64 but that register is also used for arguments and therefore not able to resolve all circular dependencies. We should use `v8` instead which is also save on call for Java.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306301](https://bugs.openjdk.org/browse/JDK-8306301): [lworld] Circular dependency when unpacking


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/835/head:pull/835` \
`$ git checkout pull/835`

Update a local copy of the PR: \
`$ git checkout pull/835` \
`$ git pull https://git.openjdk.org/valhalla.git pull/835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 835`

View PR using the GUI difftool: \
`$ git pr show -t 835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/835.diff">https://git.openjdk.org/valhalla/pull/835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/835#issuecomment-1513280880)