### PR TITLE
8310819: [lw5] loading NonAtomic can produce completion errors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -185,6 +185,7 @@ public class Check {
         allowModules = Feature.MODULES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         allowSealed = Feature.SEALED_CLASSES.allowedInSource(source);
+        allowValueClasses = Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     /** Character for synthetic names
@@ -227,6 +228,10 @@ public class Check {
     /** Are sealed classes allowed
      */
     private final boolean allowSealed;
+
+    /** Are value classes allowed
+     */
+    private final boolean allowValueClasses;
 /* *************************************************************************
  * Errors and Warnings
  **************************************************************************/
@@ -2789,7 +2794,12 @@ public class Check {
         }
         checkCompatibleConcretes(pos, c);
 
-        boolean implementsNonAtomic = types.asSuper(c, syms.nonAtomicType.tsym) != null;
+        boolean implementsNonAtomic = false;
+        try {
+            implementsNonAtomic = allowValueClasses ? types.asSuper(c, syms.nonAtomicType.tsym) != null : false;
+        } catch (CompletionFailure cf) {
+            // ignore
+        }
         boolean cIsValue = (c.tsym.flags() & VALUE_CLASS) != 0;
         boolean cHasIdentity = (c.tsym.flags() & IDENTITY_TYPE) != 0;
         if (c.getKind() == TypeKind.DECLARED && implementsNonAtomic && !c.tsym.isAbstract()) {


### PR DESCRIPTION
loading java.lang.NonAtomic can produce completion errors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310819](https://bugs.openjdk.org/browse/JDK-8310819): [lw5] loading NonAtomic can produce completion errors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/875/head:pull/875` \
`$ git checkout pull/875`

Update a local copy of the PR: \
`$ git checkout pull/875` \
`$ git pull https://git.openjdk.org/valhalla.git pull/875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 875`

View PR using the GUI difftool: \
`$ git pr show -t 875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/875.diff">https://git.openjdk.org/valhalla/pull/875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/875#issuecomment-1604994563)