### PR TITLE
8314899: [lw5] rename j.l.NonAtomic to j.l.LooselyConsistentValue

### DIFF
--- a/src/java.base/share/classes/java/lang/LooselyConsistentValue.java
+++ b/src/java.base/share/classes/java/lang/LooselyConsistentValue.java
@@ -61,5 +61,5 @@ package java.lang;
  * @since Valhalla
  */
 
-public interface NonAtomic {
+public interface LooselyConsistentValue {
 }


### PR DESCRIPTION
simple refactoring

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314899](https://bugs.openjdk.org/browse/JDK-8314899): [lw5] rename j.l.NonAtomic to j.l.LooselyConsistentValue (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/913/head:pull/913` \
`$ git checkout pull/913`

Update a local copy of the PR: \
`$ git checkout pull/913` \
`$ git pull https://git.openjdk.org/valhalla.git pull/913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 913`

View PR using the GUI difftool: \
`$ git pr show -t 913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/913.diff">https://git.openjdk.org/valhalla/pull/913.diff</a>

</details>
