### PR TITLE
8314913: [lw5] null restrictions can only be applied to value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1153,9 +1153,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
 
         public Type constType(Object constValue) {
-            return isPrimitive() ?
-                    addMetadata(new ConstantValue(constValue)) :
-                    addMetadata(new ConstantValue(constValue)).addMetadata(new TypeMetadata.NullMarker(NullMarker.NOT_NULL));
+            return addMetadata(new ConstantValue(constValue));
         }
 
         /** The Java source which this type represents.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1345,6 +1345,17 @@ public class Attr extends JCTree.Visitor {
                     log.error(tree, Errors.IllegalRecordComponentName(v));
                 }
             }
+            Type elemOrType = result;
+            while (!elemOrType.hasTag(ERROR) && types.elemtype(elemOrType) != null) {
+                elemOrType = types.elemtype(elemOrType);
+            }
+            if ((result.isNonNullable() || elemOrType.isNonNullable()) && (!elemOrType.isValueClass() || !elemOrType.hasImplicitConstructor())) {
+                log.error(tree.pos(),
+                        types.elemtype(result) == null?
+                                Errors.TypeCantBeNullRestricted(result) :
+                                Errors.TypeCantBeNullRestricted2(result)
+                );
+            }
         }
         finally {
             chk.setLint(prevLint);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4164,10 +4164,20 @@ compiler.err.enclosing.class.type.non.denotable=\
     enclosing class type: {0}\n\
     is non-denotable, try casting to a denotable type
 
-### bang types
+### null-restricted types
 
 compiler.err.non.nullable.cannot.be.assigned.null=\
     non-nullable type cannot be assigned null
+
+# 0: type
+compiler.err.type.cant.be.null.restricted=\
+    type: {0}, cannot be a null restricted type\n\
+    it must be a value class with an implicit constructor
+
+# 0: type
+compiler.err.type.cant.be.null.restricted.2=\
+    type: {0}, cannot be a null restricted type\n\
+    its element type must be a value class with an implicit constructor
 
 compiler.warn.narrowing.nullness.conversion=\
     narrowing nullness conversion

--- a/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/NewObjects.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/referenceinfos/NewObjects.java
@@ -61,14 +61,14 @@ public class NewObjects {
 
     @TADescription(annotation = "TA", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE)
     public String eqtestObject() {
-        return "void eqtestObject(String! s) { if (s == new @TA String()); }";
+        return "void eqtestObject(String s) { if (s == new @TA String()); }";
     }
 
     @TADescription(annotation = "TA", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE)
     @TADescription(annotation = "TB", type = NEW,
             genericLocation = { 3, 0 }, offset = ReferenceInfoUtil.IGNORE_VALUE)
     public String eqtestObjectGeneric() {
-        return "void eqtestObjectGeneric(ArrayList!<String> as) { if (as == new @TA ArrayList<@TB String >()); }";
+        return "void eqtestObjectGeneric(ArrayList<String> as) { if (as == new @TA ArrayList<@TB String >()); }";
     }
 
     @TADescription(annotation = "TA", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE,
@@ -165,14 +165,14 @@ public class NewObjects {
 
     @TADescription(annotation = "RTAs", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE)
     public String eqtestObjectRepeatableAnnotation() {
-        return "void eqtestObject(String! s) { if (s == new @RTA @RTA String()); }";
+        return "void eqtestObject(String s) { if (s == new @RTA @RTA String()); }";
     }
 
     @TADescription(annotation = "RTAs", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE)
     @TADescription(annotation = "RTBs", type = NEW,
             genericLocation = { 3, 0 }, offset = ReferenceInfoUtil.IGNORE_VALUE)
     public String eqtestObjectGenericRepeatableAnnotation() {
-        return "void eqtestObjectGeneric(ArrayList!<String> as) { if (as == new @RTA @RTA ArrayList<@RTB @RTB String >()); }";
+        return "void eqtestObjectGeneric(ArrayList<String> as) { if (as == new @RTA @RTA ArrayList<@RTB @RTB String >()); }";
     }
 
     @TADescription(annotation = "RTAs", type = NEW, offset = ReferenceInfoUtil.IGNORE_VALUE,

--- a/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
+++ b/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,30 +21,10 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 8198749
- * @summary Test that qualified this based access to instance fields works ok.
- * @compile -XDenablePrimitiveClasses ValueConstructorRef.java
- * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses ValueConstructorRef
- */
+// key: compiler.err.type.cant.be.null.restricted
+// key: compiler.err.type.cant.be.null.restricted.2
 
