### PR TITLE
8306443: [lworld] Incorrect loading of is-init-byte from stack

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6320,7 +6320,7 @@ bool MacroAssembler::pack_inline_helper(const GrowableArray<SigEntry>* sig, int&
       Label L_notNull;
       if (fromReg->is_stack()) {
         int ld_off = fromReg->reg2stack() * VMRegImpl::stack_slot_size;
-        ldr(tmp2, Address(sp, ld_off));
+        ldrb(tmp2, Address(sp, ld_off));
         cbnz(tmp2, L_notNull);
       } else {
         cbnz(fromReg->as_Register(), L_notNull);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -772,7 +772,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
             Label L_notNull;
             if (reg->is_stack()) {
               int ld_off = reg->reg2stack() * VMRegImpl::stack_slot_size + extraspace;
-              __ ldr(tmp1, Address(sp, ld_off));
+              __ ldrb(tmp1, Address(sp, ld_off));
               __ cbnz(tmp1, L_notNull);
             } else {
               __ cbnz(reg->as_Register(), L_notNull);


### PR DESCRIPTION
Incorrect loading of the is-init-byte (that determines if a scalarized argument is non-null) from the stack when buffering scalarized arguments leads to intermittent failures.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306443](https://bugs.openjdk.org/browse/JDK-8306443): [lworld] Incorrect loading of is-init-byte from stack


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/836/head:pull/836` \
`$ git checkout pull/836`

Update a local copy of the PR: \
`$ git checkout pull/836` \
`$ git pull https://git.openjdk.org/valhalla.git pull/836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 836`

View PR using the GUI difftool: \
`$ git pr show -t 836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/836.diff">https://git.openjdk.org/valhalla/pull/836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/836#issuecomment-1514649032)