### PR TITLE
8310684: [lw5] adding missing ImplicitCreation and NullRestricted visitors in regression tests

### DIFF
--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1233,6 +1233,11 @@ public class ClassfileInspector {
         }
 
         @Override
+        public Void visitImplicitCreation(ImplicitCreation_attribute attr, T p) {
+            return null;
+        }
+
+        @Override
         public Void visitInnerClasses(InnerClasses_attribute attr, T p) {
             return null;
         }
@@ -1253,7 +1258,12 @@ public class ClassfileInspector {
         }
 
         @Override
-          public Void visitNestHost(NestHost_attribute attr, T p) {
+        public Void visitNestHost(NestHost_attribute attr, T p) {
+            return null;
+        }
+
+        @Override
+        public Void visitNullRestricted(NullRestricted_attribute attr, T p) {
             return null;
         }
 

--- a/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
+++ b/test/langtools/tools/javac/MethodParameters/AttributeVisitor.java
@@ -38,6 +38,7 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitDeprecated(Deprecated_attribute attr, P p) { return null; }
     public R visitEnclosingMethod(EnclosingMethod_attribute attr, P p) { return null; }
     public R visitExceptions(Exceptions_attribute attr, P p) { return null; }
+    public R visitImplicitCreation(ImplicitCreation_attribute attr, P p) { return null; }
     public R visitInnerClasses(InnerClasses_attribute attr, P p) { return null; }
     public R visitLineNumberTable(LineNumberTable_attribute attr, P p) { return null; }
     public R visitLocalVariableTable(LocalVariableTable_attribute attr, P p) { return null; }
@@ -51,6 +52,7 @@ class AttributeVisitor<R, P> implements Attribute.Visitor<R, P> {
     public R visitModuleResolution(ModuleResolution_attribute attr, P p) { return null; }
     public R visitModuleTarget(ModuleTarget_attribute attr, P p) { return null; }
     public R visitNestMembers(NestMembers_attribute attr, P p) { return null; }
+    public R visitNullRestricted(NullRestricted_attribute attr, P p) { return null; }
     public R visitRuntimeVisibleAnnotations(RuntimeVisibleAnnotations_attribute attr, P p) { return null; }
     public R visitRuntimeInvisibleAnnotations(RuntimeInvisibleAnnotations_attribute attr, P p) { return null; }
     public R visitRuntimeVisibleParameterAnnotations(RuntimeVisibleParameterAnnotations_attribute attr, P p) { return null; }


### PR DESCRIPTION
minor fixes to couple of regression tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310684](https://bugs.openjdk.org/browse/JDK-8310684): [lw5] adding missing ImplicitCreation and NullRestricted visitors in regression tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/871/head:pull/871` \
`$ git checkout pull/871`

Update a local copy of the PR: \
`$ git checkout pull/871` \
`$ git pull https://git.openjdk.org/valhalla.git pull/871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 871`

View PR using the GUI difftool: \
`$ git pr show -t 871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/871.diff">https://git.openjdk.org/valhalla/pull/871.diff</a>

</details>
