### PR TITLE
8309036: [lworld] Assert during C2 compilation "possible deadlock"

### DIFF
--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -106,7 +106,7 @@ public:
   ciType* type() { return (_type == nullptr) ? compute_type() : _type; }
 
   // How is this field actually stored in memory?
-  BasicType layout_type() { return type2field[type()->basic_type()]; }
+  BasicType layout_type() { return type2field[(_type == nullptr) ? T_OBJECT : _type->basic_type()]; }
 
   // How big is this field in memory?
   int size_in_bytes() { return type2aelembytes(layout_type()); }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2351,7 +2351,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
 
         ciField* field = vk->get_non_flattened_field_by_offset(off);
         if (field != nullptr) {
-          BasicType bt = field->layout_type();
+          BasicType bt = field->type()->basic_type();
           if (bt == T_ARRAY || bt == T_NARROWOOP || (bt == T_PRIMITIVE_OBJECT && !field->is_flattened())) {
             bt = T_OBJECT;
           }
@@ -2439,7 +2439,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
       field = k->get_non_flattened_field_by_offset(off);
     }
     if (field != nullptr) {
-      bt = field->layout_type();
+      bt = field->type()->basic_type();
     }
     assert(bt == alias_type->basic_type() || bt == T_PRIMITIVE_OBJECT, "should match");
     if (field != nullptr && bt == T_PRIMITIVE_OBJECT && !field->is_flattened()) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2351,7 +2351,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
 
         ciField* field = vk->get_non_flattened_field_by_offset(off);
         if (field != nullptr) {
-          BasicType bt = field->type()->basic_type();
+          BasicType bt = type2field[field->type()->basic_type()];
           if (bt == T_ARRAY || bt == T_NARROWOOP || (bt == T_PRIMITIVE_OBJECT && !field->is_flattened())) {
             bt = T_OBJECT;
           }
@@ -2439,7 +2439,7 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
       field = k->get_non_flattened_field_by_offset(off);
     }
     if (field != nullptr) {
-      bt = field->type()->basic_type();
+      bt = type2field[field->type()->basic_type()];
     }
     assert(bt == alias_type->basic_type() || bt == T_PRIMITIVE_OBJECT, "should match");
     if (field != nullptr && bt == T_PRIMITIVE_OBJECT && !field->is_flattened()) {


### PR DESCRIPTION
The fix for [JDK-8304743](https://bugs.openjdk.org/browse/JDK-8304743) that came in with the recent merge removed the `ttyUnlocker` from `ciEnv::get_klass_by_name_impl` which revealed an old regression from [JDK-8206144](https://bugs.openjdk.org/browse/JDK-8206144): A call to `ciField::layout_type()` triggers a re-computation of the type via a SystemDictionary lookup while holding the ttyLock.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309036](https://bugs.openjdk.org/browse/JDK-8309036): [lworld] Assert during C2 compilation "possible deadlock"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/854/head:pull/854` \
`$ git checkout pull/854`

Update a local copy of the PR: \
`$ git checkout pull/854` \
`$ git pull https://git.openjdk.org/valhalla.git pull/854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 854`

View PR using the GUI difftool: \
`$ git pr show -t 854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/854.diff">https://git.openjdk.org/valhalla/pull/854.diff</a>

</details>
