### PR TITLE
8303000: [lworld] C2 compilation fails with assert(phase->C->get_alias_index(t) == phase->C->get_alias_index(t_adr)) failed: correct memory chain

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -232,6 +232,8 @@ Node *MemNode::optimize_memory_chain(Node *mchain, const TypePtr *t_adr, Node *l
         mem_t = mem_t->is_aryptr()
                      ->cast_to_stable(t_oop->is_aryptr()->is_stable())
                      ->cast_to_size(t_oop->is_aryptr()->size())
+                     ->cast_to_not_flat(t_oop->is_aryptr()->is_not_flat())
+                     ->cast_to_not_null_free(t_oop->is_aryptr()->is_not_null_free())
                      ->with_offset(t_oop->is_aryptr()->offset())
                      ->is_aryptr();
       }


### PR DESCRIPTION
Mainline fix for [JDK-8288204](https://bugs.openjdk.org/browse/JDK-8288204) needs to be extended to account for flat/null-free arrays.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8303000](https://bugs.openjdk.org/browse/JDK-8303000): [lworld] C2 compilation fails with assert(phase-&gt;C-&gt;get_alias_index(t) == phase-&gt;C-&gt;get_alias_index(t_adr)) failed: correct memory chain


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/841/head:pull/841` \
`$ git checkout pull/841`

Update a local copy of the PR: \
`$ git checkout pull/841` \
`$ git pull https://git.openjdk.org/valhalla.git pull/841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 841`

View PR using the GUI difftool: \
`$ git pr show -t 841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/841.diff">https://git.openjdk.org/valhalla/pull/841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/841#issuecomment-1517461796)