### PR TITLE
8311080: [lworld+vector] Fix jdk build failures with different options

### DIFF
--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -31,6 +31,7 @@
 #include "utilities/vmEnums.hpp"
 
 class MultiFieldInfo;
+
 static constexpr u4 flag_mask(int pos) {
   return (u4)1 << pos;
 }
@@ -231,6 +232,21 @@ class FieldInfo {
   void static print_from_growable_array(outputStream* os, GrowableArray<FieldInfo>* array, ConstantPool* cp);
 };
 
+class MultiFieldInfo : public MetaspaceObj {
+ private:
+  Symbol* _name;
+  u2 _base_index;
+  jbyte _multifield_index;
+ public:
+  MultiFieldInfo() : _name(nullptr), _base_index(0), _multifield_index(-1) {}
+  MultiFieldInfo(Symbol* name, u2 base, jbyte index) : _name(name), _base_index(base), _multifield_index(index) {}
+  Symbol* name() const { return _name; }
+  u2 base_index() const { return _base_index; }
+  jbyte multifield_index() const { return _multifield_index; }
+  FieldInfo base_field_info(InstanceKlass* ik);
+  void metaspace_pointers_do(MetaspaceClosure* it);
+  MetaspaceObj::Type type() const { return MultiFieldInfoType; }
+};
 
 class FieldInfoStream;
 

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -506,6 +506,7 @@ InlineKlass* InlineKlass::returned_inline_klass(const RegisterMap& map) {
 
 // CDS support
 
+#if INCLUDE_CDS
 void InlineKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   InstanceKlass::metaspace_pointers_do(it);
 
@@ -544,6 +545,7 @@ void InlineKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle 
     value_array_klasses()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);
   }
 }
+#endif
 
 // oop verify
 

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,10 +133,14 @@ class InlineKlass: public InstanceKlass {
 
   int first_field_offset_old();
 
+// CDS support
+
+#if INCLUDE_CDS
   virtual void remove_unshareable_info();
   virtual void remove_java_mirror();
   virtual void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS);
   virtual void metaspace_pointers_do(MetaspaceClosure* it);
+#endif
 
  private:
   int collect_fields(GrowableArray<SigEntry>* sig, int base_off = 0);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -135,22 +135,6 @@ struct JvmtiCachedClassFileData;
 
 class SigEntry;
 
-class MultiFieldInfo : public MetaspaceObj {
- private:
-  Symbol* _name;
-  u2 _base_index;
-  jbyte _multifield_index;
- public:
-  MultiFieldInfo() : _name(nullptr), _base_index(0), _multifield_index(-1) {}
-  MultiFieldInfo(Symbol* name, u2 base, jbyte index) : _name(name), _base_index(base), _multifield_index(index) {}
-  Symbol* name() const { return _name; }
-  u2 base_index() const { return _base_index; }
-  jbyte multifield_index() const { return _multifield_index; }
-  FieldInfo base_field_info(InstanceKlass* ik);
-  void metaspace_pointers_do(MetaspaceClosure* it);
-  MetaspaceObj::Type type() const { return MultiFieldInfoType; }
-};
-
 class InlineKlassFixedBlock : public MetaspaceObj {
    Array<SigEntry>** _extended_sig;
    Array<VMRegPair>** _return_regs;

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -119,6 +119,7 @@ jint VectorSupport::klass2length(InstanceKlass* ik) {
   return vlen;
 }
 
+#ifdef COMPILER2
 Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, int num_elem, BasicType elem_bt, int larval, TRAPS) {
   assert(ik->is_inline_klass(), "");
   instanceOop obj = InlineKlass::cast(ik)->allocate_instance(THREAD);
@@ -327,6 +328,7 @@ instanceOop VectorSupport::allocate_vector(InstanceKlass* ik, frame* fr, Registe
   }
   return vbox;
 }
