### PR TITLE
8313080: [lw5] javac parser is not accepting some array types with nullness markers

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2893,11 +2893,12 @@ public class Attr extends JCTree.Visitor {
                 return;
             }
 
-            if (tree.constructor != null && tree.constructor.kind == MTH)
+            if (tree.constructor != null && tree.constructor.kind == MTH) {
                 owntype = clazztype;
                 if (owntype.getMetadata(TypeMetadata.NullMarker.class) == null) {
                     owntype = owntype.addMetadata(new TypeMetadata.NullMarker(NullMarker.NOT_NULL)); // constructor invocations are always null restricted
                 }
+            }
         }
         result = check(tree, owntype, KindSelector.VAL, resultInfo);
         InferenceContext inferenceContext = resultInfo.checkContext.inferenceContext();

--- a/test/langtools/tools/javac/bang/BangTypesCompilationTests.java
+++ b/test/langtools/tools/javac/bang/BangTypesCompilationTests.java
@@ -646,6 +646,26 @@ public class BangTypesCompilationTests extends CompilationTestCase {
                                 }
                                 """,
                                 Result.Clean,
+                                ""),
+                        new DiagAndCode(
+                                """
+                                class Test {
+                                    void m(Test t1, Test[] t2, Test[][] t3, Test[][][] t4) {
+                                        Test! l1 = (Test!) t1;
+                                        Test![] l2 = (Test![]) t2;
+                                        Test![][] l3 = (Test![][]) t3;
+                                        Test![][][] l4 = (Test![][][]) t4;
+
+                                        Test[]! l5 = (Test[]!) t2;
+                                        Test[][]! l6 = (Test[][]!) t3;
+                                        Test[][][]! l7 = (Test[][][]!) t4;
+
+                                        Test[]![]! l8 = (Test[]![]!) t3;
+                                        Test[]![]![]! l9 = (Test[]![]![]!) t4;
+                                    }
+                                }
+                                """,
+                                Result.Clean,
                                 "")
                 )
         );


### PR DESCRIPTION
Code like:

```
class Test {
    void m(Test[][] t1, Test[][][] t2) {
        Test[][]! l1 = (Test[][]!) t1;
        Test[][][]! l2 = (Test[][][]!) t2;

        Test[]![]! l3 = (Test[]![]!) t1;
        Test[]![]![]! l4 = (Test[]![]![]!) t2;
    }
}
```

is being rejected by javac. Basically the compiler can't deal with nullness markers interleaved in array type declarations. This patch is fixing this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8313080](https://bugs.openjdk.org/browse/JDK-8313080): [lw5] javac parser is not accepting some array types with nullness markers (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/889/head:pull/889` \
`$ git checkout pull/889`

Update a local copy of the PR: \
`$ git checkout pull/889` \
`$ git pull https://git.openjdk.org/valhalla.git pull/889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 889`

View PR using the GUI difftool: \
`$ git pr show -t 889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/889.diff">https://git.openjdk.org/valhalla/pull/889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/889#issuecomment-1650537171)