### PR TITLE
8306986: [lworld] C2 compilation fails with assert "Should have been buffered"

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -823,8 +823,8 @@ void CallGenerator::do_late_inline_helper() {
 
           // Update oop input to buffer
           kit.gvn().hash_delete(vt);
-          vt->set_is_buffered();
           vt->set_oop(kit.gvn().transform(oop));
+          vt->set_is_buffered(kit.gvn());
           vt = kit.gvn().transform(vt)->as_InlineType();
 
           kit.set_control(kit.gvn().transform(region));

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1924,7 +1924,6 @@ static bool return_val_keeps_allocations_alive(Node* ret_val) {
   bool some_allocations = false;
   for (uint i = 0; i < wq.size(); i++) {
     Node* n = wq.at(i);
-    assert(n == ret_val || !n->is_InlineType(), "chain of inline type nodes");
     if (n->outcnt() > 1) {
       // Some other use for the allocation
       return false;
@@ -2021,11 +2020,14 @@ void Compile::process_inline_types(PhaseIterGVN &igvn, bool remove) {
               must_be_buffered = true;
             }
           }
+        } else if (u->is_Phi()) {
+          // TODO 8302217 Remove this once InlineTypeNodes are reliably pushed through
         } else if (u->Opcode() != Op_Return || !tf()->returns_inline_type_as_fields()) {
           must_be_buffered = true;
         }
         if (must_be_buffered && !vt->is_allocated(&igvn)) {
-          vt->dump(-3);
+          vt->dump(0);
+          u->dump(0);
           assert(false, "Should have been buffered");
         }
 #endif

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -232,7 +232,6 @@ void Parse::do_put_xxx(Node* obj, ciField* field, bool is_field) {
   BasicType bt = field->layout_type();
   Node* val = type2size[bt] == 1 ? pop() : pop_pair();
 
-  assert(!field->is_null_free() || !gvn().type(val)->maybe_null(), "Null store to inline type field");
   if (field->is_null_free() && field->type()->as_inline_klass()->is_empty()) {
     // Storing to a field of an empty inline type. Ignore.
     return;

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -362,10 +362,9 @@ void Parse::do_withfield() {
   }
 
   // Clone the inline type node and set the new field value
-  InlineTypeNode* new_vt = InlineTypeNode::make_uninitialized(gvn(), gvn().type(holder)->inline_klass());
-  for (uint i = 2; i < holder->req(); ++i) {
-    new_vt->set_req(i, holder->in(i));
-  }
+  InlineTypeNode* new_vt = holder->clone()->as_InlineType();
+  new_vt->set_oop(gvn().zerocon(T_PRIMITIVE_OBJECT));
+  new_vt->set_is_buffered(gvn(), false);
   new_vt->set_field_value_by_offset(field->offset(), val);
   {
     PreserveReexecuteState preexecs(this);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /**
  * @test
- * @bug 8260034 8260225 8260283 8261037 8261874 8262128 8262831
- * @summary Generated inline type tests.
+ * @bug 8260034 8260225 8260283 8261037 8261874 8262128 8262831 8306986
+ * @summary A selection of generated tests that triggered bugs not covered by other tests.
  * @compile -XDenablePrimitiveClasses TestGenerated.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses -Xbatch
  *                   compiler.valhalla.inlinetypes.TestGenerated
@@ -34,7 +34,11 @@
 
 package compiler.valhalla.inlinetypes;
 
-primitive class EmptyValue {
+primitive class EmptyPrimitive {
+
+}
+
+value class EmptyValue {
 
 }
 
@@ -71,11 +75,15 @@ primitive class MyValue5 {
     int b = 2;
 }
 
-public class TestGenerated {
-    EmptyValue f1 = new EmptyValue();
-    EmptyValue f2 = new EmptyValue();
+value class MyValue6 {
+    int x = 42;
+}
 
-    void test1(EmptyValue[] array) {
+public class TestGenerated {
+    EmptyPrimitive f1 = new EmptyPrimitive();
+    EmptyPrimitive f2 = new EmptyPrimitive();
+
+    void test1(EmptyPrimitive[] array) {
         for (int i = 0; i < 10; ++i) {
             f1 = array[0];
             f2 = array[0];
@@ -254,9 +262,38 @@ public class TestGenerated {
         }
     }
 
+    static MyValue6 test17Field = new MyValue6();
+
+    void test17() {
+        for (int i = 0; i < 10; ++i) {
+            MyValue6 val = new MyValue6();
+            for (int j = 0; j < 10; ++j) {
+                test17Field = val;
+            }
+        }
+    }
+
+    EmptyValue test18Field;
+
+    EmptyValue test18() {
+        EmptyValue val = new EmptyValue();
+        test18Field = val;
+        return test18Field;
+    }
+
+    MyValue1 test19Field = new MyValue1();
+
+    public void test19() {
+        for (int i = 0; i < 10; ++i) {
+            MyValue1 val = new MyValue1();
+            for (int j = 0; j < 10; ++j)
+                test19Field = val;
+        }
+    }
+
     public static void main(String[] args) {
         TestGenerated t = new TestGenerated();
-        EmptyValue[] array1 = { new EmptyValue() };
+        EmptyPrimitive[] array1 = { new EmptyPrimitive() };
         MyValue1[] array2 = new MyValue1[10];
         MyValue1[] array3 = { new MyValue1() };
         MyValue3[] array4 = { new MyValue3() };
@@ -280,6 +317,9 @@ public class TestGenerated {
             t.test14(false, MyValue4.default);
             t.test15();
             t.test16();
+            t.test17();
+            t.test18();
+            t.test19();
         }
     }
 }


### PR DESCRIPTION
An assert failed because C2 was not able to prove that an inline type was always buffered. I replaced the hacky `InlineTypeNode::_is_buffered` field by a proper node input to propagate the allocation state through C2 IR. We need it in addition to the oop input because for a `null` the oop input is `null` but the node should still be treated as buffered. Reviving my prototype test generator, I found some tests that trigger two too strong asserts. I added the tests and removed the asserts.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8306986](https://bugs.openjdk.org/browse/JDK-8306986): [lworld] C2 compilation fails with assert "Should have been buffered"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/844/head:pull/844` \
`$ git checkout pull/844`

Update a local copy of the PR: \
`$ git checkout pull/844` \
`$ git pull https://git.openjdk.org/valhalla.git pull/844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 844`

View PR using the GUI difftool: \
`$ git pr show -t 844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/844.diff">https://git.openjdk.org/valhalla/pull/844.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/844#issuecomment-1525940205)