### PR TITLE
8306568: [lworld] Oop verification failure in InlineKlass::returned_inline_klass

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -486,19 +486,16 @@ InlineKlass* InlineKlass::returned_inline_klass(const RegisterMap& map) {
   address loc = map.location(pair.first(), nullptr);
   intptr_t ptr = *(intptr_t*)loc;
   if (is_set_nth_bit(ptr, 0)) {
-    // Oop is tagged, must be an InlineKlass oop
+    // Return value is tagged, must be an InlineKlass pointer
     clear_nth_bit(ptr, 0);
     assert(Metaspace::contains((void*)ptr), "should be klass");
     InlineKlass* vk = (InlineKlass*)ptr;
     assert(vk->can_be_returned_as_fields(), "must be able to return as fields");
     return vk;
   }
-#ifdef ASSERT
-  // Oop is not tagged, must be a valid oop
-  if (VerifyOops) {
-    oopDesc::verify(cast_to_oop(ptr));
-  }
-#endif
+  // Return value is not tagged, must be a valid oop
+  assert(oopDesc::is_oop_or_null(cast_to_oop(ptr), true),
+         "Bad oop return: " PTR_FORMAT, ptr);
   return NULL;
 }
 


### PR DESCRIPTION
Oop verification intermittently fails with ZGC when checking the oop return value of a method from `ThreadSafepointState::handle_polling_page_exception` -> `InlineKlass::returned_inline_klass`  at returns. The problem is that header verification in `oopDesc::is_oop` fails because the mark word is set. Given that this code is executed outside of a safepoint, it's not safe to assume that the mark word is zero. I changed the verification code accordingly.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306568](https://bugs.openjdk.org/browse/JDK-8306568): [lworld] Oop verification failure in InlineKlass::returned_inline_klass


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/840/head:pull/840` \
`$ git checkout pull/840`

Update a local copy of the PR: \
`$ git checkout pull/840` \
`$ git pull https://git.openjdk.org/valhalla.git pull/840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 840`

View PR using the GUI difftool: \
`$ git pr show -t 840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/840.diff">https://git.openjdk.org/valhalla/pull/840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/840#issuecomment-1517387797)