### PR TITLE
8308756: [lworld] compiler/ciReplay/TestInliningProtectionDomain.java fails because CDS is disabled

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -42,7 +42,8 @@ public class TestInliningProtectionDomain extends InliningBase {
     public static void main(String[] args) {
         new TestInliningProtectionDomain(ProtectionDomainTestCompiledBefore.class, true);
         new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPublic.class, false);
-        new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivate.class, false);
+        // TODO Re-enable this once 8284443 fixed handling of unloaded return types
+        // new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivate.class, false);
         new TestInliningProtectionDomain(ProtectionDomainTestNoOtherCompilationPrivateString.class, false);
     }
 
@@ -51,7 +52,6 @@ public class TestInliningProtectionDomain extends InliningBase {
         if (compileBar) {
             commandLineNormal.add("-XX:CompileCommand=compileonly," + testClass.getName() + "::bar");
         }
-        commandLineNormal.add("-XX:-InlineTypeReturnedAsFields"); // TODO Remove this once 8284443 fixed handling of unloaded return types
         runTest();
     }
 


### PR DESCRIPTION
I added `-XX:-InlineTypeReturnedAsFields` as a temporary workaround with [JDK-8301007](https://bugs.openjdk.org/browse/JDK-8301007) until [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) is fixed but that disables CDS because of a flag mismatch (see [JDK-8272290](https://bugs.openjdk.org/browse/JDK-8272290)). The test now fails due to mainline issue [JDK-8277301](https://bugs.openjdk.org/browse/JDK-8277301) which we seem to reliably trigger after the recent merge.

Let's just disable the problematic sub-test completely until [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8308756](https://bugs.openjdk.org/browse/JDK-8308756): [lworld] compiler/ciReplay/TestInliningProtectionDomain.java fails because CDS is disabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/856/head:pull/856` \
`$ git checkout pull/856`

Update a local copy of the PR: \
`$ git checkout pull/856` \
`$ git pull https://git.openjdk.org/valhalla.git pull/856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 856`

View PR using the GUI difftool: \
`$ git pr show -t 856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/856.diff">https://git.openjdk.org/valhalla/pull/856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/856#issuecomment-1573675659)