### PR TITLE
8306677: [lworld] TestCallingConventionC1 fails on AArch64 with -XX:+PatchALot

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConventionC1.java
@@ -71,7 +71,9 @@ public class TestCallingConventionC1 {
                 new Scenario(3,
                              "-XX:+EnableValhalla", "-XX:+EnablePrimitiveClasses",
                              "-XX:TieredStopAtLevel=1",
-                             "-XX:+TieredCompilation"),
+                             "-XX:+TieredCompilation",
+                             "-XX:+IgnoreUnrecognizedVMOptions",
+                             "-XX:-PatchALot"),
                 // Only C2.
                 new Scenario(4,
                              "-XX:+EnableValhalla", "-XX:+EnablePrimitiveClasses",


### PR DESCRIPTION
On AArch64, patching in C1 is handled by deoptimization (`DEOPTIMIZE_WHEN_PATCHING`) and therefore TestCallingConventionC1 fails with `-XX:+PatchALot` because some test methods are unexpectedly deoptimized. The fix is to disable that flag if C1 is the only available compiler.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306677](https://bugs.openjdk.org/browse/JDK-8306677): [lworld] TestCallingConventionC1 fails on AArch64 with -XX:+PatchALot


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/842/head:pull/842` \
`$ git checkout pull/842`

Update a local copy of the PR: \
`$ git checkout pull/842` \
`$ git pull https://git.openjdk.org/valhalla.git pull/842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 842`

View PR using the GUI difftool: \
`$ git pr show -t 842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/842.diff">https://git.openjdk.org/valhalla/pull/842.diff</a>

</details>
