### PR TITLE
8314628: [lworld+vector] validation regression fixes and cleanups.

### DIFF
--- a/src/hotspot/share/ci/ciField.cpp
+++ b/src/hotspot/share/ci/ciField.cpp
@@ -89,6 +89,8 @@ ciField::ciField(ciInstanceKlass* klass, int index, Bytecodes::Code bc) :
   int sig_index = cpool->signature_ref_index_at(nt_index);
   Symbol* signature = cpool->symbol_at(sig_index);
   _signature = ciEnv::current(THREAD)->get_symbol(signature);
+  _is_multifield = false;
+  _is_multifield_base = false;
 
   BasicType field_type = Signature::basic_type(signature);
 

--- a/src/hotspot/share/ci/ciField.hpp
+++ b/src/hotspot/share/ci/ciField.hpp
@@ -209,8 +209,19 @@ private:
   ciMultiField(ciField* field, ciInstanceKlass* holder, int offset, bool is_final) :
        ciField(field, holder, offset, is_final) {}
 public:
+  void set_secondary_fields(GrowableArray<ciField*>* fields) {
+     Arena* arena = CURRENT_ENV->arena();
+     _secondary_fields = new (arena) GrowableArray<ciField*>(arena, fields->length(), 0, nullptr);
+     for (int i = 0; i < fields->length(); i++) {
+       ciField* field = fields->at(i);
+       _secondary_fields->append(new (arena) ciField(field, field->holder(), field->offset_in_bytes(), field->is_final()));
+     }
+  }
+
   void add_secondary_fields(GrowableArray<ciField*>* fields) { _secondary_fields = fields; }
+
   GrowableArray<ciField*>* secondary_fields() { return _secondary_fields; }
