### PR TITLE
8314165: [lw5] check for illegal circularity at class loading time

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -409,7 +409,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
     }
 
     public boolean isInterface() {
-        return (flags() & INTERFACE) != 0;
+        return (flags_field & INTERFACE) != 0;
     }
 
     public boolean isAbstract() {
@@ -421,7 +421,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
     }
 
     public boolean isValueClass() {
-        return !isInterface() && (flags() & VALUE_CLASS) != 0;
+        return !isInterface() && (flags_field & VALUE_CLASS) != 0;
     }
 
     public boolean isConcreteValueClass() {
@@ -429,15 +429,15 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
     }
 
     public boolean isIdentityClass() {
-        return !isInterface() && (flags() & IDENTITY_TYPE) != 0;
+        return !isInterface() && (flags_field & IDENTITY_TYPE) != 0;
     }
 
     public boolean isValueInterface() {
-        return isInterface() && (flags() & VALUE_CLASS) != 0;
+        return isInterface() && (flags_field & VALUE_CLASS) != 0;
     }
 
     public boolean isIdentityInterface() {
-        return isInterface() && (flags() & IDENTITY_TYPE) != 0;
+        return isInterface() && (flags_field & IDENTITY_TYPE) != 0;
     }
 
     public boolean isPublic() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2513,6 +2513,9 @@ public class Check {
     // A primitive class cannot contain a field of its own type either or indirectly.
     // TODO, update this method once we have null restricted types
     void checkNonCyclicMembership(JCClassDecl tree) {
+        if (!tree.sym.type.hasImplicitConstructor()) {
+            return;
+        }
         Assert.check((tree.sym.flags_field & LOCKED) == 0);
         try {
             tree.sym.flags_field |= LOCKED;
@@ -2545,7 +2548,7 @@ public class Check {
     }
         // where
         private boolean cyclePossible(VarSymbol symbol) {
-            return (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.isNonNullable();
+            return (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.hasImplicitConstructor() && symbol.type.isNonNullable();
         }
 
     void checkNonCyclicDecl(JCClassDecl tree) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -3178,6 +3178,10 @@ public class ClassReader {
 
     // A value class cannot contain a non-nullable instance field of its own type either directly or indirectly.
     void checkNonCyclicMembership(ClassSymbol csym) {
+        if (!csym.type.hasImplicitConstructor()) {
+            // nothing to see here
+            return;
+        }
         Assert.check((csym.flags_field & LOCKED) == 0);
         try {
             ListBuffer<Symbol> fields = new ListBuffer<>();
@@ -3220,6 +3224,6 @@ public class ClassReader {
     }
     // where
     private boolean cyclePossible(VarSymbol symbol) {
-        return (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.isNonNullable();
+        return (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.hasImplicitConstructor() && symbol.type.isNonNullable();
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -60,6 +60,7 @@ import com.sun.tools.javac.file.PathFileObject;
 import com.sun.tools.javac.jvm.ClassFile.Version;
 import com.sun.tools.javac.jvm.PoolConstant.NameAndType;
 import com.sun.tools.javac.main.Option;
+import com.sun.tools.javac.resources.CompilerProperties;
 import com.sun.tools.javac.resources.CompilerProperties.Fragments;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.tree.JCTree;
@@ -74,6 +75,7 @@ import static com.sun.tools.javac.code.Kinds.Kind.*;
 
 import com.sun.tools.javac.code.Scope.LookupKind;
 
+import static com.sun.tools.javac.code.Scope.LookupKind.NON_RECURSIVE;
 import static com.sun.tools.javac.code.TypeTag.ARRAY;
 import static com.sun.tools.javac.code.TypeTag.CLASS;
 import static com.sun.tools.javac.code.TypeTag.TYPEVAR;
@@ -2724,7 +2726,9 @@ public class ClassReader {
             ct.interfaces_field = is.reverse();
 
         Assert.check(fieldCount == nextChar());
-        for (int i = 0; i < fieldCount; i++) enterMember(c, readField());
+        for (int i = 0; i < fieldCount; i++) {
+            enterMember(c, readField());
+        }
         Assert.check(methodCount == nextChar());
         for (int i = 0; i < methodCount; i++) enterMember(c, readMethod());
         if (c.isRecord()) {
@@ -2893,6 +2897,8 @@ public class ClassReader {
             foundTypeVariables = List.nil();
             filling = false;
         }
+        // we need to do some checks now that the class has been loaded
+        checkNonCyclicMembership(c);
     }
 
     /** We can only read a single class file at a time; this
@@ -3168,5 +3174,52 @@ public class ClassReader {
             currentModule.provides = provides.toList();
             currentModule.directives = directives.toList();
         }
+    }
+
+    // A value class cannot contain a non-nullable instance field of its own type either directly or indirectly.
+    void checkNonCyclicMembership(ClassSymbol csym) {
+        Assert.check((csym.flags_field & LOCKED) == 0);
+        try {
+            ListBuffer<Symbol> fields = new ListBuffer<>();
+            // invoking c::members can provoke symbol completion and thus the LOCKED flag can be set before expected
+            for (Symbol field : csym.members().getSymbols(s -> s.kind == VAR && cyclePossible((VarSymbol) s), NON_RECURSIVE)) {
+                fields.add(field);
+            }
+            csym.flags_field |= LOCKED;
+            for (Symbol field : fields) {
+                checkNonCyclicMembershipHelper((ClassSymbol) field.type.tsym);
+            }
+        } finally {
+            csym.flags_field &= ~LOCKED;
+        }
+    }
+    // where
+    private void checkNonCyclicMembershipHelper(ClassSymbol c) {
+        if ((c.flags_field & LOCKED) != 0) {
+            JavaFileObject prevSource = log.useSource(currentClassFile);
+            try {
+                log.error(CompilerProperties.Errors.CyclicPrimitiveClassMembership(c));
+                return;
+            } finally {
+                log.useSource(prevSource);
+            }
+        }
+        try {
+            ListBuffer<Symbol> fields = new ListBuffer<>();
+            // invoking c::members can provoke symbol completion and thus the LOCKED flag can be set before expected
+            for (Symbol fld : c.members().getSymbols(s -> s.kind == VAR && cyclePossible((VarSymbol) s), NON_RECURSIVE)) {
+                fields.add(fld);
+            }
+            c.flags_field |= LOCKED;
+            for (Symbol field : fields) {
+                checkNonCyclicMembershipHelper((ClassSymbol) field.type.tsym);
+            }
+        } finally {
+            c.flags_field &= ~LOCKED;
+        }
+    }
+    // where
+    private boolean cyclePossible(VarSymbol symbol) {
+        return (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.isNonNullable();
     }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.java
@@ -1,0 +1,10 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8314165
+ * @summary check for illegal circularity at class loading time
+ * @build CyclicValueClass
+ * @compile/fail/ref=CheckForCyclesAtClassLoadingTimeTest.out -XDrawDiagnostics CheckForCyclesAtClassLoadingTimeTest.java
+ */
+class CheckForCyclesAtClassLoadingTimeTest {
+    CyclicValueClass cyclicValueClass;
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.out
+++ b/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.out
@@ -1,0 +1,2 @@
+CyclicValueClass.class:-:-: compiler.err.cyclic.primitive.class.membership: CyclicValueClass
+1 error

--- a/test/langtools/tools/javac/valhalla/value-objects/cycles/CyclicValueClass.jcod
+++ b/test/langtools/tools/javac/valhalla/value-objects/cycles/CyclicValueClass.jcod
@@ -1,0 +1,78 @@
+class CyclicValueClass {
+  0xCAFEBABE;
+  0; // minor version
+  66; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    class #2; // #1
+    Utf8 "CyclicValueClass"; // #2
+    class #4; // #3
+    Utf8 "java/lang/Object"; // #4
+    Utf8 "cyclicField"; // #5
+    Utf8 "LCyclicValueClass;"; // #6
+    Utf8 "NullRestricted"; // #7
+    Utf8 "<vnew>"; // #8
+    Utf8 "()LCyclicValueClass;"; // #9
+    Utf8 "Code"; // #10
+    Utf8 "LineNumberTable"; // #11
+    Utf8 "SourceFile"; // #12
+    Utf8 "CyclicValueClass.java"; // #13
+    Utf8 "ImplicitCreation"; // #14
+  } // Constant Pool
+
+  0x0050; // access
+  #1;// this_cpx
+  #3;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0010; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#7) { // NullRestricted
+        } // end NullRestricted
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0009; // access
+      #8; // name_index
+      #9; // descriptor_index
+      [] { // Attributes
+        Attr(#10) { // Code
+          1; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0xCB00014B2AB0;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#11) { // LineNumberTable
+              [] { // line_number_table
+                0  4;
+                4  1;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#12) { // SourceFile
+      #13;
+    } // end SourceFile
+    ;
+    Attr(#14) { // ImplicitCreation
+      0x0001;
+    } // end ImplicitCreation
+  } // Attributes
+} // end class CyclicValueClass


### PR DESCRIPTION
This PR is implementing this assertion of JEP 401:

```
At class load time, an error occurs if an ACC_DEFAULT class has an illegal circularity in its instance field types
```

which is in section: `class file representation & interpretation`

So for example if a Java compiler were able to create a class file for class:
```
value class Test {
    Test! test; // illegal circularity
    public implicit Test();
}
```
then javac should issue an error while loading such a class

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314165](https://bugs.openjdk.org/browse/JDK-8314165): [lw5] check for illegal circularity at class loading time (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/903/head:pull/903` \
`$ git checkout pull/903`

Update a local copy of the PR: \
`$ git checkout pull/903` \
`$ git pull https://git.openjdk.org/valhalla.git pull/903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 903`

View PR using the GUI difftool: \
`$ git pr show -t 903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/903.diff">https://git.openjdk.org/valhalla/pull/903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/903#issuecomment-1675473157)