### PR TITLE
8310678: [lw5] add implicit constructors

### DIFF
--- a/src/java.base/share/classes/java/lang/NonAtomic.java
+++ b/src/java.base/share/classes/java/lang/NonAtomic.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+/**
+ * A restricted interface optionally implemented by value objects.
+ *
+ * A value object is an instance of a value class, lacking identity.
+ *
+ * Every object is either an *identity object* or a *value object*. Identity
+ * objects have a unique identity determined for them at instance creation time and
+ * preserved throughout their life.
+ *
+ * value objects do *not* have an identity. Instead, they simply aggregate a
+ * set of immutable field values. The lack of identity enables certain performance
+ * optimizations by Java Virtual Machine implementations.
+ * The following operations have special behavior when applied to value
+ * objects:
+ *
+ * - The `==` operator, and the default implementation of the `Object.equals`
+ * method, compare the values of the operands' fields. Value objects
+ * created at different points in a program may be `==`.
+ *
+ * - The `System.identityHashCode` method, and the default implementation of the
+ * `Object.hashCode` method, generate a hash code from the hash codes of a
+ * value object's fields.
+ *
+ * - The `synchronized` modifier and `synchronized` statement always fail when
+ * applied to a value object.
+ *
+ * A value class with an `implicit` constructor may also declare that it tolerates
+ * implicit creation of instances via non-atomic field and array updates.
+ * This means that, in a race condition, new class instances may be accidentally
+ * created by intermixing field values from other instances, without any code
+ * execution or other additional cooperation from the value class. A value class
+ * opts in to allowing this behavior by implementing this interface.
+ *
+ * @since Valhalla
+ */
+
+public interface NonAtomic {
+}

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -97,6 +97,12 @@ public enum Modifier {
      */
     IDENTITY,
 
+    /**
+     * The modifier {@code implicit}
+     * @since 21
+     */
+    IMPLICIT,
+
     /** The modifier {@code final} */           FINAL,
     /** The modifier {@code transient} */       TRANSIENT,
     /** The modifier {@code volatile} */        VOLATILE,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -105,11 +105,13 @@ public class Flags {
     // bit positions, we translate them when reading and writing class
     // files into unique bits positions: ACC_SYNTHETIC <-> SYNTHETIC,
     // for example.
-    public static final int ACC_IDENTITY = 0x0020;
-    public static final int ACC_VALUE    = 0x0040;
-    public static final int ACC_BRIDGE   = 0x0040;
-    public static final int ACC_VARARGS  = 0x0080;
-    public static final int ACC_MODULE   = 0x8000;
+    public static final int ACC_DEFAULT    = 0x0001;
+    public static final int ACC_NON_ATOMIC = 0x0002;
+    public static final int ACC_IDENTITY   = 0x0020;
+    public static final int ACC_VALUE      = 0x0040;
+    public static final int ACC_BRIDGE     = 0x0040;
+    public static final int ACC_VARARGS    = 0x0080;
+    public static final int ACC_MODULE     = 0x8000;
 
     /*****************************************
      * Internal compiler flags (no bits in the lower 16).
@@ -420,6 +422,11 @@ public class Flags {
     public static final long NON_SEALED = 1L<<63; // ClassSymbols
 
     /**
+     * Flag to indicate that a value class constructor is implicit
+     */
+    public static final int IMPLICIT    = 1<<59; // MethodSymbols
+
+    /**
      * Describe modifier flags as they migh appear in source code, i.e.,
      * separated by spaces and in the order suggested by JLS 8.1.1.
      */
@@ -441,7 +448,7 @@ public class Flags {
         InterfaceVarFlags                 = FINAL | STATIC | PUBLIC,
         VarFlags                          = AccessFlags | FINAL | STATIC |
                                             VOLATILE | TRANSIENT | ENUM,
-        ConstructorFlags                  = AccessFlags,
+        ConstructorFlags                  = AccessFlags | IMPLICIT,
         InterfaceMethodFlags              = ABSTRACT | PUBLIC,
         MethodFlags                       = AccessFlags | ABSTRACT | STATIC | NATIVE |
                                             SYNCHRONIZED | FINAL | STRICTFP,
@@ -455,7 +462,7 @@ public class Flags {
         ExtendedClassFlags                = (long)ClassFlags | SEALED | NON_SEALED | VALUE_CLASS,
         ExtendedLocalClassFlags           = (long) LocalClassFlags | VALUE_CLASS,
         ExtendedStaticLocalClassFlags     = (long) StaticLocalClassFlags | VALUE_CLASS,
-        ModifierFlags                     = ((long)StandardFlags & ~INTERFACE) | DEFAULT | SEALED | NON_SEALED | VALUE_CLASS,
+        ModifierFlags                     = ((long)StandardFlags & ~INTERFACE) | DEFAULT | SEALED | NON_SEALED | VALUE_CLASS | IMPLICIT,
         InterfaceMethodMask               = ABSTRACT | PRIVATE | STATIC | PUBLIC | STRICTFP | DEFAULT,
         AnnotationTypeElementMask         = ABSTRACT | PUBLIC,
         LocalVarFlags                     = FINAL | PARAMETER,
@@ -482,6 +489,7 @@ public class Flags {
             if (0 != (flags & STRICTFP))  modifiers.add(Modifier.STRICTFP);
             if (0 != (flags & DEFAULT))   modifiers.add(Modifier.DEFAULT);
             if (0 != (flags & VALUE_CLASS))     modifiers.add(Modifier.VALUE);
+            if (0 != (flags & IMPLICIT))        modifiers.add(Modifier.IMPLICIT);
             modifiers = Collections.unmodifiableSet(modifiers);
             modifierSets.put(flags, modifiers);
         }
@@ -502,7 +510,6 @@ public class Flags {
     public static boolean isConstant(Symbol.VarSymbol symbol) {
         return symbol.getConstValue() != null;
     }
-
 
     public enum Flag {
         PUBLIC(Flags.PUBLIC),
@@ -531,6 +538,7 @@ public class Flags {
                 return "identity";
             }
         },
+        IMPLICIT(Flags.IMPLICIT),
         UNNAMED_CLASS(Flags.UNNAMED_CLASS),
         BLOCK(Flags.BLOCK),
         FROM_SOURCE(Flags.FROM_SOURCE),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -238,7 +238,6 @@ public enum Source {
         UNCONDITIONAL_PATTERN_IN_INSTANCEOF(JDK21, Fragments.FeatureUnconditionalPatternsInInstanceof, DiagKind.PLURAL),
         RECORD_PATTERNS(JDK21, Fragments.FeatureDeconstructionPatterns, DiagKind.PLURAL),
         STRING_TEMPLATES(JDK21, Fragments.FeatureStringTemplates, DiagKind.PLURAL),
-        PRIMITIVE_CLASSES(JDK21, Fragments.FeaturePrimitiveClasses, DiagKind.PLURAL),
         VALUE_CLASSES(JDK21, Fragments.FeatureValueClasses, DiagKind.PLURAL),
         UNNAMED_CLASSES(JDK21, Fragments.FeatureUnnamedClasses, DiagKind.PLURAL),
         WARN_ON_ILLEGAL_UTF8(MIN, JDK21),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -485,6 +485,12 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return name == name.table.names.vnew && this.type.getReturnType().tsym == this.owner;
     }
 
+    /** Is this symbol an implicit constructor?
+     */
+    public boolean isImplicitConstructor() {
+        return isInitOrVNew() && ((flags() & IMPLICIT) != 0);
+    }
+
     /** Is this symbol a constructor or value factory?
      */
     public boolean isInitOrVNew() {
@@ -1679,6 +1685,21 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         public boolean isUnnamed() {
             return (flags_field & Flags.UNNAMED_CLASS) != 0 ;
         }
+
+        public MethodSymbol getImplicitConstructor() {
+            for (Symbol s : members().getSymbols(NON_RECURSIVE)) {
+                switch (s.kind) {
+                    case MTH:
+                        if (s.isInitOrVNew()) {
+                            if (s.isImplicitConstructor()) {
+                                return (MethodSymbol) s;
+                            }
+                        }
+                }
+            }
+            return null;
+        }
+
     }
 
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -245,6 +245,9 @@ public class Symtab {
     public final Type processorType;
     public final Type linkageType;
 
+    // for value objects
+    public final Type nonAtomicType;
+
     /** The symbol representing the length field of an array.
      */
     public final VarSymbol lengthVar;
@@ -639,6 +642,9 @@ public class Symtab {
         templateRuntimeType = enterClass("java.lang.runtime.TemplateRuntime");
         processorType = enterClass("java.lang.StringTemplate$Processor");
         linkageType = enterClass("java.lang.StringTemplate$Processor$Linkage");
+
+        // for value objects
+        nonAtomicType = enterClass("java.lang.NonAtomic");
 
         // Enter a synthetic class that is used to mark internal
         // proprietary classes in ct.sym.  This class does not have a

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2553,7 +2553,7 @@ public class Flow {
                                     } else {
                                         checkInit(TreeInfo.diagnosticPositionFor(var, vardecl), var);
                                     }
-                                } else {
+                                } else if (!tree.sym.isImplicitConstructor()) { // implicit constructors are special, ignore them
                                     checkInit(TreeInfo.diagEndPos(tree.body), var);
                                 }
                             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -244,7 +244,8 @@ public class MemberEnter extends JCTree.Visitor {
         }
 
         if (m.isInitOrVNew() && m.type.getParameterTypes().size() == 0) {
-            int statsSize = tree.body.stats.size();
+            // implicit constructors are empty bodied
+            int statsSize = (tree.body == null) && ((tree.mods.flags & IMPLICIT) != 0) ? 0 : tree.body.stats.size();
             if (statsSize == 0) {
                 m.flags_field |= EMPTYNOARGCONSTR;
             } else if (statsSize == 1 && TreeInfo.isSuperCall(tree.body.stats.head)) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -1070,6 +1070,7 @@ public class TypeEnter implements Completer {
                 defaultConstructor = defaultConstructor(make.at(tree.pos), helper);
                 tree.defs = tree.defs.prepend(defaultConstructor);
             }
+
             if (!sym.isRecord()) {
                 enterThisAndSuper(sym, env);
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
@@ -207,6 +207,12 @@ public enum Target {
         return compareTo(JDK1_15) >= 0;
     }
 
+    /** Does the target VM support value classes
+     */
+    public boolean hasValueClasses() {
+        return compareTo(JDK1_19) >= 0;
+    }
+
     /** Is the ACC_STRICT bit redundant and obsolete
      */
     public boolean obsoleteAccStrict() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3565,6 +3565,10 @@ public class JavacParser implements Parser {
                     flag = Flags.IDENTITY_TYPE;
                     break;
                 }
+                if (isImplicitModifier()) {
+                    flag = Flags.IMPLICIT;
+                    break;
+                }
                 break loop;
             }
             default: break loop;
@@ -3840,6 +3844,13 @@ public class JavacParser implements Parser {
         }
         if (name == names.identity) {
             if (shouldWarn) {
+                log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.JDK18));
+            }
+        }
+        if (name == names.implicit) {
+            if (allowValueClasses) {
+                return Source.JDK18;
+            } else if (shouldWarn) {
                 log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.JDK18));
             }
         }
@@ -4957,6 +4968,25 @@ public class JavacParser implements Parser {
                     break;
             }
             if (isIdentityModifier) {
+                checkSourceLevel(Feature.VALUE_CLASSES);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean isImplicitModifier() {
+        if (token.kind == IDENTIFIER && token.name() == names.implicit) {
+            boolean isImplicitModifier = false;
+            Token next = S.token(1);
+            switch (next.kind) {
+                case PRIVATE: case PROTECTED: case PUBLIC: case MONKEYS_AT:
+                case STATIC: case FINAL: case ABSTRACT: case NATIVE:
+                case SYNCHRONIZED: case STRICTFP: case DEFAULT: case IDENTIFIER:
+                    isImplicitModifier = true;
+                    break;
+            }
+            if (isImplicitModifier) {
                 checkSourceLevel(Feature.VALUE_CLASSES);
                 return true;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4088,6 +4088,20 @@ compiler.err.abstract.value.class.declares.init.block=\
 compiler.err.abstract.value.class.cannot.be.inner=\
     {0} is an inner class. This is disallowed.
 
+# 0: symbol
+compiler.err.value.class.with.implicit.cannot.be.inner=\
+    The value class {0} declares an implicit constructor. It cannot be an inner class.
+
+# 0: symbol
+compiler.err.value.class.with.implicit.declares.init.block=\
+    The value class {0} declares an implicit constructor.\n\
+    It cannot declare one or more non-empty instance initializer blocks
+
+# 0: symbol
+compiler.err.value.class.with.implicit.instance.field.initializer=\
+    The value class {0} declares an implicit constructor.\n\
+    And it defines an instance field with an initializer. This is disallowed.
+
 # 0: symbol, 1: type
 compiler.misc.superclass.of.value.class=\
     The super class {1} of the value class {0}
@@ -4101,6 +4115,9 @@ compiler.err.projection.cant.be.instantiated=\
 
 compiler.err.call.to.super.not.allowed.in.value.ctor=\
     call to super not allowed in value class constructor
+
+compiler.err.implicit.const.cant.have.body=\
+    implicit constructors cannot have a body
 
 # 0: symbol
 compiler.err.deconstruction.pattern.only.records=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -124,6 +124,12 @@ public class TreeInfo {
         return false;
     }
 
+    public static JCMethodDecl getImplicitConstructor(List<JCTree> trees) {
+        for (List<JCTree> l = trees; l.nonEmpty(); l = l.tail)
+            if (isConstructor(l.head) && (((JCMethodDecl)l.head).mods.flags & IMPLICIT) != 0) return (JCMethodDecl) l.head;
+        return null;
+    }
+
     /** Is there a constructor invocation in the given list of trees?
      *  Optionally, check only for no-arg ctor invocation
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -173,6 +173,8 @@ public class Names {
     public final Name Value;
     public final Name Varargs;
     public final Name PermittedSubclasses;
+    public final Name ImplicitCreation;
+    public final Name NullRestricted;
 
     // members of java.lang.annotation.ElementType
     public final Name ANNOTATION_TYPE;
@@ -244,6 +246,9 @@ public class Names {
     public final Name newStringTemplate;
     public final Name newLargeStringTemplate;
     public final Name processStringTemplate;
+
+    // value classes
+    public final Name implicit;
 
     public final Name.Table table;
 
@@ -379,6 +384,8 @@ public class Names {
         Value = fromString("Value");
         Varargs = fromString("Varargs");
         PermittedSubclasses = fromString("PermittedSubclasses");
+        ImplicitCreation = fromString("ImplicitCreation");
+        NullRestricted = fromString("NullRestricted");
 
         // members of java.lang.annotation.ElementType
         ANNOTATION_TYPE = fromString("ANNOTATION_TYPE");
@@ -443,6 +450,9 @@ public class Names {
         typeSwitch = fromString("typeSwitch");
         enumSwitch = fromString("enumSwitch");
         enumConstant = fromString("enumConstant");
+
+        //value classes
+        implicit = fromString("implicit");
     }
 
     protected Name.Table createTable(Options options) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/AccessFlags.java
@@ -61,7 +61,10 @@ public class AccessFlags {
     public static final int ACC_MANDATED      = 0x8000; //                          method parameter
     public static final int ACC_MODULE        = 0x8000; // class
 
-    public static enum Kind { Class, InnerClass, Field, Method}
+    public static final int ACC_DEFAULT       = 0x0001; // ImplicitCreation attribute
+    public static final int ACC_NON_ATOMIC    = 0x0002; // ImplicitCreation attribute
+
+    public static enum Kind { Class, InnerClass, Field, Method, ImplicitCreationAttr}
 
     AccessFlags(ClassReader cr) throws IOException {
         this(cr.readUnsignedShort());
@@ -157,6 +160,12 @@ public class AccessFlags {
         return getFlags(methodFlags, Kind.Method);
     }
 
+    private static final int[] implicitCreationAttrFlags = { ACC_DEFAULT, ACC_NON_ATOMIC };
+
+    public Set<String> getImplicitCreationAttrFlags() {
+        return getFlags(implicitCreationAttrFlags, Kind.ImplicitCreationAttr);
+    }
+
     private Set<String> getModifiers(int[] modifierFlags, Kind t) {
         return getModifiers(flags, modifierFlags, t);
     }
@@ -221,9 +230,9 @@ public class AccessFlags {
     private static String flagToName(int flag, Kind t) {
         switch (flag) {
         case ACC_PUBLIC:
-            return "ACC_PUBLIC";
+            return t == Kind.ImplicitCreationAttr ? "ACC_DEFAULT" : "ACC_PUBLIC";
         case ACC_PRIVATE:
-            return "ACC_PRIVATE";
+            return t == Kind.ImplicitCreationAttr ? "ACC_NON_ATOMIC" : "ACC_PRIVATE";
         case ACC_PROTECTED:
             return "ACC_PROTECTED";
         case ACC_STATIC:

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/Attribute.java
@@ -47,6 +47,7 @@ public abstract class Attribute {
     public static final String Deprecated               = "Deprecated";
     public static final String EnclosingMethod          = "EnclosingMethod";
     public static final String Exceptions               = "Exceptions";
+    public static final String ImplicitCreation         = "ImplicitCreation";
     public static final String InnerClasses             = "InnerClasses";
     public static final String LineNumberTable          = "LineNumberTable";
     public static final String LocalVariableTable       = "LocalVariableTable";
@@ -60,6 +61,7 @@ public abstract class Attribute {
     public static final String ModuleTarget             = "ModuleTarget";
     public static final String NestHost                 = "NestHost";
     public static final String NestMembers              = "NestMembers";
+    public static final String NullRestricted           = "NullRestricted";
     public static final String Preload                  = "Preload";
     public static final String Record                   = "Record";
     public static final String RuntimeVisibleAnnotations = "RuntimeVisibleAnnotations";
@@ -124,6 +126,7 @@ public abstract class Attribute {
             standardAttributes.put(Deprecated,        Deprecated_attribute.class);
             standardAttributes.put(EnclosingMethod,   EnclosingMethod_attribute.class);
             standardAttributes.put(Exceptions,        Exceptions_attribute.class);
+            standardAttributes.put(ImplicitCreation, ImplicitCreation_attribute.class);
             standardAttributes.put(InnerClasses,      InnerClasses_attribute.class);
             standardAttributes.put(LineNumberTable,   LineNumberTable_attribute.class);
             standardAttributes.put(LocalVariableTable, LocalVariableTable_attribute.class);
@@ -137,6 +140,7 @@ public abstract class Attribute {
             standardAttributes.put(ModuleTarget,      ModuleTarget_attribute.class);
             standardAttributes.put(NestHost, NestHost_attribute.class);
             standardAttributes.put(NestMembers, NestMembers_attribute.class);
+            standardAttributes.put(NullRestricted, NullRestricted_attribute.class);
             standardAttributes.put(Preload, Preload_attribute.class);
             standardAttributes.put(Record, Record_attribute.class);
             standardAttributes.put(RuntimeInvisibleAnnotations, RuntimeInvisibleAnnotations_attribute.class);
@@ -192,6 +196,7 @@ public abstract class Attribute {
         R visitDeprecated(Deprecated_attribute attr, P p);
         R visitEnclosingMethod(EnclosingMethod_attribute attr, P p);
         R visitExceptions(Exceptions_attribute attr, P p);
+        R visitImplicitCreation(ImplicitCreation_attribute attr, P p);
         R visitInnerClasses(InnerClasses_attribute attr, P p);
         R visitLineNumberTable(LineNumberTable_attribute attr, P p);
         R visitLocalVariableTable(LocalVariableTable_attribute attr, P p);
@@ -205,6 +210,7 @@ public abstract class Attribute {
         R visitModuleTarget(ModuleTarget_attribute attr, P p);
         R visitNestHost(NestHost_attribute attr, P p);
         R visitNestMembers(NestMembers_attribute attr, P p);
+        R visitNullRestricted(NullRestricted_attribute attr, P p);
         R visitPreload(Preload_attribute attr, P p);
         R visitRecord(Record_attribute attr, P p);
         R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -467,6 +467,12 @@ public class ClassWriter {
         }
 
         @Override
+        public Void visitImplicitCreation(ImplicitCreation_attribute attr, ClassOutputStream out) {
+            out.writeShort(attr.flags);
+            return null;
+        }
+
+        @Override
         public Void visitInnerClasses(InnerClasses_attribute attr, ClassOutputStream out) {
             out.writeShort(attr.classes.length);
             for (InnerClasses_attribute.Info info: attr.classes)
@@ -529,6 +535,11 @@ public class ClassWriter {
         @Override
         public Void visitNestHost(NestHost_attribute attr, ClassOutputStream out) {
             out.writeShort(attr.top_index);
+            return null;
+        }
+
+        @Override
+        public Void visitNullRestricted(NullRestricted_attribute attr, ClassOutputStream out) {
             return null;
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ImplicitCreation_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ImplicitCreation_attribute.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+import java.io.IOException;
+
+public class ImplicitCreation_attribute extends Attribute {
+
+    public int flags;
+
+    ImplicitCreation_attribute(ClassReader cr, int name_index, int length) throws IOException {
+        super(name_index, length);
+        flags = cr.readUnsignedShort();
+    }
+
+    public ImplicitCreation_attribute(int name_index, int flags) {
+        super(name_index, 2);
+        this.flags = flags;
+    }
+
+    @Override
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitImplicitCreation(this, data);
+    }
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/NullRestricted_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/NullRestricted_attribute.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.classfile;
+
+public class NullRestricted_attribute extends Attribute {
+    NullRestricted_attribute(ClassReader cr, int name_index, int length) {
+        super(name_index, length);
+    }
+
+    public NullRestricted_attribute(int name_index) {
+        super(name_index, 0);
+    }
+
+    @Override
+    public <R, D> R accept(Visitor<R, D> visitor, D data) {
+        return visitor.visitNullRestricted(this, data);
+    }
+}

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -34,6 +34,7 @@ import com.sun.tools.classfile.Attributes;
 import com.sun.tools.classfile.BootstrapMethods_attribute;
 import com.sun.tools.classfile.CharacterRangeTable_attribute;
 import com.sun.tools.classfile.CharacterRangeTable_attribute.Entry;
+import com.sun.tools.classfile.ClassWriter;
 import com.sun.tools.classfile.Code_attribute;
 import com.sun.tools.classfile.CompilationID_attribute;
 import com.sun.tools.classfile.ConstantPool;
@@ -46,6 +47,7 @@ import com.sun.tools.classfile.Descriptor;
 import com.sun.tools.classfile.Descriptor.InvalidDescriptor;
 import com.sun.tools.classfile.EnclosingMethod_attribute;
 import com.sun.tools.classfile.Exceptions_attribute;
+import com.sun.tools.classfile.ImplicitCreation_attribute;
 import com.sun.tools.classfile.InnerClasses_attribute;
 import com.sun.tools.classfile.InnerClasses_attribute.Info;
 import com.sun.tools.classfile.LineNumberTable_attribute;
@@ -60,6 +62,7 @@ import com.sun.tools.classfile.ModuleResolution_attribute;
 import com.sun.tools.classfile.ModuleTarget_attribute;
 import com.sun.tools.classfile.NestHost_attribute;
 import com.sun.tools.classfile.NestMembers_attribute;
+import com.sun.tools.classfile.NullRestricted_attribute;
 import com.sun.tools.classfile.Record_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleAnnotations_attribute;
 import com.sun.tools.classfile.RuntimeInvisibleParameterAnnotations_attribute;
@@ -315,6 +318,15 @@ public class AttributeWriter extends BasicWriter
         }
     }
 
+    @Override
+    public Void visitImplicitCreation(ImplicitCreation_attribute attr, Void ignore) {
+        println("ImplicitCreation:");
+        indent(+1);
+        AccessFlags flags = new AccessFlags(attr.flags);
+        writeList(String.format("flags: (0x%04x) ", attr.flags), flags.getImplicitCreationAttrFlags(), "\n");
+        indent(-1);
+        return null;
+    }
 
     @Override
     public Void visitInnerClasses(InnerClasses_attribute attr, Void ignore) {
@@ -414,6 +426,12 @@ public class AttributeWriter extends BasicWriter
         print("NestHost: ");
         constantWriter.write(attr.top_index);
         println();
+        return null;
+    }
+
+    @Override
+    public Void visitNullRestricted(NullRestricted_attribute attr, Void ignore) {
+        println("NullRestricted");
         return null;
     }
 


### PR DESCRIPTION
add support for implicit constructors, add the ImplicitCreation and NullRestricted class file attributes, and the NonAtomic interface

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310678](https://bugs.openjdk.org/browse/JDK-8310678): [lw5] add implicit constructors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/869/head:pull/869` \
`$ git checkout pull/869`

Update a local copy of the PR: \
`$ git checkout pull/869` \
`$ git pull https://git.openjdk.org/valhalla.git pull/869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 869`

View PR using the GUI difftool: \
`$ git pr show -t 869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/869.diff">https://git.openjdk.org/valhalla/pull/869.diff</a>

</details>
