### PR TITLE
8310651: [lworld] ValueConstantDesc fails after merge with jdk-21+25

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
@@ -73,18 +73,23 @@ final class ClassDescImpl implements ClassDesc {
             }
             // Class.forName is slow on class or interface arrays
             int depth = ConstantUtils.arrayDepth(descriptor);
-            Class<?> clazz = lookup.findClass(internalToBinary(descriptor.substring(depth + 1, descriptor.length() - 1)));
-            if (isValue) {
-                if (!PrimitiveClass.isPrimitiveClass(clazz)) {
-                    throw new LinkageError(clazz.getName() + " is not a primitive class");
-                }
-                clazz = PrimitiveClass.asValueType(clazz);
-            }
+            Class<?> clazz = findClass(lookup, internalToBinary(descriptor.substring(depth + 1, descriptor.length() - 1)));
             for (int i = 0; i < depth; i++)
                 clazz = clazz.arrayType();
             return clazz;
         }
-        return lookup.findClass(internalToBinary(dropFirstAndLastChar(descriptor)));
+        return findClass(lookup, internalToBinary(dropFirstAndLastChar(descriptor)));
+    }
+
+    private Class<?> findClass(MethodHandles.Lookup lookup, String name) throws ReflectiveOperationException {
+        Class<?> c = lookup.findClass(name);
+        if (isValue) {
+            if (!PrimitiveClass.isPrimitiveClass(c)) {
+                throw new LinkageError(c.getName() + " is not a primitive class");
+            }
+            return PrimitiveClass.asValueType(c);
+        }
+        return c;
     }
 
     /**

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -767,7 +767,6 @@ jdk/classfile/LowAdaptTest.java                                 8308778 generic-
 jdk/classfile/BuilderBlockTest.java                             8308778 generic-all
 jdk/classfile/BuilderTryCatchTest.java                          8308778 generic-all
 jdk/classfile/PrimitiveClassConstantTest.java                   8310649 generic-all
-valhalla/valuetypes/ValueConstantDesc.java                      8310651 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The test fails because of an incorrect merge with [JDK-8304928](https://bugs.openjdk.org/browse/JDK-8304928).   JDK-8304928 special cases the array type and the merge moves the logic to determine Q-descriptor just for the array type case but misses the normal class case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310651](https://bugs.openjdk.org/browse/JDK-8310651): [lworld] ValueConstantDesc fails after merge with jdk-21+25 (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/885/head:pull/885` \
`$ git checkout pull/885`

Update a local copy of the PR: \
`$ git checkout pull/885` \
`$ git pull https://git.openjdk.org/valhalla.git pull/885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 885`

View PR using the GUI difftool: \
`$ git pr show -t 885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/885.diff">https://git.openjdk.org/valhalla/pull/885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/885#issuecomment-1633259939)