### PR TITLE
8313607: [lworld] runtime/valhalla/inlinetypes/InlineOops.java GenZ assertion on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1145,7 +1145,7 @@ void MacroAssembler::get_default_value_oop(Register inline_klass, Register temp_
 
   // Getting the pre-allocated default value from the mirror
   Address field(obj, offset);
-  load_heap_oop(obj, field, temp_reg, rscratch2);
+  load_heap_oop(obj, field, inline_klass, rscratch2);
 }
 
 void MacroAssembler::get_empty_inline_type_oop(Register inline_klass, Register temp_reg, Register obj) {


### PR DESCRIPTION
Use different temp reg not related to src.index()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8313607](https://bugs.openjdk.org/browse/JDK-8313607): [lworld] runtime/valhalla/inlinetypes/InlineOops.java GenZ assertion on aarch64 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/896/head:pull/896` \
`$ git checkout pull/896`

Update a local copy of the PR: \
`$ git checkout pull/896` \
`$ git pull https://git.openjdk.org/valhalla.git pull/896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 896`

View PR using the GUI difftool: \
`$ git pr show -t 896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/896.diff">https://git.openjdk.org/valhalla/pull/896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/896#issuecomment-1665067637)