### PR TITLE
8314181: [lw5] the check for illegal circularity should only be done if value classes are available

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -3178,7 +3178,7 @@ public class ClassReader {
 
     // A value class cannot contain a non-nullable instance field of its own type either directly or indirectly.
     void checkNonCyclicMembership(ClassSymbol csym) {
-        if (!csym.type.hasImplicitConstructor()) {
+        if (!allowValueClasses || !csym.type.hasImplicitConstructor()) {
             // nothing to see here
             return;
         }


### PR DESCRIPTION
fixing minor missing check from the fix for JDK-8314165

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314181](https://bugs.openjdk.org/browse/JDK-8314181): [lw5] the check for illegal circularity should only be done if value classes are available (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/904/head:pull/904` \
`$ git checkout pull/904`

Update a local copy of the PR: \
`$ git checkout pull/904` \
`$ git pull https://git.openjdk.org/valhalla.git pull/904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 904`

View PR using the GUI difftool: \
`$ git pr show -t 904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/904.diff">https://git.openjdk.org/valhalla/pull/904.diff</a>

</details>
