### PR TITLE
8309777: [lworld+vector] Fix re-materialize crash for vector objects with un-vectorized multi-fields during deoptimization

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -507,28 +507,45 @@ void JVMState::format(PhaseRegAlloc *regalloc, const Node *n, outputStream* st) 
           Node* init_node = mcall->in(first_ind++);
           if (!init_node->is_top()) {
             st->print(" [is_init");
-            format_helper(regalloc, st, init_node, ":", -1, NULL);
+            format_helper(regalloc, st, init_node, ":", -2, NULL);
           }
+
+          Node* larval_node = mcall->in(first_ind++);
+          assert(larval_node != NULL && larval_node->is_Con(), "is_larval node not found");
+          st->print(" [is_larval");
+          format_helper(regalloc, st, larval_node, ":", -1, NULL);
         }
-        Node* fld_node = mcall->in(first_ind);
+
         ciField* cifield;
-        if (iklass != NULL) {
-          st->print(" [");
-          cifield = iklass->nonstatic_field_at(0);
-          cifield->print_name_on(st);
-          format_helper(regalloc, st, fld_node, ":", 0, &scobjs);
-        } else {
-          format_helper(regalloc, st, fld_node, "[", 0, &scobjs);
-        }
-        for (uint j = 1; j < nf; j++) {
-          fld_node = mcall->in(first_ind+j);
+        uint sec_fields_count = 0;
+        for (uint j = 0; j < nf; j++) {
+          Node* fld_node = mcall->in(first_ind + j);
           if (iklass != NULL) {
-            st->print(", [");
-            cifield = iklass->nonstatic_field_at(j);
+            st->print(" [");
+            cifield = iklass->nonstatic_field_at(j - sec_fields_count);
             cifield->print_name_on(st);
             format_helper(regalloc, st, fld_node, ":", j, &scobjs);
+            sec_fields_count = 0;
+            if (cifield->is_multifield_base() && !fld_node->bottom_type()->isa_vect()) {
+              sec_fields_count = cifield->secondary_fields_count() - 1;
+              for (uint f = 0; f < sec_fields_count; f++) {
+                st->print(" [");
+                fld_node = mcall->in(first_ind + j + f + 1);
+                ciField* sec_field = static_cast<ciMultiField*>(cifield)->secondary_field_at(f);
+                sec_field->print_name_on(st);
+                format_helper(regalloc, st, fld_node, ":", j + f + 1, &scobjs);
+                if (f < sec_fields_count - 1) {
+                  st->print(",");
+                }
+              }
+              j += sec_fields_count;
+            }
           } else {
-            format_helper(regalloc, st, fld_node, ", [", j, &scobjs);
+            format_helper(regalloc, st, fld_node, " [", j, &scobjs);
+          }
+
+          if (j < nf - 1) {
+            st->print(",");
           }
         }
       }

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -299,6 +299,9 @@ InstanceKlass* VectorSupport::get_vector_payload_klass(BasicType elem_bt, int nu
 }
 
 Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, int num_elem, BasicType elem_bt, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS) {
+  assert(ov->field_size() == 1, "%s not a vector", ik->name()->as_C_string());
+  assert(ik->is_inline_klass(), "");
+
   ScopeValue* payload = ov->field_at(0);
   intptr_t is_larval = StackValue::create_stack_value(fr, reg_map, ov->is_larval())->get_int();
   jint larval = (jint)*((jint*)&is_larval);

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,6 @@ class VectorSupport : AllStatic {
  private:
   static Handle allocate_vector_payload_helper(InstanceKlass* ik, int num_elem, BasicType elem_bt, frame* fr, RegisterMap* reg_map, Location location, int larval, TRAPS);
   static Handle allocate_vector_payload(InstanceKlass* ik, int num_elem, BasicType elem_bt, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS);
-
-  static void init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr);
 
   static BasicType klass2bt(InstanceKlass* ik);
   static jint klass2length(InstanceKlass* ik);


### PR DESCRIPTION
Some vector API jtreg tests crash when running on hardwares that do
 not support the relative vector species.

Here is the log:

```
  A fatal error has been detected by the Java Runtime Environment:

  Internal Error (valhalla/src/hotspot/share/prims/vectorSupport.cpp:317), pid=2529357, tid=2529377
  assert(loc_type == Location::oop || loc_type == Location::narrowoop) failed: expected 'oop'(2) or 'narrowoop'(9) types location but got: 3

  JRE version: OpenJDK Runtime Environment (21.0) (fastdebug build 21-internal-git-62ba7fc27)
  Java VM: OpenJDK 64-Bit Server VM (fastdebug 21-internal-git-62ba7fc27, mixed mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
  Problematic frame:
  V [[libjvm.so](http://libjvm.so/)+0x1aed828] VectorSupport::allocate_vector_payload(InstanceKlass*, int, BasicType, frame*, RegisterMap*, ObjectValue*, JavaThread*)+0x41
```

The root cause is `VectorSupport::allocate_vector_payload` assumes the
 `ScopeValue` which denotes the field value generated by C2 compiler
 is a vector or an oop. But after the vector's payload is changed to be
 the `MultiField` annotated field, the non-static fields of the vector
 class is changed to be a series of fields with the same primitive type.
 In C2 compiler, operations for such multi-fields can be vectorized only
 if the running hardware supports the vector operations for the specified
 vector size. For such cases, the field value generated by C2 is a vector.
 Otherwise, the fields are the scalarized primitive type values. Hence
 the re-materizalization for such vector objects should be handled just
 like other normal objects.

To make things right when re-materializing vector objects whose fields
 are not vectorized, two parts need to be modified:

1. In c2 compiler, pass the un-vectorized multi-fields on safepoint when
 scalaring an `InlineTypeNode`. To try to vectorize the multi-fields in
 compiler, only the multi-field base is added to the klass's non-static
 field list. And the other multi-fields are saved in a secondary field list
 of their multi-field base. So if the multi-fields are not vectorized, all
 the field members should be found out and passed to the safepoint.

2. During deoptimization, re-materialize the vector objects with different
 routines based on the `ScopeValue` types. That is, go to the `VectorSupport`
 routine to re-allocate the objects from a vector value, while go to the
 normal objects re-allocation path if the field value is not a vector.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309777](https://bugs.openjdk.org/browse/JDK-8309777): [lworld+vector] Fix re-materialize crash for vector objects with un-vectorized multi-fields during deoptimization (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/863/head:pull/863` \
`$ git checkout pull/863`

Update a local copy of the PR: \
`$ git checkout pull/863` \
`$ git pull https://git.openjdk.org/valhalla.git pull/863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 863`

View PR using the GUI difftool: \
`$ git pr show -t 863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/863.diff">https://git.openjdk.org/valhalla/pull/863.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/863#issuecomment-1598190157)