### PR TITLE
8310832: [lw5] reflective creation of arrays of non-nullable types

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -739,6 +739,18 @@ public final class Class<T> implements java.io.Serializable,
     }
 
     /**
+     * Returns a {@code Class} object representing the null restricted type
+     * of this class or interface.
+     *
+     * @return the {@code Class} representing the null restricted type of
+     *         this class or interface
+     * @since Valhalla
+     */
+    public Class<?> asNullRestrictedType() {
+        return this;
+    }
+
+    /**
      * Returns {@code true} if this {@code Class} object represents the primary type
      * of this class or interface.
      * <p>

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -80,12 +80,6 @@ public enum Modifier {
     },
 
     /**
-     * The modifier {@code primitive}
-     * @since 18
-     */
-    PRIMITIVE,
-
-    /**
      * The modifier {@code value}
      * @since 18
      */

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -247,6 +247,7 @@ public class Symtab {
 
     // for value objects
     public final Type nonAtomicType;
+    public final Type reflectArrayType;
 
     /** The symbol representing the length field of an array.
      */
@@ -645,6 +646,7 @@ public class Symtab {
 
         // for value objects
         nonAtomicType = enterClass("java.lang.NonAtomic");
+        reflectArrayType = enterClass("java.lang.reflect.Array");
 
         // Enter a synthetic class that is used to mark internal
         // proprietary classes in ct.sym.  This class does not have a

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2194,10 +2194,18 @@ public class Types {
      * @return the ArrayType for the given component
      */
     public ArrayType makeArrayType(Type t) {
+        return makeArrayType(t, 1);
+    }
+
+    public ArrayType makeArrayType(Type t, int dimensions) {
         if (t.hasTag(VOID) || t.hasTag(PACKAGE)) {
             Assert.error("Type t must not be a VOID or PACKAGE type, " + t.toString());
         }
-        return new ArrayType(t, syms.arrayClass);
+        ArrayType result = new ArrayType(t, syms.arrayClass);
+        for (int i = 1; i < dimensions; i++) {
+            result = new ArrayType(result, syms.arrayClass);
+        }
+        return result;
     }
     // </editor-fold>
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -719,6 +719,10 @@ public class JavacParser implements Parser {
                 t = toP(F.at(tyannos.head.pos).AnnotatedType(tyannos, t));
             }
         }
+        if (EMOTIONAL_QUALIFIER.test(token.kind)) {
+            setNullMarker(t);
+            nextToken();
+        }
         return t;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -249,6 +249,8 @@ public class Names {
 
     // value classes
     public final Name implicit;
+    public final Name newInstance;
+    public final Name asNullRestrictedType;
 
     public final Name.Table table;
 
@@ -453,6 +455,8 @@ public class Names {
 
         //value classes
         implicit = fromString("implicit");
+        newInstance = fromString("newInstance");
+        asNullRestrictedType = fromString("asNullRestrictedType");
     }
 
     protected Name.Table createTable(Options options) {

--- a/test/langtools/tools/javac/bang/RuntimeNullChecks.java
+++ b/test/langtools/tools/javac/bang/RuntimeNullChecks.java
@@ -95,6 +95,15 @@ public class RuntimeNullChecks extends TestRunner {
                 """,
                 """
                 class Test {
+                    public static void main(String... args) {
+                        String s = null;
+                        String![] sr = new String![10];
+                        sr[0] = s; // NPE at runtime, assignment
+                    }
+                }
+                """,
+                """
+                class Test {
                     static String id(String! arg) { return arg; }
                     public static void main(String... args) {
                         String s = null;


### PR DESCRIPTION
adding support for reflective creation of arrays of non-nullable types

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310832](https://bugs.openjdk.org/browse/JDK-8310832): [lw5] reflective creation of arrays of non-nullable types (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/876/head:pull/876` \
`$ git checkout pull/876`

Update a local copy of the PR: \
`$ git checkout pull/876` \
`$ git pull https://git.openjdk.org/valhalla.git pull/876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 876`

View PR using the GUI difftool: \
`$ git pr show -t 876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/876.diff">https://git.openjdk.org/valhalla/pull/876.diff</a>

</details>
