### PR TITLE
8315272: [lworld] Replacing NULL with nullptr in aarch64 code

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1237,7 +1237,7 @@ source %{
 
     // r27 is not allocatable when compressed oops is on and heapbase is not
     // zero, compressed klass pointers doesn't use r27 after JDK-8234794
-    if (UseCompressedOops && (CompressedOops::ptrs_base() != NULL)) {
+    if (UseCompressedOops && (CompressedOops::ptrs_base() != nullptr)) {
       _NO_SPECIAL_REG32_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
       _NO_SPECIAL_REG_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
       _NO_SPECIAL_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
@@ -1581,7 +1581,7 @@ bool needs_releasing_store(const Node *n)
 {
   // assert n->is_Store();
   StoreNode *st = n->as_Store();
-  return st->trailing_membar() != NULL;
+  return st->trailing_membar() != nullptr;
 }
 
 // predicate controlling translation of CAS
@@ -1593,9 +1593,9 @@ bool needs_acquiring_load_exclusive(const Node *n)
   assert(is_CAS(n->Opcode(), true), "expecting a compare and swap");
   LoadStoreNode* ldst = n->as_LoadStore();
   if (is_CAS(n->Opcode(), false)) {
-    assert(ldst->trailing_membar() != NULL, "expected trailing membar");
+    assert(ldst->trailing_membar() != nullptr, "expected trailing membar");
   } else {
-    return ldst->trailing_membar() != NULL;
+    return ldst->trailing_membar() != nullptr;
   }
 
   // so we can just return true here
@@ -1644,7 +1644,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb) {
     return 1 * NativeInstruction::instruction_size;
-  } else if (_entry_point == NULL) {
+  } else if (_entry_point == nullptr) {
     // See CallLeafNoFPIndirect
     return 1 * NativeInstruction::instruction_size;
   } else {
@@ -1737,7 +1737,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
     st->print("mov  rscratch1, #%d\n\t", framesize - 2 * wordSize);
     st->print("sub  sp, sp, rscratch1");
   }
-  if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("\n\t");
     st->print("ldr  rscratch1, [guard]\n\t");
     st->print("dmb ishld\n\t");
@@ -1764,7 +1764,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ verified_entry(C, 0);
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     __ entry_barrier();
   }
 
@@ -2108,12 +2108,12 @@ void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   if (!ra_)
     st->print("N%d = SpillCopy(N%d)", _idx, in(1)->_idx);
   else
-    implementation(NULL, ra_, false, st);
+    implementation(nullptr, ra_, false, st);
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -2183,7 +2183,7 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
     __ nop();
 
     // TODO 8284443 Avoid creation of temporary frame
-    if (ra_->C->stub_function() == NULL) {
+    if (ra_->C->stub_function() == nullptr) {
       __ verified_entry(ra_->C, 0);
       __ entry_barrier();
       int framesize = ra_->C->output()->frame_slots() << LogBytesPerInt;
@@ -2250,7 +2250,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2268,7 +2268,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2404,7 +2404,7 @@ MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* generic_opnd, 
     case Op_VecX: return new vecXOper();
   }
   ShouldNotReachHere();
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -2577,7 +2577,7 @@ Assembler::Condition to_assembler_cond(BoolTest::mask cond) {
 
 // Binary src (Replicate con)
 bool is_valid_sve_arith_imm_pattern(Node* n, Node* m) {
-  if (n == NULL || m == NULL) {
+  if (n == nullptr || m == nullptr) {
     return false;
   }
 
@@ -2618,7 +2618,7 @@ bool is_valid_sve_arith_imm_pattern(Node* n, Node* m) {
 // (XorV src (Replicate m1))
 // (XorVMask src (MaskAll m1))
 bool is_vector_bitwise_not_pattern(Node* n, Node* m) {
-  if (n != NULL && m != NULL) {
+  if (n != nullptr && m != nullptr) {
     return (n->Opcode() == Op_XorV || n->Opcode() == Op_XorVMask) &&
            VectorNode::is_all_ones_vector(m);
   }
@@ -3424,7 +3424,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL || con == (address)1) {
+    if (con == nullptr || con == (address)1) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3467,7 +3467,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3486,7 +3486,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3669,7 +3669,7 @@ encode %{
      Label miss;
      C2_MacroAssembler _masm(&cbuf);
      __ check_klass_subtype_slow_path(sub_reg, super_reg, temp_reg, result_reg,
-                                     NULL, &miss,
+                                     nullptr, &miss,
                                      /*set_cond_codes:*/ true);
      if ($primary) {
        __ mov(result_reg, zr);
@@ -3685,7 +3685,7 @@ encode %{
     if (!_method) {
       // A call to a runtime wrapper, e.g. new, new_typeArray_Java, uncommon_trap.
       call = __ trampoline_call(Address(addr, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3699,7 +3699,7 @@ encode %{
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
                                                   : static_call_Relocation::spec(method_index);
       call = __ trampoline_call(Address(addr, rspec));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3710,7 +3710,7 @@ encode %{
       } else {
         // Emit stub for static call
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, call);
-        if (stub == NULL) {
+        if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
         }
@@ -3729,7 +3729,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     int method_index = resolved_method_index(cbuf);
     address call = __ ic_call((address)$meth$$method, method_index);
-    if (call == NULL) {
+    if (call == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -3791,7 +3791,7 @@ encode %{
     CodeBlob *cb = CodeCache::find_blob(entry);
     if (cb) {
       address call = __ trampoline_call(Address(entry, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3914,10 +3914,10 @@ encode %{
     // Handle existing monitor.
     __ bind(object_has_monitor);
 
-    // The object's monitor m is unlocked iff m->owner == NULL,
+    // The object's monitor m is unlocked iff m->owner == nullptr,
     // otherwise m->owner may contain a thread or a stack address.
     //
-    // Try to CAS m->owner from NULL to current thread.
+    // Try to CAS m->owner from nullptr to current thread.
     __ add(tmp, disp_hdr, (in_bytes(ObjectMonitor::owner_offset())-markWord::monitor_value));
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, rscratch1); // Sets flags for result
@@ -4891,7 +4891,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -5023,7 +5023,7 @@ operand immN()
   interface(CONST_INTER);
 %}
 
-// Narrow NULL Pointer Immediate
+// Narrow nullptr Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);
@@ -7447,7 +7447,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# NULL ptr" %}
+  format %{ "mov  $dst, $con\t# nullptr ptr" %}
 
   ins_encode(aarch64_enc_mov_p0(dst, con));
 
@@ -7461,7 +7461,7 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# NULL ptr" %}
+  format %{ "mov  $dst, $con\t# nullptr ptr" %}
 
   ins_encode(aarch64_enc_mov_p1(dst, con));
 
@@ -7503,7 +7503,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# compressed NULL ptr" %}
+  format %{ "mov  $dst, $con\t# compressed nullptr ptr" %}
 
   ins_encode(aarch64_enc_mov_n0(dst, con));
 
@@ -15481,7 +15481,7 @@ instruct clearArray_reg_reg_immL0(iRegL_R11 cnt, iRegP_R10 base, immL0 zero, Uni
 
   ins_encode %{
     address tpc = __ zero_words($base$$Register, $cnt$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -15519,7 +15519,7 @@ instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, iRegL_R11 temp, Universe d
 
   ins_encode %{
     address tpc = __ zero_words($base$$Register, (uint64_t)$cnt$$constant);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -16809,7 +16809,7 @@ instruct CallLeafDirect(method meth)
 // entry point is null, target holds the address to call
 instruct CallLeafNoFPIndirect(iRegP target)
 %{
-  predicate(n->as_Call()->entry_point() == NULL);
+  predicate(n->as_Call()->entry_point() == nullptr);
 
   match(CallLeafNoFP target);
 
@@ -16826,7 +16826,7 @@ instruct CallLeafNoFPIndirect(iRegP target)
 
 instruct CallLeafNoFPDirect(method meth)
 %{
-  predicate(n->as_Call()->entry_point() != NULL);
+  predicate(n->as_Call()->entry_point() != nullptr);
 
   match(CallLeafNoFP);
 
@@ -17400,7 +17400,7 @@ instruct array_equalsB(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
     address tpc = __ arrays_equals($ary1$$Register, $ary2$$Register,
                                    $tmp1$$Register, $tmp2$$Register, $tmp3$$Register,
                                    $result$$Register, $tmp$$Register, 1);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17425,7 +17425,7 @@ instruct array_equalsC(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
     address tpc = __ arrays_equals($ary1$$Register, $ary2$$Register,
                                    $tmp1$$Register, $tmp2$$Register, $tmp3$$Register,
                                    $result$$Register, $tmp$$Register, 2);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17440,7 +17440,7 @@ instruct count_positives(iRegP_R1 ary1, iRegI_R2 len, iRegI_R0 result, rFlagsReg
   format %{ "count positives byte[] $ary1,$len -> $result" %}
   ins_encode %{
     address tpc = __ count_positives($ary1$$Register, $len$$Register, $result$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17483,7 +17483,7 @@ instruct string_inflate(Universe dummy, iRegP_R0 src, iRegP_R1 dst, iRegI_R2 len
     address tpc = __ byte_array_inflate($src$$Register, $dst$$Register, $len$$Register,
                                         $vtmp0$$FloatRegister, $vtmp1$$FloatRegister,
                                         $vtmp2$$FloatRegister, $tmp$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -335,7 +335,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   CodeStub* throw_imse_stub =
       x->maybe_inlinetype() ?
       new SimpleExceptionStub(Runtime1::throw_illegal_monitor_state_exception_id, LIR_OprFact::illegalOpr, state_for(x)) :
-      NULL;
+      nullptr;
 
   // this CodeEmitInfo must not have the xhandlers because here the
   // object is already locked (xhandlers expect object to be unlocked)

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -47,7 +47,7 @@ typedef void (MacroAssembler::* chr_insn)(Register Rt, const Address &adr);
 
 void C2_MacroAssembler::entry_barrier() {
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-  if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     // Dummy labels for just measuring the code size
     Label dummy_slow_path;
     Label dummy_continuation;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -788,7 +788,7 @@ frame::frame(void* sp, void* fp, void* pc) {
 // a stack repair and return the repaired sender stack pointer.
 intptr_t* frame::repair_sender_sp(intptr_t* sender_sp, intptr_t** saved_fp_addr) const {
   CompiledMethod* cm = _cb->as_compiled_method_or_null();
-  if (cm != NULL && cm->needs_stack_repair()) {
+  if (cm != nullptr && cm->needs_stack_repair()) {
     // The stack increment resides just below the saved FP on the stack and
     // records the total frame size excluding the two words for saving FP and LR.
     intptr_t* sp_inc_addr = (intptr_t*) (saved_fp_addr - 1);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6273,12 +6273,12 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
 
   // The following code is similar to allocate_instance but has some slight differences,
   // e.g. object size is always not zero, sometimes it's constant; storing klass ptr after
-  // allocating is not necessary if vk != NULL, etc. allocate_instance is not aware of these.
+  // allocating is not necessary if vk != nullptr, etc. allocate_instance is not aware of these.
   Label slow_case;
   // 1. Try to allocate a new buffered inline instance either from TLAB or eden space
   mov(r0_preserved, r0); // save r0 for slow_case since *_allocate may corrupt it when allocation failed
 
-  if (vk != NULL) {
+  if (vk != nullptr) {
     // Called from C1, where the return type is statically known.
     movptr(klass, (intptr_t)vk->get_InlineKlass());
     jint obj_size = vk->layout_helper();
@@ -6304,13 +6304,13 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
     mov(rscratch1, (intptr_t)markWord::inline_type_prototype().value());
     str(rscratch1, Address(buffer_obj, oopDesc::mark_offset_in_bytes()));
     store_klass_gap(buffer_obj, zr);
-    if (vk == NULL) {
+    if (vk == nullptr) {
       // store_klass corrupts klass, so save it for later use (interpreter case only).
       mov(tmp1, klass);
     }
     store_klass(buffer_obj, klass);
     // 3. Initialize its fields with an inline class specific handler
-    if (vk != NULL) {
+    if (vk != nullptr) {
       far_call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.
     } else {
       // tmp1 holds klass preserved above

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -471,7 +471,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   __ str(zr, Address(rfp, frame::interpreter_frame_last_sp_offset * wordSize));
 
   if (state == atos && InlineTypeReturnedAsFields) {
-    __ store_inline_type_fields_to_buf(NULL, true);
+    __ store_inline_type_fields_to_buf(nullptr, true);
   }
 
   __ restore_bcp();


### PR DESCRIPTION
NULL -> nullptr replacement in aarch64 code.

Tested with Mach5 tier1.

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8315272](https://bugs.openjdk.org/browse/JDK-8315272): [lworld] Replacing NULL with nullptr in aarch64 code (**Enhancement** - P4)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/920/head:pull/920` \
`$ git checkout pull/920`

Update a local copy of the PR: \
`$ git checkout pull/920` \
`$ git pull https://git.openjdk.org/valhalla.git pull/920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 920`

View PR using the GUI difftool: \
`$ git pr show -t 920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/920.diff">https://git.openjdk.org/valhalla/pull/920.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/920#issuecomment-1698091145)