### PR TITLE
8309586: [lworld] Feature version post merge doesn't match CheckFeatureGate1.java & CheckFeatureGate2.java

### DIFF
--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate1.out
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate1.out
@@ -1,2 +1,2 @@
-CheckFeatureGate1.java:10:12: compiler.err.primitive.classes.not.supported: 19
+CheckFeatureGate1.java:10:12: compiler.err.primitive.classes.not.supported: 21
 1 error

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate2.out
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFeatureGate2.out
@@ -1,2 +1,2 @@
-CheckFeatureGate2.java:11:17: compiler.err.primitive.classes.not.supported: 19
+CheckFeatureGate2.java:11:17: compiler.err.primitive.classes.not.supported: 21
 1 error


### PR DESCRIPTION
Tweak expected output version

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309586](https://bugs.openjdk.org/browse/JDK-8309586): [lworld] Feature version post merge doesn't match CheckFeatureGate1.java &amp; CheckFeatureGate2.java (**Bug** - `"4"`)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/859/head:pull/859` \
`$ git checkout pull/859`

Update a local copy of the PR: \
`$ git checkout pull/859` \
`$ git pull https://git.openjdk.org/valhalla.git pull/859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 859`

View PR using the GUI difftool: \
`$ git pr show -t 859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/859.diff">https://git.openjdk.org/valhalla/pull/859.diff</a>

</details>
