### PR TITLE
8307715: Integrate VectorMask/Shuffle with value/primitive classes

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4892,10 +4892,7 @@ bool ClassFileParser::is_jdk_internal_class(const Symbol* outer_class, const cha
       inner_class &&
       (vmSymbols::jdk_internal_vm_vector_VectorSupport() == outer_class ||
        vmSymbols::jdk_internal_vm_vector_VectorPayloadMF() == outer_class)) {
-    if (strstr(inner_class, "VectorPayloadMF64")  ||
-        strstr(inner_class, "VectorPayloadMF128") ||
-        strstr(inner_class, "VectorPayloadMF256") ||
-        strstr(inner_class, "VectorPayloadMF512")) {
+    if (strstr(inner_class, "VectorPayloadMF")) {
       return true;
     }
   }

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -200,6 +200,9 @@
   do_klass(vector_VectorPayloadMF128Z_klass,            jdk_internal_vm_vector_VectorPayloadMF128Z            ) \
   do_klass(vector_VectorPayloadMF256Z_klass,            jdk_internal_vm_vector_VectorPayloadMF256Z            ) \
   do_klass(vector_VectorPayloadMF512Z_klass,            jdk_internal_vm_vector_VectorPayloadMF512Z            ) \
+  do_klass(vector_VectorPayloadMF8B_klass,              jdk_internal_vm_vector_VectorPayloadMF8B              ) \
+  do_klass(vector_VectorPayloadMF16B_klass,             jdk_internal_vm_vector_VectorPayloadMF16B             ) \
+  do_klass(vector_VectorPayloadMF32B_klass,             jdk_internal_vm_vector_VectorPayloadMF32B             ) \
   do_klass(vector_VectorPayloadMF64B_klass,             jdk_internal_vm_vector_VectorPayloadMF64B             ) \
   do_klass(vector_VectorPayloadMF128B_klass,            jdk_internal_vm_vector_VectorPayloadMF128B            ) \
   do_klass(vector_VectorPayloadMF256B_klass,            jdk_internal_vm_vector_VectorPayloadMF256B            ) \

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,6 +193,13 @@
                                                                                                                 \
   /* support multi-field based vectors */                                                                       \
   do_klass(vector_VectorPayloadMF_klass,                jdk_internal_vm_vector_VectorPayloadMF                ) \
+  do_klass(vector_VectorPayloadMF8Z_klass,              jdk_internal_vm_vector_VectorPayloadMF8Z              ) \
+  do_klass(vector_VectorPayloadMF16Z_klass,             jdk_internal_vm_vector_VectorPayloadMF16Z             ) \
+  do_klass(vector_VectorPayloadMF32Z_klass,             jdk_internal_vm_vector_VectorPayloadMF32Z             ) \
+  do_klass(vector_VectorPayloadMF64Z_klass,             jdk_internal_vm_vector_VectorPayloadMF64Z             ) \
+  do_klass(vector_VectorPayloadMF128Z_klass,            jdk_internal_vm_vector_VectorPayloadMF128Z            ) \
+  do_klass(vector_VectorPayloadMF256Z_klass,            jdk_internal_vm_vector_VectorPayloadMF256Z            ) \
+  do_klass(vector_VectorPayloadMF512Z_klass,            jdk_internal_vm_vector_VectorPayloadMF512Z            ) \
   do_klass(vector_VectorPayloadMF64B_klass,             jdk_internal_vm_vector_VectorPayloadMF64B             ) \
   do_klass(vector_VectorPayloadMF128B_klass,            jdk_internal_vm_vector_VectorPayloadMF128B            ) \
   do_klass(vector_VectorPayloadMF256B_klass,            jdk_internal_vm_vector_VectorPayloadMF256B            ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,12 +88,19 @@
   template(java_lang_Long,                            "java/lang/Long")                           \
   template(java_lang_Long_LongCache,                  "java/lang/Long$LongCache")                 \
                                                                                                   \
-  template(jdk_internal_vm_vector_VectorSupport,      "jdk/internal/vm/vector/VectorSupport")               \
-  template(jdk_internal_vm_vector_VectorPayload,      "jdk/internal/vm/vector/VectorSupport$VectorPayload") \
-  template(jdk_internal_vm_vector_Vector,             "jdk/internal/vm/vector/VectorSupport$Vector")        \
-  template(jdk_internal_vm_vector_VectorMask,         "jdk/internal/vm/vector/VectorSupport$VectorMask")    \
-  template(jdk_internal_vm_vector_VectorShuffle,      "jdk/internal/vm/vector/VectorSupport$VectorShuffle") \
-  template(jdk_internal_vm_vector_VectorPayloadMF,    "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF")    \
+  template(jdk_internal_vm_vector_VectorSupport,       "jdk/internal/vm/vector/VectorSupport")                     \
+  template(jdk_internal_vm_vector_VectorPayload,       "jdk/internal/vm/vector/VectorSupport$VectorPayload")       \
+  template(jdk_internal_vm_vector_Vector,              "jdk/internal/vm/vector/VectorSupport$Vector")              \
+  template(jdk_internal_vm_vector_VectorMask,          "jdk/internal/vm/vector/VectorSupport$VectorMask")          \
+  template(jdk_internal_vm_vector_VectorShuffle,       "jdk/internal/vm/vector/VectorSupport$VectorShuffle")       \
+  template(jdk_internal_vm_vector_VectorPayloadMF,     "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF")     \
+  template(jdk_internal_vm_vector_VectorPayloadMF8Z,   "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF8Z")   \
+  template(jdk_internal_vm_vector_VectorPayloadMF16Z,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF16Z")  \
+  template(jdk_internal_vm_vector_VectorPayloadMF32Z,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF32Z")  \
+  template(jdk_internal_vm_vector_VectorPayloadMF64Z,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF64Z")  \
+  template(jdk_internal_vm_vector_VectorPayloadMF128Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128Z") \
+  template(jdk_internal_vm_vector_VectorPayloadMF256Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256Z") \
+  template(jdk_internal_vm_vector_VectorPayloadMF512Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF512Z") \
   template(jdk_internal_vm_vector_VectorPayloadMF64B,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF64B")  \
   template(jdk_internal_vm_vector_VectorPayloadMF128B, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128B") \
   template(jdk_internal_vm_vector_VectorPayloadMF256B, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256B") \
@@ -118,10 +125,10 @@
   template(jdk_internal_vm_vector_VectorPayloadMF128D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128D") \
   template(jdk_internal_vm_vector_VectorPayloadMF256D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256D") \
   template(jdk_internal_vm_vector_VectorPayloadMF512D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF512D") \
-  template(payload_name,                               "payload")                                 \
-  template(mfield_name,                                "mfield")                                  \
-  template(ETYPE_name,                                 "ETYPE")                                   \
-  template(VLENGTH_name,                               "VLENGTH")                                 \
+  template(payload_name,                               "payload")                                                  \
+  template(mfield_name,                                "mfield")                                                   \
+  template(ETYPE_name,                                 "ETYPE")                                                    \
+  template(VLENGTH_name,                               "VLENGTH")                                                  \
                                                                                                   \
   template(jdk_internal_vm_FillerObject,              "jdk/internal/vm/FillerObject")             \
                                                                                                   \
@@ -293,6 +300,13 @@
   template(jdk_internal_ValueBased_signature,                                "Ljdk/internal/ValueBased;") \
                                                                                                   \
   /* VectorAPI support */                                                                         \
+  template(vector_VectorPayloadMF8Z_signature,        "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF8Z;")   \
+  template(vector_VectorPayloadMF16Z_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF16Z;")  \
+  template(vector_VectorPayloadMF32Z_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF32Z;")  \
+  template(vector_VectorPayloadMF64Z_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF64Z;")  \
+  template(vector_VectorPayloadMF128Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF128Z;") \
+  template(vector_VectorPayloadMF256Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF256Z;") \
+  template(vector_VectorPayloadMF512Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF512Z;") \
   template(vector_VectorPayloadMF64B_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF64B;")  \
   template(vector_VectorPayloadMF128B_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF128B;") \
   template(vector_VectorPayloadMF256B_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF256B;") \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -101,6 +101,9 @@
   template(jdk_internal_vm_vector_VectorPayloadMF128Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128Z") \
   template(jdk_internal_vm_vector_VectorPayloadMF256Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256Z") \
   template(jdk_internal_vm_vector_VectorPayloadMF512Z, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF512Z") \
+  template(jdk_internal_vm_vector_VectorPayloadMF8B,   "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF8B")   \
+  template(jdk_internal_vm_vector_VectorPayloadMF16B,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF16B")  \
+  template(jdk_internal_vm_vector_VectorPayloadMF32B,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF32B")  \
   template(jdk_internal_vm_vector_VectorPayloadMF64B,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF64B")  \
   template(jdk_internal_vm_vector_VectorPayloadMF128B, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128B") \
   template(jdk_internal_vm_vector_VectorPayloadMF256B, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256B") \
@@ -307,6 +310,9 @@
   template(vector_VectorPayloadMF128Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF128Z;") \
   template(vector_VectorPayloadMF256Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF256Z;") \
   template(vector_VectorPayloadMF512Z_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF512Z;") \
+  template(vector_VectorPayloadMF8B_signature,        "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF8B;")   \
+  template(vector_VectorPayloadMF16B_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF16B;")  \
+  template(vector_VectorPayloadMF32B_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF32B;")  \
   template(vector_VectorPayloadMF64B_signature,       "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF64B;")  \
   template(vector_VectorPayloadMF128B_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF128B;") \
   template(vector_VectorPayloadMF256B_signature,      "Qjdk/internal/vm/vector/VectorSupport$VectorPayloadMF256B;") \

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,13 +87,15 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Push cast through InlineTypeNode
-  InlineTypeNode* vt = in(1)->isa_InlineType();
-  if (vt != NULL && phase->type(vt)->filter_speculative(_type) != Type::TOP) {
-    Node* cast = clone();
-    cast->set_req(1, vt->get_oop());
-    vt = vt->clone()->as_InlineType();
-    vt->set_oop(phase->transform(cast));
-    return vt;
+  if (in(1)->is_InlineType() && !in(1)->is_VectorBox()) {
+    InlineTypeNode* vt = in(1)->as_InlineType();
+    if (phase->type(vt)->filter_speculative(_type) != Type::TOP) {
+      Node* cast = clone();
+      cast->set_req(1, vt->get_oop());
+      vt = vt->clone()->as_InlineType();
+      vt->set_oop(phase->transform(cast));
+      return vt;
+    }
   }
 
   return NULL;

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2557,7 +2557,17 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       Node* phi = worklist.at(next);
       for (uint i = 1; i < phi->req() && can_optimize; i++) {
         Node* n = phi->in(i);
-        if (n == NULL) {
+        // FIXME: Skipping pushing VectorBox across Phi
+        // since they are special type of InlineTypeNode
+        // carrying VBA as oop fields.
+        // We have a seperate handling for pushing VectorBoxes
+        // across PhiNodes in merge_through_phi.
+        // In long run we should eliminate VectorBox which is
+        // just a light weight wrapper of InlineTypeNode.
+        // Only reason to keep VectorBox was to defer buffering
+        // to a later stage and associate VBA which carry
+        // JVM state to reinitialize GraphKit before buffering.
+        if (n == NULL || n->Opcode() == Op_VectorBox) {
           can_optimize = false;
           break;
         }
@@ -2571,7 +2581,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           n = n->in(1);
         }
         const Type* t = phase->type(n);
-        if (n->is_InlineType() && !n->is_VectorBox() && (vk == NULL || vk == t->inline_klass())) {
+        if (n->is_InlineType() && (vk == NULL || vk == t->inline_klass())) {
           vk = (vk == NULL) ? t->inline_klass() : vk;
           if (phase->find_int_con(n->as_InlineType()->get_is_init(), 0) != 1) {
             is_init = false;

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2571,7 +2571,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           n = n->in(1);
         }
         const Type* t = phase->type(n);
-        if (n->is_InlineType() && (vk == NULL || vk == t->inline_klass())) {
+        if (n->is_InlineType() && !n->is_VectorBox() && (vk == NULL || vk == t->inline_klass())) {
           vk = (vk == NULL) ? t->inline_klass() : vk;
           if (phase->find_int_con(n->as_InlineType()->get_is_init(), 0) != 1) {
             is_init = false;

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -916,7 +916,7 @@ class GraphKit : public Phase {
 
   // Vector API support (implemented in vectorIntrinsics.cpp)
   Node* box_vector(Node* in, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem, bool deoptimize_on_exception = false);
-  Node* unbox_vector(Node* in, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem, bool shuffle_to_vector = false);
+  Node* unbox_vector(Node* in, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem);
   Node* vector_shift_count(Node* cnt, int shift_op, BasicType bt, int num_elem);
 };
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -151,6 +151,7 @@ bool InlineTypeNode::has_phi_inputs(Node* region) {
 
 // Merges 'this' with 'other' by updating the input PhiNodes added by 'clone_with_phis'
 InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* other, int pnum, bool transform) {
+  assert(this->Opcode() == other->Opcode(), "");
   _is_buffered = _is_buffered && other->_is_buffered;
   // Merge oop inputs
   PhiNode* phi = get_oop()->as_Phi();

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -425,7 +425,7 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass*
       const TypeOopPtr* oop_ptr = kit->gvn().type(base)->isa_oopptr();
       bool is_array = (oop_ptr->isa_aryptr() != NULL);
       bool mismatched = (decorators & C2_MISMATCHED) != 0;
-      if (base->is_Con() && !is_array && !mismatched) {
+      if (base->is_Con() && !is_array && !mismatched && ft->bundle_size() == 1) {
         // If the oop to the inline type is constant (static final field), we can
         // also treat the fields as constants because the inline type is immutable.
         ciObject* constant_oop = oop_ptr->const_oop();
@@ -439,12 +439,6 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass*
         if (con_type->is_inlinetypeptr() && !con_type->is_zero_type()) {
           ft = con_type->inline_klass();
           null_free = true;
-        }
-        BasicType bt = con_type->basic_type();
-        int vec_len = field->secondary_fields_count();
-        if (field->is_multifield_base() &&
-          Matcher::match_rule_supported_vector(VectorNode::replicate_opcode(bt), vec_len, bt)) {
-          value = kit->gvn().transform(VectorNode::scalar2vector(value, vec_len, Type::get_const_type(field->type()), false));
         }
       } else {
         // Load field value from memory

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -151,7 +151,6 @@ bool InlineTypeNode::has_phi_inputs(Node* region) {
 
 // Merges 'this' with 'other' by updating the input PhiNodes added by 'clone_with_phis'
 InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* other, int pnum, bool transform) {
-  assert(this->Opcode() == other->Opcode(), "");
   _is_buffered = _is_buffered && other->_is_buffered;
   // Merge oop inputs
   PhiNode* phi = get_oop()->as_Phi();
@@ -409,6 +408,11 @@ const TypePtr* InlineTypeNode::field_adr_type(Node* base, int offset, ciInstance
 }
 
 void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass* holder, int holder_offset, DecoratorSet decorators) {
+  // FIXME: It is possible that "base" is a constant NULL_PTR, which is
+  // created by "gvn.zerocon(T_PRIMITIVE_OBJECT)". It has to do special
+  // handling for such cases.
+  assert(!kit->gvn().type(base)->maybe_null(), "the memory cannot be null");
+
   // Initialize the inline type by loading its field values from
   // memory and adding the values as input edges to the node.
   for (uint i = 0; i < field_count(); ++i) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2318,7 +2318,9 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
       }
       base = vt->get_oop();
       AllocateNode* alloc = AllocateNode::Ideal_allocation(base, &_gvn);
-      assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
+      if (alloc != NULL) {
+        assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
+      }
     } else {
       if (offset->is_Con()) {
         long off = find_long_con(offset, 0);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2317,6 +2317,10 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
         return false;
       }
       base = vt->get_oop();
+      // FIXME: Larval bit check is needed to preserve the semantics of value
+      // objects which can be mutated only if its _larval bit is set. Since
+      // the oop is not always an AllocateNode, we have to find an utility way
+      // to check the larval state for all kind of oops.
       AllocateNode* alloc = AllocateNode::Ideal_allocation(base, &_gvn);
       if (alloc != NULL) {
         assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");

--- a/src/hotspot/share/opto/vector.hpp
+++ b/src/hotspot/share/opto/vector.hpp
@@ -45,26 +45,13 @@ class PhaseVector : public Phase {
 
   Node* expand_vbox_alloc_node(VectorBoxNode* vec_box,
                                VectorBoxAllocateNode* vbox_alloc,
-                               Node* value,
                                const TypeInstPtr* box_type,
                                const TypeVect* vect_type);
-
-  Node* expand_vbox_alloc_node_vector(VectorBoxNode* vec_box,
-                                      VectorBoxAllocateNode* vbox_alloc,
-                                      const TypeInstPtr* box_type,
-                                      const TypeVect* vect_type);
-
-  Node* expand_vbox_alloc_node_shuffle(VectorBoxAllocateNode* vbox_alloc,
-                                            Node* value,
-                                            const TypeInstPtr* box_type,
-                                            const TypeVect* vect_type);
 
   void scalarize_vbox_nodes();
   void scalarize_vbox_node(VectorBoxNode* vec_box);
   void expand_vunbox_nodes();
   void expand_vunbox_node(VectorUnboxNode* vec_box);
-  void expand_vunbox_node_vector(VectorUnboxNode* vec_unbox);
-  void expand_vunbox_node_shuffle(VectorUnboxNode* vec_unbox);
   void eliminate_vbox_alloc_nodes();
   void eliminate_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc);
   void do_cleanup();

--- a/src/hotspot/share/opto/vector.hpp
+++ b/src/hotspot/share/opto/vector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,34 +37,34 @@ class PhaseVector : public Phase {
 
   void expand_vbox_nodes();
   void expand_vbox_node(VectorBoxNode* vec_box);
-  Node* expand_vbox_node_helper(Node* vbox_alloc,
+  Node* expand_vbox_node_helper(VectorBoxNode* vec_box,
+                                Node* vbox_alloc,
                                 Node* vect,
                                 const TypeInstPtr* box_type,
                                 const TypeVect* vect_type);
 
-  Node* expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
+  Node* expand_vbox_alloc_node(VectorBoxNode* vec_box,
+                               VectorBoxAllocateNode* vbox_alloc,
                                Node* value,
                                const TypeInstPtr* box_type,
                                const TypeVect* vect_type);
 
-  Node* expand_vbox_alloc_node_vector(VectorBoxAllocateNode* vbox_alloc,
-                                      Node* value,
+  Node* expand_vbox_alloc_node_vector(VectorBoxNode* vec_box,
+                                      VectorBoxAllocateNode* vbox_alloc,
                                       const TypeInstPtr* box_type,
                                       const TypeVect* vect_type);
 
-  Node* expand_vbox_alloc_node_mask_shuffle(VectorBoxAllocateNode* vbox_alloc,
+  Node* expand_vbox_alloc_node_shuffle(VectorBoxAllocateNode* vbox_alloc,
                                             Node* value,
                                             const TypeInstPtr* box_type,
                                             const TypeVect* vect_type);
-
-  Node* get_loaded_payload(VectorUnboxNode* vec_unbox);
 
   void scalarize_vbox_nodes();
   void scalarize_vbox_node(VectorBoxNode* vec_box);
   void expand_vunbox_nodes();
   void expand_vunbox_node(VectorUnboxNode* vec_box);
   void expand_vunbox_node_vector(VectorUnboxNode* vec_unbox);
-  void expand_vunbox_node_mask_shuffle(VectorUnboxNode* vec_unbox);
+  void expand_vunbox_node_shuffle(VectorUnboxNode* vec_unbox);
   void eliminate_vbox_alloc_nodes();
   void eliminate_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc);
   void do_cleanup();

--- a/src/hotspot/share/opto/vector.hpp
+++ b/src/hotspot/share/opto/vector.hpp
@@ -37,14 +37,13 @@ class PhaseVector : public Phase {
 
   void expand_vbox_nodes();
   void expand_vbox_node(VectorBoxNode* vec_box);
-  Node* expand_vbox_node_helper(VectorBoxNode* vec_box,
-                                Node* vbox_alloc,
+  Node* expand_vbox_node_helper(Node* vbox_alloc,
                                 Node* vect,
                                 const TypeInstPtr* box_type,
                                 const TypeVect* vect_type);
 
-  Node* expand_vbox_alloc_node(VectorBoxNode* vec_box,
-                               VectorBoxAllocateNode* vbox_alloc,
+  Node* expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
+                               Node* vect,
                                const TypeInstPtr* box_type,
                                const TypeVect* vect_type);
 

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -31,10 +31,6 @@
 #include "prims/vectorSupport.hpp"
 #include "runtime/stubRoutines.hpp"
 
-static bool is_vector(ciKlass* klass) {
-  return klass->is_subclass_of(ciEnv::current()->vector_Vector_klass());
-}
-
 static bool is_vector_mask(ciKlass* klass) {
   return klass->is_subclass_of(ciEnv::current()->vector_VectorMask_klass());
 }
@@ -44,11 +40,15 @@ static bool is_vector_shuffle(ciKlass* klass) {
 }
 
 #ifdef ASSERT
+static bool is_vector(ciKlass* klass) {
+  return klass->is_subclass_of(ciEnv::current()->vector_VectorPayload_klass());
+}
+
 static bool check_vbox(const TypeInstPtr* vbox_type) {
   assert(vbox_type->klass_is_exact(), "");
 
   ciInstanceKlass* ik = vbox_type->instance_klass();
-  assert(is_vector(ik) || is_vector_mask(ik), "not a vector or a vector mask");
+  assert(is_vector(ik), "not a vector");
 
   ciField* fd1 = ik->get_field_by_name(ciSymbols::ETYPE_name(), ciSymbols::class_signature(), /* is_static */ true);
   assert(fd1 != NULL, "element type info is missing");
@@ -157,6 +157,10 @@ Node* GraphKit::box_vector(Node* vector, const TypeInstPtr* vbox_type, BasicType
 
   assert(check_vbox(vbox_type), "");
 
+  if (is_vector_shuffle(vbox_type->instance_klass())) {
+    assert(elem_bt == T_BYTE, "must be consistent with shuffle representation");
+  }
+
   // VectorMask format conversion
   if (is_vector_mask(vbox_type->instance_klass()) &&
       (vector->bottom_type()->isa_vectmask() || elem_bt != T_BOOLEAN)) {
@@ -170,7 +174,7 @@ Node* GraphKit::box_vector(Node* vector, const TypeInstPtr* vbox_type, BasicType
   return gvn().transform(vbox);
 }
 
-Node* GraphKit::unbox_vector(Node* v, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem, bool shuffle_to_vector) {
+Node* GraphKit::unbox_vector(Node* v, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem) {
   assert(EnableVectorSupport, "");
   const TypeInstPtr* vbox_type_v = gvn().type(v)->is_instptr();
   if (vbox_type->instance_klass() != vbox_type_v->instance_klass()) {
@@ -179,18 +183,14 @@ Node* GraphKit::unbox_vector(Node* v, const TypeInstPtr* vbox_type, BasicType el
   if (vbox_type_v->maybe_null()) {
     return NULL; // no nulls are allowed
   }
-  // TODO[valhalla] Limiting support to only vector and vector mask cases untill shuffle becomes inline types.
-  if (!is_vector(vbox_type->instance_klass()) && !is_vector_mask(vbox_type->instance_klass())) {
-    return NULL;
-  }
-  assert(check_vbox(vbox_type), "");
 
+  assert(check_vbox(vbox_type), "");
   BasicType unbox_bt = elem_bt;
   if (is_vector_mask(vbox_type->instance_klass())) {
     unbox_bt = T_BOOLEAN;
   }
   const TypeVect* vt = TypeVect::make(unbox_bt, num_elem);
-  Node* unbox = gvn().transform(new VectorUnboxNode(C, vt, v, merged_memory(), shuffle_to_vector));
+  Node* unbox = gvn().transform(new VectorUnboxNode(C, vt, v, merged_memory()));
   if (is_vector_mask(vbox_type->instance_klass())) {
     unbox = gvn().transform(new VectorLoadMaskNode(unbox, TypeVect::makemask(elem_bt, num_elem)));
   }
@@ -738,7 +738,7 @@ bool LibraryCallKit::inline_vector_mask_operation() {
   const Type* elem_ty = Type::get_const_basic_type(elem_bt);
   ciKlass* mbox_klass = mask_klass->const_oop()->as_instance()->java_lang_Class_klass();
   const TypeInstPtr* mask_box_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
-  Node* mask_vec = unbox_vector(mask, mask_box_type, elem_bt, num_elem, true);
+  Node* mask_vec = unbox_vector(mask, mask_box_type, elem_bt, num_elem);
   if (mask_vec == NULL) {
     if (C->print_intrinsics()) {
         tty->print_cr("  ** unbox failed mask=%s",
@@ -809,9 +809,7 @@ bool LibraryCallKit::inline_vector_shuffle_to_vector() {
   ciKlass* sbox_klass = shuffle_klass->const_oop()->as_instance()->java_lang_Class_klass();
   const TypeInstPtr* shuffle_box_type = TypeInstPtr::make_exact(TypePtr::NotNull, sbox_klass);
 
-  // Unbox shuffle with true flag to indicate its load shuffle to vector
-  // shuffle is a byte array
-  Node* shuffle_vec = unbox_vector(shuffle, shuffle_box_type, T_BYTE, num_elem, true);
+  Node* shuffle_vec = unbox_vector(shuffle, shuffle_box_type, T_BYTE, num_elem);
   if (shuffle_vec == NULL) {
     return false;
   }
@@ -878,11 +876,6 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
 
   bool is_mask = is_vector_mask(vbox_klass);
-  bool is_shuffle = is_vector_shuffle(vbox_klass);
-  // TODO[valhalla] Preventing intrinsification for shuffle till they become inline types.
-  if (is_shuffle) {
-    return false;
-  }
   int  bcast_mode = mode->get_con();
   VectorMaskUseType checkFlags = (VectorMaskUseType)(is_mask ? VecMaskUseAll : VecMaskNotUsed);
   int opc = bcast_mode == VectorSupport::MODE_BITS_COERCED_LONG_TO_MASK ? Op_VectorLongToMask : VectorNode::replicate_opcode(elem_bt);
@@ -1024,11 +1017,6 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   ciKlass* vbox_klass = vector_klass->const_oop()->as_instance()->java_lang_Class_klass();
   bool is_mask = is_vector_mask(vbox_klass);
-  bool is_shuffle = is_vector_shuffle(vbox_klass);
-  // TODO[valhalla] Preventing intrinsification for shuffle till they become inline types.
-  if (is_shuffle) {
-    return false;
-  }
 
   Node* base = argument(3);
   Node* offset = ConvL2X(argument(4));
@@ -2084,7 +2072,6 @@ bool LibraryCallKit::inline_vector_rearrange() {
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
-  BasicType shuffle_bt = elem_bt;
   int num_elem = vlen->get_con();
 
   if (!arch_supports_vector(Op_VectorLoadShuffle, num_elem, elem_bt, VecMaskNotUsed)) {
@@ -2126,8 +2113,7 @@ bool LibraryCallKit::inline_vector_rearrange() {
   const TypeInstPtr* shbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, shbox_klass);
 
   Node* v1 = unbox_vector(argument(5), vbox_type, elem_bt, num_elem);
-  Node* shuffle = unbox_vector(argument(6), shbox_type, shuffle_bt, num_elem);
-
+  Node* shuffle = unbox_vector(argument(6), shbox_type, T_BYTE, num_elem);
   if (v1 == NULL || shuffle == NULL) {
     return false; // operand unboxing failed
   }
@@ -2146,6 +2132,7 @@ bool LibraryCallKit::inline_vector_rearrange() {
     }
   }
 
+  shuffle = gvn().transform(new VectorLoadShuffleNode(shuffle, TypeVect::make(elem_bt, num_elem)));
   Node* rearrange = new VectorRearrangeNode(v1, shuffle);
   if (is_masked_op) {
     if (use_predicate) {

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -855,10 +855,6 @@ bool VectorNode::is_all_ones_vector(Node* n) {
   case Op_ReplicateL:
   case Op_MaskAll:
     return is_con(n->in(1), -1);
-  case Op_ReplicateF:
-    return n->in(1)->bottom_type() == TypeF::ONE;
-  case Op_ReplicateD:
-    return n->in(1)->bottom_type() == TypeD::ONE;
   default:
     return false;
   }
@@ -1301,12 +1297,34 @@ Node* ReductionNode::Ideal(PhaseGVN* phase, bool can_reshape) {
   return NULL;
 }
 
+Node* VectorLoadMaskNode::Ideal(PhaseGVN* phase, bool can_reshape) {
+  if (in(1)->Opcode() == Op_VectorStoreMask) {
+    if (Type::cmp(bottom_type(), in(1)->in(1)->bottom_type()) == 0) {
+      // // Handled by VectorLoadMaskNode::Identity()
+    } else {
+      const TypeVect* out_vt = vect_type();
+      const TypeVect* in_vt = in(1)->in(1)->bottom_type()->is_vect();
+      if (out_vt->length() == in_vt->length() &&
+          out_vt->length_in_bytes() == in_vt->length_in_bytes()) {
+        const TypeVect* vmask_type = TypeVect::makemask(out_vt->element_basic_type(), out_vt->length());
+        return new VectorMaskCastNode(in(1)->in(1), vmask_type);
+      }
+    }
+  }
+  return VectorNode::Ideal(phase, can_reshape);
+}
+
 Node* VectorLoadMaskNode::Identity(PhaseGVN* phase) {
-  BasicType out_bt = type()->is_vect()->element_basic_type();
+  BasicType out_bt = vect_type()->element_basic_type();
   if (!Matcher::has_predicated_vectors() && out_bt == T_BOOLEAN) {
     return in(1); // redundant conversion
   }
 
+  // VectorLoadMask (VectorStoreMask mask) ==> mask
+  if (in(1)->Opcode() == Op_VectorStoreMask &&
+      Type::cmp(bottom_type(), in(1)->in(1)->bottom_type()) == 0) {
+    return in(1)->in(1);
+  }
   return this;
 }
 
@@ -1656,20 +1674,14 @@ Node* VectorUnboxNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 
       if (in_vt->length() == out_vt->length()) {
         Node* value = vbox->field_value(0);
-
-        bool is_vector_mask    = vbox_klass->is_subclass_of(ciEnv::current()->vector_VectorMask_klass());
         bool is_vector_shuffle = vbox_klass->is_subclass_of(ciEnv::current()->vector_VectorShuffle_klass());
-        if (is_vector_mask) {
-          // VectorUnbox (VectorBox vmask) ==> VectorMaskCast vmask
-          const TypeVect* vmask_type = TypeVect::makemask(out_vt->element_basic_type(), out_vt->length());
-          return new VectorMaskCastNode(value, vmask_type);
-        } else if (is_vector_shuffle) {
+        if (is_vector_shuffle) {
           if (!is_shuffle_to_vector()) {
             // VectorUnbox (VectorBox vshuffle) ==> VectorLoadShuffle vshuffle
             return new VectorLoadShuffleNode(value, out_vt);
           }
         } else {
-          // Vector type mismatch is only supported for masks and shuffles, but sometimes it happens in pathological cases.
+          // Vector type mismatch is only supported for shuffles, but sometimes it happens in pathological cases.
         }
       } else {
         // Vector length mismatch.

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1730,14 +1730,11 @@ class VectorBoxAllocateNode : public CallStaticJavaNode {
 };
 
 class VectorUnboxNode : public VectorNode {
- private:
-  bool _shuffle_to_vector;
  protected:
   uint size_of() const { return sizeof(*this); }
  public:
-  VectorUnboxNode(Compile* C, const TypeVect* vec_type, Node* obj, Node* mem, bool shuffle_to_vector)
+  VectorUnboxNode(Compile* C, const TypeVect* vec_type, Node* obj, Node* mem)
     : VectorNode(mem, obj, vec_type) {
-    _shuffle_to_vector = shuffle_to_vector;
     init_class_id(Class_VectorUnbox);
     init_flags(Flag_is_macro);
     C->add_macro_node(this);
@@ -1747,8 +1744,6 @@ class VectorUnboxNode : public VectorNode {
   Node* obj() const { return in(2); }
   Node* mem() const { return in(1); }
   virtual Node* Identity(PhaseGVN* phase);
-  Node* Ideal(PhaseGVN* phase, bool can_reshape);
-  bool is_shuffle_to_vector() { return _shuffle_to_vector; }
 };
 
 class RotateRightVNode : public VectorNode {

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1489,6 +1489,7 @@ class VectorLoadMaskNode : public VectorNode {
 
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 class VectorStoreMaskNode : public VectorNode {
@@ -1688,8 +1689,6 @@ class VectorBoxNode : public InlineTypeNode {
                                       const TypeInstPtr* box_type, const TypeVect* vt) {
     ciInlineKlass* vk = static_cast<ciInlineKlass*>(box_type->inline_klass());
     ciInlineKlass* payload = vk->declared_nonstatic_field_at(0)->type()->as_inline_klass();
-
-    Node* payload_oop = payload->is_initialized() ? default_oop(gvn, payload) : gvn.zerocon(T_PRIMITIVE_OBJECT);
     Node* payload_value = InlineTypeNode::make_uninitialized(gvn, payload, true);
     payload_value->as_InlineType()->set_field_value(0, val);
     payload_value = gvn.transform(payload_value);
@@ -1697,7 +1696,6 @@ class VectorBoxNode : public InlineTypeNode {
     VectorBoxNode* box_node = new VectorBoxNode(C, vk, box, box_type, vt, false, vk->is_empty() && vk->is_initialized());
     box_node->set_field_value(0, payload_value);
     box_node->set_is_init(gvn);
-
     return box_node;
   }
 

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,9 @@ bool VectorSupport::is_vector_shuffle(Klass* klass) {
 }
 
 bool VectorSupport::skip_value_scalarization(Klass* klass) {
-  return VectorSupport::is_vector(klass) || VectorSupport::is_vector_payload_mf(klass);
+  return VectorSupport::is_vector(klass) ||
+         VectorSupport::is_vector_mask(klass) ||
+         VectorSupport::is_vector_payload_mf(klass);
 }
 
 BasicType VectorSupport::klass2bt(InstanceKlass* ik) {

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -154,24 +154,13 @@ public class VectorSupport {
 
     public static class VectorSpecies<E> { }
 
-    public abstract static class VectorPayload {
-        protected abstract Object getPayload();
-    }
+    public abstract static class VectorPayload { }
 
     public static abstract class Vector<E> extends VectorPayload { }
 
     public static abstract class VectorMask<E> extends VectorPayload { }
 
-    public static class VectorShuffle<E> extends VectorPayload {
-        private final Object payload; // array of primitives
-
-        protected final Object getPayload() {
-            return VectorSupport.maybeRebox(this).payload;
-        }
-        public VectorShuffle(Object payload) {
-            this.payload = payload;
-        }
-    }
+    public static abstract class VectorShuffle<E> extends VectorPayload { }
 
     public abstract static class VectorPayloadMF {
         public abstract long multiFieldOffset();
@@ -191,6 +180,9 @@ public class VectorSupport {
                 }
             } else if (elemType == byte.class) {
                 switch(length) {
+                    case  1: return new VectorPayloadMF8B();
+                    case  2: return new VectorPayloadMF16B();
+                    case  4: return new VectorPayloadMF32B();
                     case  8: return new VectorPayloadMF64B();
                     case 16: return new VectorPayloadMF128B();
                     case 32: return new VectorPayloadMF256B();
@@ -398,6 +390,33 @@ public class VectorSupport {
         @MultiField(value = 64)
         boolean mfield = false;
         static long MFOFFSET = multiFieldOffset(VectorPayloadMF512Z.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMF8B extends VectorPayloadMF {
+        @MultiField(value = 1)
+        byte mfield = 0;
+        static long MFOFFSET = multiFieldOffset(VectorPayloadMF8B.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMF16B extends VectorPayloadMF {
+        @MultiField(value = 2)
+        byte mfield = 0;
+        static long MFOFFSET = multiFieldOffset(VectorPayloadMF16B.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMF32B extends VectorPayloadMF {
+        @MultiField(value = 4)
+        byte mfield = 0;
+        static long MFOFFSET = multiFieldOffset(VectorPayloadMF32B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -70,7 +70,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         boolean apply(int i, boolean a);
     }
 
-    AbstractMask<E> uOp(MUnOp f) {
+    AbstractMask<E> uOpMF(MUnOp f) {
         int length = vspecies().laneCount();
         VectorPayloadMF bits = getBits();
         VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
@@ -90,7 +90,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         boolean apply(int i, boolean a, boolean b);
     }
 
-    AbstractMask<E> bOp(AbstractMask<E> m, MBinOp f) {
+    AbstractMask<E> bOpMF(AbstractMask<E> m, MBinOp f) {
         int length = vspecies().laneCount();
         VectorPayloadMF bits = getBits();
         VectorPayloadMF mbits = m.getBits();
@@ -108,7 +108,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
 
     // Store operator
 
-    void stOp(boolean[] arr, int idx) {
+    void stOpMF(boolean[] arr, int idx) {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < vspecies().laneCount(); i++) {
@@ -161,7 +161,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
             vsp.maskType(), vsp.elementType(), laneCount,
             bits, (long) i + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
             this, bits, i,
-            (c, idx, s) -> s.stOp(c, (int) idx));
+            (c, idx, s) -> s.stOpMF(c, (int) idx));
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,13 +34,35 @@ import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.incubator.vector.VectorOperators.*;
 
+import static jdk.internal.vm.vector.VectorSupport.*;
+
 abstract class AbstractMask<E> extends VectorMask<E> {
-    AbstractMask(boolean[] bits) {
-        super(bits);
-    }
 
     /*package-private*/
-    abstract boolean[] getBits();
+    abstract VectorPayloadMF getBits();
+
+    static VectorPayloadMF prepare(VectorPayloadMF payload, int offset, int length) {
+        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        long mOffset = res.multiFieldOffset();
+        for (int i = 0; i < length; i++) {
+            boolean b = Unsafe.getUnsafe().getBoolean(payload, mOffset + i + offset);
+            Unsafe.getUnsafe().putBoolean(res, mOffset + i, b);
+        }
+        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        return res;
+    }
+
+    static VectorPayloadMF prepare(boolean val, int length) {
+        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        long mOffset = res.multiFieldOffset();
+        for (int i = 0; i < length; i++) {
+            Unsafe.getUnsafe().putBoolean(res, mOffset + i, val);
+        }
+        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        return res;
+    }
 
     // Unary operator
 
@@ -48,7 +70,19 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         boolean apply(int i, boolean a);
     }
 
-    abstract AbstractMask<E> uOp(MUnOp f);
+    AbstractMask<E> uOp(MUnOp f) {
+        int length = vspecies().laneCount();
+        VectorPayloadMF bits = getBits();
+        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        long mOffset = res.multiFieldOffset();
+        for (int i = 0; i < length; i++) {
+            boolean b = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
+            Unsafe.getUnsafe().putBoolean(res, mOffset + i, f.apply(i, b));
+        }
+        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        return vspecies().maskFactory(res);
+    }
 
     // Binary operator
 
@@ -56,7 +90,31 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         boolean apply(int i, boolean a, boolean b);
     }
 
-    abstract AbstractMask<E> bOp(VectorMask<E> o, MBinOp f);
+    AbstractMask<E> bOp(AbstractMask<E> m, MBinOp f) {
+        int length = vspecies().laneCount();
+        VectorPayloadMF bits = getBits();
+        VectorPayloadMF mbits = m.getBits();
+        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        long mOffset = res.multiFieldOffset();
+        for (int i = 0; i < length; i++) {
+            boolean b = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
+            boolean mb = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i);
+            Unsafe.getUnsafe().putBoolean(res, mOffset + i, f.apply(i, b, mb));
+        }
+        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        return vspecies().maskFactory(res);
+    }
+
+    // Store operator
+
+    void stOp(boolean[] arr, int idx) {
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < vspecies().laneCount(); i++) {
+            arr[idx++] = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
+        }
+    }
 
     /*package-private*/
     abstract AbstractSpecies<E> vspecies();
@@ -69,13 +127,28 @@ abstract class AbstractMask<E> extends VectorMask<E> {
 
     @Override
     @ForceInline
+    public <F> VectorMask<F> cast(VectorSpecies<F> dsp) {
+        AbstractSpecies<F> species = (AbstractSpecies<F>) dsp;
+        if (length() != species.laneCount())
+            throw new IllegalArgumentException("VectorMask length and species length differ");
+
+        return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                this.getClass(), vspecies().elementType(), vspecies().laneCount,
+                species.maskType(), species.elementType(), vspecies().laneCount,
+                this, species,
+                (m, s) -> s.maskFactory(m.getBits()).check(s));
+    }
+
+    @Override
+    @ForceInline
     public boolean laneIsSet(int i) {
         int length = length();
         Objects.checkIndex(i, length);
         if (length <= Long.SIZE) {
             return ((toLong() >>> i) & 1L) == 1;
         } else {
-            return getBits()[i];
+            VectorPayloadMF bits = getBits();
+            return Unsafe.getUnsafe().getBoolean(bits, bits.multiFieldOffset() + i);
         }
     }
 
@@ -88,13 +161,14 @@ abstract class AbstractMask<E> extends VectorMask<E> {
             vsp.maskType(), vsp.elementType(), laneCount,
             bits, (long) i + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
             this, bits, i,
-            (c, idx, s) -> System.arraycopy(s.getBits(), 0, c, (int) idx, s.length()));
-
+            (c, idx, s) -> s.stOp(c, (int) idx));
     }
 
     @Override
     public boolean[] toArray() {
-        return getBits().clone();
+        boolean[] arr = new boolean[length()];
+        intoArray(arr, 0);
+        return arr;
     }
 
     @Override
@@ -142,54 +216,66 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     }
 
     /*package-private*/
-    static boolean anyTrueHelper(boolean[] bits) {
+    boolean anyTrueHelper() {
         // FIXME: Maybe use toLong() != 0 here.
-        for (boolean i : bits) {
-            if (i) return true;
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < length(); i++) {
+            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return true;
         }
         return false;
     }
 
     /*package-private*/
-    static boolean allTrueHelper(boolean[] bits) {
+    boolean allTrueHelper() {
         // FIXME: Maybe use not().toLong() == 0 here.
-        for (boolean i : bits) {
-            if (!i) return false;
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < length(); i++) {
+            if (!Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return false;
         }
         return true;
     }
 
     /*package-private*/
-    static int trueCountHelper(boolean[] bits) {
+    int trueCountHelper() {
         int c = 0;
-        for (boolean i : bits) {
-            if (i) c++;
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < length(); i++) {
+            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) c++;
         }
         return c;
     }
 
     /*package-private*/
-    static int firstTrueHelper(boolean[] bits) {
-        for (int i = 0; i < bits.length; i++) {
-            if (bits[i])  return i;
+    int firstTrueHelper() {
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < length(); i++) {
+            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return i;
         }
-        return bits.length;
+        return length();
     }
 
     /*package-private*/
-    static int lastTrueHelper(boolean[] bits) {
-        for (int i = bits.length-1; i >= 0; i--) {
-            if (bits[i])  return i;
+    int lastTrueHelper() {
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = length() - 1; i >= 0; i--) {
+            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return i;
         }
         return -1;
     }
 
     /*package-private*/
-    static long toLongHelper(boolean[] bits) {
+    long toLongHelper() {
         long res = 0;
         long set = 1;
-        for (int i = 0; i < bits.length; i++) {
-            res = bits[i] ? res | set : res;
+        VectorPayloadMF bits = getBits();
+        long mOffset = bits.multiFieldOffset();
+        for (int i = 0; i < length(); i++) {
+            res = Unsafe.getUnsafe().getBoolean(bits, mOffset + i) ? res | set : res;
             set = set << 1;
         }
         return res;

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
@@ -310,30 +310,12 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
      */
     @ForceInline
     /*package-private*/
-    AbstractVector<E> dummyVector() {
-        // This JITs to a constant value:
-        AbstractVector<E> dummy = dummyVector;
-        if (dummy != null)  return dummy;
-        // The rest of this computation is probably not JIT-ted.
-        return makeDummyVector();
-    }
-    @ForceInline
-    /*package-private*/
     AbstractVector<E> dummyVectorMF() {
         // This JITs to a constant value:
         AbstractVector<E> dummy = dummyVectorMF;
         if (dummy != null)  return dummy;
         // The rest of this computation is probably not JIT-ted.
         return makeDummyVectorMF();
-    }
-
-    @ForceInline
-    private AbstractVector<E> makeDummyVector() {
-        Object za = Array.newInstance(elementType(), laneCount);
-        return dummyVector = vectorFactory.apply(za);
-        // This is the only use of vectorFactory.
-        // All other factory requests are routed
-        // through the dummy vector.
     }
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,10 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.IntUnaryOperator;
+import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.vector.VectorSupport;
 
+import static jdk.internal.vm.vector.VectorSupport.*;
 
 abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
                                   implements VectorSpecies<E> {
@@ -373,7 +375,7 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
         case LaneType.SK_SHORT:
         case LaneType.SK_INT:
         case LaneType.SK_LONG:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstance(elementType(), laneCount);
+            za = VectorPayloadMF.newInstanceFactory(elementType(), laneCount);
             break;
         default:
             assert false : "Unsupported elemType in makeDummyVectorMF";
@@ -391,8 +393,8 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
      */
     @ForceInline
     /*package-private*/
-    AbstractMask<E> maskFactory(boolean[] bits) {
-        return dummyVectorMF().maskFromArray(bits);
+    AbstractMask<E> maskFactory(VectorPayloadMF payload) {
+        return dummyVectorMF().maskFromPayload(payload);
     }
 
     public final
@@ -527,11 +529,14 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
     }
 
     AbstractMask<E> opm(FOpm f) {
-        boolean[] res = new boolean[laneCount];
-        for (int i = 0; i < res.length; i++) {
-            res[i] = f.apply(i);
+        VectorPayloadMF payload = VectorPayloadMF.newInstanceFactory(boolean.class, laneCount);
+        payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
+        long mOffset = payload.multiFieldOffset();
+        for (int i = 0; i < laneCount; i++) {
+            Unsafe.getUnsafe().putBoolean(payload, mOffset + i, f.apply(i));
         }
-        return dummyVectorMF().maskFromArray(res);
+        payload = Unsafe.getUnsafe().finishPrivateBuffer(payload);
+        return maskFactory(payload);
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.nio.ByteOrder;
 import java.util.function.IntUnaryOperator;
 
 import static jdk.incubator.vector.VectorOperators.*;
+import static jdk.internal.vm.vector.VectorSupport.*;
 
 @SuppressWarnings({"cast", "missing-explicit-ctor"})
 abstract class AbstractVector<E> extends Vector<E> {
@@ -183,8 +184,7 @@ abstract class AbstractVector<E> extends Vector<E> {
         return (ByteVector) asVectorRawTemplate(LaneType.BYTE);
     }
 
-
-    abstract AbstractMask<E> maskFromArray(boolean[] bits);
+    abstract AbstractMask<E> maskFromPayload(VectorPayloadMF payload);
 
     abstract AbstractShuffle<E> iotaShuffle();
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -72,6 +72,9 @@ abstract class AbstractVector<E> extends Vector<E> {
     // Extractors
 
     /*package-private*/
+    abstract VectorPayloadMF vec();
+
+    /*package-private*/
     abstract AbstractSpecies<E> vspecies();
 
     /*package-private*/
@@ -191,7 +194,7 @@ abstract class AbstractVector<E> extends Vector<E> {
     abstract AbstractShuffle<E> iotaShuffle(int start, int step, boolean wrap);
 
     /*do not alias this byte array*/
-    abstract AbstractShuffle<E> shuffleFromBytes(byte[] reorder);
+    abstract AbstractShuffle<E> shuffleFromBytes(VectorPayloadMF reorder);
 
     abstract AbstractShuffle<E> shuffleFromArray(int[] indexes, int i);
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -656,7 +656,7 @@ value class Byte128Vector extends ByteVector {
             Byte128Mask m = (Byte128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Byte128Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Byte128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -666,7 +666,7 @@ value class Byte128Vector extends ByteVector {
             Byte128Mask m = (Byte128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Byte128Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Byte128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -676,7 +676,7 @@ value class Byte128Vector extends ByteVector {
             Byte128Mask m = (Byte128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte128Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Byte128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -60,16 +60,13 @@ value class Byte128Vector extends ByteVector {
     private final VectorPayloadMF128B payload;
 
     Byte128Vector(Object value) {
-        this.payload = (VectorPayloadMF128B)value;
+        this.payload = (VectorPayloadMF128B) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Byte128Vector ZERO = new Byte128Vector(VectorPayloadMF.newInstanceFactory(byte.class, 16));
@@ -122,15 +119,6 @@ value class Byte128Vector extends ByteVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    byte[] vec() {
-        return (byte[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Byte128Vector broadcast(byte e) {
@@ -166,7 +154,7 @@ value class Byte128Vector extends ByteVector {
 
     @Override
     @ForceInline
-    Byte128Shuffle shuffleFromBytes(byte[] reorder) { return new Byte128Shuffle(reorder); }
+    Byte128Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Byte128Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     Byte128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Byte128Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Byte128Vector vectorFactory(byte[] vec) {
-        return new Byte128Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -555,7 +536,7 @@ value class Byte128Vector extends ByteVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getByte(vecpayload, start_offset + ix * Byte.BYTES);
                              });
@@ -590,7 +571,7 @@ value class Byte128Vector extends ByteVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putByte(tpayload, start_offset + ix * Byte.BYTES, (byte)bits);
@@ -629,14 +610,9 @@ value class Byte128Vector extends ByteVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -768,24 +744,34 @@ value class Byte128Vector extends ByteVector {
 
     // Shuffle
 
-    static final class Byte128Shuffle extends AbstractShuffle<Byte> {
+    static final value class Byte128Shuffle extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        Byte128Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF128B payload;
+
+        Byte128Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF128B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Byte128Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Byte128Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Byte128Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -822,13 +808,17 @@ value class Byte128Vector extends ByteVector {
         @Override
         public Byte128Shuffle rearrange(VectorShuffle<Byte> shuffle) {
             Byte128Shuffle s = (Byte128Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Byte128Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Byte256Vector extends ByteVector {
        return vec_mf();
     }
 
-    static final Byte256Vector ZERO = new Byte256Vector(VectorPayloadMF.createVectPayloadInstance(byte.class, 32));
-    static final Byte256Vector IOTA = new Byte256Vector(VectorPayloadMF.createVectPayloadInstanceB(32, (byte [])(VSPECIES.iotaArray())));
+    static final Byte256Vector ZERO = new Byte256Vector(VectorPayloadMF.newInstanceFactory(byte.class, 32));
+    static final Byte256Vector IOTA = new Byte256Vector(VectorPayloadMF.createVectPayloadInstanceB(32, (byte[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Byte256Vector extends ByteVector {
 
     @Override
     @ForceInline
-    Byte256Mask maskFromArray(boolean[] bits) {
-        return new Byte256Mask(bits);
+    Byte256Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Byte256Mask(payload);
     }
 
     @Override
@@ -633,34 +633,22 @@ value class Byte256Vector extends ByteVector {
 
     // Mask
 
-    static final class Byte256Mask extends AbstractMask<Byte> {
+    static final value class Byte256Mask extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        Byte256Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF256Z payload;
+
+        Byte256Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF256Z) payload;
         }
 
-        Byte256Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Byte256Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Byte256Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -673,29 +661,14 @@ value class Byte256Vector extends ByteVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Byte256Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Byte256Mask(res);
-        }
-
-        @Override
-        Byte256Mask bOp(VectorMask<Byte> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Byte256Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Byte256Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -703,33 +676,6 @@ value class Byte256Vector extends ByteVector {
         public final
         Byte256Vector toVector() {
             return (Byte256Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -751,7 +697,7 @@ value class Byte256Vector extends ByteVector {
         @Override
         @ForceInline
         public Byte256Mask compress() {
-            return (Byte256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Byte256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Byte256Vector.class, Byte256Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -764,9 +710,9 @@ value class Byte256Vector extends ByteVector {
         public Byte256Mask and(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte256Mask m = (Byte256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Byte256Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Byte256Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -774,9 +720,9 @@ value class Byte256Vector extends ByteVector {
         public Byte256Mask or(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte256Mask m = (Byte256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Byte256Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Byte256Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -784,9 +730,9 @@ value class Byte256Vector extends ByteVector {
         Byte256Mask xor(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte256Mask m = (Byte256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte256Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte256Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -795,21 +741,21 @@ value class Byte256Vector extends ByteVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Byte256Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Byte256Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Byte256Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Byte256Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Byte256Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Byte256Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -819,7 +765,7 @@ value class Byte256Vector extends ByteVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Byte256Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Byte256Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -829,7 +775,7 @@ value class Byte256Vector extends ByteVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Byte256Mask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Byte256Mask)m).getBits()));
+                                         (m, __) -> ((Byte256Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -837,7 +783,7 @@ value class Byte256Vector extends ByteVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Byte256Mask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Byte256Mask)m).getBits()));
+                                         (m, __) -> ((Byte256Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -688,7 +688,7 @@ value class Byte256Vector extends ByteVector {
             Byte256Mask m = (Byte256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Byte256Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -698,7 +698,7 @@ value class Byte256Vector extends ByteVector {
             Byte256Mask m = (Byte256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Byte256Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -708,7 +708,7 @@ value class Byte256Vector extends ByteVector {
             Byte256Mask m = (Byte256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte256Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Byte256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -752,7 +752,7 @@ value class Byte512Vector extends ByteVector {
             Byte512Mask m = (Byte512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Byte512Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -762,7 +762,7 @@ value class Byte512Vector extends ByteVector {
             Byte512Mask m = (Byte512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Byte512Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -772,7 +772,7 @@ value class Byte512Vector extends ByteVector {
             Byte512Mask m = (Byte512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte512Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Byte512Vector extends ByteVector {
        return vec_mf();
     }
 
-    static final Byte512Vector ZERO = new Byte512Vector(VectorPayloadMF.createVectPayloadInstance(byte.class, 64));
-    static final Byte512Vector IOTA = new Byte512Vector(VectorPayloadMF.createVectPayloadInstanceB(64, (byte [])(VSPECIES.iotaArray())));
+    static final Byte512Vector ZERO = new Byte512Vector(VectorPayloadMF.newInstanceFactory(byte.class, 64));
+    static final Byte512Vector IOTA = new Byte512Vector(VectorPayloadMF.createVectPayloadInstanceB(64, (byte[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Byte512Vector extends ByteVector {
 
     @Override
     @ForceInline
-    Byte512Mask maskFromArray(boolean[] bits) {
-        return new Byte512Mask(bits);
+    Byte512Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Byte512Mask(payload);
     }
 
     @Override
@@ -697,34 +697,22 @@ value class Byte512Vector extends ByteVector {
 
     // Mask
 
-    static final class Byte512Mask extends AbstractMask<Byte> {
+    static final value class Byte512Mask extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        Byte512Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF512Z payload;
+
+        Byte512Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF512Z) payload;
         }
 
-        Byte512Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Byte512Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Byte512Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -737,29 +725,14 @@ value class Byte512Vector extends ByteVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Byte512Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Byte512Mask(res);
-        }
-
-        @Override
-        Byte512Mask bOp(VectorMask<Byte> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Byte512Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Byte512Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -767,33 +740,6 @@ value class Byte512Vector extends ByteVector {
         public final
         Byte512Vector toVector() {
             return (Byte512Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -815,7 +761,7 @@ value class Byte512Vector extends ByteVector {
         @Override
         @ForceInline
         public Byte512Mask compress() {
-            return (Byte512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Byte512Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Byte512Vector.class, Byte512Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -828,9 +774,9 @@ value class Byte512Vector extends ByteVector {
         public Byte512Mask and(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte512Mask m = (Byte512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Byte512Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Byte512Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -838,9 +784,9 @@ value class Byte512Vector extends ByteVector {
         public Byte512Mask or(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte512Mask m = (Byte512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Byte512Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Byte512Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -848,9 +794,9 @@ value class Byte512Vector extends ByteVector {
         Byte512Mask xor(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
             Byte512Mask m = (Byte512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte512Mask.class, null, byte.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte512Mask.class, null,
+                                          byte.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Byte512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -859,21 +805,21 @@ value class Byte512Vector extends ByteVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Byte512Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Byte512Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Byte512Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Byte512Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Byte512Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Byte512Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -883,7 +829,7 @@ value class Byte512Vector extends ByteVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Byte512Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Byte512Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -893,7 +839,7 @@ value class Byte512Vector extends ByteVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Byte512Mask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Byte512Mask)m).getBits()));
+                                         (m, __) -> ((Byte512Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -901,7 +847,7 @@ value class Byte512Vector extends ByteVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Byte512Mask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Byte512Mask)m).getBits()));
+                                         (m, __) -> ((Byte512Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -640,7 +640,7 @@ value class Byte64Vector extends ByteVector {
             Byte64Mask m = (Byte64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Byte64Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -650,7 +650,7 @@ value class Byte64Vector extends ByteVector {
             Byte64Mask m = (Byte64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Byte64Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -660,7 +660,7 @@ value class Byte64Vector extends ByteVector {
             Byte64Mask m = (Byte64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte64Mask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -60,16 +60,13 @@ value class Byte64Vector extends ByteVector {
     private final VectorPayloadMF64B payload;
 
     Byte64Vector(Object value) {
-        this.payload = (VectorPayloadMF64B)value;
+        this.payload = (VectorPayloadMF64B) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Byte64Vector ZERO = new Byte64Vector(VectorPayloadMF.newInstanceFactory(byte.class, 8));
@@ -122,15 +119,6 @@ value class Byte64Vector extends ByteVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    byte[] vec() {
-        return (byte[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Byte64Vector broadcast(byte e) {
@@ -166,7 +154,7 @@ value class Byte64Vector extends ByteVector {
 
     @Override
     @ForceInline
-    Byte64Shuffle shuffleFromBytes(byte[] reorder) { return new Byte64Shuffle(reorder); }
+    Byte64Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Byte64Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     Byte64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Byte64Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Byte64Vector vectorFactory(byte[] vec) {
-        return new Byte64Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -547,7 +528,7 @@ value class Byte64Vector extends ByteVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getByte(vecpayload, start_offset + ix * Byte.BYTES);
                              });
@@ -574,7 +555,7 @@ value class Byte64Vector extends ByteVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putByte(tpayload, start_offset + ix * Byte.BYTES, (byte)bits);
@@ -613,14 +594,9 @@ value class Byte64Vector extends ByteVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -752,24 +728,34 @@ value class Byte64Vector extends ByteVector {
 
     // Shuffle
 
-    static final class Byte64Shuffle extends AbstractShuffle<Byte> {
+    static final value class Byte64Shuffle extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        Byte64Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF64B payload;
+
+        Byte64Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF64B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Byte64Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Byte64Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Byte64Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -806,13 +792,17 @@ value class Byte64Vector extends ByteVector {
         @Override
         public Byte64Shuffle rearrange(VectorShuffle<Byte> shuffle) {
             Byte64Shuffle s = (Byte64Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Byte64Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Byte> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Byte> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     ByteVector vOpMF(VectorMask<Byte> m, FVOp f) {
         byte[] res = new byte[length()];
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     ByteVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v = Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(i, v));
+            byte v = Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES);
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v = Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, mbits[i] ? f.apply(i, v): v);
+            byte v = Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec1, start_offset + i * Byte.BYTES);
-            byte v2 = Unsafe.getUnsafe().getByte(vec2, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(i, v1, v2));
+            byte v1 = Unsafe.getUnsafe().getByte(vec1, vOffset + i * Byte.BYTES);
+            byte v2 = Unsafe.getUnsafe().getByte(vec2, vOffset + i * Byte.BYTES);
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec1, start_offset + i * Byte.BYTES);
-            byte v2 = Unsafe.getUnsafe().getByte(vec2, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            byte v1 = Unsafe.getUnsafe().getByte(vec1, vOffset + i * Byte.BYTES);
+            byte v2 = Unsafe.getUnsafe().getByte(vec2, vOffset + i * Byte.BYTES);
+            byte v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         VectorPayloadMF vec2 = ((ByteVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((ByteVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec1, start_offset + i * Byte.BYTES);
-            byte v2 = Unsafe.getUnsafe().getByte(vec2, start_offset + i * Byte.BYTES);
-            byte v3 = Unsafe.getUnsafe().getByte(vec3, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(i, v1, v2, v3));
+            byte v1 = Unsafe.getUnsafe().getByte(vec1, vOffset + i * Byte.BYTES);
+            byte v2 = Unsafe.getUnsafe().getByte(vec2, vOffset + i * Byte.BYTES);
+            byte v3 = Unsafe.getUnsafe().getByte(vec3, vOffset + i * Byte.BYTES);
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ByteVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((ByteVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec1, start_offset + i * Byte.BYTES);
-            byte v2 = Unsafe.getUnsafe().getByte(vec2, start_offset + i * Byte.BYTES);
-            byte v3 = Unsafe.getUnsafe().getByte(vec3, start_offset + i * Byte.BYTES);
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            byte v1 = Unsafe.getUnsafe().getByte(vec1, vOffset + i * Byte.BYTES);
+            byte v2 = Unsafe.getUnsafe().getByte(vec2, vOffset + i * Byte.BYTES);
+            byte v3 = Unsafe.getUnsafe().getByte(vec3, vOffset + i * Byte.BYTES);
+            byte v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            byte v1 = Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     byte rOpTemplateMF(byte v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES);
+            byte v1 = Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 byte.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 byte.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 byte.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 byte.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putByte(tpayload, start_offset + i * Byte.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putByte(tpayload, vOffset + i * Byte.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                   VectorMask<Byte> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                   VectorMask<Byte> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, start_offset + i * Byte.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getByte(vec, vOffset + i * Byte.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     AbstractMask<Byte> bTestMF(int cond,
                                   Vector<Byte> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            byte v1 = Unsafe.getUnsafe().getByte(vec1, start_offset + i * Byte.BYTES);
-            byte v2 = Unsafe.getUnsafe().getByte(vec2, start_offset + i * Byte.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            byte v1 = Unsafe.getUnsafe().getByte(vec1, vOffset + i * Byte.BYTES);
+            byte v2 = Unsafe.getUnsafe().getByte(vec2, vOffset + i * Byte.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
     /*package-private*/
@@ -4341,9 +4356,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
         ByteVector vOpMF(VectorMask<Byte> m, FVOp f) {
             byte[] res = new byte[laneCount()];
-            boolean[] mbits = ((AbstractMask<Byte>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -93,20 +93,13 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract byte[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract ByteVector vectorFactory(byte[] vec);
-
     abstract ByteVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     @ForceInline
     final
     ByteVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     ByteVector bOpTemplateMF(Vector<Byte> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((ByteVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ByteVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     ByteVector tOpTemplateMF(Vector<Byte> o1,
                                      Vector<Byte> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ByteVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((ByteVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ByteVector)o1).vec();
+        VectorPayloadMF vec3 = ((ByteVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ByteVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((ByteVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ByteVector)o1).vec();
+        VectorPayloadMF vec3 = ((ByteVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     @ForceInline
     final
     byte rOpTemplateMF(byte v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Byte> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Byte> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Byte>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                                   Vector<Byte> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ByteVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((ByteVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -60,16 +60,13 @@ value class Double128Vector extends DoubleVector {
     private final VectorPayloadMF128D payload;
 
     Double128Vector(Object value) {
-        this.payload = (VectorPayloadMF128D)value;
+        this.payload = (VectorPayloadMF128D) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Double128Vector ZERO = new Double128Vector(VectorPayloadMF.newInstanceFactory(double.class, 2));
@@ -122,15 +119,6 @@ value class Double128Vector extends DoubleVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    double[] vec() {
-        return (double[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Double128Vector broadcast(double e) {
@@ -166,7 +154,7 @@ value class Double128Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    Double128Shuffle shuffleFromBytes(byte[] reorder) { return new Double128Shuffle(reorder); }
+    Double128Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Double128Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     Double128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Double128Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Double128Vector vectorFactory(double[] vec) {
-        return new Double128Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -530,7 +511,7 @@ value class Double128Vector extends DoubleVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Double.doubleToLongBits(Unsafe.getUnsafe().getDouble(vecpayload, start_offset + ix * Double.BYTES));
                      });
@@ -551,7 +532,7 @@ value class Double128Vector extends DoubleVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Double.doubleToLongBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putDouble(tpayload, start_offset + ix * Double.BYTES, Double.longBitsToDouble((long)bits));
@@ -590,14 +571,9 @@ value class Double128Vector extends DoubleVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -729,24 +705,34 @@ value class Double128Vector extends DoubleVector {
 
     // Shuffle
 
-    static final class Double128Shuffle extends AbstractShuffle<Double> {
+    static final value class Double128Shuffle extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        Double128Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF16B payload;
+
+        Double128Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF16B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Double128Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Double128Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Double128Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -783,13 +769,17 @@ value class Double128Vector extends DoubleVector {
         @Override
         public Double128Shuffle rearrange(VectorShuffle<Double> shuffle) {
             Double128Shuffle s = (Double128Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Double128Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -617,7 +617,7 @@ value class Double128Vector extends DoubleVector {
             Double128Mask m = (Double128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Double128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Double128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -627,7 +627,7 @@ value class Double128Vector extends DoubleVector {
             Double128Mask m = (Double128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Double128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Double128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -637,7 +637,7 @@ value class Double128Vector extends DoubleVector {
             Double128Mask m = (Double128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Double128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Double128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -621,7 +621,7 @@ value class Double256Vector extends DoubleVector {
             Double256Mask m = (Double256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Double256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Double256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -631,7 +631,7 @@ value class Double256Vector extends DoubleVector {
             Double256Mask m = (Double256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Double256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Double256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -641,7 +641,7 @@ value class Double256Vector extends DoubleVector {
             Double256Mask m = (Double256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Double256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Double256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -60,16 +60,13 @@ value class Double256Vector extends DoubleVector {
     private final VectorPayloadMF256D payload;
 
     Double256Vector(Object value) {
-        this.payload = (VectorPayloadMF256D)value;
+        this.payload = (VectorPayloadMF256D) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Double256Vector ZERO = new Double256Vector(VectorPayloadMF.newInstanceFactory(double.class, 4));
@@ -122,15 +119,6 @@ value class Double256Vector extends DoubleVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    double[] vec() {
-        return (double[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Double256Vector broadcast(double e) {
@@ -166,7 +154,7 @@ value class Double256Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    Double256Shuffle shuffleFromBytes(byte[] reorder) { return new Double256Shuffle(reorder); }
+    Double256Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Double256Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     Double256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Double256Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Double256Vector vectorFactory(double[] vec) {
-        return new Double256Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -532,7 +513,7 @@ value class Double256Vector extends DoubleVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Double.doubleToLongBits(Unsafe.getUnsafe().getDouble(vecpayload, start_offset + ix * Double.BYTES));
                      });
@@ -555,7 +536,7 @@ value class Double256Vector extends DoubleVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Double.doubleToLongBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putDouble(tpayload, start_offset + ix * Double.BYTES, Double.longBitsToDouble((long)bits));
@@ -594,14 +575,9 @@ value class Double256Vector extends DoubleVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -733,24 +709,34 @@ value class Double256Vector extends DoubleVector {
 
     // Shuffle
 
-    static final class Double256Shuffle extends AbstractShuffle<Double> {
+    static final value class Double256Shuffle extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        Double256Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF32B payload;
+
+        Double256Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF32B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Double256Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Double256Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Double256Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -787,13 +773,17 @@ value class Double256Vector extends DoubleVector {
         @Override
         public Double256Shuffle rearrange(VectorShuffle<Double> shuffle) {
             Double256Shuffle s = (Double256Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Double256Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -629,7 +629,7 @@ value class Double512Vector extends DoubleVector {
             Double512Mask m = (Double512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Double512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Double512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -639,7 +639,7 @@ value class Double512Vector extends DoubleVector {
             Double512Mask m = (Double512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Double512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Double512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -649,7 +649,7 @@ value class Double512Vector extends DoubleVector {
             Double512Mask m = (Double512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Double512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Double512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -60,16 +60,13 @@ value class Double512Vector extends DoubleVector {
     private final VectorPayloadMF512D payload;
 
     Double512Vector(Object value) {
-        this.payload = (VectorPayloadMF512D)value;
+        this.payload = (VectorPayloadMF512D) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Double512Vector ZERO = new Double512Vector(VectorPayloadMF.newInstanceFactory(double.class, 8));
@@ -122,15 +119,6 @@ value class Double512Vector extends DoubleVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    double[] vec() {
-        return (double[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Double512Vector broadcast(double e) {
@@ -166,7 +154,7 @@ value class Double512Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    Double512Shuffle shuffleFromBytes(byte[] reorder) { return new Double512Shuffle(reorder); }
+    Double512Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Double512Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     Double512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Double512Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Double512Vector vectorFactory(double[] vec) {
-        return new Double512Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -536,7 +517,7 @@ value class Double512Vector extends DoubleVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Double.doubleToLongBits(Unsafe.getUnsafe().getDouble(vecpayload, start_offset + ix * Double.BYTES));
                      });
@@ -563,7 +544,7 @@ value class Double512Vector extends DoubleVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Double.doubleToLongBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putDouble(tpayload, start_offset + ix * Double.BYTES, Double.longBitsToDouble((long)bits));
@@ -602,14 +583,9 @@ value class Double512Vector extends DoubleVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -741,24 +717,34 @@ value class Double512Vector extends DoubleVector {
 
     // Shuffle
 
-    static final class Double512Shuffle extends AbstractShuffle<Double> {
+    static final value class Double512Shuffle extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        Double512Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF64B payload;
+
+        Double512Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF64B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Double512Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Double512Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Double512Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -795,13 +781,17 @@ value class Double512Vector extends DoubleVector {
         @Override
         public Double512Shuffle rearrange(VectorShuffle<Double> shuffle) {
             Double512Shuffle s = (Double512Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Double512Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -615,7 +615,7 @@ value class Double64Vector extends DoubleVector {
             Double64Mask m = (Double64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Double64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -625,7 +625,7 @@ value class Double64Vector extends DoubleVector {
             Double64Mask m = (Double64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Double64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -635,7 +635,7 @@ value class Double64Vector extends DoubleVector {
             Double64Mask m = (Double64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Double64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Double> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Double> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     DoubleVector vOpMF(VectorMask<Double> m, FVOp f) {
         double[] res = new double[length()];
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     DoubleVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v = Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(i, v));
+            double v = Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES);
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v = Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, mbits[i] ? f.apply(i, v): v);
+            double v = Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec1, start_offset + i * Double.BYTES);
-            double v2 = Unsafe.getUnsafe().getDouble(vec2, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(i, v1, v2));
+            double v1 = Unsafe.getUnsafe().getDouble(vec1, vOffset + i * Double.BYTES);
+            double v2 = Unsafe.getUnsafe().getDouble(vec2, vOffset + i * Double.BYTES);
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec1, start_offset + i * Double.BYTES);
-            double v2 = Unsafe.getUnsafe().getDouble(vec2, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            double v1 = Unsafe.getUnsafe().getDouble(vec1, vOffset + i * Double.BYTES);
+            double v2 = Unsafe.getUnsafe().getDouble(vec2, vOffset + i * Double.BYTES);
+            double v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         VectorPayloadMF vec2 = ((DoubleVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((DoubleVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec1, start_offset + i * Double.BYTES);
-            double v2 = Unsafe.getUnsafe().getDouble(vec2, start_offset + i * Double.BYTES);
-            double v3 = Unsafe.getUnsafe().getDouble(vec3, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(i, v1, v2, v3));
+            double v1 = Unsafe.getUnsafe().getDouble(vec1, vOffset + i * Double.BYTES);
+            double v2 = Unsafe.getUnsafe().getDouble(vec2, vOffset + i * Double.BYTES);
+            double v3 = Unsafe.getUnsafe().getDouble(vec3, vOffset + i * Double.BYTES);
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((DoubleVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((DoubleVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec1, start_offset + i * Double.BYTES);
-            double v2 = Unsafe.getUnsafe().getDouble(vec2, start_offset + i * Double.BYTES);
-            double v3 = Unsafe.getUnsafe().getDouble(vec3, start_offset + i * Double.BYTES);
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            double v1 = Unsafe.getUnsafe().getDouble(vec1, vOffset + i * Double.BYTES);
+            double v2 = Unsafe.getUnsafe().getDouble(vec2, vOffset + i * Double.BYTES);
+            double v3 = Unsafe.getUnsafe().getDouble(vec3, vOffset + i * Double.BYTES);
+            double v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            double v1 = Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     double rOpTemplateMF(double v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES);
+            double v1 = Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 double.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 double.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 double.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 double.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putDouble(tpayload, start_offset + i * Double.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                   VectorMask<Double> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                   VectorMask<Double> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Double>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, start_offset + i * Double.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getDouble(vec, vOffset + i * Double.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     AbstractMask<Double> bTestMF(int cond,
                                   Vector<Double> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            double v1 = Unsafe.getUnsafe().getDouble(vec1, start_offset + i * Double.BYTES);
-            double v2 = Unsafe.getUnsafe().getDouble(vec2, start_offset + i * Double.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            double v1 = Unsafe.getUnsafe().getDouble(vec1, vOffset + i * Double.BYTES);
+            double v2 = Unsafe.getUnsafe().getDouble(vec2, vOffset + i * Double.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
 
@@ -3945,9 +3960,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
         DoubleVector vOpMF(VectorMask<Double> m, FVOp f) {
             double[] res = new double[laneCount()];
-            boolean[] mbits = ((AbstractMask<Double>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -93,20 +93,13 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract double[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract DoubleVector vectorFactory(double[] vec);
-
     abstract DoubleVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     @ForceInline
     final
     DoubleVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     DoubleVector bOpTemplateMF(Vector<Double> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((DoubleVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((DoubleVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     DoubleVector tOpTemplateMF(Vector<Double> o1,
                                      Vector<Double> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((DoubleVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((DoubleVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((DoubleVector)o1).vec();
+        VectorPayloadMF vec3 = ((DoubleVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((DoubleVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((DoubleVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((DoubleVector)o1).vec();
+        VectorPayloadMF vec3 = ((DoubleVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     @ForceInline
     final
     double rOpTemplateMF(double v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Double> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Double> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   Vector<Double> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((DoubleVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((DoubleVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -621,7 +621,7 @@ value class Float128Vector extends FloatVector {
             Float128Mask m = (Float128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Float128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Float128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -631,7 +631,7 @@ value class Float128Vector extends FloatVector {
             Float128Mask m = (Float128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Float128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Float128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -641,7 +641,7 @@ value class Float128Vector extends FloatVector {
             Float128Mask m = (Float128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Float128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Float128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -60,16 +60,13 @@ value class Float128Vector extends FloatVector {
     private final VectorPayloadMF128F payload;
 
     Float128Vector(Object value) {
-        this.payload = (VectorPayloadMF128F)value;
+        this.payload = (VectorPayloadMF128F) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Float128Vector ZERO = new Float128Vector(VectorPayloadMF.newInstanceFactory(float.class, 4));
@@ -122,15 +119,6 @@ value class Float128Vector extends FloatVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    float[] vec() {
-        return (float[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Float128Vector broadcast(float e) {
@@ -166,7 +154,7 @@ value class Float128Vector extends FloatVector {
 
     @Override
     @ForceInline
-    Float128Shuffle shuffleFromBytes(byte[] reorder) { return new Float128Shuffle(reorder); }
+    Float128Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Float128Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     Float128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float128Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Float128Vector vectorFactory(float[] vec) {
-        return new Float128Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -532,7 +513,7 @@ value class Float128Vector extends FloatVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Float.floatToIntBits(Unsafe.getUnsafe().getFloat(vecpayload, start_offset + ix * Float.BYTES));
                      });
@@ -555,7 +536,7 @@ value class Float128Vector extends FloatVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Float.floatToIntBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putFloat(tpayload, start_offset + ix * Float.BYTES, Float.intBitsToFloat((int)bits));
@@ -594,14 +575,9 @@ value class Float128Vector extends FloatVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -733,24 +709,34 @@ value class Float128Vector extends FloatVector {
 
     // Shuffle
 
-    static final class Float128Shuffle extends AbstractShuffle<Float> {
+    static final value class Float128Shuffle extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        Float128Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF32B payload;
+
+        Float128Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF32B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Float128Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Float128Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Float128Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -787,13 +773,17 @@ value class Float128Vector extends FloatVector {
         @Override
         public Float128Shuffle rearrange(VectorShuffle<Float> shuffle) {
             Float128Shuffle s = (Float128Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Float128Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Float256Vector extends FloatVector {
        return vec_mf();
     }
 
-    static final Float256Vector ZERO = new Float256Vector(VectorPayloadMF.createVectPayloadInstance(float.class, 8));
-    static final Float256Vector IOTA = new Float256Vector(VectorPayloadMF.createVectPayloadInstanceF(8, (float [])(VSPECIES.iotaArray())));
+    static final Float256Vector ZERO = new Float256Vector(VectorPayloadMF.newInstanceFactory(float.class, 8));
+    static final Float256Vector IOTA = new Float256Vector(VectorPayloadMF.createVectPayloadInstanceF(8, (float[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Float256Vector extends FloatVector {
 
     @Override
     @ForceInline
-    Float256Mask maskFromArray(boolean[] bits) {
-        return new Float256Mask(bits);
+    Float256Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Float256Mask(payload);
     }
 
     @Override
@@ -574,34 +574,22 @@ value class Float256Vector extends FloatVector {
 
     // Mask
 
-    static final class Float256Mask extends AbstractMask<Float> {
+    static final value class Float256Mask extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        Float256Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF64Z payload;
+
+        Float256Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF64Z) payload;
         }
 
-        Float256Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Float256Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Float256Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -614,29 +602,14 @@ value class Float256Vector extends FloatVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Float256Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Float256Mask(res);
-        }
-
-        @Override
-        Float256Mask bOp(VectorMask<Float> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Float256Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Float256Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -644,33 +617,6 @@ value class Float256Vector extends FloatVector {
         public final
         Float256Vector toVector() {
             return (Float256Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -692,7 +638,7 @@ value class Float256Vector extends FloatVector {
         @Override
         @ForceInline
         public Float256Mask compress() {
-            return (Float256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Float256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Float256Vector.class, Float256Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -705,9 +651,9 @@ value class Float256Vector extends FloatVector {
         public Float256Mask and(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
             Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Float256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Float256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -715,9 +661,9 @@ value class Float256Vector extends FloatVector {
         public Float256Mask or(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
             Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Float256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Float256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -725,9 +671,9 @@ value class Float256Vector extends FloatVector {
         Float256Mask xor(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
             Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -736,21 +682,21 @@ value class Float256Vector extends FloatVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Float256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Float256Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Float256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Float256Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Float256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Float256Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -760,7 +706,7 @@ value class Float256Vector extends FloatVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Float256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Float256Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -770,7 +716,7 @@ value class Float256Vector extends FloatVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Float256Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Float256Mask)m).getBits()));
+                                         (m, __) -> ((Float256Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -778,7 +724,7 @@ value class Float256Vector extends FloatVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Float256Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Float256Mask)m).getBits()));
+                                         (m, __) -> ((Float256Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -629,7 +629,7 @@ value class Float256Vector extends FloatVector {
             Float256Mask m = (Float256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Float256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -639,7 +639,7 @@ value class Float256Vector extends FloatVector {
             Float256Mask m = (Float256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Float256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -649,7 +649,7 @@ value class Float256Vector extends FloatVector {
             Float256Mask m = (Float256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Float256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -60,16 +60,13 @@ value class Float256Vector extends FloatVector {
     private final VectorPayloadMF256F payload;
 
     Float256Vector(Object value) {
-        this.payload = (VectorPayloadMF256F)value;
+        this.payload = (VectorPayloadMF256F) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Float256Vector ZERO = new Float256Vector(VectorPayloadMF.newInstanceFactory(float.class, 8));
@@ -122,15 +119,6 @@ value class Float256Vector extends FloatVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    float[] vec() {
-        return (float[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Float256Vector broadcast(float e) {
@@ -166,7 +154,7 @@ value class Float256Vector extends FloatVector {
 
     @Override
     @ForceInline
-    Float256Shuffle shuffleFromBytes(byte[] reorder) { return new Float256Shuffle(reorder); }
+    Float256Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Float256Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     Float256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float256Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Float256Vector vectorFactory(float[] vec) {
-        return new Float256Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -536,7 +517,7 @@ value class Float256Vector extends FloatVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Float.floatToIntBits(Unsafe.getUnsafe().getFloat(vecpayload, start_offset + ix * Float.BYTES));
                      });
@@ -563,7 +544,7 @@ value class Float256Vector extends FloatVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Float.floatToIntBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putFloat(tpayload, start_offset + ix * Float.BYTES, Float.intBitsToFloat((int)bits));
@@ -602,14 +583,9 @@ value class Float256Vector extends FloatVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -741,24 +717,34 @@ value class Float256Vector extends FloatVector {
 
     // Shuffle
 
-    static final class Float256Shuffle extends AbstractShuffle<Float> {
+    static final value class Float256Shuffle extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        Float256Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF64B payload;
+
+        Float256Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF64B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Float256Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Float256Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Float256Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -795,13 +781,17 @@ value class Float256Vector extends FloatVector {
         @Override
         public Float256Shuffle rearrange(VectorShuffle<Float> shuffle) {
             Float256Shuffle s = (Float256Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Float256Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -60,16 +60,13 @@ value class Float512Vector extends FloatVector {
     private final VectorPayloadMF512F payload;
 
     Float512Vector(Object value) {
-        this.payload = (VectorPayloadMF512F)value;
+        this.payload = (VectorPayloadMF512F) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Float512Vector ZERO = new Float512Vector(VectorPayloadMF.newInstanceFactory(float.class, 16));
@@ -122,15 +119,6 @@ value class Float512Vector extends FloatVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    float[] vec() {
-        return (float[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Float512Vector broadcast(float e) {
@@ -166,7 +154,7 @@ value class Float512Vector extends FloatVector {
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromBytes(byte[] reorder) { return new Float512Shuffle(reorder); }
+    Float512Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Float512Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     Float512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float512Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Float512Vector vectorFactory(float[] vec) {
-        return new Float512Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -544,7 +525,7 @@ value class Float512Vector extends FloatVector {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)Float.floatToIntBits(Unsafe.getUnsafe().getFloat(vecpayload, start_offset + ix * Float.BYTES));
                      });
@@ -579,7 +560,7 @@ value class Float512Vector extends FloatVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Float.floatToIntBits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putFloat(tpayload, start_offset + ix * Float.BYTES, Float.intBitsToFloat((int)bits));
@@ -618,14 +599,9 @@ value class Float512Vector extends FloatVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -757,24 +733,34 @@ value class Float512Vector extends FloatVector {
 
     // Shuffle
 
-    static final class Float512Shuffle extends AbstractShuffle<Float> {
+    static final value class Float512Shuffle extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        Float512Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF128B payload;
+
+        Float512Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF128B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Float512Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Float512Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Float512Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -811,13 +797,17 @@ value class Float512Vector extends FloatVector {
         @Override
         public Float512Shuffle rearrange(VectorShuffle<Float> shuffle) {
             Float512Shuffle s = (Float512Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Float512Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -645,7 +645,7 @@ value class Float512Vector extends FloatVector {
             Float512Mask m = (Float512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Float512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Float512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -655,7 +655,7 @@ value class Float512Vector extends FloatVector {
             Float512Mask m = (Float512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Float512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Float512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -665,7 +665,7 @@ value class Float512Vector extends FloatVector {
             Float512Mask m = (Float512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Float512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Float512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -617,7 +617,7 @@ value class Float64Vector extends FloatVector {
             Float64Mask m = (Float64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Float64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Float64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -627,7 +627,7 @@ value class Float64Vector extends FloatVector {
             Float64Mask m = (Float64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Float64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Float64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -637,7 +637,7 @@ value class Float64Vector extends FloatVector {
             Float64Mask m = (Float64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Float64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Float64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Float> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Float> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     FloatVector vOpMF(VectorMask<Float> m, FVOp f) {
         float[] res = new float[length()];
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
     FloatVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v = Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(i, v));
+            float v = Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES);
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v = Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, mbits[i] ? f.apply(i, v): v);
+            float v = Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec1, start_offset + i * Float.BYTES);
-            float v2 = Unsafe.getUnsafe().getFloat(vec2, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(i, v1, v2));
+            float v1 = Unsafe.getUnsafe().getFloat(vec1, vOffset + i * Float.BYTES);
+            float v2 = Unsafe.getUnsafe().getFloat(vec2, vOffset + i * Float.BYTES);
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec1, start_offset + i * Float.BYTES);
-            float v2 = Unsafe.getUnsafe().getFloat(vec2, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            float v1 = Unsafe.getUnsafe().getFloat(vec1, vOffset + i * Float.BYTES);
+            float v2 = Unsafe.getUnsafe().getFloat(vec2, vOffset + i * Float.BYTES);
+            float v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
         VectorPayloadMF vec2 = ((FloatVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((FloatVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec1, start_offset + i * Float.BYTES);
-            float v2 = Unsafe.getUnsafe().getFloat(vec2, start_offset + i * Float.BYTES);
-            float v3 = Unsafe.getUnsafe().getFloat(vec3, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(i, v1, v2, v3));
+            float v1 = Unsafe.getUnsafe().getFloat(vec1, vOffset + i * Float.BYTES);
+            float v2 = Unsafe.getUnsafe().getFloat(vec2, vOffset + i * Float.BYTES);
+            float v3 = Unsafe.getUnsafe().getFloat(vec3, vOffset + i * Float.BYTES);
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((FloatVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((FloatVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec1, start_offset + i * Float.BYTES);
-            float v2 = Unsafe.getUnsafe().getFloat(vec2, start_offset + i * Float.BYTES);
-            float v3 = Unsafe.getUnsafe().getFloat(vec3, start_offset + i * Float.BYTES);
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            float v1 = Unsafe.getUnsafe().getFloat(vec1, vOffset + i * Float.BYTES);
+            float v2 = Unsafe.getUnsafe().getFloat(vec2, vOffset + i * Float.BYTES);
+            float v3 = Unsafe.getUnsafe().getFloat(vec3, vOffset + i * Float.BYTES);
+            float v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            float v1 = Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     float rOpTemplateMF(float v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES);
+            float v1 = Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 float.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 float.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 float.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 float.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putFloat(tpayload, start_offset + i * Float.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
                   VectorMask<Float> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
                   VectorMask<Float> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, start_offset + i * Float.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getFloat(vec, vOffset + i * Float.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
     AbstractMask<Float> bTestMF(int cond,
                                   Vector<Float> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            float v1 = Unsafe.getUnsafe().getFloat(vec1, start_offset + i * Float.BYTES);
-            float v2 = Unsafe.getUnsafe().getFloat(vec2, start_offset + i * Float.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            float v1 = Unsafe.getUnsafe().getFloat(vec1, vOffset + i * Float.BYTES);
+            float v2 = Unsafe.getUnsafe().getFloat(vec2, vOffset + i * Float.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
 
@@ -3886,9 +3901,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         FloatVector vOpMF(VectorMask<Float> m, FVOp f) {
             float[] res = new float[laneCount()];
-            boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -93,20 +93,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract float[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract FloatVector vectorFactory(float[] vec);
-
     abstract FloatVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     final
     FloatVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     FloatVector bOpTemplateMF(Vector<Float> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((FloatVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((FloatVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
     FloatVector tOpTemplateMF(Vector<Float> o1,
                                      Vector<Float> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((FloatVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((FloatVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((FloatVector)o1).vec();
+        VectorPayloadMF vec3 = ((FloatVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((FloatVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((FloatVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((FloatVector)o1).vec();
+        VectorPayloadMF vec3 = ((FloatVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     final
     float rOpTemplateMF(float v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Float> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Float> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   Vector<Float> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((FloatVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((FloatVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -632,7 +632,7 @@ value class Int128Vector extends IntVector {
             Int128Mask m = (Int128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Int128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Int128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -642,7 +642,7 @@ value class Int128Vector extends IntVector {
             Int128Mask m = (Int128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Int128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Int128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -652,7 +652,7 @@ value class Int128Vector extends IntVector {
             Int128Mask m = (Int128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Int128Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Int128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -60,16 +60,13 @@ value class Int128Vector extends IntVector {
     private final VectorPayloadMF128I payload;
 
     Int128Vector(Object value) {
-        this.payload = (VectorPayloadMF128I)value;
+        this.payload = (VectorPayloadMF128I) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Int128Vector ZERO = new Int128Vector(VectorPayloadMF.newInstanceFactory(int.class, 4));
@@ -122,15 +119,6 @@ value class Int128Vector extends IntVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    int[] vec() {
-        return (int[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Int128Vector broadcast(int e) {
@@ -166,7 +154,7 @@ value class Int128Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int128Shuffle shuffleFromBytes(byte[] reorder) { return new Int128Shuffle(reorder); }
+    Int128Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Int128Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Int128Vector extends IntVector {
     @Override
     @ForceInline
     Int128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Int128Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Int128Vector vectorFactory(int[] vec) {
-        return new Int128Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -543,7 +524,7 @@ value class Int128Vector extends IntVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getInt(vecpayload, start_offset + ix * Integer.BYTES);
                              });
@@ -566,7 +547,7 @@ value class Int128Vector extends IntVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putInt(tpayload, start_offset + ix * Integer.BYTES, (int)bits);
@@ -605,14 +586,9 @@ value class Int128Vector extends IntVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -744,24 +720,34 @@ value class Int128Vector extends IntVector {
 
     // Shuffle
 
-    static final class Int128Shuffle extends AbstractShuffle<Integer> {
+    static final value class Int128Shuffle extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int128Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF32B payload;
+
+        Int128Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF32B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Int128Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Int128Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Int128Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -798,13 +784,17 @@ value class Int128Vector extends IntVector {
         @Override
         public Int128Shuffle rearrange(VectorShuffle<Integer> shuffle) {
             Int128Shuffle s = (Int128Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Int128Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -60,16 +60,13 @@ value class Int256Vector extends IntVector {
     private final VectorPayloadMF256I payload;
 
     Int256Vector(Object value) {
-        this.payload = (VectorPayloadMF256I)value;
+        this.payload = (VectorPayloadMF256I) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Int256Vector ZERO = new Int256Vector(VectorPayloadMF.newInstanceFactory(int.class, 8));
@@ -122,15 +119,6 @@ value class Int256Vector extends IntVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    int[] vec() {
-        return (int[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Int256Vector broadcast(int e) {
@@ -166,7 +154,7 @@ value class Int256Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int256Shuffle shuffleFromBytes(byte[] reorder) { return new Int256Shuffle(reorder); }
+    Int256Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Int256Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Int256Vector extends IntVector {
     @Override
     @ForceInline
     Int256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Int256Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Int256Vector vectorFactory(int[] vec) {
-        return new Int256Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -547,7 +528,7 @@ value class Int256Vector extends IntVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getInt(vecpayload, start_offset + ix * Integer.BYTES);
                              });
@@ -574,7 +555,7 @@ value class Int256Vector extends IntVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putInt(tpayload, start_offset + ix * Integer.BYTES, (int)bits);
@@ -613,14 +594,9 @@ value class Int256Vector extends IntVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -752,24 +728,34 @@ value class Int256Vector extends IntVector {
 
     // Shuffle
 
-    static final class Int256Shuffle extends AbstractShuffle<Integer> {
+    static final value class Int256Shuffle extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int256Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF64B payload;
+
+        Int256Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF64B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Int256Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Int256Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Int256Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -806,13 +792,17 @@ value class Int256Vector extends IntVector {
         @Override
         public Int256Shuffle rearrange(VectorShuffle<Integer> shuffle) {
             Int256Shuffle s = (Int256Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Int256Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Int256Vector extends IntVector {
        return vec_mf();
     }
 
-    static final Int256Vector ZERO = new Int256Vector(VectorPayloadMF.createVectPayloadInstance(int.class, 8));
-    static final Int256Vector IOTA = new Int256Vector(VectorPayloadMF.createVectPayloadInstanceI(8, (int [])(VSPECIES.iotaArray())));
+    static final Int256Vector ZERO = new Int256Vector(VectorPayloadMF.newInstanceFactory(int.class, 8));
+    static final Int256Vector IOTA = new Int256Vector(VectorPayloadMF.createVectPayloadInstanceI(8, (int[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Int256Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int256Mask maskFromArray(boolean[] bits) {
-        return new Int256Mask(bits);
+    Int256Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Int256Mask(payload);
     }
 
     @Override
@@ -585,34 +585,22 @@ value class Int256Vector extends IntVector {
 
     // Mask
 
-    static final class Int256Mask extends AbstractMask<Integer> {
+    static final value class Int256Mask extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int256Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF64Z payload;
+
+        Int256Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF64Z) payload;
         }
 
-        Int256Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Int256Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Int256Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -625,29 +613,14 @@ value class Int256Vector extends IntVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Int256Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Int256Mask(res);
-        }
-
-        @Override
-        Int256Mask bOp(VectorMask<Integer> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Int256Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Int256Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -655,33 +628,6 @@ value class Int256Vector extends IntVector {
         public final
         Int256Vector toVector() {
             return (Int256Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -703,7 +649,7 @@ value class Int256Vector extends IntVector {
         @Override
         @ForceInline
         public Int256Mask compress() {
-            return (Int256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Int256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Int256Vector.class, Int256Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -716,9 +662,9 @@ value class Int256Vector extends IntVector {
         public Int256Mask and(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int256Mask m = (Int256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Int256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Int256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -726,9 +672,9 @@ value class Int256Vector extends IntVector {
         public Int256Mask or(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int256Mask m = (Int256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Int256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Int256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -736,9 +682,9 @@ value class Int256Vector extends IntVector {
         Int256Mask xor(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int256Mask m = (Int256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int256Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int256Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -747,21 +693,21 @@ value class Int256Vector extends IntVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Int256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Int256Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Int256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Int256Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Int256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Int256Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -771,7 +717,7 @@ value class Int256Vector extends IntVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Int256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Int256Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -781,7 +727,7 @@ value class Int256Vector extends IntVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Int256Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Int256Mask)m).getBits()));
+                                         (m, __) -> ((Int256Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -789,7 +735,7 @@ value class Int256Vector extends IntVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Int256Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Int256Mask)m).getBits()));
+                                         (m, __) -> ((Int256Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -640,7 +640,7 @@ value class Int256Vector extends IntVector {
             Int256Mask m = (Int256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Int256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -650,7 +650,7 @@ value class Int256Vector extends IntVector {
             Int256Mask m = (Int256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Int256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -660,7 +660,7 @@ value class Int256Vector extends IntVector {
             Int256Mask m = (Int256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Int256Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Int256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -60,16 +60,13 @@ value class Int512Vector extends IntVector {
     private final VectorPayloadMF512I payload;
 
     Int512Vector(Object value) {
-        this.payload = (VectorPayloadMF512I)value;
+        this.payload = (VectorPayloadMF512I) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Int512Vector ZERO = new Int512Vector(VectorPayloadMF.newInstanceFactory(int.class, 16));
@@ -122,15 +119,6 @@ value class Int512Vector extends IntVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    int[] vec() {
-        return (int[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Int512Vector broadcast(int e) {
@@ -166,7 +154,7 @@ value class Int512Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int512Shuffle shuffleFromBytes(byte[] reorder) { return new Int512Shuffle(reorder); }
+    Int512Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Int512Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Int512Vector extends IntVector {
     @Override
     @ForceInline
     Int512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Int512Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Int512Vector vectorFactory(int[] vec) {
-        return new Int512Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -555,7 +536,7 @@ value class Int512Vector extends IntVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getInt(vecpayload, start_offset + ix * Integer.BYTES);
                              });
@@ -590,7 +571,7 @@ value class Int512Vector extends IntVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putInt(tpayload, start_offset + ix * Integer.BYTES, (int)bits);
@@ -629,14 +610,9 @@ value class Int512Vector extends IntVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -768,24 +744,34 @@ value class Int512Vector extends IntVector {
 
     // Shuffle
 
-    static final class Int512Shuffle extends AbstractShuffle<Integer> {
+    static final value class Int512Shuffle extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int512Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF128B payload;
+
+        Int512Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF128B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Int512Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Int512Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Int512Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -822,13 +808,17 @@ value class Int512Vector extends IntVector {
         @Override
         public Int512Shuffle rearrange(VectorShuffle<Integer> shuffle) {
             Int512Shuffle s = (Int512Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Int512Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -656,7 +656,7 @@ value class Int512Vector extends IntVector {
             Int512Mask m = (Int512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Int512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -666,7 +666,7 @@ value class Int512Vector extends IntVector {
             Int512Mask m = (Int512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Int512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -676,7 +676,7 @@ value class Int512Vector extends IntVector {
             Int512Mask m = (Int512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Int512Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Int512Vector extends IntVector {
        return vec_mf();
     }
 
-    static final Int512Vector ZERO = new Int512Vector(VectorPayloadMF.createVectPayloadInstance(int.class, 16));
-    static final Int512Vector IOTA = new Int512Vector(VectorPayloadMF.createVectPayloadInstanceI(16, (int [])(VSPECIES.iotaArray())));
+    static final Int512Vector ZERO = new Int512Vector(VectorPayloadMF.newInstanceFactory(int.class, 16));
+    static final Int512Vector IOTA = new Int512Vector(VectorPayloadMF.createVectPayloadInstanceI(16, (int[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Int512Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int512Mask maskFromArray(boolean[] bits) {
-        return new Int512Mask(bits);
+    Int512Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Int512Mask(payload);
     }
 
     @Override
@@ -601,34 +601,22 @@ value class Int512Vector extends IntVector {
 
     // Mask
 
-    static final class Int512Mask extends AbstractMask<Integer> {
+    static final value class Int512Mask extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int512Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF128Z payload;
+
+        Int512Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF128Z) payload;
         }
 
-        Int512Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Int512Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Int512Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -641,29 +629,14 @@ value class Int512Vector extends IntVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Int512Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Int512Mask(res);
-        }
-
-        @Override
-        Int512Mask bOp(VectorMask<Integer> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Int512Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Int512Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -671,33 +644,6 @@ value class Int512Vector extends IntVector {
         public final
         Int512Vector toVector() {
             return (Int512Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -719,7 +665,7 @@ value class Int512Vector extends IntVector {
         @Override
         @ForceInline
         public Int512Mask compress() {
-            return (Int512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Int512Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Int512Vector.class, Int512Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -732,9 +678,9 @@ value class Int512Vector extends IntVector {
         public Int512Mask and(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int512Mask m = (Int512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Int512Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Int512Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -742,9 +688,9 @@ value class Int512Vector extends IntVector {
         public Int512Mask or(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int512Mask m = (Int512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Int512Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Int512Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -752,9 +698,9 @@ value class Int512Vector extends IntVector {
         Int512Mask xor(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int512Mask m = (Int512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int512Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int512Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -763,21 +709,21 @@ value class Int512Vector extends IntVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Int512Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Int512Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Int512Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Int512Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Int512Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Int512Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -787,7 +733,7 @@ value class Int512Vector extends IntVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Int512Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Int512Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -797,7 +743,7 @@ value class Int512Vector extends IntVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Int512Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Int512Mask)m).getBits()));
+                                         (m, __) -> ((Int512Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -805,7 +751,7 @@ value class Int512Vector extends IntVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Int512Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Int512Mask)m).getBits()));
+                                         (m, __) -> ((Int512Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Int64Vector extends IntVector {
        return vec_mf();
     }
 
-    static final Int64Vector ZERO = new Int64Vector(VectorPayloadMF.createVectPayloadInstance(int.class, 2));
-    static final Int64Vector IOTA = new Int64Vector(VectorPayloadMF.createVectPayloadInstanceI(2, (int [])(VSPECIES.iotaArray())));
+    static final Int64Vector ZERO = new Int64Vector(VectorPayloadMF.newInstanceFactory(int.class, 2));
+    static final Int64Vector IOTA = new Int64Vector(VectorPayloadMF.createVectPayloadInstanceI(2, (int[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Int64Vector extends IntVector {
 
     @Override
     @ForceInline
-    Int64Mask maskFromArray(boolean[] bits) {
-        return new Int64Mask(bits);
+    Int64Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Int64Mask(payload);
     }
 
     @Override
@@ -573,34 +573,22 @@ value class Int64Vector extends IntVector {
 
     // Mask
 
-    static final class Int64Mask extends AbstractMask<Integer> {
+    static final value class Int64Mask extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int64Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF16Z payload;
+
+        Int64Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF16Z) payload;
         }
 
-        Int64Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Int64Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Int64Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -613,29 +601,14 @@ value class Int64Vector extends IntVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Int64Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Int64Mask(res);
-        }
-
-        @Override
-        Int64Mask bOp(VectorMask<Integer> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Int64Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Int64Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -643,33 +616,6 @@ value class Int64Vector extends IntVector {
         public final
         Int64Vector toVector() {
             return (Int64Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -691,7 +637,7 @@ value class Int64Vector extends IntVector {
         @Override
         @ForceInline
         public Int64Mask compress() {
-            return (Int64Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Int64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Int64Vector.class, Int64Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -704,9 +650,9 @@ value class Int64Vector extends IntVector {
         public Int64Mask and(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Int64Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Int64Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -714,9 +660,9 @@ value class Int64Vector extends IntVector {
         public Int64Mask or(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Int64Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Int64Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -724,9 +670,9 @@ value class Int64Vector extends IntVector {
         Int64Mask xor(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
             Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int64Mask.class, null, int.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int64Mask.class, null,
+                                          int.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -735,21 +681,21 @@ value class Int64Vector extends IntVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Int64Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Int64Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Int64Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Int64Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Int64Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Int64Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -759,7 +705,7 @@ value class Int64Vector extends IntVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Int64Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Int64Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -769,7 +715,7 @@ value class Int64Vector extends IntVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Int64Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Int64Mask)m).getBits()));
+                                         (m, __) -> ((Int64Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -777,7 +723,7 @@ value class Int64Vector extends IntVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Int64Mask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Int64Mask)m).getBits()));
+                                         (m, __) -> ((Int64Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -628,7 +628,7 @@ value class Int64Vector extends IntVector {
             Int64Mask m = (Int64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Int64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -638,7 +638,7 @@ value class Int64Vector extends IntVector {
             Int64Mask m = (Int64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Int64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -648,7 +648,7 @@ value class Int64Vector extends IntVector {
             Int64Mask m = (Int64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Int64Mask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -93,20 +93,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract int[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract IntVector vectorFactory(int[] vec);
-
     abstract IntVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     @ForceInline
     final
     IntVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     IntVector bOpTemplateMF(Vector<Integer> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((IntVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((IntVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class IntVector extends AbstractVector<Integer> {
     IntVector tOpTemplateMF(Vector<Integer> o1,
                                      Vector<Integer> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((IntVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((IntVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((IntVector)o1).vec();
+        VectorPayloadMF vec3 = ((IntVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class IntVector extends AbstractVector<Integer> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((IntVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((IntVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((IntVector)o1).vec();
+        VectorPayloadMF vec3 = ((IntVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     @ForceInline
     final
     int rOpTemplateMF(int v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Integer> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Integer> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
                                   Vector<Integer> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((IntVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Integer> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Integer> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     IntVector vOpMF(VectorMask<Integer> m, FVOp f) {
         int[] res = new int[length()];
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class IntVector extends AbstractVector<Integer> {
     IntVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v = Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(i, v));
+            int v = Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES);
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class IntVector extends AbstractVector<Integer> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v = Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, mbits[i] ? f.apply(i, v): v);
+            int v = Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec1, start_offset + i * Integer.BYTES);
-            int v2 = Unsafe.getUnsafe().getInt(vec2, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(i, v1, v2));
+            int v1 = Unsafe.getUnsafe().getInt(vec1, vOffset + i * Integer.BYTES);
+            int v2 = Unsafe.getUnsafe().getInt(vec2, vOffset + i * Integer.BYTES);
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class IntVector extends AbstractVector<Integer> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec1, start_offset + i * Integer.BYTES);
-            int v2 = Unsafe.getUnsafe().getInt(vec2, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            int v1 = Unsafe.getUnsafe().getInt(vec1, vOffset + i * Integer.BYTES);
+            int v2 = Unsafe.getUnsafe().getInt(vec2, vOffset + i * Integer.BYTES);
+            int v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
         VectorPayloadMF vec2 = ((IntVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((IntVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec1, start_offset + i * Integer.BYTES);
-            int v2 = Unsafe.getUnsafe().getInt(vec2, start_offset + i * Integer.BYTES);
-            int v3 = Unsafe.getUnsafe().getInt(vec3, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(i, v1, v2, v3));
+            int v1 = Unsafe.getUnsafe().getInt(vec1, vOffset + i * Integer.BYTES);
+            int v2 = Unsafe.getUnsafe().getInt(vec2, vOffset + i * Integer.BYTES);
+            int v3 = Unsafe.getUnsafe().getInt(vec3, vOffset + i * Integer.BYTES);
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class IntVector extends AbstractVector<Integer> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((IntVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((IntVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec1, start_offset + i * Integer.BYTES);
-            int v2 = Unsafe.getUnsafe().getInt(vec2, start_offset + i * Integer.BYTES);
-            int v3 = Unsafe.getUnsafe().getInt(vec3, start_offset + i * Integer.BYTES);
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            int v1 = Unsafe.getUnsafe().getInt(vec1, vOffset + i * Integer.BYTES);
+            int v2 = Unsafe.getUnsafe().getInt(vec2, vOffset + i * Integer.BYTES);
+            int v3 = Unsafe.getUnsafe().getInt(vec3, vOffset + i * Integer.BYTES);
+            int v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            int v1 = Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class IntVector extends AbstractVector<Integer> {
     final
     int rOpTemplateMF(int v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES);
+            int v1 = Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class IntVector extends AbstractVector<Integer> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 int.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 int.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class IntVector extends AbstractVector<Integer> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 int.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class IntVector extends AbstractVector<Integer> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 int.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putInt(tpayload, start_offset + i * Integer.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putInt(tpayload, vOffset + i * Integer.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class IntVector extends AbstractVector<Integer> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
                   VectorMask<Integer> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class IntVector extends AbstractVector<Integer> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class IntVector extends AbstractVector<Integer> {
                   VectorMask<Integer> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, start_offset + i * Integer.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getInt(vec, vOffset + i * Integer.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class IntVector extends AbstractVector<Integer> {
     AbstractMask<Integer> bTestMF(int cond,
                                   Vector<Integer> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((IntVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            int v1 = Unsafe.getUnsafe().getInt(vec1, start_offset + i * Integer.BYTES);
-            int v2 = Unsafe.getUnsafe().getInt(vec2, start_offset + i * Integer.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            int v1 = Unsafe.getUnsafe().getInt(vec1, vOffset + i * Integer.BYTES);
+            int v2 = Unsafe.getUnsafe().getInt(vec2, vOffset + i * Integer.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
     /*package-private*/
@@ -4054,9 +4069,10 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
         IntVector vOpMF(VectorMask<Integer> m, FVOp f) {
             int[] res = new int[laneCount()];
-            boolean[] mbits = ((AbstractMask<Integer>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Integer>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -618,7 +618,7 @@ value class Long128Vector extends LongVector {
             Long128Mask m = (Long128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Long128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Long128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -628,7 +628,7 @@ value class Long128Vector extends LongVector {
             Long128Mask m = (Long128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Long128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Long128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -638,7 +638,7 @@ value class Long128Vector extends LongVector {
             Long128Mask m = (Long128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Long128Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Long128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Long256Vector extends LongVector {
        return vec_mf();
     }
 
-    static final Long256Vector ZERO = new Long256Vector(VectorPayloadMF.createVectPayloadInstance(long.class, 4));
-    static final Long256Vector IOTA = new Long256Vector(VectorPayloadMF.createVectPayloadInstanceL(4, (long [])(VSPECIES.iotaArray())));
+    static final Long256Vector ZERO = new Long256Vector(VectorPayloadMF.newInstanceFactory(long.class, 4));
+    static final Long256Vector IOTA = new Long256Vector(VectorPayloadMF.createVectPayloadInstanceL(4, (long[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -140,8 +140,8 @@ value class Long256Vector extends LongVector {
 
     @Override
     @ForceInline
-    Long256Mask maskFromArray(boolean[] bits) {
-        return new Long256Mask(bits);
+    Long256Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Long256Mask(payload);
     }
 
     @Override
@@ -567,34 +567,22 @@ value class Long256Vector extends LongVector {
 
     // Mask
 
-    static final class Long256Mask extends AbstractMask<Long> {
+    static final value class Long256Mask extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        Long256Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF32Z payload;
+
+        Long256Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF32Z) payload;
         }
 
-        Long256Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Long256Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Long256Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -607,29 +595,14 @@ value class Long256Vector extends LongVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Long256Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Long256Mask(res);
-        }
-
-        @Override
-        Long256Mask bOp(VectorMask<Long> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Long256Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Long256Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -637,33 +610,6 @@ value class Long256Vector extends LongVector {
         public final
         Long256Vector toVector() {
             return (Long256Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -685,7 +631,7 @@ value class Long256Vector extends LongVector {
         @Override
         @ForceInline
         public Long256Mask compress() {
-            return (Long256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Long256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Long256Vector.class, Long256Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -698,9 +644,9 @@ value class Long256Vector extends LongVector {
         public Long256Mask and(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long256Mask m = (Long256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Long256Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Long256Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -708,9 +654,9 @@ value class Long256Vector extends LongVector {
         public Long256Mask or(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long256Mask m = (Long256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Long256Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Long256Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -718,9 +664,9 @@ value class Long256Vector extends LongVector {
         Long256Mask xor(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long256Mask m = (Long256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Long256Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Long256Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -729,21 +675,21 @@ value class Long256Vector extends LongVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Long256Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Long256Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Long256Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Long256Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Long256Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Long256Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -753,7 +699,7 @@ value class Long256Vector extends LongVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Long256Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Long256Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -763,7 +709,7 @@ value class Long256Vector extends LongVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Long256Mask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Long256Mask)m).getBits()));
+                                         (m, __) -> ((Long256Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -771,7 +717,7 @@ value class Long256Vector extends LongVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Long256Mask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Long256Mask)m).getBits()));
+                                         (m, __) -> ((Long256Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -622,7 +622,7 @@ value class Long256Vector extends LongVector {
             Long256Mask m = (Long256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Long256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -632,7 +632,7 @@ value class Long256Vector extends LongVector {
             Long256Mask m = (Long256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Long256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -642,7 +642,7 @@ value class Long256Vector extends LongVector {
             Long256Mask m = (Long256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Long256Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Long256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -630,7 +630,7 @@ value class Long512Vector extends LongVector {
             Long512Mask m = (Long512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Long512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -640,7 +640,7 @@ value class Long512Vector extends LongVector {
             Long512Mask m = (Long512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Long512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -650,7 +650,7 @@ value class Long512Vector extends LongVector {
             Long512Mask m = (Long512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Long512Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Long512Vector extends LongVector {
        return vec_mf();
     }
 
-    static final Long512Vector ZERO = new Long512Vector(VectorPayloadMF.createVectPayloadInstance(long.class, 8));
-    static final Long512Vector IOTA = new Long512Vector(VectorPayloadMF.createVectPayloadInstanceL(8, (long [])(VSPECIES.iotaArray())));
+    static final Long512Vector ZERO = new Long512Vector(VectorPayloadMF.newInstanceFactory(long.class, 8));
+    static final Long512Vector IOTA = new Long512Vector(VectorPayloadMF.createVectPayloadInstanceL(8, (long[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -140,8 +140,8 @@ value class Long512Vector extends LongVector {
 
     @Override
     @ForceInline
-    Long512Mask maskFromArray(boolean[] bits) {
-        return new Long512Mask(bits);
+    Long512Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Long512Mask(payload);
     }
 
     @Override
@@ -575,34 +575,22 @@ value class Long512Vector extends LongVector {
 
     // Mask
 
-    static final class Long512Mask extends AbstractMask<Long> {
+    static final value class Long512Mask extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        Long512Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF64Z payload;
+
+        Long512Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF64Z) payload;
         }
 
-        Long512Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Long512Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Long512Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -615,29 +603,14 @@ value class Long512Vector extends LongVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Long512Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Long512Mask(res);
-        }
-
-        @Override
-        Long512Mask bOp(VectorMask<Long> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Long512Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Long512Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -645,33 +618,6 @@ value class Long512Vector extends LongVector {
         public final
         Long512Vector toVector() {
             return (Long512Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -693,7 +639,7 @@ value class Long512Vector extends LongVector {
         @Override
         @ForceInline
         public Long512Mask compress() {
-            return (Long512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Long512Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Long512Vector.class, Long512Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -706,9 +652,9 @@ value class Long512Vector extends LongVector {
         public Long512Mask and(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long512Mask m = (Long512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Long512Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Long512Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -716,9 +662,9 @@ value class Long512Vector extends LongVector {
         public Long512Mask or(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long512Mask m = (Long512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Long512Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Long512Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -726,9 +672,9 @@ value class Long512Vector extends LongVector {
         Long512Mask xor(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
             Long512Mask m = (Long512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Long512Mask.class, null, long.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Long512Mask.class, null,
+                                          long.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Long512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -737,21 +683,21 @@ value class Long512Vector extends LongVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Long512Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Long512Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Long512Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Long512Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Long512Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Long512Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -761,7 +707,7 @@ value class Long512Vector extends LongVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Long512Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Long512Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -771,7 +717,7 @@ value class Long512Vector extends LongVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Long512Mask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Long512Mask)m).getBits()));
+                                         (m, __) -> ((Long512Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -779,7 +725,7 @@ value class Long512Vector extends LongVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Long512Mask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Long512Mask)m).getBits()));
+                                         (m, __) -> ((Long512Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -616,7 +616,7 @@ value class Long64Vector extends LongVector {
             Long64Mask m = (Long64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Long64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -626,7 +626,7 @@ value class Long64Vector extends LongVector {
             Long64Mask m = (Long64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Long64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -636,7 +636,7 @@ value class Long64Vector extends LongVector {
             Long64Mask m = (Long64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Long64Mask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -60,16 +60,13 @@ value class Long64Vector extends LongVector {
     private final VectorPayloadMF64L payload;
 
     Long64Vector(Object value) {
-        this.payload = (VectorPayloadMF64L)value;
+        this.payload = (VectorPayloadMF64L) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Long64Vector ZERO = new Long64Vector(VectorPayloadMF.newInstanceFactory(long.class, 1));
@@ -122,15 +119,6 @@ value class Long64Vector extends LongVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    long[] vec() {
-        return (long[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Long64Vector broadcast(long e) {
@@ -161,7 +149,7 @@ value class Long64Vector extends LongVector {
 
     @Override
     @ForceInline
-    Long64Shuffle shuffleFromBytes(byte[] reorder) { return new Long64Shuffle(reorder); }
+    Long64Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Long64Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -170,13 +158,6 @@ value class Long64Vector extends LongVector {
     @Override
     @ForceInline
     Long64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Long64Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Long64Vector vectorFactory(long[] vec) {
-        return new Long64Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -530,7 +511,7 @@ value class Long64Vector extends LongVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getLong(vecpayload, start_offset + ix * Long.BYTES);
                              });
@@ -550,7 +531,7 @@ value class Long64Vector extends LongVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putLong(tpayload, start_offset + ix * Long.BYTES, (long)bits);
@@ -589,14 +570,9 @@ value class Long64Vector extends LongVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -728,24 +704,34 @@ value class Long64Vector extends LongVector {
 
     // Shuffle
 
-    static final class Long64Shuffle extends AbstractShuffle<Long> {
+    static final value class Long64Shuffle extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        Long64Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF8B payload;
+
+        Long64Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF8B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Long64Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Long64Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Long64Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -782,13 +768,17 @@ value class Long64Vector extends LongVector {
         @Override
         public Long64Shuffle rearrange(VectorShuffle<Long> shuffle) {
             Long64Shuffle s = (Long64Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Long64Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class LongVector extends AbstractVector<Long> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Long> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Long> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     LongVector vOpMF(VectorMask<Long> m, FVOp f) {
         long[] res = new long[length()];
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class LongVector extends AbstractVector<Long> {
     LongVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v = Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(i, v));
+            long v = Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES);
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class LongVector extends AbstractVector<Long> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v = Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, mbits[i] ? f.apply(i, v): v);
+            long v = Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class LongVector extends AbstractVector<Long> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec1, start_offset + i * Long.BYTES);
-            long v2 = Unsafe.getUnsafe().getLong(vec2, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(i, v1, v2));
+            long v1 = Unsafe.getUnsafe().getLong(vec1, vOffset + i * Long.BYTES);
+            long v2 = Unsafe.getUnsafe().getLong(vec2, vOffset + i * Long.BYTES);
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class LongVector extends AbstractVector<Long> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec1, start_offset + i * Long.BYTES);
-            long v2 = Unsafe.getUnsafe().getLong(vec2, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            long v1 = Unsafe.getUnsafe().getLong(vec1, vOffset + i * Long.BYTES);
+            long v2 = Unsafe.getUnsafe().getLong(vec2, vOffset + i * Long.BYTES);
+            long v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class LongVector extends AbstractVector<Long> {
         VectorPayloadMF vec2 = ((LongVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((LongVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec1, start_offset + i * Long.BYTES);
-            long v2 = Unsafe.getUnsafe().getLong(vec2, start_offset + i * Long.BYTES);
-            long v3 = Unsafe.getUnsafe().getLong(vec3, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(i, v1, v2, v3));
+            long v1 = Unsafe.getUnsafe().getLong(vec1, vOffset + i * Long.BYTES);
+            long v2 = Unsafe.getUnsafe().getLong(vec2, vOffset + i * Long.BYTES);
+            long v3 = Unsafe.getUnsafe().getLong(vec3, vOffset + i * Long.BYTES);
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class LongVector extends AbstractVector<Long> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((LongVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((LongVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec1, start_offset + i * Long.BYTES);
-            long v2 = Unsafe.getUnsafe().getLong(vec2, start_offset + i * Long.BYTES);
-            long v3 = Unsafe.getUnsafe().getLong(vec3, start_offset + i * Long.BYTES);
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            long v1 = Unsafe.getUnsafe().getLong(vec1, vOffset + i * Long.BYTES);
+            long v2 = Unsafe.getUnsafe().getLong(vec2, vOffset + i * Long.BYTES);
+            long v3 = Unsafe.getUnsafe().getLong(vec3, vOffset + i * Long.BYTES);
+            long v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class LongVector extends AbstractVector<Long> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            long v1 = Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     long rOpTemplateMF(long v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES);
+            long v1 = Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 long.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 long.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 long.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 long.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putLong(tpayload, start_offset + i * Long.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class LongVector extends AbstractVector<Long> {
                   VectorMask<Long> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class LongVector extends AbstractVector<Long> {
                   VectorMask<Long> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Long>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, start_offset + i * Long.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getLong(vec, vOffset + i * Long.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class LongVector extends AbstractVector<Long> {
     AbstractMask<Long> bTestMF(int cond,
                                   Vector<Long> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            long v1 = Unsafe.getUnsafe().getLong(vec1, start_offset + i * Long.BYTES);
-            long v2 = Unsafe.getUnsafe().getLong(vec2, start_offset + i * Long.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            long v1 = Unsafe.getUnsafe().getLong(vec1, vOffset + i * Long.BYTES);
+            long v2 = Unsafe.getUnsafe().getLong(vec2, vOffset + i * Long.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
     /*package-private*/
@@ -3989,9 +4004,10 @@ public abstract class LongVector extends AbstractVector<Long> {
 
         LongVector vOpMF(VectorMask<Long> m, FVOp f) {
             long[] res = new long[laneCount()];
-            boolean[] mbits = ((AbstractMask<Long>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -93,20 +93,13 @@ public abstract class LongVector extends AbstractVector<Long> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract long[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract LongVector vectorFactory(long[] vec);
-
     abstract LongVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     @ForceInline
     final
     LongVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class LongVector extends AbstractVector<Long> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     LongVector bOpTemplateMF(Vector<Long> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((LongVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class LongVector extends AbstractVector<Long> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((LongVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class LongVector extends AbstractVector<Long> {
     LongVector tOpTemplateMF(Vector<Long> o1,
                                      Vector<Long> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((LongVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((LongVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((LongVector)o1).vec();
+        VectorPayloadMF vec3 = ((LongVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class LongVector extends AbstractVector<Long> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((LongVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((LongVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((LongVector)o1).vec();
+        VectorPayloadMF vec3 = ((LongVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     @ForceInline
     final
     long rOpTemplateMF(long v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Long> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class LongVector extends AbstractVector<Long> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Long> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   Vector<Long> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((LongVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((LongVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -640,7 +640,7 @@ value class Short128Vector extends ShortVector {
             Short128Mask m = (Short128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Short128Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -650,7 +650,7 @@ value class Short128Vector extends ShortVector {
             Short128Mask m = (Short128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Short128Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -660,7 +660,7 @@ value class Short128Vector extends ShortVector {
             Short128Mask m = (Short128Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Short128Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -60,16 +60,13 @@ value class Short256Vector extends ShortVector {
     private final VectorPayloadMF256S payload;
 
     Short256Vector(Object value) {
-        this.payload = (VectorPayloadMF256S)value;
+        this.payload = (VectorPayloadMF256S) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Short256Vector ZERO = new Short256Vector(VectorPayloadMF.newInstanceFactory(short.class, 16));
@@ -122,15 +119,6 @@ value class Short256Vector extends ShortVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    short[] vec() {
-        return (short[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Short256Vector broadcast(short e) {
@@ -166,7 +154,7 @@ value class Short256Vector extends ShortVector {
 
     @Override
     @ForceInline
-    Short256Shuffle shuffleFromBytes(byte[] reorder) { return new Short256Shuffle(reorder); }
+    Short256Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Short256Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     Short256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Short256Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Short256Vector vectorFactory(short[] vec) {
-        return new Short256Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -555,7 +536,7 @@ value class Short256Vector extends ShortVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getShort(vecpayload, start_offset + ix * Short.BYTES);
                              });
@@ -590,7 +571,7 @@ value class Short256Vector extends ShortVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putShort(tpayload, start_offset + ix * Short.BYTES, (short)bits);
@@ -629,14 +610,9 @@ value class Short256Vector extends ShortVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -768,24 +744,34 @@ value class Short256Vector extends ShortVector {
 
     // Shuffle
 
-    static final class Short256Shuffle extends AbstractShuffle<Short> {
+    static final value class Short256Shuffle extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short256Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF128B payload;
+
+        Short256Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF128B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Short256Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Short256Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Short256Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -822,13 +808,17 @@ value class Short256Vector extends ShortVector {
         @Override
         public Short256Shuffle rearrange(VectorShuffle<Short> shuffle) {
             Short256Shuffle s = (Short256Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Short256Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -656,7 +656,7 @@ value class Short256Vector extends ShortVector {
             Short256Mask m = (Short256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Short256Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -666,7 +666,7 @@ value class Short256Vector extends ShortVector {
             Short256Mask m = (Short256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Short256Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -676,7 +676,7 @@ value class Short256Vector extends ShortVector {
             Short256Mask m = (Short256Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Short256Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Short256Vector extends ShortVector {
        return vec_mf();
     }
 
-    static final Short256Vector ZERO = new Short256Vector(VectorPayloadMF.createVectPayloadInstance(short.class, 16));
-    static final Short256Vector IOTA = new Short256Vector(VectorPayloadMF.createVectPayloadInstanceS(16, (short [])(VSPECIES.iotaArray())));
+    static final Short256Vector ZERO = new Short256Vector(VectorPayloadMF.newInstanceFactory(short.class, 16));
+    static final Short256Vector IOTA = new Short256Vector(VectorPayloadMF.createVectPayloadInstanceS(16, (short[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Short256Vector extends ShortVector {
 
     @Override
     @ForceInline
-    Short256Mask maskFromArray(boolean[] bits) {
-        return new Short256Mask(bits);
+    Short256Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Short256Mask(payload);
     }
 
     @Override
@@ -601,34 +601,22 @@ value class Short256Vector extends ShortVector {
 
     // Mask
 
-    static final class Short256Mask extends AbstractMask<Short> {
+    static final value class Short256Mask extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short256Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF128Z payload;
+
+        Short256Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF128Z) payload;
         }
 
-        Short256Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Short256Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Short256Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -641,29 +629,14 @@ value class Short256Vector extends ShortVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Short256Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Short256Mask(res);
-        }
-
-        @Override
-        Short256Mask bOp(VectorMask<Short> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Short256Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Short256Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -671,33 +644,6 @@ value class Short256Vector extends ShortVector {
         public final
         Short256Vector toVector() {
             return (Short256Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -719,7 +665,7 @@ value class Short256Vector extends ShortVector {
         @Override
         @ForceInline
         public Short256Mask compress() {
-            return (Short256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Short256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Short256Vector.class, Short256Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -732,9 +678,9 @@ value class Short256Vector extends ShortVector {
         public Short256Mask and(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short256Mask m = (Short256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Short256Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Short256Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -742,9 +688,9 @@ value class Short256Vector extends ShortVector {
         public Short256Mask or(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short256Mask m = (Short256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Short256Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Short256Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -752,9 +698,9 @@ value class Short256Vector extends ShortVector {
         Short256Mask xor(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short256Mask m = (Short256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short256Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short256Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short256Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -763,21 +709,21 @@ value class Short256Vector extends ShortVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Short256Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Short256Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Short256Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Short256Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Short256Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Short256Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -787,7 +733,7 @@ value class Short256Vector extends ShortVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Short256Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Short256Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -797,7 +743,7 @@ value class Short256Vector extends ShortVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Short256Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Short256Mask)m).getBits()));
+                                         (m, __) -> ((Short256Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -805,7 +751,7 @@ value class Short256Vector extends ShortVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Short256Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Short256Mask)m).getBits()));
+                                         (m, __) -> ((Short256Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -688,7 +688,7 @@ value class Short512Vector extends ShortVector {
             Short512Mask m = (Short512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Short512Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -698,7 +698,7 @@ value class Short512Vector extends ShortVector {
             Short512Mask m = (Short512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Short512Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -708,7 +708,7 @@ value class Short512Vector extends ShortVector {
             Short512Mask m = (Short512Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Short512Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Short512Vector extends ShortVector {
        return vec_mf();
     }
 
-    static final Short512Vector ZERO = new Short512Vector(VectorPayloadMF.createVectPayloadInstance(short.class, 32));
-    static final Short512Vector IOTA = new Short512Vector(VectorPayloadMF.createVectPayloadInstanceS(32, (short [])(VSPECIES.iotaArray())));
+    static final Short512Vector ZERO = new Short512Vector(VectorPayloadMF.newInstanceFactory(short.class, 32));
+    static final Short512Vector IOTA = new Short512Vector(VectorPayloadMF.createVectPayloadInstanceS(32, (short[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Short512Vector extends ShortVector {
 
     @Override
     @ForceInline
-    Short512Mask maskFromArray(boolean[] bits) {
-        return new Short512Mask(bits);
+    Short512Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Short512Mask(payload);
     }
 
     @Override
@@ -633,34 +633,22 @@ value class Short512Vector extends ShortVector {
 
     // Mask
 
-    static final class Short512Mask extends AbstractMask<Short> {
+    static final value class Short512Mask extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short512Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF256Z payload;
+
+        Short512Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF256Z) payload;
         }
 
-        Short512Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Short512Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Short512Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -673,29 +661,14 @@ value class Short512Vector extends ShortVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Short512Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Short512Mask(res);
-        }
-
-        @Override
-        Short512Mask bOp(VectorMask<Short> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Short512Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Short512Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -703,33 +676,6 @@ value class Short512Vector extends ShortVector {
         public final
         Short512Vector toVector() {
             return (Short512Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -751,7 +697,7 @@ value class Short512Vector extends ShortVector {
         @Override
         @ForceInline
         public Short512Mask compress() {
-            return (Short512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Short512Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Short512Vector.class, Short512Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -764,9 +710,9 @@ value class Short512Vector extends ShortVector {
         public Short512Mask and(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short512Mask m = (Short512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Short512Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Short512Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -774,9 +720,9 @@ value class Short512Vector extends ShortVector {
         public Short512Mask or(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short512Mask m = (Short512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Short512Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Short512Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -784,9 +730,9 @@ value class Short512Vector extends ShortVector {
         Short512Mask xor(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short512Mask m = (Short512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short512Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short512Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short512Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -795,21 +741,21 @@ value class Short512Vector extends ShortVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Short512Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Short512Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Short512Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Short512Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Short512Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Short512Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -819,7 +765,7 @@ value class Short512Vector extends ShortVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Short512Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Short512Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -829,7 +775,7 @@ value class Short512Vector extends ShortVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Short512Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Short512Mask)m).getBits()));
+                                         (m, __) -> ((Short512Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -837,7 +783,7 @@ value class Short512Vector extends ShortVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Short512Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Short512Mask)m).getBits()));
+                                         (m, __) -> ((Short512Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -632,7 +632,7 @@ value class Short64Vector extends ShortVector {
             Short64Mask m = (Short64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, Short64Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -642,7 +642,7 @@ value class Short64Vector extends ShortVector {
             Short64Mask m = (Short64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, Short64Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -652,7 +652,7 @@ value class Short64Vector extends ShortVector {
             Short64Mask m = (Short64Mask)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, Short64Mask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class Short64Vector extends ShortVector {
        return vec_mf();
     }
 
-    static final Short64Vector ZERO = new Short64Vector(VectorPayloadMF.createVectPayloadInstance(short.class, 4));
-    static final Short64Vector IOTA = new Short64Vector(VectorPayloadMF.createVectPayloadInstanceS(4, (short [])(VSPECIES.iotaArray())));
+    static final Short64Vector ZERO = new Short64Vector(VectorPayloadMF.newInstanceFactory(short.class, 4));
+    static final Short64Vector IOTA = new Short64Vector(VectorPayloadMF.createVectPayloadInstanceS(4, (short[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -145,8 +145,8 @@ value class Short64Vector extends ShortVector {
 
     @Override
     @ForceInline
-    Short64Mask maskFromArray(boolean[] bits) {
-        return new Short64Mask(bits);
+    Short64Mask maskFromPayload(VectorPayloadMF payload) {
+        return new Short64Mask(payload);
     }
 
     @Override
@@ -577,34 +577,22 @@ value class Short64Vector extends ShortVector {
 
     // Mask
 
-    static final class Short64Mask extends AbstractMask<Short> {
+    static final value class Short64Mask extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short64Mask(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF32Z payload;
+
+        Short64Mask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF32Z) payload;
         }
 
-        Short64Mask(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        Short64Mask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         Short64Mask(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -617,29 +605,14 @@ value class Short64Vector extends ShortVector {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        Short64Mask uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new Short64Mask(res);
-        }
-
-        @Override
-        Short64Mask bOp(VectorMask<Short> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = ((Short64Mask)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new Short64Mask(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -647,33 +620,6 @@ value class Short64Vector extends ShortVector {
         public final
         Short64Vector toVector() {
             return (Short64Vector) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -695,7 +641,7 @@ value class Short64Vector extends ShortVector {
         @Override
         @ForceInline
         public Short64Mask compress() {
-            return (Short64Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return (Short64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 Short64Vector.class, Short64Mask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -708,9 +654,9 @@ value class Short64Vector extends ShortVector {
         public Short64Mask and(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short64Mask m = (Short64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Short64Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Short64Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -718,9 +664,9 @@ value class Short64Vector extends ShortVector {
         public Short64Mask or(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short64Mask m = (Short64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Short64Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Short64Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -728,9 +674,9 @@ value class Short64Vector extends ShortVector {
         Short64Mask xor(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
             Short64Mask m = (Short64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short64Mask.class, null, short.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short64Mask.class, null,
+                                          short.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> (Short64Mask) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -739,21 +685,21 @@ value class Short64Vector extends ShortVector {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Short64Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> ((Short64Mask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Short64Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> ((Short64Mask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Short64Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> ((Short64Mask) m).lastTrueHelper());
         }
 
         @Override
@@ -763,7 +709,7 @@ value class Short64Vector extends ShortVector {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Short64Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> ((Short64Mask) m).toLongHelper());
         }
 
         // Reductions
@@ -773,7 +719,7 @@ value class Short64Vector extends ShortVector {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, Short64Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Short64Mask)m).getBits()));
+                                         (m, __) -> ((Short64Mask) m).anyTrueHelper());
         }
 
         @Override
@@ -781,7 +727,7 @@ value class Short64Vector extends ShortVector {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, Short64Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Short64Mask)m).getBits()));
+                                         (m, __) -> ((Short64Mask) m).allTrueHelper());
         }
 
         @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -60,16 +60,13 @@ value class Short64Vector extends ShortVector {
     private final VectorPayloadMF64S payload;
 
     Short64Vector(Object value) {
-        this.payload = (VectorPayloadMF64S)value;
+        this.payload = (VectorPayloadMF64S) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final Short64Vector ZERO = new Short64Vector(VectorPayloadMF.newInstanceFactory(short.class, 4));
@@ -122,15 +119,6 @@ value class Short64Vector extends ShortVector {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    short[] vec() {
-        return (short[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final Short64Vector broadcast(short e) {
@@ -166,7 +154,7 @@ value class Short64Vector extends ShortVector {
 
     @Override
     @ForceInline
-    Short64Shuffle shuffleFromBytes(byte[] reorder) { return new Short64Shuffle(reorder); }
+    Short64Shuffle shuffleFromBytes(VectorPayloadMF reorder) { return new Short64Shuffle(reorder); }
 
     @Override
     @ForceInline
@@ -175,13 +163,6 @@ value class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     Short64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Short64Shuffle(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    Short64Vector vectorFactory(short[] vec) {
-        return new Short64Vector(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -543,7 +524,7 @@ value class Short64Vector extends ShortVector {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().getShort(vecpayload, start_offset + ix * Short.BYTES);
                              });
@@ -566,7 +547,7 @@ value class Short64Vector extends ShortVector {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().putShort(tpayload, start_offset + ix * Short.BYTES, (short)bits);
@@ -605,14 +586,9 @@ value class Short64Vector extends ShortVector {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -744,24 +720,34 @@ value class Short64Vector extends ShortVector {
 
     // Shuffle
 
-    static final class Short64Shuffle extends AbstractShuffle<Short> {
+    static final value class Short64Shuffle extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short64Shuffle(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF32B payload;
+
+        Short64Shuffle(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF32B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public Short64Shuffle(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public Short64Shuffle(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public Short64Shuffle(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -798,13 +784,17 @@ value class Short64Vector extends ShortVector {
         @Override
         public Short64Shuffle rearrange(VectorShuffle<Short> shuffle) {
             Short64Shuffle s = (Short64Shuffle) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new Short64Shuffle(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -93,20 +93,13 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract short[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract ShortVector vectorFactory(short[] vec);
-
     abstract ShortVector vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -165,7 +158,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     final
     ShortVector uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -189,7 +182,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -218,8 +211,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     ShortVector bOpTemplateMF(Vector<Short> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((ShortVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -246,8 +239,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ShortVector)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -279,9 +272,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
     ShortVector tOpTemplateMF(Vector<Short> o1,
                                      Vector<Short> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ShortVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((ShortVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ShortVector)o1).vec();
+        VectorPayloadMF vec3 = ((ShortVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -311,9 +304,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ShortVector)o1).vec_mf();
-        VectorPayloadMF vec3 = ((ShortVector)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = ((ShortVector)o1).vec();
+        VectorPayloadMF vec3 = ((ShortVector)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -341,7 +334,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -356,7 +349,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     final
     short rOpTemplateMF(short v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -470,7 +463,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -484,7 +477,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<Short> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -506,7 +499,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -520,7 +513,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<Short> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -550,8 +543,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
                                   Vector<Short> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = ((ShortVector)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,8 +116,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Short> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<Short> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -141,9 +141,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     ShortVector vOpMF(VectorMask<Short> m, FVOp f) {
         short[] res = new short[length()];
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -166,11 +167,11 @@ public abstract class ShortVector extends AbstractVector<Short> {
     ShortVector uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v = Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(i, v));
+            short v = Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES);
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -187,14 +188,16 @@ public abstract class ShortVector extends AbstractVector<Short> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v = Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, mbits[i] ? f.apply(i, v): v);
+            short v = Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -218,12 +221,12 @@ public abstract class ShortVector extends AbstractVector<Short> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec1, start_offset + i * Short.BYTES);
-            short v2 = Unsafe.getUnsafe().getShort(vec2, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(i, v1, v2));
+            short v1 = Unsafe.getUnsafe().getShort(vec1, vOffset + i * Short.BYTES);
+            short v2 = Unsafe.getUnsafe().getShort(vec2, vOffset + i * Short.BYTES);
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -242,16 +245,18 @@ public abstract class ShortVector extends AbstractVector<Short> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec1, start_offset + i * Short.BYTES);
-            short v2 = Unsafe.getUnsafe().getShort(vec2, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            short v1 = Unsafe.getUnsafe().getShort(vec1, vOffset + i * Short.BYTES);
+            short v2 = Unsafe.getUnsafe().getShort(vec2, vOffset + i * Short.BYTES);
+            short v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -278,13 +283,13 @@ public abstract class ShortVector extends AbstractVector<Short> {
         VectorPayloadMF vec2 = ((ShortVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((ShortVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec1, start_offset + i * Short.BYTES);
-            short v2 = Unsafe.getUnsafe().getShort(vec2, start_offset + i * Short.BYTES);
-            short v3 = Unsafe.getUnsafe().getShort(vec3, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(i, v1, v2, v3));
+            short v1 = Unsafe.getUnsafe().getShort(vec1, vOffset + i * Short.BYTES);
+            short v2 = Unsafe.getUnsafe().getShort(vec2, vOffset + i * Short.BYTES);
+            short v3 = Unsafe.getUnsafe().getShort(vec3, vOffset + i * Short.BYTES);
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -305,18 +310,20 @@ public abstract class ShortVector extends AbstractVector<Short> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ShortVector)o1).vec_mf();
         VectorPayloadMF vec3 = ((ShortVector)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec1, start_offset + i * Short.BYTES);
-            short v2 = Unsafe.getUnsafe().getShort(vec2, start_offset + i * Short.BYTES);
-            short v3 = Unsafe.getUnsafe().getShort(vec3, start_offset + i * Short.BYTES);
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            short v1 = Unsafe.getUnsafe().getShort(vec1, vOffset + i * Short.BYTES);
+            short v2 = Unsafe.getUnsafe().getShort(vec2, vOffset + i * Short.BYTES);
+            short v3 = Unsafe.getUnsafe().getShort(vec3, vOffset + i * Short.BYTES);
+            short v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -335,12 +342,13 @@ public abstract class ShortVector extends AbstractVector<Short> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            short v1 = Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -349,10 +357,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
     final
     short rOpTemplateMF(short v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES);
+            short v1 = Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -372,11 +380,11 @@ public abstract class ShortVector extends AbstractVector<Short> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 short.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -390,13 +398,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 short.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -416,11 +425,11 @@ public abstract class ShortVector extends AbstractVector<Short> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 short.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -434,13 +443,14 @@ public abstract class ShortVector extends AbstractVector<Short> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 short.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().putShort(tpayload, start_offset + i * Short.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().putShort(tpayload, vOffset + i * Short.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -461,10 +471,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES));
         }
     }
 
@@ -475,12 +485,13 @@ public abstract class ShortVector extends AbstractVector<Short> {
                   VectorMask<Short> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES));
             }
         }
     }
@@ -496,10 +507,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES));
         }
     }
 
@@ -510,12 +521,13 @@ public abstract class ShortVector extends AbstractVector<Short> {
                   VectorMask<Short> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<Short>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, start_offset + i * Short.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().getShort(vec, vOffset + i * Short.BYTES));
             }
         }
     }
@@ -537,17 +549,20 @@ public abstract class ShortVector extends AbstractVector<Short> {
     AbstractMask<Short> bTestMF(int cond,
                                   Vector<Short> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = ((ShortVector)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            short v1 = Unsafe.getUnsafe().getShort(vec1, start_offset + i * Short.BYTES);
-            short v2 = Unsafe.getUnsafe().getShort(vec2, start_offset + i * Short.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            short v1 = Unsafe.getUnsafe().getShort(vec1, vOffset + i * Short.BYTES);
+            short v2 = Unsafe.getUnsafe().getShort(vec2, vOffset + i * Short.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
     /*package-private*/
@@ -4335,9 +4350,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
         ShortVector vOpMF(VectorMask<Short> m, FVOp f) {
             short[] res = new short[laneCount()];
-            boolean[] mbits = ((AbstractMask<Short>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<Short>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,11 @@ import java.util.Objects;
  */
 @SuppressWarnings("exports")
 public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport.VectorMask<E> {
-    VectorMask(boolean[] bits) { super(bits); }
+
+    /**
+     * Default Constructor for abstract VectorMask.
+     */
+    public VectorMask() {}
 
     /**
      * Returns the vector species to which this mask applies.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShuffle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,9 +133,10 @@ import java.util.function.IntUnaryOperator;
  */
 @SuppressWarnings("exports")
 public abstract class VectorShuffle<E> extends jdk.internal.vm.vector.VectorSupport.VectorShuffle<E> {
-    VectorShuffle(byte[] reorder) {
-        super(reorder);
-    }
+    /**
+     * Default Constructor for abstract VectorShuffle.
+     */
+    public VectorShuffle() {}
 
     /**
      * Returns the species of this shuffle.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -97,20 +97,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     // Virtualized getter
 
-    /*package-private*/
-    abstract $type$[] vec();
-
-    abstract VectorPayloadMF vec_mf();
-
     // Virtualized constructors
 
     /**
      * Build a vector directly using my own constructor.
-     * It is an error if the array is aliased elsewhere.
+     * It is an error if the vec is aliased elsewhere.
      */
     /*package-private*/
-    abstract $abstractvectortype$ vectorFactory($type$[] vec);
-
     abstract $abstractvectortype$ vectorFactory(VectorPayloadMF vec);
 
     /**
@@ -169,7 +162,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     $abstractvectortype$ uOpTemplateMF(FUnOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -193,7 +186,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             return uOpTemplateMF(f);
         }
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -222,8 +215,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ bOpTemplateMF(Vector<$Boxtype$> o,
                                      FBinOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -250,8 +243,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             return bOpTemplateMF(o, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -283,9 +276,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ tOpTemplateMF(Vector<$Boxtype$> o1,
                                      Vector<$Boxtype$> o2,
                                      FTriOp f) {
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec_mf();
-        VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec();
+        VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
@@ -315,9 +308,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             return tOpTemplateMF(o1, o2, f);
         }
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec_mf();
-        VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec_mf();
+        VectorPayloadMF vec1 = this.vec();
+        VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec();
+        VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -345,7 +338,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return rOpTemplateMF(v, f);
         }
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = this.vec();
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -360,7 +353,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     $type$ rOpTemplateMF($type$ v, FBinOp f) {
-        VectorPayloadMF vec = this.vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -474,7 +467,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -488,7 +481,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> void stOpMF(M memory, int offset,
                   VectorMask<$Boxtype$> m,
                   FStOp<M> f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -510,7 +503,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
@@ -524,7 +517,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     void stLongOpMF(MemorySegment memory, long offset,
                   VectorMask<$Boxtype$> m,
                   FStLongOp f) {
-        VectorPayloadMF vec = vec_mf();
+        VectorPayloadMF vec = vec();
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -554,8 +547,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   Vector<$Boxtype$> o,
                                   FBinTest f) {
         int length = vspecies().length();
-        VectorPayloadMF vec1 = this.vec_mf();
-        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
+        VectorPayloadMF vec1 = vec();
+        VectorPayloadMF vec2 = (($abstractvectortype$)o).vec();
         VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,8 +120,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<$Boxtype$> maskFactory(boolean[] bits) {
-        return vspecies().maskFactory(bits);
+    AbstractMask<$Boxtype$> maskFactory(VectorPayloadMF payload) {
+        return vspecies().maskFactory(payload);
     }
 
     // Constant loader (takes dummy as vector arg)
@@ -145,9 +145,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ vOpMF(VectorMask<$Boxtype$> m, FVOp f) {
         $type$[] res = new $type$[length()];
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < res.length; i++) {
-            if (mbits[i]) {
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                 res[i] = f.apply(i);
             }
         }
@@ -170,11 +171,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ uOpTemplateMF(FUnOp f) {
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v = Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(i, v));
+            $type$ v = Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES);
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(i, v));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -191,14 +192,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return uOpTemplateMF(f);
         }
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         VectorPayloadMF vec = this.vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v = Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, mbits[i] ? f.apply(i, v): v);
+            $type$ v = Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v) : v;
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -222,12 +225,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, start_offset + i * $Boxtype$.BYTES);
-            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(i, v1, v2));
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, vOffset + i * $Boxtype$.BYTES);
+            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, vOffset + i * $Boxtype$.BYTES);
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(i, v1, v2));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -246,16 +249,18 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return bOpTemplateMF(o, f);
         }
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, start_offset + i * $Boxtype$.BYTES);
-            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, mbits[i] ? f.apply(i, v1, v2): v1);
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, vOffset + i * $Boxtype$.BYTES);
+            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, vOffset + i * $Boxtype$.BYTES);
+            $type$ v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2) : v1;
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -282,13 +287,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec_mf();
         VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, start_offset + i * $Boxtype$.BYTES);
-            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, start_offset + i * $Boxtype$.BYTES);
-            $type$ v3 = Unsafe.getUnsafe().get$Type$(vec3, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(i, v1, v2, v3));
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, vOffset + i * $Boxtype$.BYTES);
+            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, vOffset + i * $Boxtype$.BYTES);
+            $type$ v3 = Unsafe.getUnsafe().get$Type$(vec3, vOffset + i * $Boxtype$.BYTES);
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(i, v1, v2, v3));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -309,18 +314,20 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return tOpTemplateMF(o1, o2, f);
         }
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = (($abstractvectortype$)o1).vec_mf();
         VectorPayloadMF vec3 = (($abstractvectortype$)o2).vec_mf();
         VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec1);
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, start_offset + i * $Boxtype$.BYTES);
-            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, start_offset + i * $Boxtype$.BYTES);
-            $type$ v3 = Unsafe.getUnsafe().get$Type$(vec3, start_offset + i * $Boxtype$.BYTES);
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, mbits[i] ? f.apply(i, v1, v2, v3): v1);
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, vOffset + i * $Boxtype$.BYTES);
+            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, vOffset + i * $Boxtype$.BYTES);
+            $type$ v3 = Unsafe.getUnsafe().get$Type$(vec3, vOffset + i * $Boxtype$.BYTES);
+            $type$ v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v1, v2, v3) : v1;
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, v);
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -339,12 +346,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             return rOpTemplateMF(v, f);
         }
         VectorPayloadMF vec = this.vec_mf();
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES);
-            v = mbits[i] ? f.apply(i, v, v1) : v;
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES);
+            v = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i) ? f.apply(i, v, v1) : v;
         }
         return v;
     }
@@ -353,10 +361,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $type$ rOpTemplateMF($type$ v, FBinOp f) {
         VectorPayloadMF vec = this.vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES);
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES);
             v = f.apply(i, v, v1);
         }
         return v;
@@ -376,11 +384,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 $type$.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -394,13 +402,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   FLdOp<M> f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 $type$.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -420,11 +429,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 $type$.class, length));
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
+            Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
         return vectorFactory(tpayload);
@@ -438,13 +447,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   FLdLongOp f) {
         int length = vspecies().length();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.createVectPayloadInstance(
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
                 $type$.class, length));
-        long start_offset = this.multiFieldOffset();
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                Unsafe.getUnsafe().put$Type$(tpayload, start_offset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
             }
         }
         tpayload = Unsafe.getUnsafe().finishPrivateBuffer(tpayload);
@@ -465,10 +475,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> void stOpMF(M memory, int offset,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES));
         }
     }
 
@@ -479,12 +489,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                   VectorMask<$Boxtype$> m,
                   FStOp<M> f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES));
             }
         }
     }
@@ -500,10 +511,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     void stLongOpMF(MemorySegment memory, long offset,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        long start_offset = this.multiFieldOffset();
+        long vOffset = this.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES));
+            f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES));
         }
     }
 
@@ -514,12 +525,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                   VectorMask<$Boxtype$> m,
                   FStLongOp f) {
         VectorPayloadMF vec = vec_mf();
-        boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
-        long start_offset = this.multiFieldOffset();
+        VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         int length = vspecies().length();
         for (int i = 0; i < length; i++) {
-            if (mbits[i]) {
-                f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, start_offset + i * $Boxtype$.BYTES));
+            if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
+                f.apply(memory, offset, i, Unsafe.getUnsafe().get$Type$(vec, vOffset + i * $Boxtype$.BYTES));
             }
         }
     }
@@ -541,17 +553,20 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     AbstractMask<$Boxtype$> bTestMF(int cond,
                                   Vector<$Boxtype$> o,
                                   FBinTest f) {
+        int length = vspecies().length();
         VectorPayloadMF vec1 = this.vec_mf();
         VectorPayloadMF vec2 = (($abstractvectortype$)o).vec_mf();
-        int length = vspecies().length();
-        long start_offset = this.multiFieldOffset();
-        boolean[] bits = new boolean[length];
+        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
+        long vOffset = this.multiFieldOffset();
+        long mOffset = mbits.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, start_offset + i * $Boxtype$.BYTES);
-            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, start_offset + i * $Boxtype$.BYTES);
-            bits[i] = f.apply(cond, i, v1, v2);
+            $type$ v1 = Unsafe.getUnsafe().get$Type$(vec1, vOffset + i * $Boxtype$.BYTES);
+            $type$ v2 = Unsafe.getUnsafe().get$Type$(vec2, vOffset + i * $Boxtype$.BYTES);
+            Unsafe.getUnsafe().putBoolean(mbits, mOffset + i, f.apply(cond, i, v1, v2));
         }
-        return maskFactory(bits);
+        mbits = Unsafe.getUnsafe().finishPrivateBuffer(mbits);
+        return maskFactory(mbits);
     }
 
 #if[BITWISE]
@@ -5627,9 +5642,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         $Type$Vector vOpMF(VectorMask<$Boxtype$> m, FVOp f) {
             $type$[] res = new $type$[laneCount()];
-            boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+            VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
+            long mOffset = mbits.multiFieldOffset();
             for (int i = 0; i < res.length; i++) {
-                if (mbits[i]) {
+                if (Unsafe.getUnsafe().getBoolean(mbits, mOffset + i)) {
                     res[i] = f.apply(i);
                 }
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -903,7 +903,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             $masktype$ m = ($masktype$)mask;
             return VectorSupport.binaryOp(VECTOR_OP_AND, $masktype$.class, null,
                                           $bitstype$.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> ($masktype$) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -913,7 +913,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             $masktype$ m = ($masktype$)mask;
             return VectorSupport.binaryOp(VECTOR_OP_OR, $masktype$.class, null,
                                           $bitstype$.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> ($masktype$) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -923,7 +923,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             $masktype$ m = ($masktype$)mask;
             return VectorSupport.binaryOp(VECTOR_OP_XOR, $masktype$.class, null,
                                           $bitstype$.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> ($masktype$) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ value class $vectortype$ extends $abstractvectortype$ {
        return vec_mf();
     }
 
-    static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.createVectPayloadInstance($type$.class, $numLanes$));
-    static final $vectortype$ IOTA = new $vectortype$(VectorPayloadMF.createVectPayloadInstance$Boxinitials$($numLanes$, ($type$ [])(VSPECIES.iotaArray())));
+    static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.newInstanceFactory($type$.class, $numLanes$));
+    static final $vectortype$ IOTA = new $vectortype$(VectorPayloadMF.createVectPayloadInstance$Boxinitials$($numLanes$, ($type$[])(VSPECIES.iotaArray())));
 
     static {
         // Warm up a few species caches.
@@ -147,8 +147,8 @@ value class $vectortype$ extends $abstractvectortype$ {
 
     @Override
     @ForceInline
-    $masktype$ maskFromArray(boolean[] bits) {
-        return new $masktype$(bits);
+    $masktype$ maskFromPayload(VectorPayloadMF payload) {
+        return new $masktype$(payload);
     }
 
     @Override
@@ -848,34 +848,22 @@ value class $vectortype$ extends $abstractvectortype$ {
 
     // Mask
 
-    static final class $masktype$ extends AbstractMask<$Boxtype$> {
+    static final value class $masktype$ extends AbstractMask<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
 
-        $masktype$(boolean[] bits) {
-            this(bits, 0);
+        private final VectorPayloadMF$vectorsizeinbytes$Z payload;
+
+        $masktype$(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF$vectorsizeinbytes$Z) payload;
         }
 
-        $masktype$(boolean[] bits, int offset) {
-            super(prepare(bits, offset));
+        $masktype$(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, VLENGTH));
         }
 
         $masktype$(boolean val) {
-            super(prepare(val));
-        }
-
-        private static boolean[] prepare(boolean[] bits, int offset) {
-            boolean[] newBits = new boolean[VSPECIES.laneCount()];
-            for (int i = 0; i < newBits.length; i++) {
-                newBits[i] = bits[offset + i];
-            }
-            return newBits;
-        }
-
-        private static boolean[] prepare(boolean val) {
-            boolean[] bits = new boolean[VSPECIES.laneCount()];
-            Arrays.fill(bits, val);
-            return bits;
+            this(prepare(val, VLENGTH));
         }
 
         @ForceInline
@@ -888,29 +876,14 @@ value class $vectortype$ extends $abstractvectortype$ {
         }
 
         @ForceInline
-        boolean[] getBits() {
-            return (boolean[])getPayload();
+        final @Override
+        VectorPayloadMF getBits() {
+            return payload;
         }
 
         @Override
-        $masktype$ uOp(MUnOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i]);
-            }
-            return new $masktype$(res);
-        }
-
-        @Override
-        $masktype$ bOp(VectorMask<$Boxtype$> m, MBinOp f) {
-            boolean[] res = new boolean[vspecies().laneCount()];
-            boolean[] bits = getBits();
-            boolean[] mbits = (($masktype$)m).getBits();
-            for (int i = 0; i < res.length; i++) {
-                res[i] = f.apply(i, bits[i], mbits[i]);
-            }
-            return new $masktype$(res);
+        protected final Object getPayload() {
+            return getBits();
         }
 
         @ForceInline
@@ -918,33 +891,6 @@ value class $vectortype$ extends $abstractvectortype$ {
         public final
         $vectortype$ toVector() {
             return ($vectortype$) super.toVectorTemplate();  // specialize
-        }
-
-        /**
-         * Helper function for lane-wise mask conversions.
-         * This function kicks in after intrinsic failure.
-         */
-        @ForceInline
-        private final <E>
-        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
-            if (length() != dsp.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-            boolean[] maskArray = toArray();
-            return  dsp.maskFactory(maskArray).check(dsp);
-        }
-
-        @Override
-        @ForceInline
-        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
-            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
-            if (length() != species.laneCount())
-                throw new IllegalArgumentException("VectorMask length and species length differ");
-
-            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                this.getClass(), ETYPE, VLENGTH,
-                species.maskType(), species.elementType(), VLENGTH,
-                this, species,
-                (m, s) -> s.maskFactory(m.toArray()).check(s));
         }
 
         @Override
@@ -966,7 +912,7 @@ value class $vectortype$ extends $abstractvectortype$ {
         @Override
         @ForceInline
         public $masktype$ compress() {
-            return ($masktype$)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+            return ($masktype$) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 $vectortype$.class, $masktype$.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
@@ -979,9 +925,9 @@ value class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ and(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, $masktype$.class, null, $bitstype$.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+            return VectorSupport.binaryOp(VECTOR_OP_AND, $masktype$.class, null,
+                                          $bitstype$.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
@@ -989,9 +935,9 @@ value class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ or(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, $masktype$.class, null, $bitstype$.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+            return VectorSupport.binaryOp(VECTOR_OP_OR, $masktype$.class, null,
+                                          $bitstype$.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @ForceInline
@@ -999,9 +945,9 @@ value class $vectortype$ extends $abstractvectortype$ {
         $masktype$ xor(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, $masktype$.class, null, $bitstype$.class, VLENGTH,
-                                          this, m, null,
-                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, $masktype$.class, null,
+                                          $bitstype$.class, VLENGTH, this, m, null,
+                                          (m1, m2, vm) -> ($masktype$) m1.bOp(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -1010,21 +956,21 @@ value class $vectortype$ extends $abstractvectortype$ {
         @ForceInline
         public int trueCount() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, $masktype$.class, $bitstype$.class, VLENGTH, this,
-                                                      (m) -> trueCountHelper(m.getBits()));
+                                                            (m) -> (($masktype$) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, $masktype$.class, $bitstype$.class, VLENGTH, this,
-                                                      (m) -> firstTrueHelper(m.getBits()));
+                                                            (m) -> (($masktype$) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
             return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, $masktype$.class, $bitstype$.class, VLENGTH, this,
-                                                      (m) -> lastTrueHelper(m.getBits()));
+                                                            (m) -> (($masktype$) m).lastTrueHelper());
         }
 
         @Override
@@ -1034,7 +980,7 @@ value class $vectortype$ extends $abstractvectortype$ {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
             return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, $masktype$.class, $bitstype$.class, VLENGTH, this,
-                                                      (m) -> toLongHelper(m.getBits()));
+                                                      (m) -> (($masktype$) m).toLongHelper());
         }
 
         // Reductions
@@ -1044,7 +990,7 @@ value class $vectortype$ extends $abstractvectortype$ {
         public boolean anyTrue() {
             return VectorSupport.test(BT_ne, $masktype$.class, $bitstype$.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper((($masktype$)m).getBits()));
+                                         (m, __) -> (($masktype$) m).anyTrueHelper());
         }
 
         @Override
@@ -1052,7 +998,7 @@ value class $vectortype$ extends $abstractvectortype$ {
         public boolean allTrue() {
             return VectorSupport.test(BT_overflow, $masktype$.class, $bitstype$.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper((($masktype$)m).getBits()));
+                                         (m, __) -> (($masktype$) m).allTrueHelper());
         }
 
         @ForceInline
@@ -1067,13 +1013,16 @@ value class $vectortype$ extends $abstractvectortype$ {
 
 #if[intAndMax]
 
-        static boolean[] maskLowerHalf() {
-            boolean[] a = new boolean[VLENGTH];
-            int len = a.length >> 1;
+        static VectorPayloadMF maskLowerHalf() {
+            VectorPayloadMF newObj = VectorSupport.VectorPayloadMF.newInstanceFactory(boolean.class, VLENGTH);
+            newObj = Unsafe.getUnsafe().makePrivateBuffer(newObj);
+            long mf_offset = newObj.multiFieldOffset();
+            int len = VLENGTH >> 1;
             for (int i = 0; i < len; i++) {
-                a[i] = true;
+                Unsafe.getUnsafe().putBoolean(newObj, mf_offset + i, true);
             }
-            return a;
+            newObj = Unsafe.getUnsafe().finishPrivateBuffer(newObj);
+            return newObj;
         }
 
 #end[intAndMax]

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -60,16 +60,13 @@ value class $vectortype$ extends $abstractvectortype$ {
     private final VectorPayloadMF$bits$$Boxinitials$ payload;
 
     $vectortype$(Object value) {
-        this.payload = (VectorPayloadMF$bits$$Boxinitials$)value;
+        this.payload = (VectorPayloadMF$bits$$Boxinitials$) value;
     }
 
-    VectorPayloadMF vec_mf() {
-        return payload;
-    }
-
+    @ForceInline
     @Override
-    protected final Object getPayload() {
-       return vec_mf();
+    final VectorPayloadMF vec() {
+        return payload;
     }
 
     static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.newInstanceFactory($type$.class, $numLanes$));
@@ -122,15 +119,6 @@ value class $vectortype$ extends $abstractvectortype$ {
     @Override
     public final long multiFieldOffset() { return MFOFFSET; }
 
-    /*package-private*/
-    @ForceInline
-    final @Override
-    $type$[] vec() {
-        return ($type$[])getPayload();
-    }
-
-    // Virtualized constructors
-
     @Override
     @ForceInline
     public final $vectortype$ broadcast($type$ e) {
@@ -168,7 +156,7 @@ value class $vectortype$ extends $abstractvectortype$ {
 
     @Override
     @ForceInline
-    $shuffletype$ shuffleFromBytes(byte[] reorder) { return new $shuffletype$(reorder); }
+    $shuffletype$ shuffleFromBytes(VectorPayloadMF reorder) { return new $shuffletype$(reorder); }
 
     @Override
     @ForceInline
@@ -177,13 +165,6 @@ value class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     $shuffletype$ shuffleFromOp(IntUnaryOperator fn) { return new $shuffletype$(fn); }
-
-    // Make a vector of the same species but the given elements:
-    @ForceInline
-    final @Override
-    $vectortype$ vectorFactory($type$[] vec) {
-        return new $vectortype$(vec);
-    }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
@@ -579,7 +560,7 @@ value class $vectortype$ extends $abstractvectortype$ {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                         VectorPayloadMF vecpayload = vec.vec_mf();
+                         VectorPayloadMF vecpayload = vec.vec();
                          long start_offset = vecpayload.multiFieldOffset();
                          return (long)$Type$.$type$To$Bitstype$Bits(Unsafe.getUnsafe().get$Type$(vecpayload, start_offset + ix * $Boxtype$.BYTES));
                      });
@@ -629,7 +610,7 @@ value class $vectortype$ extends $abstractvectortype$ {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)$Type$.$type$To$Bitstype$Bits(e),
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().put$Type$(tpayload, start_offset + ix * $Boxtype$.BYTES, $Type$.$bitstype$BitsTo$Type$(($bitstype$)bits));
@@ -734,7 +715,7 @@ value class $vectortype$ extends $abstractvectortype$ {
                              VCLASS, ETYPE, VLENGTH,
                              this, i,
                              (vec, ix) -> {
-                                 VectorPayloadMF vecpayload = vec.vec_mf();
+                                 VectorPayloadMF vecpayload = vec.vec();
                                  long start_offset = vecpayload.multiFieldOffset();
                                  return (long)Unsafe.getUnsafe().get$Type$(vecpayload, start_offset + ix * $Boxtype$.BYTES);
                              });
@@ -836,7 +817,7 @@ value class $vectortype$ extends $abstractvectortype$ {
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    VectorPayloadMF vec = v.vec_mf();
+                                    VectorPayloadMF vec = v.vec();
                                     VectorPayloadMF tpayload = Unsafe.getUnsafe().makePrivateBuffer(vec);
                                     long start_offset = tpayload.multiFieldOffset();
                                     Unsafe.getUnsafe().put$Type$(tpayload, start_offset + ix * $Boxtype$.BYTES, ($type$)bits);
@@ -876,14 +857,9 @@ value class $vectortype$ extends $abstractvectortype$ {
         }
 
         @ForceInline
-        final @Override
-        VectorPayloadMF getBits() {
-            return payload;
-        }
-
         @Override
-        protected final Object getPayload() {
-            return getBits();
+        final VectorPayloadMF getBits() {
+            return payload;
         }
 
         @ForceInline
@@ -1014,7 +990,7 @@ value class $vectortype$ extends $abstractvectortype$ {
 #if[intAndMax]
 
         static VectorPayloadMF maskLowerHalf() {
-            VectorPayloadMF newObj = VectorSupport.VectorPayloadMF.newInstanceFactory(boolean.class, VLENGTH);
+            VectorPayloadMF newObj = VectorPayloadMF.newInstanceFactory(boolean.class, VLENGTH);
             newObj = Unsafe.getUnsafe().makePrivateBuffer(newObj);
             long mf_offset = newObj.multiFieldOffset();
             int len = VLENGTH >> 1;
@@ -1033,24 +1009,34 @@ value class $vectortype$ extends $abstractvectortype$ {
 
     // Shuffle
 
-    static final class $shuffletype$ extends AbstractShuffle<$Boxtype$> {
+    static final value class $shuffletype$ extends AbstractShuffle<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
 
-        $shuffletype$(byte[] reorder) {
-            super(VLENGTH, reorder);
+        private final VectorPayloadMF$vectorsizeinbytes$B payload;
+
+        $shuffletype$(VectorPayloadMF reorder) {
+            this.payload = (VectorPayloadMF$vectorsizeinbytes$B) reorder;
+            assert(VLENGTH == reorder.length());
+            assert(indexesInRange(reorder));
         }
 
         public $shuffletype$(int[] reorder) {
-            super(VLENGTH, reorder);
+            this(reorder, 0);
         }
 
         public $shuffletype$(int[] reorder, int i) {
-            super(VLENGTH, reorder, i);
+            this(prepare(VLENGTH, reorder, i));
         }
 
         public $shuffletype$(IntUnaryOperator fn) {
-            super(VLENGTH, fn);
+            this(prepare(VLENGTH, fn));
+        }
+
+        @ForceInline
+        @Override
+        protected final VectorPayloadMF reorder() {
+            return payload;
         }
 
         @Override
@@ -1087,13 +1073,17 @@ value class $vectortype$ extends $abstractvectortype$ {
         @Override
         public $shuffletype$ rearrange(VectorShuffle<$Boxtype$> shuffle) {
             $shuffletype$ s = ($shuffletype$) shuffle;
-            byte[] reorder1 = reorder();
-            byte[] reorder2 = s.reorder();
-            byte[] r = new byte[reorder1.length];
-            for (int i = 0; i < reorder1.length; i++) {
-                int ssi = reorder2[i];
-                r[i] = reorder1[ssi];  // throws on exceptional index
+            VectorPayloadMF reorder1 = reorder();
+            VectorPayloadMF reorder2 = s.reorder();
+            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            r = Unsafe.getUnsafe().makePrivateBuffer(r);
+            long offset = r.multiFieldOffset();
+            for (int i = 0; i < VLENGTH; i++) {
+                int ssi = Unsafe.getUnsafe().getByte(reorder2, offset + i * Byte.BYTES);
+                int si = Unsafe.getUnsafe().getByte(reorder1, offset + ssi * Byte.BYTES);
+                Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
+            r = Unsafe.getUnsafe().finishPrivateBuffer(r);
             return new $shuffletype$(r);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -154,6 +154,7 @@ do
     bitsvectortype=${typeprefix}${Bitstype}${bits}Vector
     fpvectortype=${typeprefix}${Fptype}${bits}Vector
     vectorindexbits=$((bits * 4 / sizeInBytes))
+    vectorsizeinbytes=$((bits / sizeInBytes))
 
     numLanes=$((bits / (sizeInBytes * 8)))
     if [[ "${numLanes}" == "1" ]]; then
@@ -192,7 +193,7 @@ do
     if [[ "${vectortype}" == "IntMaxVector" ]]; then
       args="$args -KintAndMax"
     fi
-    bitargs="$args -Dbits=$bits -DBITS=$BITS -Dvectortype=$vectortype -DnumLanes=$numLanes  -Dmasktype=$masktype -Dshuffletype=$shuffletype -Dbitsvectortype=$bitsvectortype -Dfpvectortype=$fpvectortype -Dvectorindextype=$vectorindextype -Dshape=$shape -DShape=$Shape"
+    bitargs="$args -Dbits=$bits -DBITS=$BITS -Dvectortype=$vectortype -DnumLanes=$numLanes  -Dmasktype=$masktype -Dshuffletype=$shuffletype -Dbitsvectortype=$bitsvectortype -Dfpvectortype=$fpvectortype -Dvectorindextype=$vectorindextype -Dshape=$shape -DShape=$Shape -Dvectorsizeinbytes=$vectorsizeinbytes"
 
     case $vectortype in
     $CLASS_FILTER)


### PR DESCRIPTION
This patch changes the Vector API java side and hotspot compiler code to make the `VectorMask` and `VectorShuffle` operations work well after integrating with valhalla value/primitive classes.

Java side changes include:
 - Define the concrete `VectorMask/VectorShuffle `classes as value class.
 - Define the payload field type as primitive classes, which defines `MultiField` annotated field to save the element values.
 - Change all the relative API implementations, which use Unsafe APIs to access the new payload.
 - Move several VectorMask default operations to the abstract super class.
 - Minor code cleanup.

Compiler changes include:
 - Enable intrinsification for `VectorMask/VectorShuffle` related operations.
   Mask input/output of `VectorBox/VectorUnbox` is changed to the boolean vector format, to adapt C2's `InlineTypeNode`
   and new `VectorBox` features. Note that the mask input/output is a normal vector or predicate before.
 - Refine `VectorBox` expanding logic to make it right when the primitive payload instance is not flattened.
 - Minor code cleanup.

Basic VectorMask/VectorShuffle jtreg tests pass with"`-XX:+UnlockExperimentalVMOptions -XX:-EnableVectorSupport`",
and the basic unit tests work well after enabling vector support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8307715](https://bugs.openjdk.org/browse/JDK-8307715): Integrate VectorMask/Shuffle with value/primitive classes


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - no project role) ⚠️ Review applies to [cc776d06](https://git.openjdk.org/valhalla/pull/845/files/cc776d06063517d0c4539e7d7e478f44d89a22c4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/845/head:pull/845` \
`$ git checkout pull/845`

Update a local copy of the PR: \
`$ git checkout pull/845` \
`$ git pull https://git.openjdk.org/valhalla.git pull/845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 845`

View PR using the GUI difftool: \
`$ git pr show -t 845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/845.diff">https://git.openjdk.org/valhalla/pull/845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/845#issuecomment-1548960128)