### PR TITLE
8309344: [lworld] Initial ZGenerational fixes and support

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -364,7 +364,7 @@ template <DecoratorSet decorators, typename BarrierSetT>
 inline ZBarrierSet::OopCopyCheckStatus ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy_in_heap_check_cast(zpointer* dst, zpointer* src, size_t length, Klass* dst_klass) {
   // Check cast and copy each elements
   OopCopyCheckStatus check_status = oop_copy_check_ok;
-  for (const zpointer* const end = src + length; (check_status = oop_copy_check_ok) && (src < end); src++, dst++) {
+  for (const zpointer* const end = src + length; (check_status == oop_copy_check_ok) && (src < end); src++, dst++) {
     check_status = oop_copy_one_check_cast(dst, src, dst_klass);
   }
   return check_status;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -98,6 +98,23 @@ import test.java.lang.invoke.lib.InstructionHelper;
  *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   runtime.valhalla.inlinetypes.InlineOops
  */
+
+/**
+ * @test InlineOops_int_ZGen
+ * @requires vm.gc.Z
+ * @summary Test embedding oops into Inline types
+ * @modules java.base/jdk.internal.value
+ * @library /test/lib /test/jdk/lib/testlibrary/bytecode /test/jdk/java/lang/invoke/common
+ * @build jdk.experimental.bytecode.BasicClassBuilder test.java.lang.invoke.lib.InstructionHelper
+ * @compile -XDenablePrimitiveClasses Person.java InlineOops.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *                   jdk.test.whitebox.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ZGenerational -Xmx128m
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=128
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   runtime.valhalla.inlinetypes.InlineOops
+ */
 public class InlineOops {
 
     // Extra debug: -XX:+VerifyOops -XX:+VerifyStack -XX:+VerifyLastFrame -XX:+VerifyBeforeGC -XX:+VerifyAfterGC -XX:+VerifyDuringGC -XX:VerifySubSet=threads,heap


### PR DESCRIPTION
* BarrierSet typo
* Segmented array initialization disabled
* Sanity testing with InlineOops

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8309344](https://bugs.openjdk.org/browse/JDK-8309344): [lworld] Initial ZGenerational fixes and support (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/890/head:pull/890` \
`$ git checkout pull/890`

Update a local copy of the PR: \
`$ git checkout pull/890` \
`$ git pull https://git.openjdk.org/valhalla.git pull/890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 890`

View PR using the GUI difftool: \
`$ git pr show -t 890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/890.diff">https://git.openjdk.org/valhalla/pull/890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/890#issuecomment-1655183532)