### PR TITLE
8309357: [lworld] CDS is broken with InlineKlasses after the merge

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -508,7 +508,6 @@ void InlineKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   InstanceKlass::metaspace_pointers_do(it);
 
   InlineKlass* this_ptr = this;
-  // TODO: _adr_inlineklass_fixed_block ?
   it->push((Klass**)adr_value_array_klasses());
 }
 
@@ -534,6 +533,10 @@ void InlineKlass::remove_java_mirror() {
 }
 
 void InlineKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS) {
+  // We are no longer bookkeeping pointer to fixed block during serialization, hence reinitializing
+  // fixed block address since its size was already accounted by InstanceKlass::size() and it will
+  // anyways be part of shared archive.
+  _adr_inlineklass_fixed_block = inlineklass_static_block();
   InstanceKlass::restore_unshareable_info(loader_data, protection_domain, pkg_entry, CHECK);
   if (value_array_klasses() != NULL) {
     value_array_klasses()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1269,7 +1269,8 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
       SharedRuntime::native_method_throw_unsatisfied_link_error_entry(),
       !native_bind_event_is_interesting);
   }
-  if (InlineTypeReturnedAsFields && returns_inline_type(THREAD)) {
+  if (InlineTypeReturnedAsFields && returns_inline_type(THREAD) && !has_scalarized_return()) {
+    assert(!constMethod()->is_shared(), "Cannot update shared const objects");
     set_has_scalarized_return();
   }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3173,11 +3173,15 @@ AdapterHandlerEntry* AdapterHandlerLibrary::get_adapter(const methodHandle& meth
   CompiledEntrySignature ces(method());
   ces.compute_calling_conventions();
   if (ces.has_scalarized_args()) {
-    method->set_has_scalarized_args();
+    if (!method->has_scalarized_args()) {
+      assert(!method()->constMethod()->is_shared(), "Cannot update shared const object");
+      method->set_has_scalarized_args();
+    }
     if (ces.c1_needs_stack_repair()) {
       method->set_c1_needs_stack_repair();
     }
-    if (ces.c2_needs_stack_repair()) {
+    if (ces.c2_needs_stack_repair() && !method->c2_needs_stack_repair()) {
+      assert(!method->constMethod()->is_shared(), "Cannot update a shared const object");
       method->set_c2_needs_stack_repair();
     }
   } else if (method->is_abstract()) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -113,8 +113,6 @@ containers/docker/TestMemoryAwareness.java 8303470 linux-x64
 
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
-runtime/cds/appcds/dynamicArchive/DynamicArchiveRelocationTest.java 8309357 generic-all
-runtime/cds/appcds/dynamicArchive/HelloDynamicInlineClass.java 8309357 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
Fix the restoration of the internal pointer to the inlineklass_fixed_block when an InlineKlass is loaded from a CDS archive.
Fix the setting of the new calling convention flags when the constMethod object is shared through CDS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309357](https://bugs.openjdk.org/browse/JDK-8309357): [lworld] CDS is broken with InlineKlasses after the merge (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/883/head:pull/883` \
`$ git checkout pull/883`

Update a local copy of the PR: \
`$ git checkout pull/883` \
`$ git pull https://git.openjdk.org/valhalla.git pull/883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 883`

View PR using the GUI difftool: \
`$ git pr show -t 883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/883.diff">https://git.openjdk.org/valhalla/pull/883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/883#issuecomment-1625780045)