### PR TITLE
8309650: [lworld] Fix mismatch inline type issue during method calls

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -1167,7 +1167,7 @@ static void cast_argument(int nargs, int arg_nb, ciType* t, GraphKit& kit, bool 
     kit.set_argument(arg_nb, arg);
   }
   if (sig_type->is_inlinetypeptr()) {
-    arg = InlineTypeNode::make_from_oop(&kit, arg, t->as_inline_klass(), !kit.gvn().type(arg)->maybe_null());
+    arg = InlineTypeNode::make_from_oop(&kit, arg, sig_type->inline_klass(), !kit.gvn().type(arg)->maybe_null());
     kit.set_argument(arg_nb, arg);
   }
 }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1950,8 +1950,12 @@ Node* GraphKit::set_results_for_java_call(CallJavaNode* call, bool separate_io_p
     ret = InlineTypeNode::make_from_multi(this, call, vk, base_input, false, call->method()->signature()->returns_null_free_inline_type());
   } else {
     ret = _gvn.transform(new ProjNode(call, TypeFunc::Parms));
-    if (call->method()->return_type()->is_inlinetype()) {
-      ret = InlineTypeNode::make_from_oop(this, ret, call->method()->return_type()->as_inline_klass(), call->method()->signature()->returns_null_free_inline_type());
+    ciType* t = call->method()->return_type();
+    if (t->is_klass()) {
+      const Type* type = TypeOopPtr::make_from_klass(t->as_klass());
+      if (type->is_inlinetypeptr()) {
+        ret = InlineTypeNode::make_from_oop(this, ret, type->inline_klass(), type->inline_klass()->is_null_free());
+      }
     }
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCastMismatch.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCastMismatch.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8309650
+ * @summary Fix mismatch inline type issue during method calls
+ * @library /test/lib
+ * @compile TestCastMismatch.java
+ * @run main/othervm -XX:+EnableValhalla -XX:-TieredCompilation -Xcomp
+ *                   compiler.valhalla.inlinetypes.TestCastMismatch
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class TestCastMismatch {
+    private static int LOOP_COUNT = 50000;
+
+    private static final Random RD = Utils.getRandomInstance();
+
+    public static MultiValues add(MultiValues v1, MultiValues v2) {
+        return v1.factory(v1.value1() + v2.value1(), v1.value2() + v2.value2());
+    }
+
+    public static void main(String[] args) {
+        Point p1 = new Point(RD.nextInt(), RD.nextInt());
+        Point p2 = new Point(RD.nextInt(), RD.nextInt());
+        for (int i = 0; i < LOOP_COUNT; i++) {
+            p1 = (Point) add(p1, p2);
+        }
+
+        System.out.println("PASS");
+    }
+
+    static abstract class MultiValues {
+        public abstract int value1();
+        public abstract int value2();
+        public abstract MultiValues factory(int value1, int value2);
+    }
+
+    static value class Point extends MultiValues {
+        private int x;
+        private int y;
+
+        private Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public int value1() {
+            return x;
+        }
+
+        @Override
+        public int value2() {
+            return y;
+        }
+
+        @Override
+        public Point factory(int value1, int value2) {
+            return new Point(value1, value2);
+        }
+    }
+}
+


### PR DESCRIPTION
JVM crashes with following assertion failure when running the new added
 test case (i.e. `compiler/valhalla/inlinetypes/TestCastMismatch.java`):

```
A fatal error has been detected by the Java Runtime Environment:

 Internal Error (/mnt/local/code/valhalla/src/hotspot/share/opto/graphKit.cpp:3414), pid=1533674, tid=1533690
 assert(stopped() || !toop->is_inlinetypeptr() || obj->is_InlineType()) failed: should have been scalarized

 Problematic frame:
 V [[libjvm.so](http://libjvm.so/)+0xd2c070] GraphKit::gen_checkcast(Node*, Node*, Node**, bool)+0x46c
```

The failure happens when compiler knows the type of the `checkcast`
 input is a value/primitive class, while the input node is not an
 `InlineTypeNode`. Note that `InlineTypeNode` is use to represent each
 value/primitive class instance.

In the test case, the input of cast is a method call. And from the
 method declaration, the return type of this method is an abstract class
 whose concrete subclass is a value class. From the method signature,
 the compiler knows the return type is not a value class. Hence, when
 it handles the return result of this method call, no `InlineTypeNode`
 is generated. But when compiler handles the `checkcast` bytecode, it
 checks the speculative type of the input, which is actually the concrete
 class of the instance. In this case, it is the value class. So compiler
 expects the input node is an `InlineTypeNode`.

To fix this issue, the compiler has to use the consistent type system
 for different routines. This patch changes to use the speculative
 type of the method call as well when handling the call's return result.
 With this change, an `InlineTypeNode` is generated for this case after
 the call, and the assertion pass.

Verified with `hotspot::hotspot_all, jdk::tier1,tier2,tier3, langtool::tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309650](https://bugs.openjdk.org/browse/JDK-8309650): [lworld] Fix mismatch inline type issue during method calls (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/860/head:pull/860` \
`$ git checkout pull/860`

Update a local copy of the PR: \
`$ git checkout pull/860` \
`$ git pull https://git.openjdk.org/valhalla.git pull/860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 860`

View PR using the GUI difftool: \
`$ git pr show -t 860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/860.diff">https://git.openjdk.org/valhalla/pull/860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/860#issuecomment-1584190509)