### PR TITLE
8314190: [lworld] Missing InlineTypeNode re-materialization during type sharpening.

### DIFF
--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2437,6 +2437,10 @@ void Parse::sharpen_type_after_if(BoolTest::mask btest,
             // at the control merge.
             _gvn.set_type_bottom(ccast);
             record_for_igvn(ccast);
+            if (tboth->is_inlinetypeptr()) {
+              assert(tboth->exact_klass(true)->is_inlinetype(), "");
+              ccast = InlineTypeNode::make_from_oop(this, ccast, tboth->exact_klass(true)->as_inline_klass());
+            }
             // Here's the payoff.
             replace_in_map(obj, ccast);
           }


### PR DESCRIPTION
-  Currently we try to sharpen the object type to a narrower type to optimize object type comparison against a class constant.
 - This is achieved by inserting a CheckCastPP node which casts the object type to a higher speculative type, if cast type is an inlinetype we need to rematerialize InlineTypeNode from newly casted object which was missing and is fixed by the patch.

Kindly review.

Tier1 regressions are clean.

Best Regards,
Jatin Bhateja
 