-import java.util.function.Supplier;
-
-public value class ValueConstructorRef {
-
-    final int x;
-    final int y;
-
-    ValueConstructorRef() {
-        x = 1234;
-        y = 5678;
-    }
-
-    public static void main(String [] args) {
-        Supplier<ValueConstructorRef> sx = ValueConstructorRef::new;
-        ValueConstructorRef x = (ValueConstructorRef) sx.get();
-        if (x.x != 1234 || x.y != 5678)
-            throw new AssertionError(x);
-    }
+public class CantBeNonNullableType {
+    String! s;
+    String[]! sa;
 }

--- a/test/langtools/tools/javac/nullability/NullabilityCompilationTests.java
+++ b/test/langtools/tools/javac/nullability/NullabilityCompilationTests.java
@@ -126,21 +126,23 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                 List.of(
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String! s = null;
+                                    Point! s = null;
                                 }
                                 """,
                                 Result.Error,
                                 "compiler.err.prob.found.req"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String[]! s = null;
+                                    Point[]! s = null;
                                 }
                                 """,
                                 Result.Error,
                                 "compiler.err.prob.found.req"),
-                        new DiagAndCode(
+                        /*new DiagAndCode(
                                 """
                                 import java.util.function.*;
                                 class Test<T> {
@@ -151,12 +153,12 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 }
                                 """,
                                 Result.Error,
-                                "compiler.err.prob.found.req"),
+                                "compiler.err.prob.found.req"),*/
                         new DiagAndCode(
                                 """
-                                value class Point {}
+                                value class Point { public implicit Point(); }
                                 class MyList<T> {
-                                    void add(T! e) {}
+                                    void add(T e) {}
                                 }
                                 class Test {
                                     void m(MyList<? super Point!> ls) {
@@ -175,48 +177,54 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                 List.of(
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String! s;
+                                    Point! s;
                                 }
                                 """,
                                 Result.Warning,
                                 "compiler.warn.non.nullable.should.be.initialized"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String[]! s;
+                                    Point[]! s;
                                 }
                                 """,
                                 Result.Warning,
                                 "compiler.warn.non.nullable.should.be.initialized"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String![]! s;
+                                    Point![]! s;
                                 }
                                 """,
                                 Result.Warning,
                                 "compiler.warn.non.nullable.should.be.initialized"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String![]![]! s;
+                                    Point![]![]! s;
                                 }
                                 """,
                                 Result.Warning,
                                 "compiler.warn.non.nullable.should.be.initialized"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String[][]! s;
+                                    Point[][]! s;
                                 }
                                 """,
                                 Result.Warning,
                                 "compiler.warn.non.nullable.should.be.initialized"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    String[][][]! s;
