### PR TITLE
8306565: [lworld] Asserts with stress testing during PhaseCCP due to unexpected top types

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2198,8 +2198,8 @@ const Type* LoadNode::Value(PhaseGVN* phase) const {
     if (EnableValhalla) {
       // The mark word may contain property bits (inline, flat, null-free)
       Node* klass_node = alloc->in(AllocateNode::KlassNode);
-      const TypeKlassPtr* tkls = phase->type(klass_node)->is_klassptr();
-      if (tkls->is_loaded() && tkls->klass_is_exact()) {
+      const TypeKlassPtr* tkls = phase->type(klass_node)->isa_klassptr();
+      if (tkls != NULL && tkls->is_loaded() && tkls->klass_is_exact()) {
         return TypeX::make(tkls->exact_klass()->prototype_header().value());
       }
     } else {

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -5408,7 +5408,7 @@ const TypePtr* TypeAryPtr::add_field_offset_and_offset(intptr_t offset) const {
         offset += header;
       }
     }
-    if (offset >= (intptr_t)header || offset < 0) {
+    if (elem()->make_oopptr()->is_inlinetypeptr() && (offset >= (intptr_t)header || offset < 0)) {
       // Try to get the field of the inline type array element we are pointing to
       ciInlineKlass* vk = elem()->inline_klass();
       int shift = flat_log_elem_size();


### PR DESCRIPTION
We intermittently assert during PhaseCCP with stress flags because some node types are still top. We should simply handle such cases.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306565](https://bugs.openjdk.org/browse/JDK-8306565): [lworld] Asserts with stress testing during PhaseCCP due to unexpected top types


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/839/head:pull/839` \
`$ git checkout pull/839`

Update a local copy of the PR: \
`$ git checkout pull/839` \
`$ git pull https://git.openjdk.org/valhalla.git pull/839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 839`

View PR using the GUI difftool: \
`$ git pr show -t 839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/839.diff">https://git.openjdk.org/valhalla/pull/839.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/839#issuecomment-1516377784)