### PR TITLE
8310839: [lw5] implicit constructors must be public and declared in a value class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -448,7 +448,8 @@ public class Flags {
         InterfaceVarFlags                 = FINAL | STATIC | PUBLIC,
         VarFlags                          = AccessFlags | FINAL | STATIC |
                                             VOLATILE | TRANSIENT | ENUM,
-        ConstructorFlags                  = AccessFlags | IMPLICIT,
+        ConstructorFlags                  = AccessFlags,
+        ImplicitConstructorFlags          = PUBLIC | IMPLICIT,
         InterfaceMethodFlags              = ABSTRACT | PUBLIC,
         MethodFlags                       = AccessFlags | ABSTRACT | STATIC | NATIVE |
                                             SYNCHRONIZED | FINAL | STRICTFP,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1346,8 +1346,17 @@ public class Check {
                     // private
                     implicit = PRIVATE;
                     mask = PRIVATE;
-                } else
+                } else if ((flags & IMPLICIT) != 0) {
+                    if ((flags & PUBLIC) == 0) {
+                        log.error(pos, Errors.ImplicitConstMustBePublic);
+                    }
+                    if ((sym.owner.flags_field & VALUE_CLASS) == 0) {
+                        log.error(pos, Errors.ImplicitConstMustBeDeclaredInValueClass);
+                    }
+                    mask = ImplicitConstructorFlags;
+                } else {
                     mask = ConstructorFlags;
+                }
             }  else if ((sym.owner.flags_field & INTERFACE) != 0) {
                 if ((sym.owner.flags_field & ANNOTATION) != 0) {
                     mask = AnnotationTypeElementMask;
@@ -1495,13 +1504,7 @@ public class Check {
                                 ANNOTATION)
                 && checkDisjoint(pos, flags,
                                 VALUE_CLASS,
-                                ANNOTATION)
-                && checkDisjoint(pos, flags,
-                                IMPLICIT,
-                                PRIVATE)
-                && checkDisjoint(pos, flags,
-                                IMPLICIT,
-                                PROTECTED) ) {
+                                ANNOTATION) ) {
             // skip
         }
         return flags & (mask | ~ExtendedStandardFlags) | implicit;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4122,6 +4122,12 @@ compiler.err.call.to.super.not.allowed.in.value.ctor=\
 compiler.err.implicit.const.cant.have.body=\
     implicit constructors cannot have a body
 
+compiler.err.implicit.const.must.be.public=\
+    implicit constructors must be public
+
+compiler.err.implicit.const.must.be.declared.in.value.class=\
+    only value classes can declare implicit constructors
+
 # 0: symbol
 compiler.err.cant.implement.non.atomic=\
     class {0} cannot implement NonAtomic interface. Concrete classes implementing this interface must:\n\

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -868,4 +868,97 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                 """
         );
     }
+
+    public void testImplicitConstructor() {
+        assertOK(
+                """
+                value class V {
+                    public implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.implicit.const.must.be.public",
+                """
+                value class V {
+                    implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.implicit.const.must.be.public",
+                """
+                value class V {
+                    private implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.implicit.const.must.be.public",
+                """
+                value class V {
+                    protected implicit V();
+                }
+                """
+        );
+
+        assertFail("compiler.err.already.defined",
+                """
+                value class V {
+                    public implicit V();
+                    public V() {}
+                }
+                """
+        );
+
+        assertFail("compiler.err.implicit.const.must.be.declared.in.value.class",
+                """
+                class V {
+                    public implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
+                """
+                class Outer {
+                    value class V {
+                        public implicit V();
+                    }
+                }
+                """
+        );
+        assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
+                """
+                class Outer {
+                    new value class V() {
+                        public implicit V();
+                    };
+                }
+                """
+        );
+        assertFail("compiler.err.cyclic.primitive.class.membership",
+                """
+                value class V {
+                    V! v;
+                    public implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.value.class.with.implicit.instance.field.initializer",
+                """
+                value class V {
+                    String s = "";
+                    public implicit V();
+                }
+                """
+        );
+        assertFail("compiler.err.value.class.with.implicit.declares.init.block",
+                """
+                value class V {
+                    String s;
+                    {
+                        s = "";
+                    }
+                    public implicit V();
+                }
+                """
+        );
+    }
 }


### PR DESCRIPTION
implicit constructors must be public and declared in a value class

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310839](https://bugs.openjdk.org/browse/JDK-8310839): [lw5] implicit constructors must be public and declared in a value class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/877/head:pull/877` \
`$ git checkout pull/877`

Update a local copy of the PR: \
`$ git checkout pull/877` \
`$ git pull https://git.openjdk.org/valhalla.git pull/877/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 877`

View PR using the GUI difftool: \
`$ git pr show -t 877`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/877.diff">https://git.openjdk.org/valhalla/pull/877.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/877#issuecomment-1605239860)