### PR TITLE
Adjust testing for ZGenerational compiler failures

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,6 +73,9 @@ compiler/c2/irTests/TestVectorConditionalMove.java 8306922 generic-all
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
+compiler/gcbarriers/TestZGCBarrierElision.java 8313737 generic-all
+compiler/valhalla/inlinetypes/TestArrays.java 8313667 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
* compiler/gcbarriers/TestZGCBarrierElision.java 8313737 generic-all
* compiler/valhalla/inlinetypes/TestArrays.java 8313667 generic-all

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/897/head:pull/897` \
`$ git checkout pull/897`

Update a local copy of the PR: \
`$ git checkout pull/897` \
`$ git pull https://git.openjdk.org/valhalla.git pull/897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 897`

View PR using the GUI difftool: \
`$ git pr show -t 897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/897.diff">https://git.openjdk.org/valhalla/pull/897.diff</a>

</details>
