### PR TITLE
8312231: Replacing NULL with nullptr in shared code

### DIFF
--- a/src/hotspot/share/asm/macroAssembler_common.cpp
+++ b/src/hotspot/share/asm/macroAssembler_common.cpp
@@ -93,7 +93,7 @@ int MacroAssembler::unpack_inline_args(Compile* C, bool receiver_only) {
   assert(C->has_scalarized_args(), "inline type argument scalarization is disabled");
   Method* method = C->method()->get_Method();
   const GrowableArray<SigEntry>* sig = method->adapter()->get_sig_cc();
-  assert(sig != NULL, "must have scalarized signature");
+  assert(sig != nullptr, "must have scalarized signature");
 
   // Get unscalarized calling convention
   BasicType* sig_bt = NEW_RESOURCE_ARRAY(BasicType, 256);

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -429,12 +429,12 @@ class MonitorEnterStub: public MonitorAccessStub {
 
  public:
   MonitorEnterStub(LIR_Opr obj_reg, LIR_Opr lock_reg, CodeEmitInfo* info,
-                   CodeStub* throw_imse_stub = NULL, LIR_Opr scratch_reg = LIR_OprFact::illegalOpr)
+                   CodeStub* throw_imse_stub = nullptr, LIR_Opr scratch_reg = LIR_OprFact::illegalOpr)
     : MonitorAccessStub(obj_reg, lock_reg) {
     _info = new CodeEmitInfo(info);
     _scratch_reg = scratch_reg;
     _throw_imse_stub = throw_imse_stub;
-    if (_throw_imse_stub != NULL) {
+    if (_throw_imse_stub != nullptr) {
       assert(_scratch_reg != LIR_OprFact::illegalOpr, "must be");
     }
     FrameMap* f = Compilation::current()->frame_map();

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -228,10 +228,10 @@ class GraphBuilder {
   Bytecodes::Code   code() const                 { return stream()->cur_bc(); }
   int               bci() const                  { return stream()->cur_bci(); }
   int               next_bci() const             { return stream()->next_bci(); }
-  bool              has_pending_field_access()   { return _pending_field_access != NULL; }
+  bool              has_pending_field_access()   { return _pending_field_access != nullptr; }
   DelayedFieldAccess* pending_field_access()     { return _pending_field_access; }
   void              set_pending_field_access(DelayedFieldAccess* delayed) { _pending_field_access = delayed; }
-  bool              has_pending_load_indexed()   { return _pending_load_indexed != NULL; }
+  bool              has_pending_load_indexed()   { return _pending_load_indexed != nullptr; }
   DelayedLoadIndexed* pending_load_indexed()     { return _pending_load_indexed; }
   void              set_pending_load_indexed(DelayedLoadIndexed* delayed) { _pending_load_indexed = delayed; }
 
@@ -296,7 +296,7 @@ class GraphBuilder {
   // inline types
   void default_value(int klass_index);
   void withfield(int field_index);
-  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* encloding_field = NULL);
+  void copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* encloding_field = nullptr);
 
   // stack/code manipulation helpers
   Instruction* append_with_bci(Instruction* instr, int bci);
@@ -393,12 +393,12 @@ class GraphBuilder {
 
   // Inline type support
   void update_larval_state(Value v) {
-    if (v != NULL && v->as_NewInlineTypeInstance() != NULL) {
+    if (v != nullptr && v->as_NewInlineTypeInstance() != nullptr) {
       v->as_NewInlineTypeInstance()->set_not_larva_anymore();
     }
   }
   void update_larva_stack_count(Value v) {
-    if (v != NULL && v->as_NewInlineTypeInstance() != NULL &&
+    if (v != nullptr && v->as_NewInlineTypeInstance() != nullptr &&
         v->as_NewInlineTypeInstance()->in_larval_state()) {
       v->as_NewInlineTypeInstance()->decrement_on_stack_count();
     }

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -382,7 +382,7 @@ void InstructionPrinter::do_ArrayLength(ArrayLength* x) {
 
 void InstructionPrinter::do_LoadIndexed(LoadIndexed* x) {
   print_indexed(x);
-  if (x->delayed() != NULL) {
+  if (x->delayed() != nullptr) {
     output()->print(" +%d", x->delayed()->offset());
     output()->print(" (%c)", type2char(x->delayed()->field()->type()->basic_type()));
   } else {

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -277,7 +277,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_blackhole(Intrinsic* x);
 
   bool inline_type_field_access_prolog(AccessField* x);
-  void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = NULL, int offset = 0);
+  void access_flattened_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = nullptr, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);
   bool needs_flattened_array_store_check(StoreIndexed* x);

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -42,7 +42,7 @@ class C1_MacroAssembler: public MacroAssembler {
   void explicit_null_check(Register base);
 
   void inline_cache_check(Register receiver, Register iCache);
-  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc = 0, bool needs_stack_repair = false, bool has_scalarized_args = false, Label* verified_inline_entry_label = NULL);
+  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc = 0, bool needs_stack_repair = false, bool has_scalarized_args = false, Label* verified_inline_entry_label = nullptr);
 
   int verified_entry(const CompiledEntrySignature* ces, int frame_size_in_bytes, int bang_size_in_bytes, int sp_offset_for_orig_pc, Label& verified_inline_entry_label) {
     return scalarized_entry(ces, frame_size_in_bytes, bang_size_in_bytes, sp_offset_for_orig_pc, verified_inline_entry_label, false);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -478,9 +478,9 @@ static void profile_flat_array(JavaThread* current) {
   int bci = vfst.bci();
   Method* method = vfst.method();
   MethodData* md = method->method_data();
-  if (md != NULL) {
+  if (md != nullptr) {
     ProfileData* data = md->bci_to_data(bci);
-    assert(data != NULL && data->is_ArrayLoadStoreData(), "incorrect profiling entry");
+    assert(data != nullptr && data->is_ArrayLoadStoreData(), "incorrect profiling entry");
     ArrayLoadStoreData* load_store = (ArrayLoadStoreData*)data;
     load_store->set_flat_array();
   }
@@ -504,7 +504,7 @@ JRT_ENTRY(void, Runtime1::store_flattened_array(JavaThread* current, flatArrayOo
   }
 
   NOT_PRODUCT(_store_flattened_array_slowcase_cnt++;)
-  if (value == NULL) {
+  if (value == nullptr) {
     assert(array->klass()->is_flatArray_klass() || array->klass()->is_null_free_array_klass(), "should not be called");
     SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_NullPointerException());
   } else {

--- a/src/hotspot/share/c1/c1_ValueMap.cpp
+++ b/src/hotspot/share/c1/c1_ValueMap.cpp
@@ -587,8 +587,8 @@ void GlobalValueNumbering::substitute(Instruction* instr) {
   assert(!instr->has_subst(), "substitution already set");
   Value subst = current_map()->find_insert(instr);
   if (subst != instr) {
-    assert(instr->as_LoadIndexed() == NULL || !instr->as_LoadIndexed()->should_profile(), "should not be optimized out");
-    assert(instr->as_StoreIndexed() == NULL, "should not be optimized out");
+    assert(instr->as_LoadIndexed() == nullptr || !instr->as_LoadIndexed()->should_profile(), "should not be optimized out");
+    assert(instr->as_StoreIndexed() == nullptr, "should not be optimized out");
     assert(!subst->has_subst(), "can't have a substitution");
 
     TRACE_VALUE_NUMBERING(tty->print_cr("substitution for %c%d set to %c%d", instr->type()->tchar(), instr->id(), subst->type()->tchar(), subst->id()));

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -147,7 +147,7 @@ class ValueNumberingVisitor: public InstructionVisitor {
       kill_memory();
     } else {
       kill_field(x->field(), x->needs_patching());
-      if (x->enclosing_field() != NULL) {
+      if (x->enclosing_field() != nullptr) {
         kill_field(x->enclosing_field(), true);
       }
     }

--- a/src/hotspot/share/ci/ciArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciArrayKlass.hpp
@@ -56,7 +56,7 @@ public:
   bool is_array_klass() const { return true; }
 
   // The one-level type of the array elements.
-  virtual ciKlass* element_klass() { return NULL; }
+  virtual ciKlass* element_klass() { return nullptr; }
 
   static ciArrayKlass* make(ciType* klass, bool null_free = false);
 

--- a/src/hotspot/share/ci/ciEnv.hpp
+++ b/src/hotspot/share/ci/ciEnv.hpp
@@ -205,7 +205,7 @@ private:
     return get_object(o)->as_instance();
   }
   ciFlatArrayKlass* get_flat_array_klass(Klass* o) {
-    if (o == NULL) return NULL;
+    if (o == nullptr) return nullptr;
     return get_metadata(o)->as_flat_array_klass();
   }
   ciObjArrayKlass* get_obj_array_klass(Klass* o) {

--- a/src/hotspot/share/ci/ciFlatArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciFlatArrayKlass.cpp
@@ -50,7 +50,7 @@ ciFlatArrayKlass::ciFlatArrayKlass(Klass* h_k) : ciArrayKlass(h_k) {
   if (dimension() == 1) {
     _element_klass = _base_element_klass;
   } else {
-    _element_klass = NULL;
+    _element_klass = nullptr;
   }
   if (!ciObjectFactory::is_initialized()) {
     assert(_element_klass->is_java_lang_Object(), "only arrays of object are shared");
@@ -62,8 +62,8 @@ ciFlatArrayKlass::ciFlatArrayKlass(Klass* h_k) : ciArrayKlass(h_k) {
 //
 // What is the one-level element type of this array?
 ciKlass* ciFlatArrayKlass::element_klass() {
-  if (_element_klass == NULL) {
-    assert(dimension() > 1, "_element_klass should not be NULL");
+  if (_element_klass == nullptr) {
+    assert(dimension() > 1, "_element_klass should not be nullptr");
     assert(is_loaded(), "FlatArrayKlass must be loaded");
     // Produce the element klass.
     VM_ENTRY_MARK;
@@ -74,6 +74,6 @@ ciKlass* ciFlatArrayKlass::element_klass() {
 }
 
 ciKlass* ciFlatArrayKlass::exact_klass() {
-  assert(element_klass()->is_loaded() && element_klass()->as_inline_klass()->exact_klass() != NULL, "must have exact klass");
+  assert(element_klass()->is_loaded() && element_klass()->as_inline_klass()->exact_klass() != nullptr, "must have exact klass");
   return this;
 }

--- a/src/hotspot/share/ci/ciInlineKlass.cpp
+++ b/src/hotspot/share/ci/ciInlineKlass.cpp
@@ -30,13 +30,13 @@
 
 int ciInlineKlass::compute_nonstatic_fields() {
   int result = ciInstanceKlass::compute_nonstatic_fields();
-  assert(super() == NULL || !super()->has_nonstatic_fields(), "an inline type must not inherit fields from its superclass");
+  assert(super() == nullptr || !super()->has_nonstatic_fields(), "an inline type must not inherit fields from its superclass");
 
   // Compute declared non-static fields (without flattening of inline type fields)
-  GrowableArray<ciField*>* fields = NULL;
-  GUARDED_VM_ENTRY(fields = compute_nonstatic_fields_impl(NULL, false /* no flattening */);)
+  GrowableArray<ciField*>* fields = nullptr;
+  GUARDED_VM_ENTRY(fields = compute_nonstatic_fields_impl(nullptr, false /* no flattening */);)
   Arena* arena = CURRENT_ENV->arena();
-  _declared_nonstatic_fields = (fields != NULL) ? fields : new (arena) GrowableArray<ciField*>(arena, 0, 0, 0);
+  _declared_nonstatic_fields = (fields != nullptr) ? fields : new (arena) GrowableArray<ciField*>(arena, 0, 0, 0);
   return result;
 }
 

--- a/src/hotspot/share/ci/ciInlineKlass.hpp
+++ b/src/hotspot/share/ci/ciInlineKlass.hpp
@@ -47,7 +47,7 @@ private:
   }
 
 protected:
-  ciInlineKlass(Klass* h_k) : ciInstanceKlass(h_k), _declared_nonstatic_fields(NULL) {
+  ciInlineKlass(Klass* h_k) : ciInstanceKlass(h_k), _declared_nonstatic_fields(nullptr) {
     assert(is_final(), "InlineKlass must be final");
   };
 
@@ -61,7 +61,7 @@ public:
   bool is_inlinetype() const { return true; }
 
   int nof_declared_nonstatic_fields() {
-    if (_declared_nonstatic_fields == NULL) {
+    if (_declared_nonstatic_fields == nullptr) {
       compute_nonstatic_fields();
     }
     return _declared_nonstatic_fields->length();
@@ -69,7 +69,7 @@ public:
 
   // ith non-static declared field (presented by ascending address)
   ciField* declared_nonstatic_field_at(int i) {
-    assert(_declared_nonstatic_fields != NULL, "should be initialized");
+    assert(_declared_nonstatic_fields != nullptr, "should be initialized");
     return _declared_nonstatic_fields->at(i);
   }
 

--- a/src/hotspot/share/ci/ciInstance.hpp
+++ b/src/hotspot/share/ci/ciInstance.hpp
@@ -55,7 +55,7 @@ public:
   // If this object is a java mirror, return the corresponding type.
   // Otherwise, return null.
   // (Remember that a java mirror is an instance of java.lang.Class.)
-  ciType* java_mirror_type(bool* is_val_mirror = NULL);
+  ciType* java_mirror_type(bool* is_val_mirror = nullptr);
 
   // What kind of ciObject is this?
   bool is_instance()     { return true; }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -658,9 +658,9 @@ bool ciMethod::parameter_profiled_type(int i, ciKlass*& type, ProfilePtrKind& pt
 }
 
 bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass*& element_type, ProfilePtrKind& element_ptr, bool &flat_array, bool &null_free_array) {
-  if (method_data() != NULL && method_data()->is_mature()) {
+  if (method_data() != nullptr && method_data()->is_mature()) {
     ciProfileData* data = method_data()->bci_to_data(bci);
-    if (data != NULL && data->is_ArrayLoadStoreData()) {
+    if (data != nullptr && data->is_ArrayLoadStoreData()) {
       ciArrayLoadStoreData* array_access = (ciArrayLoadStoreData*)data->as_ArrayLoadStoreData();
       array_type = array_access->array()->valid_type();
       element_type = array_access->element()->valid_type();
@@ -674,9 +674,9 @@ bool ciMethod::array_access_profiled_type(int bci, ciKlass*& array_type, ciKlass
 }
 
 bool ciMethod::acmp_profiled_type(int bci, ciKlass*& left_type, ciKlass*& right_type, ProfilePtrKind& left_ptr, ProfilePtrKind& right_ptr, bool &left_inline_type, bool &right_inline_type) {
-  if (method_data() != NULL && method_data()->is_mature()) {
+  if (method_data() != nullptr && method_data()->is_mature()) {
     ciProfileData* data = method_data()->bci_to_data(bci);
-    if (data != NULL && data->is_ACmpData()) {
+    if (data != nullptr && data->is_ACmpData()) {
       ciACmpData* acmp = (ciACmpData*)data->as_ACmpData();
       left_type = acmp->left()->valid_type();
       right_type = acmp->right()->valid_type();
@@ -1535,8 +1535,8 @@ bool ciMethod::has_scalarized_args() const {
 
 const GrowableArray<SigEntry>* ciMethod::get_sig_cc() const {
   VM_ENTRY_MARK;
-  if (get_Method()->adapter() == NULL) {
-    return NULL;
+  if (get_Method()->adapter() == nullptr) {
+    return nullptr;
   }
   return get_Method()->adapter()->get_sig_cc();
 }

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -375,7 +375,7 @@ public:
   }
 
 #ifndef PRODUCT
-  void print_data_on(outputStream* st, const char* extra = NULL) const;
+  void print_data_on(outputStream* st, const char* extra = nullptr) const;
 #endif
 };
 
@@ -392,7 +392,7 @@ public:
   }
 
 #ifndef PRODUCT
-  void print_data_on(outputStream* st, const char* extra = NULL) const;
+  void print_data_on(outputStream* st, const char* extra = nullptr) const;
 #endif
 };
 

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -628,7 +628,7 @@ void ciTypeFlow::StateVector::do_checkcast(ciBytecodeStream* str) {
            (Deoptimization::Reason_unloaded,
             Deoptimization::Action_reinterpret));
     } else {
-      // VM's interpreter will not load 'klass' if object is NULL.
+      // VM's interpreter will not load 'klass' if object is nullptr.
       // Type flow after this block may still be needed in two situations:
       // 1) C2 uses do_null_assert() and continues compilation for later blocks
       // 2) C2 does an OSR compile in a later block (see bug 4778368).

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -450,7 +450,7 @@ void ClassLoaderData::classes_do(void f(InstanceKlass*)) {
 
 void ClassLoaderData::inline_classes_do(void f(InlineKlass*)) {
   // Lock-free access requires load_acquire
-  for (Klass* k = Atomic::load_acquire(&_klasses); k != NULL; k = k->next_link()) {
+  for (Klass* k = Atomic::load_acquire(&_klasses); k != nullptr; k = k->next_link()) {
     if (k->is_inline_klass()) {
       f(InlineKlass::cast(k));
     }

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -192,7 +192,7 @@ VerificationType StackMapReader::parse_verification_type(u1* flags, TRAPS) {
     Symbol* klass_name = _cp->klass_name_at(class_index);
     if (klass_name->is_Q_signature()) {
       Symbol* fund_name = klass_name->fundamental_name(THREAD);
-      if (fund_name == NULL) {
+      if (fund_name == nullptr) {
         _stream->stackmap_format_error("TBD something bad happened", THREAD);
         return VerificationType::bogus_type();
       }

--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -264,7 +264,7 @@ class VerificationType {
 
   static VerificationType change_ref_to_inline_type(VerificationType ref) {
     assert(ref.is_reference(), "Bad arg");
-    assert(!ref.is_null(), "Unexpected NULL");
+    assert(!ref.is_null(), "Unexpected nullptr");
     return inline_type(ref.name());
   }
 

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -452,7 +452,7 @@ class ClassVerifier : public StackObj {
     Symbol* name = cp->klass_name_at(index);
     if (name->is_Q_signature()) {
       // Remove the Q and ;
-      // TBD need error msg if fundamental_name() returns NULL?
+      // TBD need error msg if fundamental_name() returns nullptr?
       Symbol* fund_name = name->fundamental_name(CHECK_(VerificationType::bogus_type()));
       return VerificationType::inline_type(fund_name);
     }

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -387,7 +387,7 @@ void CompiledMethod::preserve_callee_argument_oops(frame fr, const RegisterMap *
       // which contains the types of all (oop) fields of the inline type.
       if (is_compiled_by_c2() && callee->has_scalarized_args()) {
         const GrowableArray<SigEntry>* sig = callee->adapter()->get_sig_cc();
-        assert(sig != NULL, "sig should never be null");
+        assert(sig != nullptr, "sig should never be null");
         TempNewSymbol tmp_sig = SigEntry::create_symbol(sig);
         has_receiver = false; // The extended signature contains the receiver type
         fr.oops_compiled_arguments_do(tmp_sig, has_receiver, has_appendix, reg_map, f);

--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -168,7 +168,7 @@ void ObjectValue::write_on(DebugInfoWriteStream* stream) {
     stream->write_int(is_auto_box() ? AUTO_BOX_OBJECT_CODE : OBJECT_CODE);
     stream->write_int(_id);
     _klass->write_on(stream);
-    if (_is_init == NULL) {
+    if (_is_init == nullptr) {
       // MarkerValue is used for null-free objects
       _is_init = new MarkerValue();
     }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -154,7 +154,7 @@ protected:
 public:
   C2ParseAccess(GraphKit* kit, DecoratorSet decorators,
                 BasicType type, Node* base, C2AccessValuePtr& addr,
-                Node* ctl = NULL) :
+                Node* ctl = nullptr) :
     C2Access(decorators, type, base, addr),
     _kit(kit),
     _ctl(ctl) {

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -423,7 +423,7 @@ JVM_FindPrimitiveClass(JNIEnv *env, const char *utf);
 
 
 /*
- * Find a class from a boot class loader. Returns NULL if class not found.
+ * Find a class from a boot class loader. Returns nullptr if class not found.
  */
 JNIEXPORT jclass JNICALL
 JVM_FindClassFromBootLoader(JNIEnv *env, const char *name);

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -538,11 +538,11 @@ private:
   AccessFlags _access_flags;
  public:
   FieldDesc() {
-    _name = NULL;
-    _signature = NULL;
+    _name = nullptr;
+    _signature = nullptr;
     _offset = -1;
     _index = -1;
-    _holder = NULL;
+    _holder = nullptr;
     _access_flags = AccessFlags();
   }
   FieldDesc(fieldDescriptor& fd) {

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -136,13 +136,13 @@ arrayOop oopFactory::new_valueArray(Klass* k, int length, TRAPS) {
   arrayOop oop;
   if (array_klass->is_flatArray_klass()) {
     oop = (arrayOop) FlatArrayKlass::cast(array_klass)->allocate(length, CHECK_NULL);
-    assert(oop == NULL || oop->is_flatArray(), "sanity");
-    assert(oop == NULL || oop->klass()->is_flatArray_klass(), "sanity");
+    assert(oop == nullptr || oop->is_flatArray(), "sanity");
+    assert(oop == nullptr || oop->klass()->is_flatArray_klass(), "sanity");
   } else {
     oop = (arrayOop) ObjArrayKlass::cast(array_klass)->allocate(length, CHECK_NULL);
   }
-  assert(oop == NULL || oop->klass()->is_null_free_array_klass(), "sanity");
-  assert(oop == NULL || oop->is_null_free_array(), "sanity");
+  assert(oop == nullptr || oop->klass()->is_null_free_array_klass(), "sanity");
+  assert(oop == nullptr || oop->is_null_free_array(), "sanity");
   return oop;
 }
 
@@ -156,7 +156,7 @@ objArrayHandle oopFactory::copy_flatArray_to_objArray(flatArrayHandle array, TRA
 }
 
 objArrayHandle  oopFactory::ensure_objArray(oop array, TRAPS) {
-  if (array != NULL && array->is_flatArray()) {
+  if (array != nullptr && array->is_flatArray()) {
     return copy_flatArray_to_objArray(flatArrayHandle(THREAD, flatArrayOop(array)), THREAD);
   } else {
     return objArrayHandle(THREAD, objArrayOop(array));

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -102,25 +102,25 @@ FlatArrayKlass* FlatArrayKlass::allocate_klass(Klass* eklass, TRAPS) {
    *
    */
   // Eagerly allocate the direct array supertype.
-  Klass* super_klass = NULL;
+  Klass* super_klass = nullptr;
   Klass* element_super = element_klass->super();
-  if (element_super != NULL) {
+  if (element_super != nullptr) {
     // The element type has a direct super.  E.g., String[] has direct super of Object[].
     super_klass = element_klass->array_klass_or_null();
-    bool supers_exist = super_klass != NULL;
+    bool supers_exist = super_klass != nullptr;
     // Also, see if the element has secondary supertypes.
     // We need an array type for each.
     const Array<Klass*>* element_supers = element_klass->secondary_supers();
     for( int i = element_supers->length()-1; i >= 0; i-- ) {
       Klass* elem_super = element_supers->at(i);
-      if (elem_super->array_klass_or_null() == NULL) {
+      if (elem_super->array_klass_or_null() == nullptr) {
         supers_exist = false;
         break;
       }
     }
     if (!supers_exist) {
       // Oops.  Not allocated yet.  Back out, allocate it, and retry.
-      Klass* ek = NULL;
+      Klass* ek = nullptr;
       {
         MutexUnlocker mu(MultiArray_lock);
         super_klass = element_klass->array_klass(CHECK_NULL);
@@ -141,7 +141,7 @@ FlatArrayKlass* FlatArrayKlass::allocate_klass(Klass* eklass, TRAPS) {
   FlatArrayKlass* vak = new (loader_data, size, THREAD) FlatArrayKlass(element_klass, name);
 
   ModuleEntry* module = vak->module();
-  assert(module != NULL, "No module entry for array");
+  assert(module != nullptr, "No module entry for array");
   complete_create_array_klass(vak, super_klass, module, CHECK_NULL);
 
   loader_data->add_class(vak);
@@ -327,7 +327,7 @@ void FlatArrayKlass::copy_array(arrayOop s, int src_pos,
      address dst = (address) da->value_at_addr(dst_pos, layout_helper());
      while (src_pos < src_end) {
        oop se = sa->obj_at(src_pos);
-       if (se == NULL) {
+       if (se == nullptr) {
          THROW(vmSymbols::java_lang_NullPointerException());
        }
        // Check exact type per element
@@ -348,7 +348,7 @@ Klass* FlatArrayKlass::array_klass(int n, TRAPS) {
   if (dim == n) return this;
 
   // lock-free read needs acquire semantics
-  if (higher_dimension_acquire() == NULL) {
+  if (higher_dimension_acquire() == nullptr) {
 
     ResourceMark rm(THREAD);
     {
@@ -356,7 +356,7 @@ Klass* FlatArrayKlass::array_klass(int n, TRAPS) {
       MutexLocker mu(THREAD, MultiArray_lock);
 
       // Check if another thread beat us
-      if (higher_dimension() == NULL) {
+      if (higher_dimension() == nullptr) {
 
         // Create multi-dim klass object and link them together
         Klass* k = ObjArrayKlass::allocate_objArray_klass(class_loader_data(), dim + 1, this, false, true, CHECK_NULL);
@@ -381,8 +381,8 @@ Klass* FlatArrayKlass::array_klass_or_null(int n) {
   if (dim == n) return this;
 
   // lock-free read needs acquire semantics
-  if (higher_dimension_acquire() == NULL) {
-    return NULL;
+  if (higher_dimension_acquire() == nullptr) {
+    return nullptr;
   }
 
   ObjArrayKlass *ak = ObjArrayKlass::cast(higher_dimension());
@@ -399,13 +399,13 @@ Klass* FlatArrayKlass::array_klass_or_null() {
 
 
 ModuleEntry* FlatArrayKlass::module() const {
-  assert(element_klass() != NULL, "FlatArrayKlass returned unexpected NULL bottom_klass");
+  assert(element_klass() != nullptr, "FlatArrayKlass returned unexpected nullptr bottom_klass");
   // The array is defined in the module of its bottom class
   return element_klass()->module();
 }
 
 PackageEntry* FlatArrayKlass::package() const {
-  assert(element_klass() != NULL, "FlatArrayKlass returned unexpected NULL bottom_klass");
+  assert(element_klass() != nullptr, "FlatArrayKlass returned unexpected nullptr bottom_klass");
   return element_klass()->package();
 }
 
@@ -415,10 +415,10 @@ bool FlatArrayKlass::can_be_primary_super_slow() const {
 
 GrowableArray<Klass*>* FlatArrayKlass::compute_secondary_supers(int num_extra_slots,
                                                                 Array<InstanceKlass*>* transitive_interfaces) {
-  assert(transitive_interfaces == NULL, "sanity");
+  assert(transitive_interfaces == nullptr, "sanity");
   // interfaces = { cloneable_klass, serializable_klass, elemSuper[], ... };
   Array<Klass*>* elem_supers = element_klass()->secondary_supers();
-  int num_elem_supers = elem_supers == NULL ? 0 : elem_supers->length();
+  int num_elem_supers = elem_supers == nullptr ? 0 : elem_supers->length();
   int num_secondaries = num_extra_slots + 2 + num_elem_supers;
   GrowableArray<Klass*>* secondaries = new GrowableArray<Klass*>(num_elem_supers+2);
 
@@ -427,7 +427,7 @@ GrowableArray<Klass*>* FlatArrayKlass::compute_secondary_supers(int num_extra_sl
   for (int i = 0; i < num_elem_supers; i++) {
     Klass* elem_super = (Klass*) elem_supers->at(i);
     Klass* array_super = elem_super->array_klass_or_null();
-    assert(array_super != NULL, "must already have been created");
+    assert(array_super != nullptr, "must already have been created");
     secondaries->push(array_super);
   }
   return secondaries;

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -59,20 +59,20 @@ InlineKlass::InlineKlass(const ClassFileParser& parser)
 void InlineKlass::init_fixed_block() {
   _adr_inlineklass_fixed_block = inlineklass_static_block();
   // Addresses used for inline type calling convention
-  *((Array<SigEntry>**)adr_extended_sig()) = NULL;
-  *((Array<VMRegPair>**)adr_return_regs()) = NULL;
-  *((address*)adr_pack_handler()) = NULL;
-  *((address*)adr_pack_handler_jobject()) = NULL;
-  *((address*)adr_unpack_handler()) = NULL;
-  assert(pack_handler() == NULL, "pack handler not null");
+  *((Array<SigEntry>**)adr_extended_sig()) = nullptr;
+  *((Array<VMRegPair>**)adr_return_regs()) = nullptr;
+  *((address*)adr_pack_handler()) = nullptr;
+  *((address*)adr_pack_handler_jobject()) = nullptr;
+  *((address*)adr_unpack_handler()) = nullptr;
+  assert(pack_handler() == nullptr, "pack handler not null");
   *((int*)adr_default_value_offset()) = 0;
-  *((address*)adr_value_array_klasses()) = NULL;
+  *((address*)adr_value_array_klasses()) = nullptr;
 }
 
 oop InlineKlass::default_value() {
   assert(is_initialized() || is_being_initialized() || is_in_error_state(), "default value is set at the beginning of initialization");
   oop val = java_mirror()->obj_field_acquire(default_value_offset());
-  assert(val != NULL, "Sanity check");
+  assert(val != nullptr, "Sanity check");
   assert(oopDesc::is_oop(val), "Sanity check");
   assert(val->is_inline_type(), "Sanity check");
   assert(val->klass() == this, "sanity check");
@@ -122,7 +122,7 @@ int InlineKlass::nonstatic_oop_count() {
 }
 
 oop InlineKlass::read_inlined_field(oop obj, int offset, TRAPS) {
-  oop res = NULL;
+  oop res = nullptr;
   assert(is_initialized() || is_being_initialized()|| is_in_error_state(),
         "Must be initialized, initializing or in a corner case of an escaped instance of a class that failed its initialization");
   if (is_empty_inline_type()) {
@@ -132,12 +132,12 @@ oop InlineKlass::read_inlined_field(oop obj, int offset, TRAPS) {
     res = allocate_instance_buffer(CHECK_NULL);
     inline_copy_payload_to_new_oop(((char*)(oopDesc*)obj_h()) + offset, res);
   }
-  assert(res != NULL, "Must be set in one of two paths above");
+  assert(res != nullptr, "Must be set in one of two paths above");
   return res;
 }
 
 void InlineKlass::write_inlined_field(oop obj, int offset, oop value, TRAPS) {
-  if (value == NULL) {
+  if (value == nullptr) {
     THROW(vmSymbols::java_lang_NullPointerException());
   }
   if (!is_empty_inline_type()) {
@@ -172,7 +172,7 @@ bool InlineKlass::flatten_array() {
 }
 
 Klass* InlineKlass::value_array_klass(int n, TRAPS) {
-  if (Atomic::load_acquire(adr_value_array_klasses()) == NULL) {
+  if (Atomic::load_acquire(adr_value_array_klasses()) == nullptr) {
     ResourceMark rm(THREAD);
     JavaThread *jt = JavaThread::cast(THREAD);
     {
@@ -180,7 +180,7 @@ Klass* InlineKlass::value_array_klass(int n, TRAPS) {
       MutexLocker ma(THREAD, MultiArray_lock);
 
       // Check if update has already taken place
-      if (value_array_klasses() == NULL) {
+      if (value_array_klasses() == nullptr) {
         ArrayKlass* k;
         if (flatten_array()) {
           k = FlatArrayKlass::allocate_klass(this, CHECK_NULL);
@@ -200,8 +200,8 @@ Klass* InlineKlass::value_array_klass(int n, TRAPS) {
 Klass* InlineKlass::value_array_klass_or_null(int n) {
   // Need load-acquire for lock-free read
   ArrayKlass* ak = Atomic::load_acquire(adr_value_array_klasses());
-  if (ak == NULL) {
-    return NULL;
+  if (ak == nullptr) {
+    return nullptr;
   } else {
     return ak->array_klass_or_null(n);
   }
@@ -301,16 +301,16 @@ void InlineKlass::initialize_calling_convention(TRAPS) {
     }
     if (!can_be_returned_as_fields() && !can_be_passed_as_fields()) {
       MetadataFactory::free_array<SigEntry>(class_loader_data(), extended_sig);
-      assert(return_regs() == NULL, "sanity");
+      assert(return_regs() == nullptr, "sanity");
     }
   }
 }
 
 void InlineKlass::deallocate_contents(ClassLoaderData* loader_data) {
-  if (extended_sig() != NULL) {
+  if (extended_sig() != nullptr) {
     MetadataFactory::free_array<SigEntry>(loader_data, extended_sig());
   }
-  if (return_regs() != NULL) {
+  if (return_regs() != nullptr) {
     MetadataFactory::free_array<VMRegPair>(loader_data, return_regs());
   }
   cleanup_blobs();
@@ -322,13 +322,13 @@ void InlineKlass::cleanup(InlineKlass* ik) {
 }
 
 void InlineKlass::cleanup_blobs() {
-  if (pack_handler() != NULL) {
+  if (pack_handler() != nullptr) {
     CodeBlob* buffered_blob = CodeCache::find_blob(pack_handler());
     assert(buffered_blob->is_buffered_inline_type_blob(), "bad blob type");
     BufferBlob::free((BufferBlob*)buffered_blob);
-    *((address*)adr_pack_handler()) = NULL;
-    *((address*)adr_pack_handler_jobject()) = NULL;
-    *((address*)adr_unpack_handler()) = NULL;
+    *((address*)adr_pack_handler()) = nullptr;
+    *((address*)adr_pack_handler_jobject()) = nullptr;
+    *((address*)adr_unpack_handler()) = nullptr;
   }
 }
 
@@ -339,7 +339,7 @@ bool InlineKlass::can_be_passed_as_fields() const {
 
 // Can this inline type be returned as multiple values?
 bool InlineKlass::can_be_returned_as_fields(bool init) const {
-  return InlineTypeReturnedAsFields && (init || return_regs() != NULL);
+  return InlineTypeReturnedAsFields && (init || return_regs() != nullptr);
 }
 
 // Create handles for all oop fields returned in registers that are going to be live across a safepoint
@@ -355,7 +355,7 @@ void InlineKlass::save_oop_fields(const RegisterMap& reg_map, GrowableArray<Hand
       VMRegPair pair = regs->at(j);
       address loc = reg_map.location(pair.first(), nullptr);
       oop v = *(oop*)loc;
-      assert(v == NULL || oopDesc::is_oop(v), "not an oop?");
+      assert(v == nullptr || oopDesc::is_oop(v), "not an oop?");
       assert(Universe::heap()->is_in_or_null(v), "must be heap pointer");
       handles.push(Handle(thread, v));
     }
@@ -377,7 +377,7 @@ void InlineKlass::restore_oop_results(RegisterMap& reg_map, GrowableArray<Handle
   assert(InlineTypeReturnedAsFields, "Inline types should never be returned as fields");
   const Array<SigEntry>* sig_vk = extended_sig();
   const Array<VMRegPair>* regs = return_regs();
-  assert(regs != NULL, "inconsistent");
+  assert(regs != nullptr, "inconsistent");
 
   int j = 1;
   for (int i = 0, k = 0; i < sig_vk->length(); i++) {
@@ -499,7 +499,7 @@ InlineKlass* InlineKlass::returned_inline_klass(const RegisterMap& map) {
   // Return value is not tagged, must be a valid oop
   assert(oopDesc::is_oop_or_null(cast_to_oop(ptr), true),
          "Bad oop return: " PTR_FORMAT, ptr);
-  return NULL;
+  return nullptr;
 }
 
 // CDS support
@@ -515,27 +515,27 @@ void InlineKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 void InlineKlass::remove_unshareable_info() {
   InstanceKlass::remove_unshareable_info();
 
-  *((Array<SigEntry>**)adr_extended_sig()) = NULL;
-  *((Array<VMRegPair>**)adr_return_regs()) = NULL;
-  *((address*)adr_pack_handler()) = NULL;
-  *((address*)adr_pack_handler_jobject()) = NULL;
-  *((address*)adr_unpack_handler()) = NULL;
-  assert(pack_handler() == NULL, "pack handler not null");
-  if (value_array_klasses() != NULL) {
+  *((Array<SigEntry>**)adr_extended_sig()) = nullptr;
+  *((Array<VMRegPair>**)adr_return_regs()) = nullptr;
+  *((address*)adr_pack_handler()) = nullptr;
+  *((address*)adr_pack_handler_jobject()) = nullptr;
+  *((address*)adr_unpack_handler()) = nullptr;
+  assert(pack_handler() == nullptr, "pack handler not null");
+  if (value_array_klasses() != nullptr) {
     value_array_klasses()->remove_unshareable_info();
   }
 }
 
 void InlineKlass::remove_java_mirror() {
   InstanceKlass::remove_java_mirror();
-  if (value_array_klasses() != NULL) {
+  if (value_array_klasses() != nullptr) {
     value_array_klasses()->remove_java_mirror();
   }
 }
 
 void InlineKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS) {
   InstanceKlass::restore_unshareable_info(loader_data, protection_domain, pkg_entry, CHECK);
-  if (value_array_klasses() != NULL) {
+  if (value_array_klasses() != nullptr) {
     value_array_klasses()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);
   }
 }

--- a/src/hotspot/share/oops/inlineKlass.hpp
+++ b/src/hotspot/share/oops/inlineKlass.hpp
@@ -55,33 +55,33 @@ class InlineKlass: public InstanceKlass {
   inline address adr_return_regs() const;
 
   address adr_extended_sig() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _extended_sig));
   }
 
   // pack and unpack handlers for inline types return
   address adr_pack_handler() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _pack_handler));
   }
 
   address adr_pack_handler_jobject() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _pack_handler_jobject));
   }
 
   address adr_unpack_handler() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _unpack_handler));
   }
 
   address adr_default_value_offset() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(default_value_offset_offset());
   }
 
   ArrayKlass* volatile* adr_value_array_klasses() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return (ArrayKlass* volatile*) ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _null_free_inline_array_klasses));
   }
 
@@ -90,17 +90,17 @@ class InlineKlass: public InstanceKlass {
   }
 
   address adr_alignment() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _alignment));
   }
 
   address adr_first_field_offset() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _first_field_offset));
   }
 
   address adr_exact_size_in_bytes() const {
-    assert(_adr_inlineklass_fixed_block != NULL, "Should have been initialized");
+    assert(_adr_inlineklass_fixed_block != nullptr, "Should have been initialized");
     return ((address)_adr_inlineklass_fixed_block) + in_bytes(byte_offset_of(InlineKlassFixedBlock, _exact_size_in_bytes));
   }
 

--- a/src/hotspot/share/oops/inlineKlass.inline.hpp
+++ b/src/hotspot/share/oops/inlineKlass.inline.hpp
@@ -34,12 +34,12 @@
 
 inline InlineKlassFixedBlock* InlineKlass::inlineklass_static_block() const {
   address adr_jf = adr_inline_type_field_klasses();
-  if (adr_jf != NULL) {
+  if (adr_jf != nullptr) {
     return (InlineKlassFixedBlock*)(adr_jf + this->java_fields_count() * sizeof(Klass*));
   }
 
   InstanceKlass* volatile* adr_impl = adr_implementor();
-  if (adr_impl != NULL) {
+  if (adr_impl != nullptr) {
     return (InlineKlassFixedBlock*)(adr_impl + 1);
   }
 

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -295,7 +295,7 @@ class InstanceKlass: public Klass {
   Array<u1>*          _fieldinfo_stream;
   Array<FieldStatus>* _fields_status;
 
-  const Klass**   _inline_type_field_klasses; // For "inline class" fields, NULL if none present
+  const Klass**   _inline_type_field_klasses; // For "inline class" fields, null if none present
   Array<u2>* _preload_classes;
   const InlineKlassFixedBlock* _adr_inlineklass_fixed_block;
 

--- a/src/hotspot/share/oops/instanceKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceKlass.inline.hpp
@@ -69,13 +69,13 @@ inline InstanceKlass* volatile* InstanceKlass::adr_implementor() const {
 inline address InstanceKlass::adr_inline_type_field_klasses() const {
   if (has_inline_type_fields()) {
     InstanceKlass* volatile* adr_impl = adr_implementor();
-    if (adr_impl != NULL) {
+    if (adr_impl != nullptr) {
       return (address)(adr_impl + 1);
     }
 
     return (address)end_of_nonstatic_oop_maps();
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -83,7 +83,7 @@ inline Klass* InstanceKlass::get_inline_type_field_klass(int idx) const {
   assert(has_inline_type_fields(), "Sanity checking");
   assert(idx < java_fields_count(), "IOOB");
   Klass* k = ((Klass**)adr_inline_type_field_klasses())[idx];
-  assert(k != NULL, "Should always be set before being read");
+  assert(k != nullptr, "Should always be set before being read");
   assert(k->is_inline_klass(), "Must be an inline type");
   return k;
 }
@@ -92,22 +92,22 @@ inline Klass* InstanceKlass::get_inline_type_field_klass_or_null(int idx) const 
   assert(has_inline_type_fields(), "Sanity checking");
   assert(idx < java_fields_count(), "IOOB");
   Klass* k = ((Klass**)adr_inline_type_field_klasses())[idx];
-  assert(k == NULL || k->is_inline_klass(), "Must be an inline type");
+  assert(k == nullptr || k->is_inline_klass(), "Must be an inline type");
   return k;
 }
 
 inline void InstanceKlass::set_inline_type_field_klass(int idx, Klass* k) {
   assert(has_inline_type_fields(), "Sanity checking");
   assert(idx < java_fields_count(), "IOOB");
-  assert(k != NULL, "Should not be set to NULL");
-  assert(((Klass**)adr_inline_type_field_klasses())[idx] == NULL, "Should not be set twice");
+  assert(k != nullptr, "Should not be set to nullptr");
+  assert(((Klass**)adr_inline_type_field_klasses())[idx] == nullptr, "Should not be set twice");
   ((Klass**)adr_inline_type_field_klasses())[idx] = k;
 }
 
 inline void InstanceKlass::reset_inline_type_field_klass(int idx) {
   assert(has_inline_type_fields(), "Sanity checking");
   assert(idx < java_fields_count(), "IOOB");
-  ((Klass**)adr_inline_type_field_klasses())[idx] = NULL;
+  ((Klass**)adr_inline_type_field_klasses())[idx] = nullptr;
 }
 
 

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -711,7 +711,7 @@ protected:
     return _prototype_header;
   }
   static inline markWord default_prototype_header(Klass* k) {
-    return (k == NULL) ? markWord::prototype() : k->prototype_header();
+    return (k == nullptr) ? markWord::prototype() : k->prototype_header();
   }
 
   inline void set_prototype_header(markWord header);

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -111,7 +111,7 @@
 //  are placed lowest next to lock bits to more easily decode forwarding pointers.
 //  G1 for example, implicitly clears age bits ("G1FullGCCompactionPoint::forward()")
 //  using "oopDesc->forwardee()", so it necessary for "markWord::decode_pointer()"
-//  to return a non-NULL for this case, but not confuse the static type bits for
+//  to return a non-nullptr for this case, but not confuse the static type bits for
 //  a pointer.
 //
 //  Static types bits are recorded in the "klass->prototype_header()", displaced
@@ -412,7 +412,7 @@ class markWord {
 
   // Recover address of oop from encoded form used in mark
   inline void* decode_pointer() {
-    return (EnableValhalla && _value < static_prototype_value_max) ? NULL :
+    return (EnableValhalla && _value < static_prototype_value_max) ? nullptr :
       (void*) (clear_lock_bits().value());
   }
 };

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -463,11 +463,11 @@ public:
   }
   ArrayLoadStoreData* as_ArrayLoadStoreData() const {
     assert(is_ArrayLoadStoreData(), "wrong type");
-    return is_ArrayLoadStoreData() ? (ArrayLoadStoreData*)this : NULL;
+    return is_ArrayLoadStoreData() ? (ArrayLoadStoreData*)this : nullptr;
   }
   ACmpData* as_ACmpData() const {
     assert(is_ACmpData(), "wrong type");
-    return is_ACmpData() ? (ACmpData*)this : NULL;
+    return is_ACmpData() ? (ACmpData*)this : nullptr;
   }
 
 
@@ -1935,7 +1935,7 @@ public:
     return cell_offset(static_cell_count());
   }
 
-  virtual void print_data_on(outputStream* st, const char* extra = NULL) const;
+  virtual void print_data_on(outputStream* st, const char* extra = nullptr) const;
 };
 
 class ACmpData : public BranchData {
@@ -2008,7 +2008,7 @@ public:
     return cell_offset(static_cell_count());
   }
 
-  virtual void print_data_on(outputStream* st, const char* extra = NULL) const;
+  virtual void print_data_on(outputStream* st, const char* extra = nullptr) const;
 };
 
 // MethodData*

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -572,18 +572,18 @@ public:
   Node* resproj[1]; // at least one projection
 
   CallProjections(uint nbres) {
-    fallthrough_proj      = NULL;
-    fallthrough_catchproj = NULL;
-    fallthrough_memproj   = NULL;
-    fallthrough_ioproj    = NULL;
-    catchall_catchproj    = NULL;
-    catchall_memproj      = NULL;
-    catchall_ioproj       = NULL;
-    exobj                 = NULL;
+    fallthrough_proj      = nullptr;
+    fallthrough_catchproj = nullptr;
+    fallthrough_memproj   = nullptr;
+    fallthrough_ioproj    = nullptr;
+    catchall_catchproj    = nullptr;
+    catchall_memproj      = nullptr;
+    catchall_ioproj       = nullptr;
+    exobj                 = nullptr;
     nb_resproj            = nbres;
-    resproj[0]            = NULL;
+    resproj[0]            = nullptr;
     for (uint i = 1; i < nb_resproj; i++) {
-      resproj[i]          = NULL;
+      resproj[i]          = nullptr;
     }
   }
 
@@ -748,7 +748,7 @@ public:
     }
     const TypeTuple *r = tf->range_sig();
     if (InlineTypeReturnedAsFields &&
-        method != NULL &&
+        method != nullptr &&
         method->is_method_handle_intrinsic() &&
         r->cnt() > TypeFunc::Parms &&
         r->field_at(TypeFunc::Parms)->isa_oopptr() &&
@@ -947,7 +947,7 @@ public:
   virtual uint size_of() const; // Size is bigger
   AllocateNode(Compile* C, const TypeFunc *atype, Node *ctrl, Node *mem, Node *abio,
                Node *size, Node *klass_node, Node *initial_test,
-               InlineTypeNode* inline_type_node = NULL);
+               InlineTypeNode* inline_type_node = nullptr);
   // Expansion modifies the JVMState, so we need to deep clone it
   virtual bool needs_deep_clone_jvms(Compile* C) { return true; }
   virtual int Opcode() const;

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -435,7 +435,7 @@ public:
   // Returns null is it couldn't improve the type.
   static const TypeInt* filtered_int_type(PhaseGVN* phase, Node* val, Node* if_proj);
 
-  bool is_flat_array_check(PhaseTransform* phase, Node** array = NULL);
+  bool is_flat_array_check(PhaseTransform* phase, Node** array = nullptr);
 
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1238,7 +1238,7 @@ bool IfNode::is_flat_array_check(PhaseTransform* phase, Node** array) {
   }
   Node* cmp = bol->in(1);
   if (cmp->isa_FlatArrayCheck()) {
-    if (array != NULL) {
+    if (array != nullptr) {
       *array = cmp->in(FlatArrayCheckNode::ArrayOrKlass);
     }
     return true;

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -160,15 +160,15 @@ void InlineTypeNode::add_new_path(Node* region) {
   assert(has_phi_inputs(region), "must have phi inputs");
 
   PhiNode* phi = get_oop()->as_Phi();
-  phi->add_req(NULL);
+  phi->add_req(nullptr);
   assert(phi->req() == region->req(), "must be same size as region");
 
   phi = get_is_buffered()->as_Phi();
-  phi->add_req(NULL);
+  phi->add_req(nullptr);
   assert(phi->req() == region->req(), "must be same size as region");
 
   phi = get_is_init()->as_Phi();
-  phi->add_req(NULL);
+  phi->add_req(nullptr);
   assert(phi->req() == region->req(), "must be same size as region");
 
   for (uint i = 0; i < field_count(); ++i) {
@@ -176,7 +176,7 @@ void InlineTypeNode::add_new_path(Node* region) {
     if (val->is_InlineType()) {
       val->as_InlineType()->add_new_path(region);
     } else {
-      val->as_Phi()->add_req(NULL);
+      val->as_Phi()->add_req(nullptr);
       assert(val->req() == region->req(), "must be same size as region");
     }
   }
@@ -195,7 +195,7 @@ Node* InlineTypeNode::field_value_by_offset(int offset, bool recursive) const {
   int index = inline_klass()->field_index_by_offset(offset);
   int sub_offset = offset - field_offset(index);
   Node* value = field_value(index);
-  assert(value != NULL, "field value not found");
+  assert(value != nullptr, "field value not found");
   if (recursive && value->is_InlineType()) {
     if (field_is_flattened(index)) {
       // Flattened inline type field
@@ -257,11 +257,11 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
   uint nfields = vk->nof_nonstatic_fields();
   JVMState* jvms = sfpt->jvms();
   // Replace safepoint edge by SafePointScalarObjectNode and add field values
-  assert(jvms != NULL, "missing JVMS");
+  assert(jvms != nullptr, "missing JVMS");
   uint first_ind = (sfpt->req() - jvms->scloff());
   SafePointScalarObjectNode* sobj = new SafePointScalarObjectNode(type()->isa_instptr(),
 #ifdef ASSERT
-                                                                  NULL,
+                                                                  nullptr,
 #endif
                                                                   first_ind, nfields);
   sobj->init_req(0, igvn->C->root());
@@ -288,7 +288,7 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
   igvn->rehash_node_delayed(sfpt);
   for (uint i = jvms->debug_start(); i < jvms->debug_end(); i++) {
     Node* debug = sfpt->in(i);
-    if (debug != NULL && debug->uncast() == this) {
+    if (debug != nullptr && debug->uncast() == this) {
       sfpt->set_req(i, sobj);
     }
   }
@@ -324,7 +324,7 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
     if (use_oop) {
       for (uint i = sfpt->jvms()->debug_start(); i < sfpt->jvms()->debug_end(); i++) {
         Node* debug = sfpt->in(i);
-        if (debug != NULL && debug->uncast() == this) {
+        if (debug != nullptr && debug->uncast() == this) {
           sfpt->set_req(i, get_oop());
         }
       }
@@ -345,8 +345,8 @@ void InlineTypeNode::make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oo
 
 const TypePtr* InlineTypeNode::field_adr_type(Node* base, int offset, ciInstanceKlass* holder, DecoratorSet decorators, PhaseGVN& gvn) const {
   const TypeAryPtr* ary_type = gvn.type(base)->isa_aryptr();
-  const TypePtr* adr_type = NULL;
-  bool is_array = ary_type != NULL;
+  const TypePtr* adr_type = nullptr;
+  bool is_array = ary_type != nullptr;
   if ((decorators & C2_MISMATCHED) != 0) {
     adr_type = TypeRawPtr::BOTTOM;
   } else if (is_array) {
@@ -354,7 +354,7 @@ const TypePtr* InlineTypeNode::field_adr_type(Node* base, int offset, ciInstance
     adr_type = ary_type->with_field_offset(offset)->add_offset(Type::OffsetBot);
   } else {
     ciField* field = holder->get_field_by_offset(offset, false);
-    assert(field != NULL, "field not found");
+    assert(field != nullptr, "field not found");
     adr_type = gvn.C->alias_type(field)->adr_type();
   }
   return adr_type;
@@ -408,7 +408,7 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass*
   // memory and adding the values as input edges to the node.
   for (uint i = 0; i < field_count(); ++i) {
     int offset = holder_offset + field_offset(i);
-    Node* value = NULL;
+    Node* value = nullptr;
     ciType* ft = field_type(i);
     bool null_free = field_is_null_free(i);
     if (null_free && ft->as_inline_klass()->is_empty()) {
@@ -419,17 +419,17 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass*
       value = make_from_flattened_impl(kit, ft->as_inline_klass(), base, ptr, holder, offset, decorators, visited);
     } else {
       const TypeOopPtr* oop_ptr = kit->gvn().type(base)->isa_oopptr();
-      bool is_array = (oop_ptr->isa_aryptr() != NULL);
+      bool is_array = (oop_ptr->isa_aryptr() != nullptr);
       bool mismatched = (decorators & C2_MISMATCHED) != 0;
       if (base->is_Con() && !is_array && !mismatched) {
         // If the oop to the inline type is constant (static final field), we can
         // also treat the fields as constants because the inline type is immutable.
         ciObject* constant_oop = oop_ptr->const_oop();
         ciField* field = holder->get_field_by_offset(offset, false);
-        assert(field != NULL, "field not found");
+        assert(field != nullptr, "field not found");
         ciConstant constant = constant_oop->as_instance()->field_value(field);
         const Type* con_type = Type::make_from_constant(constant, /*require_const=*/ true);
-        assert(con_type != NULL, "type not found");
+        assert(con_type != nullptr, "type not found");
         value = kit->gvn().transform(kit->makecon(con_type));
         // Check type of constant which might be more precise than the static field type
         if (con_type->is_inlinetypeptr() && !con_type->is_zero_type()) {
@@ -465,7 +465,7 @@ void InlineTypeNode::store_flattened(GraphKit* kit, Node* base, Node* ptr, ciIns
   }
   // The inline type is embedded into the object without an oop header. Subtract the
   // offset of the first field to account for the missing header when storing the values.
-  if (holder == NULL) {
+  if (holder == nullptr) {
     holder = inline_klass();
   }
   holder_offset -= inline_klass()->first_field_offset();
@@ -488,7 +488,7 @@ void InlineTypeNode::store(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass
       BasicType bt = type2field[ft->basic_type()];
       assert(is_java_primitive(bt) || adr->bottom_type()->is_ptr_to_narrowoop() == UseCompressedOops, "inconsistent");
       const Type* val_type = Type::get_const_type(ft);
-      bool is_array = (kit->gvn().type(base)->isa_aryptr() != NULL);
+      bool is_array = (kit->gvn().type(base)->isa_aryptr() != nullptr);
       kit->access_store_at(base, adr, adr_type, value, val_type, bt, is_array ? (decorators | IS_ARRAY) : decorators);
     }
   }
@@ -550,13 +550,13 @@ InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
     kit->kill_dead_locals();
     ciInlineKlass* vk = inline_klass();
     Node* klass_node = kit->makecon(TypeKlassPtr::make(vk));
-    Node* alloc_oop  = kit->new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true, this);
+    Node* alloc_oop  = kit->new_instance(klass_node, nullptr, nullptr, /* deoptimize_on_exception */ true, this);
     store(kit, alloc_oop, alloc_oop, vk);
 
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
     AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop, &kit->gvn());
-    assert(alloc != NULL, "must have an allocation node");
+    assert(alloc != nullptr, "must have an allocation node");
     kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
 
     region->init_req(3, kit->control());
@@ -594,7 +594,7 @@ bool InlineTypeNode::is_allocated(PhaseGVN* phase) const {
     return true;
   }
   Node* oop = get_oop();
-  const Type* oop_type = (phase != NULL) ? phase->type(oop) : oop->bottom_type();
+  const Type* oop_type = (phase != nullptr) ? phase->type(oop) : oop->bottom_type();
   return !oop_type->maybe_null();
 }
 
@@ -607,7 +607,7 @@ void InlineTypeNode::replace_call_results(GraphKit* kit, CallNode* call, Compile
   for (DUIterator_Fast imax, i = call->fast_outs(imax); i < imax; i++) {
     ProjNode* pn = call->fast_out(i)->as_Proj();
     uint con = pn->_con;
-    Node* field = NULL;
+    Node* field = nullptr;
     if (con == TypeFunc::Parms) {
       field = get_oop();
     } else if (!null_free && con == (call->tf()->range_cc()->cnt() - 1)) {
@@ -625,7 +625,7 @@ void InlineTypeNode::replace_call_results(GraphKit* kit, CallNode* call, Compile
       ciField* f = vk->nonstatic_field_at(field_nb - extra);
       field = field_value_by_offset(f->offset_in_bytes(), true);
     }
-    if (field != NULL) {
+    if (field != nullptr) {
       C->gvn_replace_by(pn, field);
       C->initial_gvn()->hash_delete(pn);
       pn->set_req(0, C->top());
@@ -659,7 +659,7 @@ static void replace_allocation(PhaseIterGVN* igvn, Node* res, Node* dom) {
     if (use->is_AddP()) {
       for (DUIterator_Fast jmax, j = use->fast_outs(jmax); j < jmax; j++) {
         Node* store = use->fast_out(j)->isa_Store();
-        if (store != NULL) {
+        if (store != nullptr) {
           igvn->rehash_node_delayed(store);
           igvn->replace_in_uses(store, store->in(MemNode::Memory));
         }
@@ -704,7 +704,7 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     // Save base oop if fields are loaded from memory and the inline
     // type is not buffered (in this case we should not use the oop).
     Node* base = is_loaded(phase);
-    if (base != NULL && !phase->type(base)->maybe_null()) {
+    if (base != nullptr && !phase->type(base)->maybe_null()) {
       set_oop(base);
       assert(is_allocated(phase), "should now be allocated");
       return this;
@@ -720,10 +720,10 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       // but later decide to inline the call after the callee code also triggered allocation.
       for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
         AllocateNode* alloc = fast_out(i)->isa_Allocate();
-        if (alloc != NULL && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
+        if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
           // Found a re-allocation
           Node* res = alloc->result_cast();
-          if (res != NULL && res->is_CheckCastPP()) {
+          if (res != nullptr && res->is_CheckCastPP()) {
             // Replace allocation by oop and unlink AllocateNode
             replace_allocation(igvn, res, oop);
             igvn->replace_input_of(alloc, AllocateNode::InlineType, igvn->C->top());
@@ -734,11 +734,11 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     }
   }
 
-  return NULL;
+  return nullptr;
 }
 
 InlineTypeNode* InlineTypeNode::make_uninitialized(PhaseGVN& gvn, ciInlineKlass* vk, bool null_free) {
-  // Create a new InlineTypeNode with uninitialized values and NULL oop
+  // Create a new InlineTypeNode with uninitialized values and nullptr oop
   Node* oop = (vk->is_empty() && vk->is_initialized()) ? default_oop(gvn, vk) : gvn.zerocon(T_PRIMITIVE_OBJECT);
   InlineTypeNode* vt = new InlineTypeNode(vk, oop, null_free);
   vt->set_is_buffered(gvn, vk->is_empty() && vk->is_initialized());
@@ -825,7 +825,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
   }
   // Create and initialize an InlineTypeNode by loading all field
   // values from a heap-allocated version and also save the oop.
-  InlineTypeNode* vt = NULL;
+  InlineTypeNode* vt = nullptr;
 
   if (oop->isa_InlineType()) {
     return oop->as_InlineType();
@@ -850,7 +850,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     vt->load(kit, not_null_oop, not_null_oop, vk, visited);
 
     if (null_ctl != kit->top()) {
-      InlineTypeNode* null_vt = NULL;
+      InlineTypeNode* null_vt = nullptr;
       if (null_free) {
         null_vt = make_default_impl(gvn, vk, visited);
       } else {
@@ -876,7 +876,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
     vt->load(kit, oop, oop, vk, visited);
 // TODO 8284443
 //    assert(!null_free || vt->as_InlineType()->is_default(&gvn) || init_ctl != kit->control() || !gvn.type(oop)->is_inlinetypeptr() || oop->is_Con() || oop->Opcode() == Op_InlineType ||
-//           AllocateNode::Ideal_allocation(oop, &gvn) != NULL || vt->as_InlineType()->is_loaded(&gvn) == oop, "inline type should be loaded");
+//           AllocateNode::Ideal_allocation(oop, &gvn) != nullptr || vt->as_InlineType()->is_loaded(&gvn) == oop, "inline type should be loaded");
   }
   assert(!null_free || vt->is_allocated(&gvn), "inline type should be allocated");
   kit->record_for_igvn(vt);
@@ -914,7 +914,7 @@ InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi,
   }
   GrowableArray<ciType*> visited;
   visited.push(vk);
-  vt->initialize_fields(kit, multi, base_input, in, null_free, NULL, visited);
+  vt->initialize_fields(kit, multi, base_input, in, null_free, nullptr, visited);
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
@@ -930,7 +930,7 @@ InlineTypeNode* InlineTypeNode::make_larval(GraphKit* kit, bool allocate) const 
     PreserveReexecuteState preexecs(kit);
     kit->jvms()->set_should_reexecute(true);
     Node* klass_node = kit->makecon(TypeKlassPtr::make(vk));
-    Node* alloc_oop  = kit->new_instance(klass_node, NULL, NULL, true);
+    Node* alloc_oop  = kit->new_instance(klass_node, nullptr, nullptr, true);
     AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop, &kit->gvn());
     alloc->_larval = true;
 
@@ -947,14 +947,14 @@ InlineTypeNode* InlineTypeNode::make_larval(GraphKit* kit, bool allocate) const 
 InlineTypeNode* InlineTypeNode::finish_larval(GraphKit* kit) const {
   Node* obj = get_oop();
   Node* mark_addr = kit->basic_plus_adr(obj, oopDesc::mark_offset_in_bytes());
-  Node* mark = kit->make_load(NULL, mark_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
+  Node* mark = kit->make_load(nullptr, mark_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
   mark = kit->gvn().transform(new AndXNode(mark, kit->MakeConX(~markWord::larval_bit_in_place)));
   kit->store_to_memory(kit->control(), mark_addr, mark, TypeX_X->basic_type(), kit->gvn().type(mark_addr)->is_ptr(), MemNode::unordered);
 
   // Do not let stores that initialize this buffer be reordered with a subsequent
   // store that would make this buffer accessible by other threads.
   AllocateNode* alloc = AllocateNode::Ideal_allocation(obj, &kit->gvn());
-  assert(alloc != NULL, "must have an allocation node");
+  assert(alloc != nullptr, "must have an allocation node");
   kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
 
   ciInlineKlass* vk = inline_klass();
@@ -975,11 +975,11 @@ bool InlineTypeNode::is_larval(PhaseGVN* gvn) const {
 
   Node* oop = get_oop();
   AllocateNode* alloc = AllocateNode::Ideal_allocation(oop, gvn);
-  return alloc != NULL && alloc->_larval;
+  return alloc != nullptr && alloc->_larval;
 }
 
 Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, int holder_offset) {
-  if (vk == NULL) {
+  if (vk == nullptr) {
     vk = inline_klass();
   }
   if (field_count() == 0 && vk->is_initialized()) {
@@ -989,7 +989,7 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
       return get_oop();
     } else {
       // TODO 8284443
-      return NULL;
+      return nullptr;
     }
   }
   for (uint i = 0; i < field_count(); ++i) {
@@ -1002,8 +1002,8 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
       } else if (field_is_flattened(i) && vt->is_InlineType()) {
         // Check inline type field load recursively
         base = vt->as_InlineType()->is_loaded(phase, vk, base, offset - vt->type()->inline_klass()->first_field_offset());
-        if (base == NULL) {
-          return NULL;
+        if (base == nullptr) {
+          return nullptr;
         }
         continue;
       } else {
@@ -1022,18 +1022,18 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
       // Check if base and offset of field load matches inline type layout
       intptr_t loffset = 0;
       Node* lbase = AddPNode::Ideal_base_and_offset(value->in(MemNode::Address), phase, loffset);
-      if (lbase == NULL || (lbase != base && base != NULL) || loffset != offset) {
-        return NULL;
-      } else if (base == NULL) {
+      if (lbase == nullptr || (lbase != base && base != nullptr) || loffset != offset) {
+        return nullptr;
+      } else if (base == nullptr) {
         // Set base and check if pointer type matches
         base = lbase;
         const TypeInstPtr* vtptr = phase->type(base)->isa_instptr();
-        if (vtptr == NULL || !vtptr->instance_klass()->equals(vk)) {
-          return NULL;
+        if (vtptr == nullptr || !vtptr->instance_klass()->equals(vk)) {
+          return nullptr;
         }
       }
     } else {
-      return NULL;
+      return nullptr;
     }
   }
   return base;
@@ -1077,7 +1077,7 @@ void InlineTypeNode::pass_fields(GraphKit* kit, Node* n, uint& base_input, bool 
 
 void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool null_free, Node* null_check_region, GrowableArray<ciType*>& visited) {
   PhaseGVN& gvn = kit->gvn();
-  Node* is_init = NULL;
+  Node* is_init = nullptr;
   if (!null_free) {
     // Nullable inline type
     if (in) {
@@ -1091,8 +1091,8 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
       base_input++;
     }
     // Add a null check to make subsequent loads dependent on
-    assert(null_check_region == NULL, "already set");
-    if (is_init == NULL) {
+    assert(null_check_region == nullptr, "already set");
+    if (is_init == nullptr) {
       // Will only be initialized below, use dummy node for now
       is_init = new Node(1);
       gvn.set_type_bottom(is_init);
@@ -1109,7 +1109,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
 
   for (uint i = 0; i < field_count(); ++i) {
     ciType* type = field_type(i);
-    Node* parm = NULL;
+    Node* parm = nullptr;
     if (field_is_flattened(i)) {
       // Flattened inline type field
       InlineTypeNode* vt = make_uninitialized(gvn, type->as_inline_klass());
@@ -1126,11 +1126,11 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
       }
       // Non-flattened inline type field
       if (type->is_inlinetype()) {
-        if (null_check_region != NULL) {
+        if (null_check_region != nullptr) {
           if (parm->is_InlineType() && kit->C->has_circular_inline_type()) {
             parm = parm->as_InlineType()->get_oop();
           }
-          // Holder is nullable, set field to NULL if holder is NULL to avoid loading from uninitialized memory
+          // Holder is nullable, set field to nullptr if holder is nullptr to avoid loading from uninitialized memory
           parm = PhiNode::make(null_check_region, parm, TypeInstPtr::make(TypePtr::BotPTR, type->as_inline_klass()));
           parm->set_req(2, kit->zerocon(T_OBJECT));
           parm = gvn.transform(parm);
@@ -1146,8 +1146,8 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
       }
       base_input += type->size();
     }
-    assert(parm != NULL, "should never be null");
-    assert(field_value(i) == NULL, "already set");
+    assert(parm != nullptr, "should never be null");
+    assert(field_value(i) == nullptr, "already set");
     set_field_value(i, parm);
     gvn.record_for_igvn(parm);
   }
@@ -1171,9 +1171,9 @@ void InlineTypeNode::remove_redundant_allocations(PhaseIdealLoop* phase) {
   // will be removed anyway and changing the memory chain will confuse other optimizations.
   for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
     AllocateNode* alloc = fast_out(i)->isa_Allocate();
-    if (alloc != NULL && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
+    if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
       Node* res = alloc->result_cast();
-      if (res == NULL || !res->is_CheckCastPP()) {
+      if (res == nullptr || !res->is_CheckCastPP()) {
         break; // No unique CheckCastPP
       }
       assert((!is_default(igvn) || !inline_klass()->is_initialized()) && !is_allocated(igvn), "re-allocation should be removed by Ideal transformation");
@@ -1181,9 +1181,9 @@ void InlineTypeNode::remove_redundant_allocations(PhaseIdealLoop* phase) {
       Node* res_dom = res;
       for (DUIterator_Fast jmax, j = fast_outs(jmax); j < jmax; j++) {
         AllocateNode* alloc_other = fast_out(j)->isa_Allocate();
-        if (alloc_other != NULL && alloc_other->in(AllocateNode::InlineType) == this && !alloc_other->_is_scalar_replaceable) {
+        if (alloc_other != nullptr && alloc_other->in(AllocateNode::InlineType) == this && !alloc_other->_is_scalar_replaceable) {
           Node* res_other = alloc_other->result_cast();
-          if (res_other != NULL && res_other->is_CheckCastPP() && res_other != res_dom &&
+          if (res_other != nullptr && res_other->is_CheckCastPP() && res_other != res_dom &&
               phase->is_dominator(res_other->in(0), res_dom->in(0))) {
             res_dom = res_other;
           }

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -44,8 +44,8 @@ protected:
 
   enum { Control,    // Control input.
          Oop,        // Oop to heap allocated buffer.
-         IsBuffered, // True if inline type is heap allocated (or NULL), false otherwise.
-         IsInit,     // Needs to be checked for NULL before using the field values.
+         IsBuffered, // True if inline type is heap allocated (or nullptr), false otherwise.
+         IsInit,     // Needs to be checked for nullptr before using the field values.
          Values      // Nodes corresponding to values of the inline type's fields.
                      // Nodes are connected in increasing order of the index of the field they correspond to.
   };
@@ -64,7 +64,7 @@ protected:
   bool is_larval(PhaseGVN* gvn) const;
 
   // Checks if the inline type is loaded from memory and if so returns the oop
-  Node* is_loaded(PhaseGVN* phase, ciInlineKlass* vk = NULL, Node* base = NULL, int holder_offset = 0);
+  Node* is_loaded(PhaseGVN* phase, ciInlineKlass* vk = nullptr, Node* base = nullptr, int holder_offset = 0);
 
   // Initialize the inline type fields with the inputs or outputs of a MultiNode
   void initialize_fields(GraphKit* kit, MultiNode* multi, uint& base_input, bool in, bool null_free, Node* null_check_region, GrowableArray<ciType*>& visited);
@@ -84,7 +84,7 @@ public:
   // Create and initialize by loading the field values from an oop
   static InlineTypeNode* make_from_oop(GraphKit* kit, Node* oop, ciInlineKlass* vk, bool null_free = true);
   // Create and initialize by loading the field values from a flattened field or array
-  static InlineTypeNode* make_from_flattened(GraphKit* kit, ciInlineKlass* vk, Node* obj, Node* ptr, ciInstanceKlass* holder = NULL, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED);
+  static InlineTypeNode* make_from_flattened(GraphKit* kit, ciInlineKlass* vk, Node* obj, Node* ptr, ciInstanceKlass* holder = nullptr, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED);
   // Create and initialize with the inputs or outputs of a MultiNode (method entry or call)
   static InlineTypeNode* make_from_multi(GraphKit* kit, MultiNode* multi, ciInlineKlass* vk, uint& base_input, bool in, bool null_free = true);
   // Create with null field values
@@ -123,7 +123,7 @@ public:
   void make_scalar_in_safepoints(PhaseIterGVN* igvn, bool allow_oop = true);
 
   // Store the inline type as a flattened (headerless) representation
-  void store_flattened(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass* holder = NULL, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED) const;
+  void store_flattened(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass* holder = nullptr, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED) const;
   // Store the field values to memory
   void store(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass* holder, int holder_offset = 0, DecoratorSet decorators = IN_HEAP | MO_UNORDERED) const;
   // Initialize the inline type by loading its field values from memory

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -66,7 +66,7 @@ Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
   // Inline types should not be split through Phis because they cannot be merged
   // through Phi nodes but each value input needs to be merged individually.
   if (n->is_InlineType()) {
-    return NULL;
+    return nullptr;
   }
 
   if (cannot_split_division(n, region)) {
@@ -707,7 +707,7 @@ Node *PhaseIdealLoop::conditional_move( Node *region ) {
       Node *inp = phi->in(j);
       if (inp->isa_InlineType()) {
         // TODO 8302217 This prevents PhiNode::push_inline_types_through
-        return NULL;
+        return nullptr;
       }
       if (get_ctrl(inp) == proj) { // Found local op
         cost++;
@@ -1414,11 +1414,11 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
   intptr_t offset;
   Node* obj = AddPNode::Ideal_base_and_offset(addr, &_igvn, offset);
 
-  if (obj == NULL) {
+  if (obj == nullptr) {
     return false;
   }
 
-  assert(obj != NULL && addr->in(AddPNode::Base) == addr->in(AddPNode::Address), "malformed AddP?");
+  assert(obj != nullptr && addr->in(AddPNode::Base) == addr->in(AddPNode::Address), "malformed AddP?");
   if (obj->Opcode() == Op_CastPP) {
     obj = obj->in(1);
   }
@@ -1435,7 +1435,7 @@ bool PhaseIdealLoop::flatten_array_element_type_check(Node *n) {
     Node* ctrl = region->in(i);
     if (addr->in(AddPNode::Base) != obj) {
       Node* cast = addr->in(AddPNode::Base);
-      assert(cast->Opcode() == Op_CastPP && cast->in(0) != NULL, "inconsistent subgraph");
+      assert(cast->Opcode() == Op_CastPP && cast->in(0) != nullptr, "inconsistent subgraph");
       Node* cast_clone = cast->clone();
       cast_clone->set_req(0, ctrl);
       cast_clone->set_req(1, in);
@@ -2052,7 +2052,7 @@ Node* PhaseIdealLoop::clone_iff(PhiNode* phi) {
   }
   Node* sample_cmp = sample_bool->in(1);
   const Type* t = Type::TOP;
-  const TypePtr* at = NULL;
+  const TypePtr* at = nullptr;
   if (sample_cmp->is_FlatArrayCheck()) {
     // Left input of a FlatArrayCheckNode is memory, set the (adr) type of the phi accordingly
     assert(sample_cmp->in(1)->bottom_type() == Type::MEMORY, "unexpected input type");

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -739,7 +739,7 @@ bool MachCallNode::returns_scalarized() const {
 const RegMask &MachCallNode::in_RegMask(uint idx) const {
   // Values in the domain use the users calling convention, embodied in the
   // _in_rms array of RegMasks.
-  if (entry_point() == NULL && idx == TypeFunc::Parms) {
+  if (entry_point() == nullptr && idx == TypeFunc::Parms) {
     // Null entry point is a special cast where the target of the call
     // is in a register.
     return MachNode::in_RegMask(idx);

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -200,9 +200,9 @@ const Type* MulNode::Value(PhaseGVN* phase) const {
   // Code pattern on return from a call that returns an __Value.  Can
   // be optimized away if the return value turns out to be an oop.
   if (op == Op_AndX &&
-      in(1) != NULL &&
+      in(1) != nullptr &&
       in(1)->Opcode() == Op_CastP2X &&
-      in(1)->in(1) != NULL &&
+      in(1)->in(1) != nullptr &&
       phase->type(in(1)->in(1))->isa_oopptr() &&
       t2->isa_intptr_t()->_lo >= 0 &&
       t2->isa_intptr_t()->_hi <= MinObjAlignmentInBytesMask) {

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -567,7 +567,7 @@ class Parse : public GraphKit {
   bool    seems_stable_comparison() const;
 
   void    do_ifnull(BoolTest::mask btest, Node* c);
-  void    do_if(BoolTest::mask btest, Node* c, bool new_path = false, Node** ctrl_taken = NULL);
+  void    do_if(BoolTest::mask btest, Node* c, bool new_path = false, Node** ctrl_taken = nullptr);
   void    do_acmp(BoolTest::mask btest, Node* left, Node* right);
   void    acmp_always_null_input(Node* input, const TypeOopPtr* tinput, BoolTest::mask btest, Node* eq_region);
   void    acmp_known_non_inline_type_input(Node* input, const TypeOopPtr* tinput, ProfilePtrKind input_ptr, ciKlass* input_type, BoolTest::mask btest, Node* eq_region);

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -56,13 +56,13 @@ extern int explicit_null_checks_inserted,
 Node* Parse::record_profile_for_speculation_at_array_load(Node* ld) {
   // Feed unused profile data to type speculation
   if (UseTypeSpeculation && UseArrayLoadStoreProfile) {
-    ciKlass* array_type = NULL;
-    ciKlass* element_type = NULL;
+    ciKlass* array_type = nullptr;
+    ciKlass* element_type = nullptr;
     ProfilePtrKind element_ptr = ProfileMaybeNull;
     bool flat_array = true;
     bool null_free_array = true;
     method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-    if (element_type != NULL || element_ptr != ProfileMaybeNull) {
+    if (element_type != nullptr || element_ptr != ProfileMaybeNull) {
       ld = record_profile_for_speculation(ld, element_type, element_ptr);
     }
   }
@@ -135,7 +135,7 @@ void Parse::array_load(BasicType bt) {
         // ordered with other unknown and known flattened array accesses.
         insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
 
-        Node* call = NULL;
+        Node* call = nullptr;
         {
           // Re-execute flattened array load if runtime call triggers deoptimization
           PreserveReexecuteState preexecs(this);
@@ -146,7 +146,7 @@ void Parse::array_load(BasicType bt) {
           call = make_runtime_call(RC_NO_LEAF | RC_NO_IO,
                                    OptoRuntime::load_unknown_inline_type(),
                                    OptoRuntime::load_unknown_inline_Java(),
-                                   NULL, TypeRawPtr::BOTTOM,
+                                   nullptr, TypeRawPtr::BOTTOM,
                                    ary, idx);
         }
         make_slow_call_ex(call, env()->Throwable_klass(), false);
@@ -177,7 +177,7 @@ void Parse::array_load(BasicType bt) {
                             IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD);
   ld = record_profile_for_speculation_at_array_load(ld);
   // Loading a non-flattened inline type
-  if (elemptr != NULL && elemptr->is_inlinetypeptr()) {
+  if (elemptr != nullptr && elemptr->is_inlinetypeptr()) {
     assert(!ary_t->is_null_free() || !elemptr->maybe_null(), "inline type array elements should never be null");
     ld = InlineTypeNode::make_from_oop(this, ld, elemptr->inline_klass(), !elemptr->maybe_null());
   }
@@ -190,7 +190,7 @@ void Parse::array_store(BasicType bt) {
   const Type* elemtype = Type::TOP;
   Node* adr = array_addressing(bt, type2size[bt], elemtype);
   if (stopped())  return;     // guaranteed null or range check
-  Node* cast_val = NULL;
+  Node* cast_val = nullptr;
   if (bt == T_OBJECT) {
     cast_val = array_store_check(adr, elemtype);
     if (stopped()) return;
@@ -233,7 +233,7 @@ void Parse::array_store(BasicType bt) {
       PreserveReexecuteState preexecs(this);
       inc_sp(3);
       jvms()->set_should_reexecute(true);
-      cast_val->as_InlineType()->store_flattened(this, ary, adr, NULL, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+      cast_val->as_InlineType()->store_flattened(this, ary, adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
       return;
     } else if (ary_t->is_null_free()) {
       // Store to non-flattened inline type array (elements can never be null)
@@ -243,7 +243,7 @@ void Parse::array_store(BasicType bt) {
         return;
       }
     } else if (!ary_t->is_not_flat() && (tval != TypePtr::NULL_PTR || StressReflectiveCode)) {
-      // Array might be flattened, emit runtime checks (for NULL, a simple inline_array_null_guard is sufficient).
+      // Array might be flattened, emit runtime checks (for nullptr, a simple inline_array_null_guard is sufficient).
       assert(UseFlatArray && !not_flattened && elemtype->is_oopptr()->can_be_inline_type() &&
              !ary_t->klass_is_exact() && !ary_t->is_not_null_free(), "array can't be flattened");
       IdealKit ideal(this);
@@ -269,14 +269,14 @@ void Parse::array_store(BasicType bt) {
           dec_sp(3);
         }
         // Try to determine the inline klass
-        ciInlineKlass* vk = NULL;
+        ciInlineKlass* vk = nullptr;
         if (tval->is_inlinetypeptr()) {
           vk = tval->inline_klass();
         } else if (elemtype->is_inlinetypeptr()) {
           vk = elemtype->inline_klass();
         }
         Node* casted_ary = ary;
-        if (vk != NULL && !stopped()) {
+        if (vk != nullptr && !stopped()) {
           // Element type is known, cast and store to flattened representation
           assert(vk->flatten_array() && elemtype->maybe_null(), "never/always flat - should be optimized");
           ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
@@ -291,7 +291,7 @@ void Parse::array_store(BasicType bt) {
           PreserveReexecuteState preexecs(this);
           inc_sp(3);
           jvms()->set_should_reexecute(true);
-          val->as_InlineType()->store_flattened(this, casted_ary, casted_adr, NULL, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+          val->as_InlineType()->store_flattened(this, casted_ary, casted_adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
         } else if (!stopped()) {
           // Element type is unknown, emit runtime call
 
@@ -428,21 +428,21 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
     // First check the speculative type
     Deoptimization::DeoptReason reason = Deoptimization::Reason_speculate_class_check;
     ciKlass* array_type = arytype->speculative_type();
-    if (too_many_traps_or_recompiles(reason) || array_type == NULL) {
+    if (too_many_traps_or_recompiles(reason) || array_type == nullptr) {
       // No speculative type, check profile data at this bci
-      array_type = NULL;
+      array_type = nullptr;
       reason = Deoptimization::Reason_class_check;
       if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
-        ciKlass* element_type = NULL;
+        ciKlass* element_type = nullptr;
         ProfilePtrKind element_ptr = ProfileMaybeNull;
         bool flat_array = true;
         bool null_free_array = true;
         method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
       }
     }
-    if (array_type != NULL) {
+    if (array_type != nullptr) {
       // Speculate that this array has the exact type reported by profile data
-      Node* better_ary = NULL;
+      Node* better_ary = nullptr;
       DEBUG_ONLY(Node* old_control = control();)
       Node* slow_ctl = type_check_receiver(ary, array_type, 1.0, &better_ary);
       if (stopped()) {
@@ -463,13 +463,13 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
   } else if (UseTypeSpeculation && UseArrayLoadStoreProfile) {
     // No need to speculate: feed profile data at this bci for the
     // array to type speculation
-    ciKlass* array_type = NULL;
-    ciKlass* element_type = NULL;
+    ciKlass* array_type = nullptr;
+    ciKlass* element_type = nullptr;
     ProfilePtrKind element_ptr = ProfileMaybeNull;
     bool flat_array = true;
     bool null_free_array = true;
     method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-    if (array_type != NULL) {
+    if (array_type != nullptr) {
       ary = record_profile_for_speculation(ary, array_type, ProfileMaybeNull);
     }
   }
@@ -482,14 +482,14 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
   if (!arytype->is_null_free() && !arytype->is_not_null_free()) {
     bool null_free_array = true;
     Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
-    if (arytype->speculative() != NULL &&
+    if (arytype->speculative() != nullptr &&
         arytype->speculative()->is_aryptr()->is_not_null_free() &&
         !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
       null_free_array = false;
       reason = Deoptimization::Reason_speculate_class_check;
     } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
-      ciKlass* array_type = NULL;
-      ciKlass* element_type = NULL;
+      ciKlass* array_type = nullptr;
+      ciKlass* element_type = nullptr;
       ProfilePtrKind element_ptr = ProfileMaybeNull;
       bool flat_array = true;
       method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
@@ -511,14 +511,14 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
   if (!arytype->is_flat() && !arytype->is_not_flat()) {
     bool flat_array = true;
     Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
-    if (arytype->speculative() != NULL &&
+    if (arytype->speculative() != nullptr &&
         arytype->speculative()->is_aryptr()->is_not_flat() &&
         !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
       flat_array = false;
       reason = Deoptimization::Reason_speculate_class_check;
     } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
-      ciKlass* array_type = NULL;
-      ciKlass* element_type = NULL;
+      ciKlass* array_type = nullptr;
+      ciKlass* element_type = nullptr;
       ProfilePtrKind element_ptr = ProfileMaybeNull;
       bool null_free_array = true;
       method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
@@ -1886,7 +1886,7 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool new_path, Node** ctrl_take
         if (new_path) {
           // Merge by using a new path
           merge_new_path(target_bci);
-        } else if (ctrl_taken != NULL) {
+        } else if (ctrl_taken != nullptr) {
           // Don't merge but save taken branch to be wired by caller
           *ctrl_taken = control();
         } else {
@@ -1900,7 +1900,7 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool new_path, Node** ctrl_take
   set_control(untaken_branch);
 
   // Branch not taken.
-  if (stopped() && ctrl_taken == NULL) {
+  if (stopped() && ctrl_taken == nullptr) {
     if (C->eliminate_boxing()) {
       // Mark the successor block as parsed (if caller does not re-wire control flow)
       next_block->next_path_num();
@@ -1912,7 +1912,7 @@ void Parse::do_if(BoolTest::mask btest, Node* c, bool new_path, Node** ctrl_take
 
 
 static ProfilePtrKind speculative_ptr_kind(const TypeOopPtr* t) {
-  if (t->speculative() == NULL) {
+  if (t->speculative() == nullptr) {
     return ProfileUnknownNull;
   }
   if (t->speculative_always_null()) {
@@ -1926,7 +1926,7 @@ static ProfilePtrKind speculative_ptr_kind(const TypeOopPtr* t) {
 
 void Parse::acmp_always_null_input(Node* input, const TypeOopPtr* tinput, BoolTest::mask btest, Node* eq_region) {
   inc_sp(2);
-  Node* cast = null_check_common(input, T_OBJECT, true, NULL,
+  Node* cast = null_check_common(input, T_OBJECT, true, nullptr,
                                  !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_null_check) &&
                                  speculative_ptr_kind(tinput) == ProfileAlwaysNull);
   dec_sp(2);
@@ -1969,7 +1969,7 @@ void Parse::acmp_known_non_inline_type_input(Node* input, const TypeOopPtr* tinp
     inc_sp(2);
     set_control(slow_ctl);
     Deoptimization::DeoptReason reason;
-    if (tinput->speculative_type() != NULL && !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
+    if (tinput->speculative_type() != nullptr && !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
       reason = Deoptimization::Reason_speculate_class_check;
     } else {
       reason = Deoptimization::Reason_class_check;
@@ -2035,8 +2035,8 @@ void Parse::acmp_unknown_non_inline_type_input(Node* input, const TypeOopPtr* ti
 }
 
 void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
-  ciKlass* left_type = NULL;
-  ciKlass* right_type = NULL;
+  ciKlass* left_type = nullptr;
+  ciKlass* right_type = nullptr;
   ProfilePtrKind left_ptr = ProfileUnknownNull;
   ProfilePtrKind right_ptr = ProfileUnknownNull;
   bool left_inline_type = true;
@@ -2046,8 +2046,8 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   if (UseACmpProfile) {
     method()->acmp_profiled_type(bci(), left_type, right_type, left_ptr, right_ptr, left_inline_type, right_inline_type);
     if (too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
-      left_type = NULL;
-      right_type = NULL;
+      left_type = nullptr;
+      right_type = nullptr;
       left_inline_type = true;
       right_inline_type = true;
     }
@@ -2103,13 +2103,13 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   const TypeOopPtr* tright = _gvn.type(right)->isa_oopptr();
   Node* cmp = CmpP(left, right);
   cmp = optimize_cmp_with_klass(cmp);
-  if (tleft == NULL || !tleft->can_be_inline_type() ||
-      tright == NULL || !tright->can_be_inline_type()) {
+  if (tleft == nullptr || !tleft->can_be_inline_type() ||
+      tright == nullptr || !tright->can_be_inline_type()) {
     // This is sufficient, if one of the operands can't be an inline type
     do_if(btest, cmp);
     return;
   }
-  Node* eq_region = NULL;
+  Node* eq_region = nullptr;
   if (btest == BoolTest::eq) {
     do_if(btest, cmp, true);
     if (stopped()) {
@@ -2117,7 +2117,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
     }
   } else {
     assert(btest == BoolTest::ne, "only eq or ne");
-    Node* is_not_equal = NULL;
+    Node* is_not_equal = nullptr;
     eq_region = new RegionNode(3);
     {
       PreserveJVMState pjvms(this);
@@ -2126,7 +2126,7 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
         eq_region->init_req(1, control());
       }
     }
-    if (is_not_equal == NULL || is_not_equal->is_top()) {
+    if (is_not_equal == nullptr || is_not_equal->is_top()) {
       record_for_igvn(eq_region);
       set_control(_gvn.transform(eq_region));
       return;
@@ -2136,10 +2136,10 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
 
   // Prefer speculative types if available
   if (!too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
-    if (tleft->speculative_type() != NULL) {
+    if (tleft->speculative_type() != nullptr) {
       left_type = tleft->speculative_type();
     }
-    if (tright->speculative_type() != NULL) {
+    if (tright->speculative_type() != nullptr) {
       right_type = tright->speculative_type();
     }
   }
@@ -2171,12 +2171,12 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
     acmp_always_null_input(right, tright, btest, eq_region);
     return;
   }
-  if (left_type != NULL && !left_type->is_inlinetype()) {
+  if (left_type != nullptr && !left_type->is_inlinetype()) {
     // Comparison with an object of known type
     acmp_known_non_inline_type_input(left, tleft, left_ptr, left_type, btest, eq_region);
     return;
   }
-  if (right_type != NULL && !right_type->is_inlinetype()) {
+  if (right_type != nullptr && !right_type->is_inlinetype()) {
     // Comparison with an object of known type
     acmp_known_non_inline_type_input(right, tright, right_ptr, right_type, btest, eq_region);
     return;
@@ -2240,9 +2240,9 @@ void Parse::do_acmp(BoolTest::mask btest, Node* left, Node* right) {
   Node* mem = reset_memory();
   Node* ne_mem_phi = PhiNode::make(ne_region, mem);
 
-  Node* eq_io_phi = NULL;
-  Node* eq_mem_phi = NULL;
-  if (eq_region != NULL) {
+  Node* eq_io_phi = nullptr;
+  Node* eq_mem_phi = nullptr;
+  if (eq_region != nullptr) {
     eq_io_phi = PhiNode::make(eq_region, i_o());
     eq_mem_phi = PhiNode::make(eq_region, mem);
   }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1441,7 +1441,7 @@ void PhaseIterGVN::subsume_node( Node *old, Node *nn ) {
 }
 
 void PhaseIterGVN::replace_in_uses(Node* n, Node* m) {
-  assert(n != NULL, "sanity");
+  assert(n != nullptr, "sanity");
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* u = n->fast_out(i);
     if (u != n) {
@@ -1715,8 +1715,8 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
       Node* c = use;
       do {
         c = c->unique_ctrl_out_or_null();
-      } while (c != NULL && c->is_Region());
-      if (c != NULL && c->is_CallStaticJava() && c->as_CallStaticJava()->uncommon_trap_request() != 0) {
+      } while (c != nullptr && c->is_Region());
+      if (c != nullptr && c->is_CallStaticJava() && c->as_CallStaticJava()->uncommon_trap_request() != 0) {
         _worklist.push(c);
       }
     }

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -877,8 +877,8 @@ Node *CmpINode::Ideal( PhaseGVN *phase, bool can_reshape ) {
 
 //------------------------------Ideal------------------------------------------
 Node* CmpLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
-  Node* a = NULL;
-  Node* b = NULL;
+  Node* a = nullptr;
+  Node* b = nullptr;
   if (is_double_null_check(phase, a, b) && (phase->type(a)->is_zero_type() || phase->type(b)->is_zero_type())) {
     // Degraded to a simple null check, use old acmp
     return new CmpPNode(a, b);
@@ -909,10 +909,10 @@ bool CmpLNode::is_double_null_check(PhaseGVN* phase, Node*& a, Node*& b) const {
 
 //------------------------------Value------------------------------------------
 const Type* CmpLNode::Value(PhaseGVN* phase) const {
-  Node* a = NULL;
-  Node* b = NULL;
+  Node* a = nullptr;
+  Node* b = nullptr;
   if (is_double_null_check(phase, a, b) && (!phase->type(a)->maybe_null() || !phase->type(b)->maybe_null())) {
-    // One operand is never NULL, emit constant false
+    // One operand is never nullptr, emit constant false
     return TypeInt::CC_GT;
   }
   return SubNode::Value(phase);
@@ -1227,7 +1227,7 @@ Node* CmpPNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // the klass for [LMyValue. Do not bypass the klass load from the primary supertype array.
   if (superklass->is_obj_array_klass() && !superklass->as_array_klass()->is_elem_null_free() &&
       superklass->as_array_klass()->element_klass()->is_inlinetype()) {
-    return NULL;
+    return nullptr;
   }
 
   // If 'superklass' has no subklasses and is not an interface, then we are
@@ -1408,7 +1408,7 @@ Node* FlatArrayCheckNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       changed = true;
     }
   }
-  return changed ? this : NULL;
+  return changed ? this : nullptr;
 }
 
 //=============================================================================

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -315,7 +315,7 @@ public:
     C->add_macro_node(this);
   }
   virtual int Opcode() const;
-  virtual const Type* sub(const Type*, const Type*) const { ShouldNotReachHere(); return NULL; }
+  virtual const Type* sub(const Type*, const Type*) const { ShouldNotReachHere(); return nullptr; }
   const Type* Value(PhaseGVN* phase) const;
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3873,7 +3873,7 @@ const TypeOopPtr* TypeOopPtr::make_from_klass_common(ciKlass *klass, bool klass_
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::POS, /* stable= */ false, /* flat= */ false, not_flat, not_null_free);
     // We used to pass NotNull in here, asserting that the sub-arrays
     // are all not-null.  This is not true in generally, as code can
-    // slam NULLs down in the subarrays.
+    // slam nullptrs down in the subarrays.
     const TypeAryPtr* arr = TypeAryPtr::make(TypePtr::BotPTR, arr0, nullptr, xk, Offset(0));
     return arr;
   } else if (klass->is_type_array_klass()) {
@@ -3948,7 +3948,7 @@ const TypeOopPtr* TypeOopPtr::make_from_constant(ciObject* o, bool require_const
     const TypeAry* arr0 = TypeAry::make(etype, TypeInt::make(o->as_array()->length()), /* stable= */ false, /* flat= */ true);
     // We used to pass NotNull in here, asserting that the sub-arrays
     // are all not-null.  This is not true in generally, as code can
-    // slam NULLs down in the subarrays.
+    // slam nullptrs down in the subarrays.
     if (make_constant) {
       return TypeAryPtr::make(TypePtr::Constant, o, arr0, klass, true, Offset(0));
     } else {

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -2143,7 +2143,7 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_preload_attribute(
        InstanceKlass* scratch_class) {
 
   Array<u2>* preload_classes = scratch_class->preload_classes();
-  assert(preload_classes != NULL, "unexpected null preload_classes");
+  assert(preload_classes != nullptr, "unexpected null preload_classes");
   for (int i = 0; i < preload_classes->length(); i++) {
     u2 cp_index = preload_classes->at(i);
     preload_classes->at_put(i, find_new_index(cp_index));

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -230,7 +230,7 @@ public:
 
   void put(T x) {
     GuardUnsafeAccess guard(_thread);
-    assert(_obj == NULL || !_obj->is_inline_type() || _obj->mark().is_larval_state(), "must be an object instance or a larval inline type");
+    assert(_obj == nullptr || !_obj->is_inline_type() || _obj->mark().is_larval_state(), "must be an object instance or a larval inline type");
     *addr() = normalize_for_write(x);
   }
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -776,7 +776,7 @@ class InterpreterFrameClosure : public OffsetClosure {
     if (offset < _max_locals) {
       addr = (oop*) _fr->interpreter_frame_local_at(offset);
       assert((intptr_t*)addr >= _fr->sp(), "must be inside the frame");
-      if (_f != NULL) {
+      if (_f != nullptr) {
         _f->do_oop(addr);
       }
     } else {
@@ -790,7 +790,7 @@ class InterpreterFrameClosure : public OffsetClosure {
         in_stack = (intptr_t*)addr >= _fr->interpreter_frame_tos_address();
       }
       if (in_stack) {
-        if (_f != NULL) {
+        if (_f != nullptr) {
           _f->do_oop(addr);
         }
       }
@@ -967,7 +967,7 @@ void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool quer
     }
   }
 
-  InterpreterFrameClosure blk(this, max_locals, m->max_stack(), f, NULL);
+  InterpreterFrameClosure blk(this, max_locals, m->max_stack(), f, nullptr);
 
   // process locals & expression stack
   InterpreterOopMap mask;
@@ -989,7 +989,7 @@ void frame::buffered_values_interpreted_do(BufferedValueClosure* f) {
   assert(!m->is_native() && bci >= 0 && bci < m->code_size(),
          "invalid bci value");
 
-  InterpreterFrameClosure blk(this, m->max_locals(), m->max_stack(), NULL, f);
+  InterpreterFrameClosure blk(this, m->max_locals(), m->max_stack(), nullptr, f);
 
   // process locals & expression stack
   InterpreterOopMap mask;

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -296,7 +296,7 @@ bool JNIHandles::is_same_object(jobject handle1, jobject handle2) {
   bool ret = obj1 == obj2;
 
   if (EnableValhalla) {
-    if (!ret && obj1 != NULL && obj2 != NULL && obj1->klass() == obj2->klass() && obj1->klass()->is_inline_klass()) {
+    if (!ret && obj1 != nullptr && obj2 != nullptr && obj1->klass() == obj2->klass() && obj1->klass()->is_inline_klass()) {
       // The two references are different, they are not null and they are both inline types,
       // a full substitutability test is required, calling ValueObjectMethods.isSubstitutable()
       // (similarly to InterpreterRuntime::is_substitutable)

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -947,12 +947,12 @@ void ThreadSafepointState::handle_polling_page_exception() {
     HandleMark hm(self);
 
     GrowableArray<Handle> return_values;
-    InlineKlass* vk = NULL;
+    InlineKlass* vk = nullptr;
     if (return_oop && InlineTypeReturnedAsFields &&
         (method->result_type() == T_PRIMITIVE_OBJECT || method->result_type() == T_OBJECT)) {
       // Check if an inline type is returned as fields
       vk = InlineKlass::returned_inline_klass(map);
-      if (vk != NULL) {
+      if (vk != nullptr) {
         // We're at a safepoint at the return of a method that returns
         // multiple values. We must make sure we preserve the oop values
         // across the safepoint.
@@ -984,7 +984,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
     if (return_oop) {
       assert(return_values.length() == 1, "only one return value");
       caller_fr.set_saved_oop_result(&map, return_values.pop()());
-    } else if (vk != NULL) {
+    } else if (vk != nullptr) {
       vk->restore_oop_results(map, return_values);
     }
   }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -511,10 +511,10 @@ InlineKlass* SignatureStream::as_inline_klass(InstanceKlass* holder) {
   Handle protection_domain(THREAD, holder->protection_domain());
   Klass* k = as_klass(class_loader, protection_domain, SignatureStream::CachedOrNull, THREAD);
   assert(!HAS_PENDING_EXCEPTION, "Should never throw");
-  if (k != NULL && k->is_inline_klass()) {
+  if (k != nullptr && k->is_inline_klass()) {
     return InlineKlass::cast(k);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1766,7 +1766,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
     // After the handshake, safely free the ObjectMonitors that were
     // deflated and unlinked in this cycle.
     if (current->is_Java_thread()) {
-      if (ls != NULL) {
+      if (ls != nullptr) {
         timer.stop();
         ls->print_cr("before setting blocked: unlinked_count=" SIZE_FORMAT
                      ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
@@ -1777,7 +1777,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
       // Mark the calling JavaThread blocked (safepoint safe) while we free
       // the ObjectMonitors so we don't delay safepoints whilst doing that.
       ThreadBlockInVM tbivm(JavaThread::cast(current));
-      if (ls != NULL) {
+      if (ls != nullptr) {
         ls->print_cr("after setting blocked: in_use_list stats: ceiling="
                      SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
                      in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -934,8 +934,8 @@ void PrintClassLayoutDCmd::execute(DCmdSource source, TRAPS) {
 
 int PrintClassLayoutDCmd::num_arguments() {
   ResourceMark rm;
-  PrintClassLayoutDCmd* dcmd = new PrintClassLayoutDCmd(NULL, false);
-  if (dcmd != NULL) {
+  PrintClassLayoutDCmd* dcmd = new PrintClassLayoutDCmd(nullptr, false);
+  if (dcmd != nullptr) {
     DCmdMark mark(dcmd);
     return dcmd->_dcmdparser.num_arguments();
   } else {

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -412,7 +412,7 @@ public:
   }
   static const JavaPermission permission() {
     JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", NULL};
+                        "monitor", nullptr};
     return p;
   }
   static int num_arguments();

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1344,10 +1344,10 @@ u2 DumperSupport::get_instance_fields_count(InstanceKlass* ik) {
 }
 
 // dumps the definition of the instance fields for a given class
-// inlined_fields_id is not-NULL for inlined fields (to get synthetic field name IDs
+// inlined_fields_id is not-nullptr for inlined fields (to get synthetic field name IDs
 // by using InlinedObjects::get_next_string_id()).
 void DumperSupport::dump_instance_field_descriptors(AbstractDumpWriter* writer, InstanceKlass* ik, uintx* inlined_fields_id) {
-  // inlined_fields_id != NULL means ik is a class of inlined field.
+  // inlined_fields_id != nullptr means ik is a class of inlined field.
   // Inlined field id pointer for this class; lazyly initialized
   // if the class has inlined field(s) and the caller didn't provide inlined_fields_id.
   uintx *this_klass_inlined_fields_id = inlined_fields_id;

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -919,7 +919,7 @@ class GrowableArrayFilterIterator : public StackObj {
   }
 
   bool at_end() const {
-    return _array == NULL || _position == _array->end()._position;
+    return _array == nullptr || _position == _array->end()._position;
   }
 };
 

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -118,17 +118,17 @@ class StringMatcher {
           char ch = _pattern_getc(patp, pattern_end);
           char mch = _string_getc(anchorp, match_end);
           if (mch != ch) {
-            anchorp = NULL;
+            anchorp = nullptr;
             break;
           }
         }
-        if (anchorp != NULL) {
+        if (anchorp != nullptr) {
           return anchorp;  // Found a full copy of the anchor.
         }
         // That did not work, so restart the search for ch1.
       }
     }
-    return NULL;
+    return nullptr;
   }
 
  public:
@@ -150,7 +150,7 @@ class StringMatcher {
       break;
     }
     patp = pattern;  // Reset after lookahead.
-    const char* matchp = string;  // NULL if failing
+    const char* matchp = string;  // nullptr if failing
     for (;;) {
       int ch = _pattern_getc(patp, pattern_end);
       switch (ch) {
@@ -168,7 +168,7 @@ class StringMatcher {
         return false;  // End of all items.
 
       case string_match_star:
-        if (matchp != NULL) {
+        if (matchp != nullptr) {
           // Wildcard:  Parse out following anchor word and look for it.
           const char* begp = patp;
           const char* endp = patp;
@@ -201,10 +201,10 @@ class StringMatcher {
         continue;
       }
       // Normal character.
-      if (matchp != NULL) {
+      if (matchp != nullptr) {
         int mch = _string_getc(matchp, string_end);
         if (mch != ch) {
-          matchp = NULL;
+          matchp = nullptr;
         }
       }
     }
@@ -279,7 +279,7 @@ class ClassListMatcher : public StringMatcher {
 
 bool StringUtils::class_list_match(const char* class_pattern_list,
                                    const char* class_name) {
-  if (class_pattern_list == NULL || class_name == NULL || class_name[0] == '\0')
+  if (class_pattern_list == nullptr || class_name == nullptr || class_name[0] == '\0')
     return false;
   ClassListMatcher clm;
   return clm.string_match(class_pattern_list, class_name);


### PR DESCRIPTION
This patch applies the NULL -> nullptr transition to shared code.

Builds tested with Mach5 (tier1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8312231](https://bugs.openjdk.org/browse/JDK-8312231): Replacing NULL with nullptr in shared code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/886/head:pull/886` \
`$ git checkout pull/886`

Update a local copy of the PR: \
`$ git checkout pull/886` \
`$ git pull https://git.openjdk.org/valhalla.git pull/886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 886`

View PR using the GUI difftool: \
`$ git pr show -t 886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/886.diff">https://git.openjdk.org/valhalla/pull/886.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/886#issuecomment-1640384885)