+                                    Point[][][]! s;
                                 }
                                 """,
                                 Result.Warning,
@@ -230,8 +238,9 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                 List.of(
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    void m(String! s1, String s3) {
+                                    void m(Point! s1, Point s3) {
                                         s1 = s3;
                                     }
                                 }
@@ -239,7 +248,7 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 Result.Warning,
                                 "compiler.warn.unchecked.nullness.conversion",
                                 1),
-                        new DiagAndCode(
+                        /*new DiagAndCode(
                                 """
                                 class Foo {
                                     void m(Object! s1, String s3) {
@@ -249,17 +258,19 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """,
                                 Result.Warning,
                                 "compiler.warn.unchecked.nullness.conversion",
-                                1),
+                                1),*/
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    void m(String! s1, String s3) {
+                                    void m(Point! s1, Point s3) {
                                         s3 = s1;
                                     }
                                 }
                                 """,
                                 Result.Clean,
                                 ""),
+                        /*
                         new DiagAndCode(
                                 """
                                 class Foo<T extends String!> {
@@ -278,13 +289,15 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 Result.Warning,
                                 "compiler.warn.unchecked.nullness.conversion",
                                 1),
+                        */
 
                         // wildcards
                         new DiagAndCode(
                                 """
                                 import java.util.*;
+                                value class Point { public implicit Point(); }
                                 class Foo {
-                                    void test(List<? extends String!> ls1, List<? extends String> ls3) {
+                                    void test(List<? extends Point!> ls1, List<? extends Point> ls3) {
                                         ls1 = ls3;
                                     }
                                 }
@@ -412,12 +425,13 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """
                                 class Test {
                                     class Box<X> {}
+                                    static value class Point { public implicit Point(); }
                                     @SafeVarargs
-                                    private <Z> Z! make_box_uni(Z!... bs) {
+                                    private <Z> Z make_box_uni(Z... bs) {
                                         return bs[0];
                                     }
-                                    void test(Box<String!> bref, Box<String> bval) {
-                                        Box<? extends String!> res = make_box_uni(bref, bval);
+                                    void test(Box<Point!> bref, Box<Point> bval) {
+                                        Box<? extends Point!> res = make_box_uni(bref, bval);
                                     }
                                 }
                                 """,
@@ -456,40 +470,8 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                 List.of(
                         new DiagAndCode(
                                 """
-                                class Test {
-                                    void m() {
-                                        String! s = "abc"; // literals are always null restricted
-                                    }
-                                }
-                                """,
-                                Result.Clean,
-                                ""),
-                        new DiagAndCode(
-                                """
-                                class Foo {
-                                    void m() {
-                                        Foo! f = new Foo();
-                                    }
-                                }
-                                """,
-                                Result.Clean,
-                                ""),
-                        new DiagAndCode(
-                                """
-                                import java.util.*;
-                                class Foo {
-                                     void m(List<? super String!> ls1) {}
-                                     void test(List<? super String!> ls2) {
-                                         m(ls2);
-                                     }
-                                }
-                                """,
-                                Result.Clean,
-                                ""),
-                        new DiagAndCode(
-                                """
                                 interface Shape {}
-                                value class Point implements Shape {}
+                                value class Point implements Shape { public implicit Point(); }
                                 class Box<T> {}
                                 class Test {
                                     void m(Box<Point!> lp) {
@@ -503,10 +485,10 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                         new DiagAndCode(
                                 """
                                 interface Shape {}
-                                value class Point implements Shape {}
+                                value class Point implements Shape { public implicit Point(); }
                                 class Box<T> {}
                                 class Test {
-                                    void m(Box<Shape!> lp) {
+                                    void m(Box<Shape> lp) {
                                         foo(lp);
                                     }
                                     void foo(Box<? super Point!> ls) {}
@@ -544,7 +526,7 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """
                                 class C<T> {
                                     T x = null;
-                                    void set(T! arg) { x = arg; }
+                                    void set(T arg) { x = arg; }
                                 }
                                 """,
                                 Result.Clean,
@@ -553,7 +535,7 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """
                                 value class Point {}
                                 class MyList<T> {
-                                    static <E> MyList<E!> of(E! e1) {
+                                    static <E> MyList<E> of(E e1) {
                                         return null;
                                     }
                                 }
@@ -567,10 +549,10 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 ""),
                         new DiagAndCode(
                                 """
-                                value class Point {}
+                                value class Point { public implicit Point(); }
                                 class MyCollection<T> {}
                                 class MyList<T> extends MyCollection<T!> {
-                                    static <E> MyList<E!> of(E! e1) {
+                                    static <E> MyList<E> of(E e1) {
                                         return null;
                                     }
                                 }
@@ -586,7 +568,7 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """
                                 class Test<T> {
                                     T field;
-                                    void foo(T! t) {
+                                    void foo(T t) {
                                         field = t;
                                     }
                                 }
@@ -649,7 +631,8 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 ""),
                         new DiagAndCode(
                                 """
-                                class Test {
+                                value class Test {
+                                    public implicit Test();
                                     void m(Test t1, Test[] t2, Test[][] t3, Test[][][] t4) {
                                         Test! l1 = (Test!) t1;
                                         Test![] l2 = (Test![]) t2;
@@ -688,12 +671,13 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 "compiler.warn.overrides.with.different.nullness.1"),
                         new DiagAndCode(
                                 """
+                                value class Point { public implicit Point(); }
                                 abstract class A {
-                                    abstract String lookup(String! arg);
+                                    abstract String lookup(Point! arg);
                                 }
 
                                 abstract class B extends A {
-                                    abstract String lookup(String arg);
+                                    abstract String lookup(Point arg);
                                 }
                                 """,
                                 Result.Warning,

--- a/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
+++ b/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
@@ -34,79 +34,81 @@ import java.util.function.*;
 import java.util.*;
 
 class NullabilityParsingTest {
+    static value class Point { public implicit Point(); }
+    static value class Shape { public implicit Shape(); }
     // fields
-    Object! o2;
+    Point! o2;
 
     // method parameters
-    void m2(Object! o) { }
+    void m2(Point! o) { }
 
     // method returns
-    Object! m2() { return new Object(); }
+    Point! m2() { return new Point(); }
 
     // locals
     void testLocals() {
-        Object! o2;
+        Point! o2;
     }
 
     // generics - field
-    Consumer<Object!> co2;
+    Consumer<Point!> co2;
 
     // generics - method param
-    void m4(Consumer<Object!> co) { }
+    void m4(Consumer<Point!> co) { }
 
     // generics - method return
-    Consumer<Object!> m4() { return null; }
+    Consumer<Point!> m4() { return null; }
 
     // generics - local
     void testGenericLocals() {
-        Consumer<Object!> co2;
+        Consumer<Point!> co2;
     }
 
     // lambdas
     void testLambdas() {
-        Consumer<Object!> co2 = (Object! co) -> {};
+        Consumer<Point!> co2 = (Point! co) -> {};
     }
 
     void testGenericLambdas() {
-        Consumer<Consumer<Object!>> co2 = (Consumer<Object!> co) -> {};
-        Consumer<Function<Object!, Object!>> co3 = (Function<Object!, Object!> co) -> {};
-        Consumer<Consumer<Consumer<Consumer<Object!>>>> co6 = (Consumer<Consumer<Consumer<Object!>>> co) -> {};
+        Consumer<Consumer<Point!>> co2 = (Consumer<Point!> co) -> {};
+        Consumer<Function<Point!, Point!>> co3 = (Function<Point!, Point!> co) -> {};
+        Consumer<Consumer<Consumer<Consumer<Point!>>>> co6 = (Consumer<Consumer<Consumer<Point!>>> co) -> {};
     }
 
     // type test patterns
 
     void testTypeTestPatterns(Object o) {
         switch (o) {
-            case Integer! i -> throw new AssertionError();
-            case String! s -> throw new AssertionError();
+            case Point! i -> throw new AssertionError();
+            case Shape! s -> throw new AssertionError();
             default -> throw new AssertionError();
         }
     }
 
     sealed interface I<X> {}
-    final class A implements I<Integer> { }
+    final class A implements I<Point> { }
 
     void genericTypeTestPatterns(A o) {
         switch (o) {
-            case I<Integer!> i -> { }
+            case I<Point!> i -> { }
         }
     }
 
     sealed interface I2<X> {}
-    final class A2 implements I2<I<Integer>> { }
+    final class A2 implements I2<I<Point>> { }
 
     void genericTypeTestPatterns(A2 o) {
         switch (o) {
-            case I2<I<Integer!>> i -> { }
+            case I2<I<Point!>> i -> { }
         }
     }
 
     sealed interface I3<X> {}
-    final class A3 implements I3<I2<I<Integer>>> { }
+    final class A3 implements I3<I2<I<Point>>> { }
 
     void genericTypeTestPatterns(A3 o) {
         switch (o) {
-            case I3<I2<I<Integer!>>> i -> { }
+            case I3<I2<I<Point!>>> i -> { }
         }
     }
 
@@ -116,7 +118,7 @@ class NullabilityParsingTest {
 
     void genericRecordPatterns(R o) {
         switch (o) {
-            case R!(I<Integer!> i) -> { }
+            case R!(I<Point!> i) -> { }
         }
     }
 
@@ -124,7 +126,7 @@ class NullabilityParsingTest {
 
     void genericRecordPatterns(R2 o) {
         switch (o) {
-            case R2!(I2<I<Integer!>> i) -> { }
+            case R2!(I2<I<Point!>> i) -> { }
         }
     }
 
@@ -132,66 +134,66 @@ class NullabilityParsingTest {
 
     void genericRecordPatterns(R3 o) {
         switch (o) {
-            case R3!(I3<I2<I<Integer!>>> i) -> { }
+            case R3!(I3<I2<I<Point!>>> i) -> { }
         }
     }
 
     // instanceof/cast
 
     void testInstanceOf(Object o) {
-        boolean r2 = o instanceof String!;
+        boolean r2 = o instanceof Point!;
     }
 
     void testInstanceRecord(R r) {
-        boolean r2 = r instanceof R(I<Integer!> i);
+        boolean r2 = r instanceof R(I<Point!> i);
     }
 
     void testCast(Object o) {
-        String! s2 = (String!)o;
+        Point! s2 = (Point!)o;
     }
 
     void testGenericCast(A a) {
-        I<Integer!> i2 = (I<Integer!>)a;
+        I<Point!> i2 = (I<Point!>)a;
     }
-
+/*
     void testGenericCast2(A a) {
-        I!<Integer!> i2 = (I!<Integer!>)a;
+        I<Point!> i2 = (I<Point!>)a;
     }
-
+*/
     // arrays
 
-    Object![]![]![]! oarr;
-    Function!<Object![]![]!, Function<Object![]![]!, Object![]![]!>>[]![]! garr;
+    Point![]![]![]! oarr;
+    Function<Point![]![]!, Function<Point![]![]!, Point![]![]!>>[][] garr;
 
     void mBad1(Object o) {
-        String s1 = o instanceof String ? (String)o : null;
-        String s2 = o instanceof String! ? (String)o : null;
+        Point s1 = o instanceof Point ? (Point)o : null;
+        Point s2 = o instanceof Point! ? (Point)o : null;
     }
 
     void mBad2(Object o) {
-        String s1 = o instanceof String ? "" : null;
-        String s2 = o instanceof String! ? "" : null;
+        Point s1 = o instanceof Point ? null : null;
+        Point s2 = o instanceof Point! ? null : null;
     }
 
     void testPatternRule(Object o) {
         switch (o) {
-            case String! s -> { }
+            case Point! s -> { }
                 default -> { }
         }
     }
 
     void testPatternCol(Object o) {
         switch (o) {
-            case String! s: { }
+            case Point! s: { }
             default: { }
         }
     }
 
     void testInstanceOfAndInfix1(Object a, boolean b) {
-        boolean x2 = a instanceof String! && b;
+        boolean x2 = a instanceof Point! && b;
     }
 
     void testInstanceOfAndInfix2(Object a, boolean b) {
-        boolean x2 = a instanceof String! s && b;
+        boolean x2 = a instanceof Point! s && b;
     }
 }

--- a/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
+++ b/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
@@ -77,45 +77,50 @@ public class RuntimeNullChecks extends TestRunner {
     public void testRuntimeChecks(Path base) throws Exception {
         for (String code: new String[] {
                 """
+                value class Point { public implicit Point(); }
                 class Test {
                     public static void main(String... args) {
-                        String s = null;
-                        String! o = s; // NPE at runtime, variable initialization
+                        Point s = null;
+                        Point! o = s; // NPE at runtime, variable initialization
                     }
                 }
                 """,
                 """
+                value class Point { public implicit Point(); }
                 class Test {
                     public static void main(String... args) {
-                        String s = null;
-                        String! o;
+                        Point s = null;
+                        Point! o;
                         o = s; // NPE at runtime, assignment, it doesn't stress the same code path as the case above
                     }
                 }
                 """,
                 """
+                value class Point { public implicit Point(); }
                 class Test {
                     public static void main(String... args) {
-                        String s = null;
-                        String![] sr = new String![10];
+                        Point s = null;
+                        Point![] sr = new Point![10];
                         sr[0] = s; // NPE at runtime, assignment
                     }
                 }
                 """,
                 """
+                value class Point { public implicit Point(); }
                 class Test {
-                    static String id(String! arg) { return arg; }
+                    static Point id(Point! arg) { return arg; }
                     public static void main(String... args) {
-                        String s = null;
+                        Point s = null;
                         Object o = id(s); // NPE at runtime, method invocation
                     }
                 }
                 """,
                 """
+                value class Point { public implicit Point(); }
                 class Test {
                     public static void main(String... args) {
-                        String s = null;
-                        Object o = (String!) s; // NPE, cast
+                        Point s = null;
+                        Object o = (Point!) s; // NPE, cast
                     }
                 }
                 """

--- a/test/langtools/tools/javac/processing/errors/EnsureAnnotationTypeMismatchException/Processor.java
+++ b/test/langtools/tools/javac/processing/errors/EnsureAnnotationTypeMismatchException/Processor.java
@@ -56,7 +56,7 @@ public class Processor extends JavacTestingAbstractProcessor {
 
             checkCorrectException(check::classValue, "java.lang.Class<java.lang.String>");
             checkCorrectException(check::intConstValue, "boolean");
-            checkCorrectException(check::enumValue, "java.lang.String!");
+            checkCorrectException(check::enumValue, "java.lang.String");
             checkCorrectException(check::incorrectAnnotationValue, "java.lang.Deprecated");
             checkCorrectException(check::incorrectArrayValue, "<any>");
             checkCorrectException(check::incorrectClassValue, "<any>");

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableFlagFromClass.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableFlagFromClass.java
@@ -7,7 +7,7 @@
  */
 
 public class CheckFlattenableFlagFromClass {
-    void foo(FlattenableFlagFromClass! f) {
+    void foo(FlattenableFlagFromClass f) {
         f.v = null; // Error.
         f.va = null; //f.va[0] = null; // Error.  we currently can't represent that elements inside an array are non-nullable
     }

--- a/test/langtools/tools/javac/valhalla/primitive-classes/ExplicitLambdaWithNullableTypes2.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/ExplicitLambdaWithNullableTypes2.java
@@ -40,6 +40,8 @@ value class OptionalInt {
     private boolean isPresent;
     private int v;
 
+    public implicit OptionalInt();
+
     public static OptionalInt empty() {
         return OptionalInt.default;
     }

--- a/test/langtools/tools/javac/valhalla/primitive-classes/PreloadAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/PreloadAttributeTest.java
@@ -35,14 +35,14 @@ import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
 
 public class PreloadAttributeTest {
 
-    public value class P1 {}
-    public value class P2 {}
-    public value class P3 {}
-    public value class P4 {}
-    public value class P5 {}
-    public value class P6 {}
-    public value class P7 {}
-    public value class P8 {}
+    public static value class P1 { public implicit P1(); }
+    public static value class P2 { public implicit P2(); }
+    public static value class P3 { public implicit P3(); }
+    public static value class P4 { public implicit P4(); }
+    public static value class P5 { public implicit P5(); }
+    public static value class P6 { public implicit P6(); }
+    public static value class P7 { public implicit P7(); }
+    public static value class P8 { public implicit P8(); }
 
     // We expect NO Preload Entries for ANY of P1 .. P4
     P1! p1;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1008,9 +1008,9 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
         String code =
                 """
                 value class V0 {
-                    public implicit V0(); 
+                    public implicit V0();
                 }
-                
+
                 value class V1 {
                     V0! f1;
                     V0 f2;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1007,9 +1007,13 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
     public void testClassAttributes() throws Exception {
         String code =
                 """
+                value class V0 {
+                    public implicit V0(); 
+                }
+                
                 value class V1 {
-                    String! f1;
-                    String f2;
+                    V0! f1;
+                    V0 f2;
                     public implicit V1();
                 }
 


### PR DESCRIPTION
according to last iteration of the spec null restrictions can only be applied to value classes that declares an implicit constructor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314913](https://bugs.openjdk.org/browse/JDK-8314913): [lw5] null restrictions can only be applied to value classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/916/head:pull/916` \
`$ git checkout pull/916`

Update a local copy of the PR: \
`$ git checkout pull/916` \
`$ git pull https://git.openjdk.org/valhalla.git pull/916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 916`

View PR using the GUI difftool: \
`$ git pr show -t 916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/916.diff">https://git.openjdk.org/valhalla/pull/916.diff</a>

</details>
