### PR TITLE
8310022: [lworld] C1 compilation asserts with new lightweight locking

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -325,12 +325,6 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
 
   // "lock" stores the address of the monitor stack slot, so this is not an oop
   LIR_Opr lock = new_register(T_INT);
-  // Need a scratch register for inline types on x86
-  LIR_Opr scratch = LIR_OprFact::illegalOpr;
-  if (EnableValhalla && x->maybe_inlinetype()) {
-    scratch = new_register(T_INT);
-    assert(LockingMode != LM_LIGHTWEIGHT, "LM_LIGHTWEIGHT not yet compatible with EnableValhalla");
-  }
 
   CodeEmitInfo* info_for_exception = nullptr;
   if (x->needs_null_check()) {
@@ -345,7 +339,8 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   // this CodeEmitInfo must not have the xhandlers because here the
   // object is already locked (xhandlers expect object to be unlocked)
   CodeEmitInfo* info = state_for(x, x->state(), true);
-  monitor_enter(obj.result(), lock, syncTempOpr(), scratch,
+  LIR_Opr tmp = LockingMode == LM_LIGHTWEIGHT ? new_register(T_ADDRESS) : LIR_OprFact::illegalOpr;
+  monitor_enter(obj.result(), lock, syncTempOpr(), tmp,
                 x->monitor_no(), info_for_exception, info, throw_imse_stub);
 }
 

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -325,6 +325,12 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
 
   // "lock" stores the address of the monitor stack slot, so this is not an oop
   LIR_Opr lock = new_register(T_INT);
+  // Need a scratch register for inline types on x86
+  LIR_Opr scratch = LIR_OprFact::illegalOpr;
+  if ((LockingMode == LM_LIGHTWEIGHT) ||
+      (EnableValhalla && x->maybe_inlinetype())) {
+    scratch = new_register(T_ADDRESS);
+  }
 
   CodeEmitInfo* info_for_exception = nullptr;
   if (x->needs_null_check()) {
@@ -339,8 +345,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   // this CodeEmitInfo must not have the xhandlers because here the
   // object is already locked (xhandlers expect object to be unlocked)
   CodeEmitInfo* info = state_for(x, x->state(), true);
-  LIR_Opr tmp = LockingMode == LM_LIGHTWEIGHT ? new_register(T_ADDRESS) : LIR_OprFact::illegalOpr;
-  monitor_enter(obj.result(), lock, syncTempOpr(), tmp,
+  monitor_enter(obj.result(), lock, syncTempOpr(), scratch,
                 x->monitor_no(), info_for_exception, info, throw_imse_stub);
 }
 

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -64,7 +64,6 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   movptr(hdr, Address(obj, hdr_offset));
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    assert(!EnableValhalla, "LM_LIGHTWEIGHT not yet compatible with EnableValhalla");
 #ifdef _LP64
     const Register thread = r15_thread;
 #else


### PR DESCRIPTION
Let's remove the asserts until support for the new lightweight locking is implemented by [JDK-8310023](https://bugs.openjdk.org/browse/JDK-8310023) to avoid failures with tests that run with `-XX:LockingMode=2` but don't use any inline types.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310022](https://bugs.openjdk.org/browse/JDK-8310022): [lworld] C1 compilation asserts with new lightweight locking (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/862/head:pull/862` \
`$ git checkout pull/862`

Update a local copy of the PR: \
`$ git checkout pull/862` \
`$ git pull https://git.openjdk.org/valhalla.git pull/862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 862`

View PR using the GUI difftool: \
`$ git pr show -t 862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/862.diff">https://git.openjdk.org/valhalla/pull/862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/862#issuecomment-1591301674)