### PR TITLE
8316561: [lw5] class file attribute NullRestricted shouldn't be generated for arrays

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -971,7 +971,7 @@ public class ClassWriter extends ClassFile {
     /** Write "NullRestricted" attribute.
      */
     int writeNullRestrictedIfNeeded(Symbol sym) {
-        if (sym.kind == VAR && sym.type.isNonNullable()) {
+        if (sym.kind == VAR && sym.type.isNonNullable() && !sym.type.hasTag(ARRAY)) {
             int alenIdx = writeAttr(names.NullRestricted);
             endAttr(alenIdx);
             return 1;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1011,6 +1011,14 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
         return result;
     }
 
+    private void checkAttributeNotPresent(Attributes attributes, Class<? extends Attribute> attrClass) {
+        for (Attribute attribute : attributes) {
+            if (attribute.getClass() == attrClass) {
+                throw new AssertionError("attribute found");
+            }
+        }
+    }
+
     public void testClassAttributes() throws Exception {
         String code =
                 """
@@ -1021,6 +1029,7 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                 value class V1 {
                     V0! f1;
                     V0 f2;
+                    V0[]! f3;
                     public implicit V1();
                 }
 
@@ -1043,6 +1052,8 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
         } catch (Throwable t) {
             // good
         }
+        Field field3 = classFile.fields[2];
+        checkAttributeNotPresent(field3.attributes, NullRestricted_attribute.class);
         findAttributeOrFail(classFile.attributes, ImplicitCreation_attribute.class, 1);
 
         classFile = ClassFile.read(findClassFileOrFail(dir, "V2.class"));


### PR DESCRIPTION
This PR is fixing a bug, basically for code like:
```
value class V {
    V[]! va;
    public implicit V();
}
```
the compiler shouldn't generate a NullRestricted attribute for field `va` in the future we probably issue a warning or a compiler error for this code pattern.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8316561](https://bugs.openjdk.org/browse/JDK-8316561): [lw5] class file attribute NullRestricted shouldn't be generated for arrays (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/928/head:pull/928` \
`$ git checkout pull/928`

Update a local copy of the PR: \
`$ git checkout pull/928` \
`$ git pull https://git.openjdk.org/valhalla.git pull/928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 928`

View PR using the GUI difftool: \
`$ git pr show -t 928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/928.diff">https://git.openjdk.org/valhalla/pull/928.diff</a>

</details>
