### PR TITLE
8306453: ProblemList CDS tests failing with dumping the shared archive: --patch-module

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -708,6 +708,11 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all
 
+com/sun/jdi/cds/CDSBreakpointTest.java                          8304168 generic-all
+com/sun/jdi/cds/CDSDeleteAllBkptsTest.java                      8304168 generic-all
+com/sun/jdi/cds/CDSFieldWatchpoints.java                        8304168 generic-all
+runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java  8304168 generic-all
+
 ############################################################################
 
 # jdk_time


### PR DESCRIPTION
Problem list tests that file due to [JDK-8304168](https://bugs.openjdk.org/browse/JDK-8304168).

com/sun/jdi/cds/CDSBreakpointTest.java
com/sun/jdi/cds/CDSDeleteAllBkptsTest.java
com/sun/jdi/cds/CDSFieldWatchpoints.java
runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306453](https://bugs.openjdk.org/browse/JDK-8306453): ProblemList CDS tests failing with dumping the shared archive: --patch-module


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/837/head:pull/837` \
`$ git checkout pull/837`

Update a local copy of the PR: \
`$ git checkout pull/837` \
`$ git pull https://git.openjdk.org/valhalla.git pull/837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 837`

View PR using the GUI difftool: \
`$ git pr show -t 837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/837.diff">https://git.openjdk.org/valhalla/pull/837.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/837#issuecomment-1514933058)