+#endif // COMPILER2
 
 #ifdef COMPILER2
 int VectorSupport::vop2ideal(jint id, BasicType bt) {

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -38,10 +38,13 @@ extern "C" {
 
 class VectorSupport : AllStatic {
  private:
+
+#ifdef COMPILER2
   static Handle allocate_vector_payload_helper(InstanceKlass* ik, int num_elem, BasicType elem_bt, int larval, TRAPS);
   static Handle allocate_vector_payload(InstanceKlass* ik, int num_elem, BasicType elem_bt, frame* fr, RegisterMap* reg_map, ObjectValue* ov, TRAPS);
-
-  static void init_payload_element(typeArrayOop arr, BasicType elem_bt, int index, address addr);
+  static InstanceKlass* get_vector_payload_klass(BasicType elem_bt, int num_elem);
+  static Symbol* get_vector_payload_field_signature(BasicType elem_bt, int num_elem);
+#endif // COMPILER2
 
   static BasicType klass2bt(InstanceKlass* ik);
   static jint klass2length(InstanceKlass* ik);
@@ -143,11 +146,10 @@ class VectorSupport : AllStatic {
 
   static int vop2ideal(jint vop, BasicType bt);
 
+#ifdef COMPILER2
   static instanceOop allocate_vector(InstanceKlass* holder, frame* fr, RegisterMap* reg_map, ObjectValue* sv, TRAPS);
   static instanceOop allocate_vector_payload(InstanceKlass* ik, frame* fr, RegisterMap* reg_map, ObjectValue* sv, TRAPS);
-
-  static InstanceKlass* get_vector_payload_klass(BasicType elem_bt, int num_elem);
-  static Symbol* get_vector_payload_field_signature(BasicType elem_bt, int num_elem);
+#endif // COMPILER2
 
   static bool is_vector(Klass* klass);
   static bool is_vector_payload_mf(Klass* klass);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -551,8 +551,8 @@ JRT_LEAF(address, SharedRuntime::exception_handler_for_return_address(JavaThread
   return raw_exception_handler_for_return_address(current, return_address);
 JRT_END
 
-JRT_LEAF(jint, SharedRuntime::skip_value_scalarization(InlineKlass* klass))
-  return (jint)VectorSupport::skip_value_scalarization(klass);
+JRT_LEAF(int, SharedRuntime::skip_value_scalarization(InlineKlass* klass))
+  return (int) VectorSupport::skip_value_scalarization(klass);
 JRT_END
 
 address SharedRuntime::get_poll_stub(address pc) {


### PR DESCRIPTION
There are several issues exposed by building jdk image with following different options:
 - `--disable-precompiled-headers`
 - `--with-jvm-variants=client`
 - `--with-jvm-variants=minimal` or `--disable-cds`

1. With `--disable-precompiled-headers`, using `class MultiFieldInfo` in `oops/fieldInfo.hpp` and `oops/fieldInfo.inline.hpp` builds error with "invalid use of incomplete type".

The reason is that class `MultiFieldInfo` is used in `fieldInfo.hpp`, but the header declaring the class is not included in it. A direct
fixing is including its header file `oops/instanceKlass.hpp` before using it. But it cannot work here since `oops/instanceKlass.hpp` has included `oops/fieldInfo.hpp`.

To resolve the circle, we can move the definition of class `MultiFieldInfo` to `oops/fieldInfo.hpp`, which I think is also reasonable since `multifield` is a kind of `field`.

2. With `--with-jvm-variants=client`, calling `Deoptimization::reassign_fields_by_klass()` in `vectorsupport.cpp` builds error since `reassign_fields_by_klass()` is defined when C2 or JVMCI compiler is enabled (See [1]).

Consider the caller method in `vectorSupport.cpp` is used only for C2 compiler (See [2]), adding the same limitation for definition of all the relative methods in `vectorSupport.cpp` is better and can fix this issue.

3. With `--with-jvm-variants=minimal` or `--disable-cds`, calling several CDS specific methods ([3]) in `oops/inlineKlass.cpp` builds error. Those caller methods defined in `inlineKlass.hpp` are all CDS related as well. Hence, adding the same CDS condition for them sounds reasonable and can fix this issue.

This patch also fixed an return type mismatch issue exposed by building the jdk image on aarch64 windows system. The relative method is:

```
jint SharedRuntime::skip_value_scalarization(InlineKlass *)
```
The declaration type is `int` (see [4]).

[1] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/runtime/deoptimization.hpp#L195
[2] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/runtime/deoptimization.cpp#L1278
[3] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/oops/instanceKlass.hpp#L1236
[4] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/runtime/sharedRuntime.hpp#L186

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8311080](https://bugs.openjdk.org/browse/JDK-8311080): [lworld+vector] Fix jdk build failures with different options (**Enhancement** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/881/head:pull/881` \
`$ git checkout pull/881`

Update a local copy of the PR: \
`$ git checkout pull/881` \
`$ git pull https://git.openjdk.org/valhalla.git pull/881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 881`

View PR using the GUI difftool: \
`$ git pr show -t 881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/881.diff">https://git.openjdk.org/valhalla/pull/881.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/881#issuecomment-1617659992)