### PR TITLE
8309353: [lworld] C2 compilations fails with assert(false) failed: type flow analysis failed for OSR compilation

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -515,7 +515,9 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
     _entry_bci = C->entry_bci();
     _flow = method()->get_osr_flow_analysis(osr_bci());
     if (_flow->failing()) {
-      assert(false, "type flow analysis failed for OSR compilation");
+      // TODO Adding a trap due to an unloaded return type in ciTypeFlow::StateVector::do_invoke
+      // can lead to this. Re-enable once 8284443 is fixed.
+      // assert(false, "type flow analysis failed for OSR compilation");
       C->record_method_not_compilable(_flow->failure_reason());
 #ifndef PRODUCT
       if (PrintOpto && (Verbose || WizardMode)) {


### PR DESCRIPTION
With [JDK-8301007](https://bugs.openjdk.org/browse/JDK-8301007) we added a trap at calls to methods with unloaded return type in C2 until [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) is fixed. This can lead to a rare and harmless compilation bailout   for OSR compilations which triggers an assert now that we merged in [JDK-8303951](https://bugs.openjdk.org/browse/JDK-8303951) from mainline. Let's simply disable that assert again until [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) is fixed.

Thanks,
Tobias