+
   ciField* secondary_field_at(int i) {
     assert(_secondary_fields->length() > i, "");
     return _secondary_fields->at(i);

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -211,6 +211,7 @@ public:
   ciField* get_field_by_name(ciSymbol* name, ciSymbol* signature, bool is_static);
   // get field descriptor at field_offset ignoring flattening
   ciField* get_non_flattened_field_by_offset(int field_offset);
+  ciField* populate_synthetic_multifields(ciField* field);
 
   // total number of nonstatic fields (including inherited):
   int nof_nonstatic_fields() {

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -321,6 +321,9 @@ int ciBytecodeStream::get_field_index() {
 // or put_static, get the referenced field.
 ciField* ciBytecodeStream::get_field(bool& will_link) {
   ciField* f = CURRENT_ENV->get_field_by_index(_holder, get_field_index(), _bc);
+  if (f && f->is_multifield_base()) {
+    GUARDED_VM_ENTRY(f = _holder->populate_synthetic_multifields(f);)
+  }
   will_link = f->will_link(_method, _bc);
   return f;
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1640,6 +1640,7 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
         FieldInfo::FieldFlags fflags(0);
         // fflags.update_injected(true);
         AccessFlags aflags;
+        aflags.set_flags(flags);
         FieldInfo fi(aflags, (u2)(mfi_idx), (u2)signature_index, 0, fflags);
         fi.set_index(field_index);
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1746,15 +1746,10 @@ class jdk_internal_misc_UnsafeConstants : AllStatic {
 // Interface to jdk.internal.vm.vector.VectorSupport.VectorPayload objects
 
 class vector_VectorPayload : AllStatic {
- private:
-  static int _payload_offset;
  public:
-  static void set_payload(oop o, oop val);
-
-  static void compute_offsets();
-  static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
-
   // Testers
+  static void compute_offsets() { }
+  static void serialize_offsets(SerializeClosure* f) { }
   static bool is_subclass(Klass* klass) {
     return klass->is_subclass_of(vmClasses::vector_VectorPayload_klass());
   }

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -510,7 +510,7 @@ void InlineTypeNode::load(GraphKit* kit, Node* base, Node* ptr, ciInstanceKlass*
       bool is_array = (oop_ptr->isa_aryptr() != NULL);
       bool mismatched = (decorators & C2_MISMATCHED) != 0;
       ciField* field = holder->get_field_by_offset(offset, false);
-      if (base->is_Con() && !is_array && !mismatched && !field->is_multifield_base() && ft->bundle_size() == 1) {
+      if (base->is_Con() && !is_array && !mismatched && !field->is_multifield_base()) {
         // If the oop to the inline type is constant (static final field), we can
         // also treat the fields as constants because the inline type is immutable.
         ciObject* constant_oop = oop_ptr->const_oop();
@@ -856,8 +856,8 @@ Node* InlineTypeNode::default_value(PhaseGVN& gvn, ciType* field_type, ciInlineK
   BasicType bt = field_type->basic_type();
   int vec_len = field_type->bundle_size();
   Node* value = gvn.zerocon(field_type->basic_type());
-  int is_multifield = klass->declared_nonstatic_field_at(index)->is_multifield_base();
-  if (is_multifield &&
+  int is_multifield_base = klass->declared_nonstatic_field_at(index)->is_multifield_base();
+  if (is_multifield_base &&
       is_java_primitive(bt) &&
       Matcher::match_rule_supported_vector(VectorNode::replicate_opcode(bt), vec_len, bt)) {
       value = gvn.transform(VectorNode::scalar2vector(value, vec_len, Type::get_const_type(field_type), false));

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -101,7 +101,7 @@ public:
   // Returns the constant oop of the default inline type allocation
   static Node* default_oop(PhaseGVN& gvn, ciInlineKlass* vk);
 
-  static Node* default_value(PhaseGVN& gvn, ciType* field_type);
+  static Node* default_value(PhaseGVN& gvn, ciType* field_type, ciInlineKlass* klass, int index);
 
   // Support for control flow merges
   bool has_phi_inputs(Node* region);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2340,7 +2340,6 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
   if (base->is_InlineType()) {
     InlineTypeNode* vt = base->as_InlineType();
     if (is_store) {
-      ciInlineKlass* vk = vt->type()->inline_klass();
       if (!vt->is_allocated(&_gvn)) {
         return false;
       }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -2396,7 +2396,7 @@ void Parse::return_current(Node* value) {
         inc_sp(1);
         value = value->as_InlineType()->allocate_fields(this);
       }
-    } else if ((is_vector_value && skip_scalarization) ||
+    } else if (skip_scalarization ||
                (value->Opcode() != Op_VectorBox && value->is_InlineType())) {
       // Inline type is returned as oop, make sure it is buffered and re-execute
       // if allocation triggers deoptimization.

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -2437,6 +2437,10 @@ void Parse::sharpen_type_after_if(BoolTest::mask btest,
             // at the control merge.
             _gvn.set_type_bottom(ccast);
             record_for_igvn(ccast);
+            if (tboth->is_inlinetypeptr()) {
+              assert(tboth->exact_klass(true)->is_inlinetype(), "");
+              ccast = InlineTypeNode::make_from_oop(this, ccast, tboth->exact_klass(true)->as_inline_klass());
+            }
             // Here's the payoff.
             replace_in_map(obj, ccast);
           }

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -369,7 +369,8 @@ void Parse::do_withfield() {
 
   BasicType bt = field->type()->basic_type();
   int vec_len = field->secondary_fields_count();
-  bool scalarize_fields = !is_java_primitive(bt) || !Matcher::match_rule_supported_vector(VectorNode::replicate_opcode(bt), vec_len, bt);
+  bool scalarize_fields = !field->is_multifield_base() || !is_java_primitive(bt) ||
+                          !Matcher::match_rule_supported_vector(VectorNode::replicate_opcode(bt), vec_len, bt);
   if (scalarize_fields) {
     for(int i = 0; i < vec_len; i++) {
       new_vt->set_field_value_by_offset(field->offset_in_bytes() + i * type2aelembytes(bt), val);

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -333,7 +333,7 @@ Node* PhaseVector::expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
   vector = gvn.transform(vector)->as_InlineType();
 
   Node* klass_node = kit.makecon(TypeKlassPtr::make(vk));
-  Node* alloc_oop  = kit.new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true, vector);
+  Node* alloc_oop  = kit.new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true);
   vector->store(&kit, alloc_oop, alloc_oop, vk);
 
   C->set_max_vector_size(MAX2(C->max_vector_size(), vect_type->length_in_bytes()));

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1719,6 +1719,7 @@ class VectorBoxNode : public InlineTypeNode {
     payload_value = gvn.transform(payload_value);
 
     box_node->set_field_value(0, payload_value);
+    box_node->set_is_buffered(gvn, false);
     box_node->set_is_init(gvn);
 
     return box_node;


### PR DESCRIPTION
Patch fixes following problem seen during validation:-

**CDS:-**
- Problem while restoring value object mirrors. These are needed to perform class level comparisons.

**VM:-**
- Remove payload offset computation logic during VM initialization. It was earlier used during object re-materialization.

**ci Model:-**
- Add a generic routine to handle synthetic ciField population for both static and non-static multifield. This enables returning fully populated ciMultiField structure to compilers during parsing.

**C1 compiler:-**
- Incorrect address displacement computation in HIR while updating multifield bundle using "withfield" bytecode in VectorPayalod constructor. This was causing  failures in Double128Mask tests.

**C2 compiler:-**
1.  Allow vector IR creation under strict check for multifield in default_value creation routine. This was incorrectly creating vector IR for non-vector API tests for Double/Long types.
2. Disable inline expansion of Unsafe.finishPrivateBuffer.  This is fixing the incorrectness problems seen with masked operations loop e.g.

>     vt = newPayload();
>     vt = Unsafe.makePrivateBuffer(vt);
>     for (int i = 0; i < Double128.length; i++) {
>          if (mask[i]) {
>               Unsafe.putDouble(vt, apply(src[i]));
>          }
>     }

   Unsafe.putDouble() only modifies the memory state by storing a new value in payload buffer but does not update any local variable in the JVM state corresponding to latch block. Thus no inductive Phi node is inserted in the loop, it also re-materializes InlineTypeNode from modified memory state. This causes incorrectness if second mask value is false as entire payload is overwritten with default value and earlier lane updates are over-written. In order to be safe, disabling intrinsification of finishPrivateBuffer if incoming argument node is of VectorPayload* type, so that it always receive updated buffer argument.

3. With non-incremental in-lining (-XX:-IncrementalInline) flow user defined routines returning a vector object is incorrectly returning uninitialized VBA connected to oop input of InlineType IR. Defer returning VectorBoxAllocation node, they are expanded and initialized during box expansion and replaces all uses of box.

4. Currently we try to sharpen the object type to a narrower type to optimize object type comparison against a class constant. This is achieved by inserting a CheckCastPP node which casts the object type to a higher speculative type, if cast type is an inlinetype we need to re-materialize InlineTypeNode from newly casted object which was missing.

**Validation Status with patch.**
  - All VectorAPI Jtreg test points except following known issues are passing on x86 at various AVX levels and compilation levels.

**Pending/know issues:-**

1. Failures in some of the mask/shuffle related test points with -XX:+DeoptimizeALot, to be resolved after mainline merge to incorporate major shuffle re-structuring changes in in mainline.
2. Test point using Max-Species are failing, to be fixed with max species support in subsequent patch.
3. Assertion failure in cyclic graph check due to unexpected graph shape seen in box expansion.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314628](https://bugs.openjdk.org/browse/JDK-8314628): [lworld+vector] validation regression fixes and cleanups. (**Bug** - P3)


### Reviewers
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/909/head:pull/909` \
`$ git checkout pull/909`

Update a local copy of the PR: \
`$ git checkout pull/909` \
`$ git pull https://git.openjdk.org/valhalla.git pull/909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 909`

View PR using the GUI difftool: \
`$ git pr show -t 909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/909.diff">https://git.openjdk.org/valhalla/pull/909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/909#issuecomment-1685817197)