### PR TITLE
8311675: [lworld+vector] Max Species support.

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2342,18 +2342,12 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 // Vector width in bytes.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  // The MaxVectorSize should have been set by detecting SVE max vector register size.
-  int size = MIN2((UseSVE > 0) ? 256 : 16, (int)MaxVectorSize);
-  // Minimum 2 values in vector
-  if (size < 2*type2aelembytes(bt)) size = 0;
-  // But never < 4
-  if (size < 4) size = 0;
-  return size;
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
-  return vector_width_in_bytes(bt)/type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
 
 int Matcher::min_vector_size(const BasicType bt) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -659,11 +659,15 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
- // The MaxVectorSize should have been set by detecting SVE max vector register size.
+  // The MaxVectorSize should have been set by detecting SVE max vector register size.
+#ifdef COMPILER2
   int size = MIN2((UseSVE > 0) ? 256 : 16, (int)MaxVectorSize);
   // Minimum 2 values in vector
   if (size < 2*type2aelembytes(bt)) size = 0;
   // But never < 4
   if (size < 4) size = 0;
   return size / type2aelembytes(bt);
+#else
+  return -1;
+#endif
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -659,5 +659,11 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
-  return MaxVectorSize / type2aelembytes(bt);
+ // The MaxVectorSize should have been set by detecting SVE max vector register size.
+  int size = MIN2((UseSVE > 0) ? 256 : 16, (int)MaxVectorSize);
+  // Minimum 2 values in vector
+  if (size < 2*type2aelembytes(bt)) size = 0;
+  // But never < 4
+  if (size < 4) size = 0;
+  return size / type2aelembytes(bt);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -657,3 +657,7 @@ void VM_Version::initialize_cpu_information(void) {
 
   _initialized = true;
 }
+
+int VM_Version::max_vector_size(BasicType bt) {
+  return MaxVectorSize / type2aelembytes(bt);
+}

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -190,6 +190,9 @@ enum Ampere_CPU_Model {
   static bool use_neon_for_vector(int vector_length_in_bytes) {
     return vector_length_in_bytes <= 16;
   }
+
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
 };
 
 #endif // CPU_AARCH64_VM_VERSION_AARCH64_HPP

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1045,7 +1045,7 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
 
 // Vector width in bytes
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  return MaxVectorSize;
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 int Matcher::scalable_vector_reg_size(const BasicType bt) {
@@ -1065,8 +1065,7 @@ uint Matcher::vector_ideal_reg(int size) {
 
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
-  assert(is_java_primitive(bt), "only primitive type vectors");
-  return vector_width_in_bytes(bt)/type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
 
 int Matcher::min_vector_size(const BasicType bt) {

--- a/src/hotspot/cpu/arm/vm_version_arm.hpp
+++ b/src/hotspot/cpu/arm/vm_version_arm.hpp
@@ -107,6 +107,10 @@ class VM_Version: public Abstract_VM_Version {
   friend class VM_Version_StubGenerator;
 
   static void initialize_cpu_information(void);
+
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
+
 };
 
 #endif // CPU_ARM_VM_VERSION_ARM_HPP

--- a/src/hotspot/cpu/arm/vm_version_arm_32.cpp
+++ b/src/hotspot/cpu/arm/vm_version_arm_32.cpp
@@ -361,3 +361,7 @@ void VM_Version::initialize_cpu_information(void) {
   snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "%s", _features_string);
   _initialized = true;
 }
+
+int VM_Version::max_vector_size(BasicType bt) {
+  return MaxVectorSize / type2aelembytes(bt);
+}

--- a/src/hotspot/cpu/arm/vm_version_arm_32.cpp
+++ b/src/hotspot/cpu/arm/vm_version_arm_32.cpp
@@ -363,5 +363,9 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
+#ifdef COMPILER2
   return MaxVectorSize / type2aelembytes(bt);
+#else
+  return -1;
+#endif
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2209,13 +2209,7 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
 
 // Vector width in bytes.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  if (SuperwordUseVSX) {
-    assert(MaxVectorSize == 16, "");
-    return 16;
-  } else {
-    assert(MaxVectorSize == 8, "");
-    return 8;
-  }
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 // Vector ideal reg.
@@ -2232,7 +2226,7 @@ uint Matcher::vector_ideal_reg(int size) {
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
   assert(is_java_primitive(bt), "only primitive type vectors");
-  return vector_width_in_bytes(bt)/type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
 
 int Matcher::min_vector_size(const BasicType bt) {

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -704,6 +704,7 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
+#ifdef COMPILER2
   int size = 0;
   if (SuperwordUseVSX) {
     assert(MaxVectorSize == 16, "");
@@ -713,4 +714,7 @@ int VM_Version::max_vector_size(BasicType bt) {
     size = 8;
   }
   return size / type2aelembytes(bt);
+#else
+  return -1;
+#endif
 }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -702,3 +702,7 @@ void VM_Version::initialize_cpu_information(void) {
   snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "PPC %s", features_string());
   _initialized = true;
 }
+
+int VM_Version::max_vector_size(BasicType bt) {
+  return MaxVectorSize / type2aelembytes(bt);
+}

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -704,5 +704,13 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
-  return MaxVectorSize / type2aelembytes(bt);
+  int size = 0;
+  if (SuperwordUseVSX) {
+    assert(MaxVectorSize == 16, "");
+    size = 16;
+  } else {
+    assert(MaxVectorSize == 8, "");
+    size = 8;
+  }
+  return size / type2aelembytes(bt);
 }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -127,6 +127,10 @@ public:
   static uint64_t _dscr_val;
 
   static void initialize_cpu_information(void);
+
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
+
 };
 
 #endif // CPU_PPC_VM_VERSION_PPC_HPP

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1955,22 +1955,12 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 // Vector width in bytes.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  if (UseRVV) {
-    // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
-    // MaxVectorSize == VM_Version::_initial_vector_length
-    int size = MaxVectorSize;
-    // Minimum 2 values in vector
-    if (size < 2 * type2aelembytes(bt)) size = 0;
-    // But never < 4
-    if (size < 4) size = 0;
-    return size;
-  }
-  return 0;
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
-  return vector_width_in_bytes(bt) / type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
 
 int Matcher::min_vector_size(const BasicType bt) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -351,5 +351,15 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
-  return MaxVectorSize / type2aelembytes(bt);
+  if (UseRVV) {
+    // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
+    // MaxVectorSize == VM_Version::_initial_vector_length
+    int size = MaxVectorSize;
+    // Minimum 2 values in vector
+    if (size < 2 * type2aelembytes(bt)) size = 0;
+    // But never < 4
+    if (size < 4) size = 0;
+    return size / type2aelembytes(bt);
+  }
+  return 0;
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -351,6 +351,7 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
+#ifdef COMPILER2
   if (UseRVV) {
     // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
     // MaxVectorSize == VM_Version::_initial_vector_length
@@ -362,4 +363,7 @@ int VM_Version::max_vector_size(BasicType bt) {
     return size / type2aelembytes(bt);
   }
   return 0;
+#else
+  return -1;
+#endif
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -349,3 +349,7 @@ void VM_Version::initialize_cpu_information(void) {
   snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64 %s", features_string());
   _initialized = true;
 }
+
+int VM_Version::max_vector_size(BasicType bt) {
+  return MaxVectorSize / type2aelembytes(bt);
+}

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -201,6 +201,9 @@ class VM_Version : public Abstract_VM_Version {
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static bool supports_on_spin_wait() { return UseZihintpause; }
+
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
 };
 
 #endif // CPU_RISCV_VM_VERSION_RISCV_HPP

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1551,8 +1551,7 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
 
 // Vector width in bytes.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  assert(MaxVectorSize == 8, "");
-  return 8;
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 // Vector ideal reg.
@@ -1564,7 +1563,7 @@ uint Matcher::vector_ideal_reg(int size) {
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
   assert(is_java_primitive(bt), "only primitive type vectors");
-  return vector_width_in_bytes(bt)/type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
 
 int Matcher::min_vector_size(const BasicType bt) {

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -1516,6 +1516,10 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
+#ifdef COMPILER2
   assert(MaxVectorSize == 8, "");
   return MaxVectorSize / type2aelembytes(bt);
+#else
+  return -1;
+#endif
 }

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -1514,3 +1514,7 @@ void VM_Version::initialize_cpu_information(void) {
   snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "s390 %s", features_string());
   _initialized = true;
 }
+
+int VM_Version::max_vector_size(BasicType bt) {
+  return MaxVectorSize / type2aelembytes(bt);
+}

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -1516,5 +1516,6 @@ void VM_Version::initialize_cpu_information(void) {
 }
 
 int VM_Version::max_vector_size(BasicType bt) {
+  assert(MaxVectorSize == 8, "");
   return MaxVectorSize / type2aelembytes(bt);
 }

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -567,6 +567,9 @@ class VM_Version: public Abstract_VM_Version {
   static unsigned long z_SIGSEGV();
 
   static void initialize_cpu_information(void);
+
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
 };
 
 #endif // CPU_S390_VM_VERSION_S390_HPP

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3217,6 +3217,7 @@ intx VM_Version::allocate_prefetch_distance(bool use_watermark_prefetch) {
 
 // Max vector size in bytes. 0 if not supported.
 int VM_Version::max_vector_size(BasicType bt) {
+#ifdef COMPILER2_OR_JVMCI
   assert(is_java_primitive(bt), "only primitive type vectors");
   if (UseSSE < 2) return 0;
   // SSE2 supports 128bit vectors for all types.
@@ -3256,6 +3257,9 @@ int VM_Version::max_vector_size(BasicType bt) {
     assert(false, "Unexpected basic type");
   }
   return size / type2aelembytes(bt);
+#else
+  return -1;
+#endif
 }
 
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -3215,6 +3215,50 @@ intx VM_Version::allocate_prefetch_distance(bool use_watermark_prefetch) {
   }
 }
 
+// Max vector size in bytes. 0 if not supported.
+int VM_Version::max_vector_size(BasicType bt) {
+  assert(is_java_primitive(bt), "only primitive type vectors");
+  if (UseSSE < 2) return 0;
+  // SSE2 supports 128bit vectors for all types.
+  // AVX2 supports 256bit vectors for all types.
+  // AVX2/EVEX supports 512bit vectors for all types.
+  int size = (UseAVX > 1) ? (1 << UseAVX) * 8 : 16;
+  // AVX1 supports 256bit vectors only for FLOAT and DOUBLE.
+  if (UseAVX > 0 && (bt == T_FLOAT || bt == T_DOUBLE))
+    size = (UseAVX > 2) ? 64 : 32;
+  if (UseAVX > 2 && (bt == T_BYTE || bt == T_SHORT || bt == T_CHAR))
+    size = (VM_Version::supports_avx512bw()) ? 64 : 32;
+  // Use flag to limit vector size.
+  size = MIN2(size,(int)MaxVectorSize);
+  // Minimum 2 values in vector (or 4 for bytes).
+  switch (bt) {
+  case T_DOUBLE:
+  case T_LONG:
+    if (size < 16) return 0;
+    break;
+  case T_FLOAT:
+  case T_INT:
+    if (size < 8) return 0;
+    break;
+  case T_BOOLEAN:
+    if (size < 4) return 0;
+    break;
+  case T_CHAR:
+    if (size < 4) return 0;
+    break;
+  case T_BYTE:
+    if (size < 4) return 0;
+    break;
+  case T_SHORT:
+    if (size < 4) return 0;
+    break;
+  default:
+    assert(false, "Unexpected basic type");
+  }
+  return size / type2aelembytes(bt);
+}
+
+
 bool VM_Version::is_intrinsic_supported(vmIntrinsicID id) {
   assert(id != vmIntrinsics::_none, "must be a VM intrinsic");
   switch (id) {

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -774,6 +774,9 @@ public:
   // Check intrinsic support
   static bool is_intrinsic_supported(vmIntrinsicID id);
 
+  // Max supported vector lane count for a particular lane type.
+  static int max_vector_size(BasicType bt);
+
   // there are several insns to force cache line sync to memory which
   // we can use to ensure mapped non-volatile memory is up to date with
   // pending in-cache changes.

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2220,45 +2220,7 @@ const TypeVectMask* Matcher::predicate_reg_type(const Type* elemTy, int length) 
 
 // Max vector size in bytes. 0 if not supported.
 int Matcher::vector_width_in_bytes(BasicType bt) {
-  assert(is_java_primitive(bt), "only primitive type vectors");
-  if (UseSSE < 2) return 0;
-  // SSE2 supports 128bit vectors for all types.
-  // AVX2 supports 256bit vectors for all types.
-  // AVX2/EVEX supports 512bit vectors for all types.
-  int size = (UseAVX > 1) ? (1 << UseAVX) * 8 : 16;
-  // AVX1 supports 256bit vectors only for FLOAT and DOUBLE.
-  if (UseAVX > 0 && (bt == T_FLOAT || bt == T_DOUBLE))
-    size = (UseAVX > 2) ? 64 : 32;
-  if (UseAVX > 2 && (bt == T_BYTE || bt == T_SHORT || bt == T_CHAR))
-    size = (VM_Version::supports_avx512bw()) ? 64 : 32;
-  // Use flag to limit vector size.
-  size = MIN2(size,(int)MaxVectorSize);
-  // Minimum 2 values in vector (or 4 for bytes).
-  switch (bt) {
-  case T_DOUBLE:
-  case T_LONG:
-    if (size < 16) return 0;
-    break;
-  case T_FLOAT:
-  case T_INT:
-    if (size < 8) return 0;
-    break;
-  case T_BOOLEAN:
-    if (size < 4) return 0;
-    break;
-  case T_CHAR:
-    if (size < 4) return 0;
-    break;
-  case T_BYTE:
-    if (size < 4) return 0;
-    break;
-  case T_SHORT:
-    if (size < 4) return 0;
-    break;
-  default:
-    ShouldNotReachHere();
-  }
-  return size;
+  return max_vector_size(bt) * type2aelembytes(bt);
 }
 
 // Limits on vector size (number of elements) loaded into vector.

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2263,8 +2263,9 @@ int Matcher::vector_width_in_bytes(BasicType bt) {
 
 // Limits on vector size (number of elements) loaded into vector.
 int Matcher::max_vector_size(const BasicType bt) {
-  return vector_width_in_bytes(bt)/type2aelembytes(bt);
+  return VM_Version::max_vector_size(bt);
 }
+
 int Matcher::min_vector_size(const BasicType bt) {
   int max_size = max_vector_size(bt);
   // Min size which can be loaded into vector is 4 bytes.

--- a/src/hotspot/cpu/zero/vm_version_zero.hpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.hpp
@@ -36,6 +36,8 @@ class VM_Version : public Abstract_VM_Version {
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static void initialize_cpu_information(void);
+
+  static int max_vector_size(BasicType bt) { return -1;}
 };
 
 #endif // CPU_ZERO_VM_VERSION_ZERO_HPP

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -1863,13 +1863,16 @@ Value GraphBuilder::make_constant(ciConstant field_value, ciField* field) {
 void GraphBuilder::copy_inline_content(ciInlineKlass* vk, Value src, int src_off, Value dest, int dest_off, ValueStack* state_before, ciField* enclosing_field) {
   for (int i = 0; i < vk->nof_nonstatic_fields(); i++) {
     ciField* inner_field = vk->nonstatic_field_at(i);
-    assert(!inner_field->is_flat(), "the iteration over nested fields is handled by the loop itself");
-    int off = inner_field->offset_in_bytes() - vk->first_field_offset();
-    LoadField* load = new LoadField(src, src_off + off, inner_field, false, state_before, false);
-    Value replacement = append(load);
-    StoreField* store = new StoreField(dest, dest_off + off, inner_field, replacement, false, state_before, false);
-    store->set_enclosing_field(enclosing_field);
-    append(store);
+    for (int j = 0, sec_offset = 0; j < inner_field->secondary_fields_count(); j++) {
+      assert(!inner_field->is_flat(), "the iteration over nested fields is handled by the loop itself");
+      int off = inner_field->offset_in_bytes() + sec_offset - vk->first_field_offset();
+      LoadField* load = new LoadField(src, src_off + off, inner_field, false, state_before, false);
+      Value replacement = append(load);
+      StoreField* store = new StoreField(dest, dest_off + off, inner_field, replacement, false, state_before, false);
+      store->set_enclosing_field(enclosing_field);
+      append(store);
+      sec_offset += type2aelembytes(inner_field->type()->basic_type());
+    }
   }
 }
 
@@ -2194,10 +2197,14 @@ void GraphBuilder::withfield(int field_index) {
             copy_inline_content(vk, obj, offset, new_instance, vk->first_field_offset(), state_before, field);
           }
         } else {
-          LoadField* load = new LoadField(obj, offset, field, false, state_before, false);
-          Value replacement = append(load);
-          StoreField* store = new StoreField(new_instance, offset, field, replacement, false, state_before, false);
-          append(store);
+          for (int i = 0, sec_offset = 0; i < field->secondary_fields_count(); i++) {
+            ciField* temp = i > 0 ? static_cast<ciMultiField*>(field)->secondary_field_at(i-1) : field;
+            LoadField* load = new LoadField(obj, offset + sec_offset, temp, false, state_before, false);
+            Value replacement = append(load);
+            StoreField* store = new StoreField(new_instance, offset + sec_offset, temp, replacement, false, state_before, false);
+            append(store);
+            sec_offset += type2aelembytes(as_BasicType(load->type()));
+          }
         }
       }
     }
@@ -2215,8 +2222,12 @@ void GraphBuilder::withfield(int field_index) {
       copy_inline_content(vk, val, vk->first_field_offset(), new_instance, offset_modify, state_before, field_modify);
     }
   } else {
-    StoreField* store = new StoreField(new_instance, offset_modify, field_modify, val, false, state_before, needs_patching);
-    append(store);
+    int sec_field_size = type2aelembytes(field_type);
+    for (int i = 0; i < field_modify->secondary_fields_count(); i++) {
+      ciField* temp = i > 0 ? static_cast<ciMultiField*>(field_modify)->secondary_field_at(i-1) : field_modify;
+      StoreField* store = new StoreField(new_instance, offset_modify + i * sec_field_size, temp, val, false, state_before, needs_patching);
+      append(store);
+    }
   }
 }
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1772,7 +1772,7 @@ void ciEnv::dump_inline_data(int compile_id) {
 }
 
 bool ciEnv::is_multifield_scalarized(BasicType bt, int vec_length) {
-#if COMPILER2
+#ifdef COMPILER2
   return InlineTypeNode::is_multifield_scalarized(bt, vec_length);
 #else
   return true;

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1773,12 +1773,7 @@ void ciEnv::dump_inline_data(int compile_id) {
 
 bool ciEnv::is_multifield_scalarized(BasicType bt, int vec_length) {
 #if COMPILER2
-  CompilerThread* ct = CompilerThread::current();
-  if (ct && ct->compiler()->is_c2()) {
-    return InlineTypeNode::is_multifield_scalarized(bt, vec_length);
-  } else {
-    return true;
-  }
+  return InlineTypeNode::is_multifield_scalarized(bt, vec_length);
 #else
   return true;
 #endif

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -52,6 +52,7 @@
 #include "memory/allocation.inline.hpp"
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
+#include "prims/vectorSupport.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/signature.hpp"
 #include "utilities/macros.hpp"

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1631,7 +1631,11 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     if (parsed_annotations.is_multifield_base() && is_java_primitive(cp->basic_type_for_signature_at(signature_index))) {
       field->field_flags_addr()->update_multifield_base(true);
       char* base_name = cp->symbol_at(name_index)->as_C_string();
-      for (int i = 1; i < parsed_annotations.multifield_arg(); i++) {
+      int bundle_size = parsed_annotations.multifield_arg();
+      if (bundle_size < 0) {
+        bundle_size = VectorSupport::get_max_multifield_count(_class_name);
+      }
+      for (int i = 1; i < bundle_size; i++) {
         field_index++;
         stringStream st;
         st.print("%s", base_name);

--- a/src/hotspot/share/classfile/vmClassMacros.hpp
+++ b/src/hotspot/share/classfile/vmClassMacros.hpp
@@ -192,41 +192,6 @@
                                                                                                                 \
   /* support multi-field based vectors */                                                                       \
   do_klass(vector_VectorPayloadMF_klass,                jdk_internal_vm_vector_VectorPayloadMF                ) \
-  do_klass(vector_VectorPayloadMF8Z_klass,              jdk_internal_vm_vector_VectorPayloadMF8Z              ) \
-  do_klass(vector_VectorPayloadMF16Z_klass,             jdk_internal_vm_vector_VectorPayloadMF16Z             ) \
-  do_klass(vector_VectorPayloadMF32Z_klass,             jdk_internal_vm_vector_VectorPayloadMF32Z             ) \
-  do_klass(vector_VectorPayloadMF64Z_klass,             jdk_internal_vm_vector_VectorPayloadMF64Z             ) \
-  do_klass(vector_VectorPayloadMF128Z_klass,            jdk_internal_vm_vector_VectorPayloadMF128Z            ) \
-  do_klass(vector_VectorPayloadMF256Z_klass,            jdk_internal_vm_vector_VectorPayloadMF256Z            ) \
-  do_klass(vector_VectorPayloadMF512Z_klass,            jdk_internal_vm_vector_VectorPayloadMF512Z            ) \
-  do_klass(vector_VectorPayloadMF8B_klass,              jdk_internal_vm_vector_VectorPayloadMF8B              ) \
-  do_klass(vector_VectorPayloadMF16B_klass,             jdk_internal_vm_vector_VectorPayloadMF16B             ) \
-  do_klass(vector_VectorPayloadMF32B_klass,             jdk_internal_vm_vector_VectorPayloadMF32B             ) \
-  do_klass(vector_VectorPayloadMF64B_klass,             jdk_internal_vm_vector_VectorPayloadMF64B             ) \
-  do_klass(vector_VectorPayloadMF128B_klass,            jdk_internal_vm_vector_VectorPayloadMF128B            ) \
-  do_klass(vector_VectorPayloadMF256B_klass,            jdk_internal_vm_vector_VectorPayloadMF256B            ) \
-  do_klass(vector_VectorPayloadMF512B_klass,            jdk_internal_vm_vector_VectorPayloadMF512B            ) \
-  do_klass(vector_VectorPayloadMF64S_klass,             jdk_internal_vm_vector_VectorPayloadMF64S             ) \
-  do_klass(vector_VectorPayloadMF128S_klass,            jdk_internal_vm_vector_VectorPayloadMF128S            ) \
-  do_klass(vector_VectorPayloadMF256S_klass,            jdk_internal_vm_vector_VectorPayloadMF256S            ) \
-  do_klass(vector_VectorPayloadMF512S_klass,            jdk_internal_vm_vector_VectorPayloadMF512S            ) \
-  do_klass(vector_VectorPayloadMF64I_klass,             jdk_internal_vm_vector_VectorPayloadMF64I             ) \
-  do_klass(vector_VectorPayloadMF128I_klass,            jdk_internal_vm_vector_VectorPayloadMF128I            ) \
-  do_klass(vector_VectorPayloadMF256I_klass,            jdk_internal_vm_vector_VectorPayloadMF256I            ) \
-  do_klass(vector_VectorPayloadMF512I_klass,            jdk_internal_vm_vector_VectorPayloadMF512I            ) \
-  do_klass(vector_VectorPayloadMF64L_klass,             jdk_internal_vm_vector_VectorPayloadMF64L             ) \
-  do_klass(vector_VectorPayloadMF128L_klass,            jdk_internal_vm_vector_VectorPayloadMF128L            ) \
-  do_klass(vector_VectorPayloadMF256L_klass,            jdk_internal_vm_vector_VectorPayloadMF256L            ) \
-  do_klass(vector_VectorPayloadMF512L_klass,            jdk_internal_vm_vector_VectorPayloadMF512L            ) \
-  do_klass(vector_VectorPayloadMF64F_klass,             jdk_internal_vm_vector_VectorPayloadMF64F             ) \
-  do_klass(vector_VectorPayloadMF128F_klass,            jdk_internal_vm_vector_VectorPayloadMF128F            ) \
-  do_klass(vector_VectorPayloadMF256F_klass,            jdk_internal_vm_vector_VectorPayloadMF256F            ) \
-  do_klass(vector_VectorPayloadMF512F_klass,            jdk_internal_vm_vector_VectorPayloadMF512F            ) \
-  do_klass(vector_VectorPayloadMF64D_klass,             jdk_internal_vm_vector_VectorPayloadMF64D             ) \
-  do_klass(vector_VectorPayloadMF128D_klass,            jdk_internal_vm_vector_VectorPayloadMF128D            ) \
-  do_klass(vector_VectorPayloadMF256D_klass,            jdk_internal_vm_vector_VectorPayloadMF256D            ) \
-  do_klass(vector_VectorPayloadMF512D_klass,            jdk_internal_vm_vector_VectorPayloadMF512D            ) \
-                                                                                                                \
                                                                                                                 \
   /* GC support */                                                                                              \
   do_klass(FillerObject_klass,                          jdk_internal_vm_FillerObject                          ) \

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -185,6 +185,7 @@ const char* vmSymbols::name_for(vmSymbolID sid) {
 }
 #endif
 
+
 void vmSymbols::symbols_do(SymbolClosure* f) {
   for (auto index : EnumRange<vmSymbolID>{}) {
     f->do_symbol(&Symbol::_vm_symbols[as_int(index)]);

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -185,8 +185,6 @@ const char* vmSymbols::name_for(vmSymbolID sid) {
 }
 #endif
 
-
-
 void vmSymbols::symbols_do(SymbolClosure* f) {
   for (auto index : EnumRange<vmSymbolID>{}) {
     f->do_symbol(&Symbol::_vm_symbols[as_int(index)]);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -92,10 +92,10 @@ class SerializeClosure;
   template(java_lang_Long_LongCache,                  "java/lang/Long$LongCache")                 \
                                                                                                   \
   template(jdk_internal_vm_vector_VectorSupport,       "jdk/internal/vm/vector/VectorSupport")                     \
-  template(jdk_internal_vm_vector_VectorPayload,       "jdk/internal/vm/vector/VectorSupport$VectorPayload")       \
   template(jdk_internal_vm_vector_Vector,              "jdk/internal/vm/vector/VectorSupport$Vector")              \
   template(jdk_internal_vm_vector_VectorMask,          "jdk/internal/vm/vector/VectorSupport$VectorMask")          \
   template(jdk_internal_vm_vector_VectorShuffle,       "jdk/internal/vm/vector/VectorSupport$VectorShuffle")       \
+  template(jdk_internal_vm_vector_VectorPayload,       "jdk/internal/vm/vector/VectorSupport$VectorPayload")       \
   template(jdk_internal_vm_vector_VectorPayloadMF,     "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF")     \
   template(jdk_internal_vm_vector_VectorPayloadMF8Z,   "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF8Z")   \
   template(jdk_internal_vm_vector_VectorPayloadMF16Z,  "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF16Z")  \
@@ -131,6 +131,20 @@ class SerializeClosure;
   template(jdk_internal_vm_vector_VectorPayloadMF128D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF128D") \
   template(jdk_internal_vm_vector_VectorPayloadMF256D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF256D") \
   template(jdk_internal_vm_vector_VectorPayloadMF512D, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMF512D") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxB, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxB") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxS, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxS") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxI, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxI") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxL, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxL") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxF, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxF") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxD, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxD") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxBZ, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxBZ") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxSZ, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxSZ") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxIZ, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxIZ") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxLZ, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxLZ") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxBB, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxBB") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxSB, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxSB") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxIB, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxIB") \
+  template(jdk_internal_vm_vector_VectorPayloadMFMaxLB, "jdk/internal/vm/vector/VectorSupport$VectorPayloadMFMaxLB") \
   template(payload_name,                               "payload")                                                  \
   template(mfield_name,                                "mfield")                                                   \
   template(ETYPE_name,                                 "ETYPE")                                                    \

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -153,6 +153,9 @@ bool InlineKlass::flat_array() {
   if (!UseFlatArray) {
     return false;
   }
+  if (VectorSupport::is_vector_payload_mf(this) || VectorSupport::is_vector(this)) {
+    return false;
+  }
   // Too big
   int elem_bytes = get_exact_size_in_bytes();
   if ((FlatArrayElementMaxSize >= 0) && (elem_bytes > FlatArrayElementMaxSize)) {

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -462,7 +462,7 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
 int VectorSupport::get_max_multifield_count(const Symbol* payload_name) {
   assert(payload_name, "");
   vmSymbolID sid = vmSymbols::find_sid(payload_name);
-  int size = VM_Version::max_vector_size(T_BYTE);
+  int size = MAX2(VM_Version::max_vector_size(T_BYTE), 8);
   switch(sid) {
     case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxB_enum:
     case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxBZ_enum:

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -459,19 +459,50 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
 }
 #endif // COMPILER2
 
+int VectorSupport::get_max_multifield_count(const Symbol* payload_name) {
+  assert(payload_name, "");
+  vmSymbolID sid = vmSymbols::find_sid(payload_name);
+  int size = VM_Version::max_vector_size(T_BYTE);
+  switch(sid) {
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxB_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxBZ_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxBB_enum:
+       return size;
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxS_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxSZ_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxSB_enum:
+       return size / type2aelembytes(T_SHORT);
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxI_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxIZ_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxIB_enum:
+       return size / type2aelembytes(T_INT);
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxL_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxLZ_enum:
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxLB_enum:
+       return size / type2aelembytes(T_LONG);
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxF_enum:
+       return size / type2aelembytes(T_FLOAT);
+    case vmSymbolID::jdk_internal_vm_vector_VectorPayloadMFMaxD_enum:
+       return size / type2aelembytes(T_DOUBLE);
+    default  : fatal("unknown symbol"); return -1;
+  }
+}
+
+int VectorSupport::max_vector_size(BasicType bt) {
+  if (is_java_primitive(bt)) {
+    return VM_Version::max_vector_size(bt);
+  }
+  return -1;
+}
+
 /**
  * Implementation of the jdk.internal.vm.vector.VectorSupport class
  */
 
 JVM_ENTRY(jint, VectorSupport_GetMaxLaneCount(JNIEnv *env, jclass vsclazz, jobject clazz)) {
-#ifdef COMPILER2
   oop mirror = JNIHandles::resolve_non_null(clazz);
-  if (java_lang_Class::is_primitive(mirror)) {
-    BasicType bt = java_lang_Class::primitive_type(mirror);
-    return Matcher::max_vector_size(bt);
-  }
-#endif // COMPILER2
-  return -1;
+  BasicType bt = java_lang_Class::primitive_type(mirror);
+  return VectorSupport::max_vector_size(bt);
 } JVM_END
 
 // JVM_RegisterVectorSupportMethods

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -140,6 +140,5 @@ class VectorSupport : AllStatic {
   static bool skip_value_scalarization(Klass* klass);
   static int  max_vector_size(BasicType bt);
   static int  get_max_multifield_count(const Symbol* payload_name);
-  static bool is_vector_payload(const Symbol* metadata);
 };
 #endif // SHARE_PRIMS_VECTORSUPPORT_HPP

--- a/src/hotspot/share/prims/vectorSupport.hpp
+++ b/src/hotspot/share/prims/vectorSupport.hpp
@@ -138,5 +138,8 @@ class VectorSupport : AllStatic {
   static bool is_vector(Klass* klass);
   static bool is_vector_payload_mf(Klass* klass);
   static bool skip_value_scalarization(Klass* klass);
+  static int  max_vector_size(BasicType bt);
+  static int  get_max_multifield_count(const Symbol* payload_name);
+  static bool is_vector_payload(const Symbol* metadata);
 };
 #endif // SHARE_PRIMS_VECTORSUPPORT_HPP

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -167,7 +167,7 @@ public class VectorSupport {
 
         @ForceInline
         public static VectorPayloadMF newMaskInstanceFactory(Class<?> elemType, int length, boolean max_payload) {
-            if (false == max_payload) {
+            if (!max_payload) {
                 switch(length) {
                     case  1: return new VectorPayloadMF8Z();
                     case  2: return new VectorPayloadMF16Z();
@@ -183,15 +183,12 @@ public class VectorSupport {
                    return new VectorPayloadMFMaxBZ();
                 } else if (elemType == short.class) {
                    return new VectorPayloadMFMaxSZ();
-                } else if (elemType == int.class) {
+                } else if (elemType == int.class || elemType == float.class) {
                    return new VectorPayloadMFMaxIZ();
-                } else if (elemType == long.class) {
+                } else if (elemType == long.class || elemType == double.class) {
                    return new VectorPayloadMFMaxLZ();
-                } else if (elemType == float.class) {
-                   return new VectorPayloadMFMaxIZ();
                 } else {
-                   assert elemType == double.class;
-                   return new VectorPayloadMFMaxLZ();
+                   assert false : "Unexpected lane type";
                 }
             }
             return null;
@@ -199,7 +196,7 @@ public class VectorSupport {
 
         @ForceInline
         public static VectorPayloadMF newShuffleInstanceFactory(Class<?> elemType, int length, boolean max_payload) {
-            if (false == max_payload) {
+            if (!max_payload) {
                 switch(length) {
                     case  1: return new VectorPayloadMF8B();
                     case  2: return new VectorPayloadMF16B();
@@ -215,15 +212,12 @@ public class VectorSupport {
                    return new VectorPayloadMFMaxBB();
                 } else if (elemType == short.class) {
                    return new VectorPayloadMFMaxSB();
-                } else if (elemType == int.class) {
+                } else if (elemType == int.class || elemType == float.class) {
                    return new VectorPayloadMFMaxIB();
-                } else if (elemType == long.class) {
+                } else if (elemType == long.class || elemType == double.class) {
                    return new VectorPayloadMFMaxLB();
-                } else if (elemType == float.class) {
-                   return new VectorPayloadMFMaxIB();
                 } else {
-                   assert elemType == double.class;
-                   return new VectorPayloadMFMaxLB();
+                   assert false : "Unexpected lane type";
                 }
             }
             return null;
@@ -302,7 +296,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceB(int length, byte [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceB(int length, byte[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(byte.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
@@ -314,7 +308,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceS(int length, short [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceS(int length, short[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(short.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
@@ -326,7 +320,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceI(int length, int [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceI(int length, int[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(int.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
@@ -338,7 +332,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceL(int length, long [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceL(int length, long[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(long.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
@@ -350,7 +344,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceF(int length, float [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceF(int length, float[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(float.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
@@ -362,7 +356,7 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceD(int length, double [] init, boolean max_payload) {
+        public static VectorPayloadMF createVectPayloadInstanceD(int length, double[] init, boolean max_payload) {
             VectorPayloadMF obj = newVectorInstanceFactory(double.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -166,8 +166,8 @@ public class VectorSupport {
         public abstract long multiFieldOffset();
 
         @ForceInline
-        public static VectorPayloadMF newInstanceFactory(Class<?> elemType, int length) {
-            if (elemType == boolean.class) {
+        public static VectorPayloadMF newMaskInstanceFactory(Class<?> elemType, int length, boolean max_payload) {
+            if (false == max_payload) {
                 switch(length) {
                     case  1: return new VectorPayloadMF8Z();
                     case  2: return new VectorPayloadMF16Z();
@@ -178,7 +178,28 @@ public class VectorSupport {
                     case 64: return new VectorPayloadMF512Z();
                     default: assert false : "Unhandled vector mask size";
                 }
-            } else if (elemType == byte.class) {
+            } else {
+                if (elemType == byte.class) {
+                   return new VectorPayloadMFMaxBZ();
+                } else if (elemType == short.class) {
+                   return new VectorPayloadMFMaxSZ();
+                } else if (elemType == int.class) {
+                   return new VectorPayloadMFMaxIZ();
+                } else if (elemType == long.class) {
+                   return new VectorPayloadMFMaxLZ();
+                } else if (elemType == float.class) {
+                   return new VectorPayloadMFMaxIZ();
+                } else {
+                   assert elemType == double.class;
+                   return new VectorPayloadMFMaxLZ();
+                }
+            }
+            return null;
+        }
+
+        @ForceInline
+        public static VectorPayloadMF newShuffleInstanceFactory(Class<?> elemType, int length, boolean max_payload) {
+            if (false == max_payload) {
                 switch(length) {
                     case  1: return new VectorPayloadMF8B();
                     case  2: return new VectorPayloadMF16B();
@@ -187,56 +208,102 @@ public class VectorSupport {
                     case 16: return new VectorPayloadMF128B();
                     case 32: return new VectorPayloadMF256B();
                     case 64: return new VectorPayloadMF512B();
-                    default: assert false : "Unhandled vector size";
-                }
-            } else if (elemType == short.class) {
-                switch(length) {
-                    case  4: return new VectorPayloadMF64S();
-                    case  8: return new VectorPayloadMF128S();
-                    case 16: return new VectorPayloadMF256S();
-                    case 32: return new VectorPayloadMF512S();
-                    default: assert false : "Unhandled vector size";
-                }
-            } else if (elemType == int.class) {
-                switch(length) {
-                    case  2: return new VectorPayloadMF64I();
-                    case  4: return new VectorPayloadMF128I();
-                    case  8: return new VectorPayloadMF256I();
-                    case 16: return new VectorPayloadMF512I();
-                    default: assert false : "Unhandled vector size";
-                }
-            } else if (elemType == long.class) {
-                switch(length) {
-                    case  1: return new VectorPayloadMF64L();
-                    case  2: return new VectorPayloadMF128L();
-                    case  4: return new VectorPayloadMF256L();
-                    case  8: return new VectorPayloadMF512L();
-                    default: assert false : "Unhandled vector size";
-                }
-            } else if (elemType == float.class) {
-                switch(length) {
-                    case  2: return new VectorPayloadMF64F();
-                    case  4: return new VectorPayloadMF128F();
-                    case  8: return new VectorPayloadMF256F();
-                    case 16: return new VectorPayloadMF512F();
-                    default: assert false : "Unhandled vector size";
+                    default: assert false : "Unhandled vector shuffle size";
                 }
             } else {
-                assert elemType == double.class;
-                switch(length) {
-                    case  1: return new VectorPayloadMF64D();
-                    case  2: return new VectorPayloadMF128D();
-                    case  4: return new VectorPayloadMF256D();
-                    case  8: return new VectorPayloadMF512D();
-                    default: assert false : "Unhandled vector size";
+                if (elemType == byte.class) {
+                   return new VectorPayloadMFMaxBB();
+                } else if (elemType == short.class) {
+                   return new VectorPayloadMFMaxSB();
+                } else if (elemType == int.class) {
+                   return new VectorPayloadMFMaxIB();
+                } else if (elemType == long.class) {
+                   return new VectorPayloadMFMaxLB();
+                } else if (elemType == float.class) {
+                   return new VectorPayloadMFMaxIB();
+                } else {
+                   assert elemType == double.class;
+                   return new VectorPayloadMFMaxLB();
                 }
             }
             return null;
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceB(int length, byte [] init) {
-            VectorPayloadMF obj = newInstanceFactory(byte.class, length);
+        public static VectorPayloadMF newVectorInstanceFactory(Class<?> elemType, int length, boolean max_payload) {
+            if (false == max_payload) {
+                if (elemType == byte.class) {
+                    switch(length) {
+                        case  8: return new VectorPayloadMF64B();
+                        case 16: return new VectorPayloadMF128B();
+                        case 32: return new VectorPayloadMF256B();
+                        case 64: return new VectorPayloadMF512B();
+                        default: assert false : "Unhandled vector size";
+                    }
+                } else if (elemType == short.class) {
+                    switch(length) {
+                        case  4: return new VectorPayloadMF64S();
+                        case  8: return new VectorPayloadMF128S();
+                        case 16: return new VectorPayloadMF256S();
+                        case 32: return new VectorPayloadMF512S();
+                        default: assert false : "Unhandled vector size";
+                    }
+                } else if (elemType == int.class) {
+                    switch(length) {
+                        case  2: return new VectorPayloadMF64I();
+                        case  4: return new VectorPayloadMF128I();
+                        case  8: return new VectorPayloadMF256I();
+                        case 16: return new VectorPayloadMF512I();
+                        default: assert false : "Unhandled vector size";
+                    }
+                } else if (elemType == long.class) {
+                    switch(length) {
+                        case  1: return new VectorPayloadMF64L();
+                        case  2: return new VectorPayloadMF128L();
+                        case  4: return new VectorPayloadMF256L();
+                        case  8: return new VectorPayloadMF512L();
+                        default: assert false : "Unhandled vector size";
+                    }
+                } else if (elemType == float.class) {
+                    switch(length) {
+                        case  2: return new VectorPayloadMF64F();
+                        case  4: return new VectorPayloadMF128F();
+                        case  8: return new VectorPayloadMF256F();
+                        case 16: return new VectorPayloadMF512F();
+                        default: assert false : "Unhandled vector size";
+                    }
+                } else {
+                    assert elemType == double.class;
+                    switch(length) {
+                        case  1: return new VectorPayloadMF64D();
+                        case  2: return new VectorPayloadMF128D();
+                        case  4: return new VectorPayloadMF256D();
+                        case  8: return new VectorPayloadMF512D();
+                        default: assert false : "Unhandled vector size";
+                    }
+                }
+            } else {
+                if (elemType == byte.class) {
+                    return new VectorPayloadMFMaxB();
+                } else if (elemType == short.class) {
+                    return new VectorPayloadMFMaxS();
+                } else if (elemType == int.class) {
+                    return new VectorPayloadMFMaxI();
+                } else if (elemType == long.class) {
+                    return new VectorPayloadMFMaxL();
+                } else if (elemType == float.class) {
+                    return new VectorPayloadMFMaxF();
+                } else {
+                    assert elemType == double.class;
+                    return new VectorPayloadMFMaxD();
+                }
+            }
+            return null;
+        }
+
+        @ForceInline
+        public static VectorPayloadMF createVectPayloadInstanceB(int length, byte [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(byte.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -247,8 +314,8 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceS(int length, short [] init) {
-            VectorPayloadMF obj = newInstanceFactory(short.class, length);
+        public static VectorPayloadMF createVectPayloadInstanceS(int length, short [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(short.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -259,8 +326,8 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceI(int length, int [] init) {
-            VectorPayloadMF obj = newInstanceFactory(int.class, length);
+        public static VectorPayloadMF createVectPayloadInstanceI(int length, int [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(int.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -271,8 +338,8 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceL(int length, long [] init) {
-            VectorPayloadMF obj = newInstanceFactory(long.class, length);
+        public static VectorPayloadMF createVectPayloadInstanceL(int length, long [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(long.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -283,8 +350,8 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceF(int length, float [] init) {
-            VectorPayloadMF obj = newInstanceFactory(float.class, length);
+        public static VectorPayloadMF createVectPayloadInstanceF(int length, float [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(float.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -295,8 +362,8 @@ public class VectorSupport {
         }
 
         @ForceInline
-        public static VectorPayloadMF createVectPayloadInstanceD(int length, double [] init) {
-            VectorPayloadMF obj = newInstanceFactory(double.class, length);
+        public static VectorPayloadMF createVectPayloadInstanceD(int length, double [] init, boolean max_payload) {
+            VectorPayloadMF obj = newVectorInstanceFactory(double.class, length, max_payload);
             obj = Unsafe.getUnsafe().makePrivateBuffer(obj);
             long start_offset = obj.multiFieldOffset();
             for (int i = 0; i < length; i++) {
@@ -307,18 +374,7 @@ public class VectorSupport {
         }
 
         public int length() {
-            try {
-                var field = this.getClass().getDeclaredField("mfield");
-                var msanno = field.getAnnotationsByType(MultiField.class);
-
-                Objects.nonNull(msanno);
-
-                assert msanno.length == 1;
-                return msanno[0].value();
-            } catch (Exception e) {
-                System.out.println(e);
-            }
-            return -1;
+            return getClass().getDeclaredFields().length - 1;
         }
 
         public static long multiFieldOffset(Class<? extends VectorPayloadMF> cls) {
@@ -332,10 +388,64 @@ public class VectorSupport {
         }
     }
 
+    public primitive static class VectorPayloadMFMaxB extends VectorPayloadMF {
+        @MultiField(value = -1)
+        byte mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxB.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxS extends VectorPayloadMF {
+        @MultiField(value = -1)
+        short mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxS.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxI extends VectorPayloadMF {
+        @MultiField(value = -1)
+        int mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxI.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxL extends VectorPayloadMF {
+        @MultiField(value = -1)
+        long mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxL.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxF extends VectorPayloadMF {
+        @MultiField(value = -1)
+        float mfield = 0.0f;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxF.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxD extends VectorPayloadMF {
+        @MultiField(value = -1)
+        double mfield = 0.0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxD.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
     public primitive static class VectorPayloadMF8Z extends VectorPayloadMF {
         @MultiField(value = 1)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF8Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF8Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -344,7 +454,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF16Z extends VectorPayloadMF {
         @MultiField(value = 2)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF16Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF16Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -353,7 +463,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF32Z extends VectorPayloadMF {
         @MultiField(value = 4)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF32Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF32Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -362,7 +472,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64Z extends VectorPayloadMF {
         @MultiField(value = 8)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -371,7 +481,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128Z extends VectorPayloadMF {
         @MultiField(value = 16)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -380,7 +490,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256Z extends VectorPayloadMF {
         @MultiField(value = 32)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256Z.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -389,7 +499,43 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512Z extends VectorPayloadMF {
         @MultiField(value = 64)
         boolean mfield = false;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512Z.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512Z.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxBZ extends VectorPayloadMF {
+        @MultiField(value = -1)
+        boolean mfield = false;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxBZ.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxSZ extends VectorPayloadMF {
+        @MultiField(value = -1)
+        boolean mfield = false;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxSZ.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxIZ extends VectorPayloadMF {
+        @MultiField(value = -1)
+        boolean mfield = false;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxIZ.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxLZ extends VectorPayloadMF {
+        @MultiField(value = -1)
+        boolean mfield = false;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxLZ.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -398,7 +544,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF8B extends VectorPayloadMF {
         @MultiField(value = 1)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF8B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF8B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -407,7 +553,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF16B extends VectorPayloadMF {
         @MultiField(value = 2)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF16B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF16B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -416,7 +562,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF32B extends VectorPayloadMF {
         @MultiField(value = 4)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF32B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF32B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -425,7 +571,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64B extends VectorPayloadMF {
         @MultiField(value = 8)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -434,7 +580,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128B extends VectorPayloadMF {
         @MultiField(value = 16)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -443,7 +589,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256B extends VectorPayloadMF {
         @MultiField(value = 32)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256B.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -452,7 +598,43 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512B extends VectorPayloadMF {
         @MultiField(value = 64)
         byte mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512B.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512B.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxBB extends VectorPayloadMF {
+        @MultiField(value = -1)
+        byte mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxBB.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxSB extends VectorPayloadMF {
+        @MultiField(value = -1)
+        byte mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxSB.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxIB extends VectorPayloadMF {
+        @MultiField(value = -1)
+        byte mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxIB.class);
+
+        @Override
+        public long multiFieldOffset() { return MFOFFSET; }
+    }
+
+    public primitive static class VectorPayloadMFMaxLB extends VectorPayloadMF {
+        @MultiField(value = -1)
+        byte mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxLB.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -461,7 +643,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64S extends VectorPayloadMF {
         @MultiField(value = 4)
         short mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64S.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64S.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -470,7 +652,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128S extends VectorPayloadMF {
         @MultiField(value = 8)
         short mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128S.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128S.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -479,7 +661,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256S extends VectorPayloadMF {
         @MultiField(value = 16)
         short mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256S.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256S.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -488,7 +670,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512S extends VectorPayloadMF {
         @MultiField(value = 32)
         short mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512S.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512S.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -497,7 +679,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64I extends VectorPayloadMF {
         @MultiField(value = 2)
         int mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64I.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64I.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -506,7 +688,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128I extends VectorPayloadMF {
         @MultiField(value = 4)
         int mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128I.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128I.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -515,7 +697,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256I extends VectorPayloadMF {
         @MultiField(value = 8)
         int mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256I.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256I.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -524,7 +706,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512I extends VectorPayloadMF {
         @MultiField(value = 16)
         int mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512I.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512I.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -532,8 +714,8 @@ public class VectorSupport {
 
     public primitive static class VectorPayloadMF64L extends VectorPayloadMF {
         @MultiField(value = 1)
-        long mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64L.class);
+        final long mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64L.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -541,8 +723,8 @@ public class VectorSupport {
 
     public primitive static class VectorPayloadMF128L extends VectorPayloadMF {
         @MultiField(value = 2)
-        long mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128L.class);
+        final long mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128L.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -550,8 +732,8 @@ public class VectorSupport {
 
     public primitive static class VectorPayloadMF256L extends VectorPayloadMF {
         @MultiField(value = 4)
-        long mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256L.class);
+        final long mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256L.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -559,8 +741,8 @@ public class VectorSupport {
 
     public primitive static class VectorPayloadMF512L extends VectorPayloadMF {
         @MultiField(value = 8)
-        long mfield = 0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512L.class);
+        final long mfield = 0;
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512L.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -569,7 +751,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64F extends VectorPayloadMF {
         @MultiField(value = 2)
         float mfield = 0.0f;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64F.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64F.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -578,7 +760,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128F extends VectorPayloadMF {
         @MultiField(value = 4)
         float mfield = 0.0f;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128F.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128F.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -587,7 +769,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256F extends VectorPayloadMF {
         @MultiField(value = 8)
         float mfield = 0.0f;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256F.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256F.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -596,7 +778,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512F extends VectorPayloadMF {
         @MultiField(value = 16)
         float mfield = 0.0f;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512F.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512F.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -605,7 +787,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF64D extends VectorPayloadMF {
         @MultiField(value = 1)
         double mfield = 0.0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF64D.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64D.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -614,7 +796,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF128D extends VectorPayloadMF {
         @MultiField(value = 2)
         double mfield = 0.0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF128D.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128D.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -623,7 +805,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF256D extends VectorPayloadMF {
         @MultiField(value = 4)
         double mfield = 0.0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF256D.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256D.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }
@@ -632,7 +814,7 @@ public class VectorSupport {
     public primitive static class VectorPayloadMF512D extends VectorPayloadMF {
         @MultiField(value = 8)
         double mfield = 0.0;
-        static long MFOFFSET = multiFieldOffset(VectorPayloadMF512D.class);
+        static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512D.class);
 
         @Override
         public long multiFieldOffset() { return MFOFFSET; }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -41,11 +41,12 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     /*package-private*/
     abstract VectorPayloadMF getBits();
 
-    static VectorPayloadMF prepare(VectorPayloadMF payload, int offset, Class<?> elementType, int length, boolean is_max_species) {
-        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(elementType, length, is_max_species);
+    static <F> VectorPayloadMF prepare(VectorPayloadMF payload, int offset, VectorSpecies<F> species) {
+        boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(species.elementType(), species.length(), isMaxShape);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
-        for (int i = 0; i < length; i++) {
+        for (int i = 0; i < species.length(); i++) {
             boolean b = Unsafe.getUnsafe().getBoolean(payload, mOffset + i + offset);
             Unsafe.getUnsafe().putBoolean(res, mOffset + i, b);
         }
@@ -53,11 +54,12 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         return res;
     }
 
-    static VectorPayloadMF prepare(boolean val, Class<?> elementType, int length, boolean is_max_species) {
-        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(elementType, length, is_max_species);
+    static <F> VectorPayloadMF prepare(boolean val, VectorSpecies<F> species) {
+        boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(species.elementType(), species.length(), isMaxShape);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
-        for (int i = 0; i < length; i++) {
+        for (int i = 0; i < species.length(); i++) {
             Unsafe.getUnsafe().putBoolean(res, mOffset + i, val);
         }
         res = Unsafe.getUnsafe().finishPrivateBuffer(res);
@@ -138,7 +140,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
                 this.getClass(), vspecies().elementType(), vspecies().laneCount,
                 species.maskType(), species.elementType(), vspecies().laneCount,
                 this, species,
-                (m, s) -> s.maskFactory(m.getBits()).check(s));
+                (m, s) -> VectorMask.fromLong(s, m.toLong()).check(s));
     }
 
     @Override

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -41,8 +41,8 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     /*package-private*/
     abstract VectorPayloadMF getBits();
 
-    static VectorPayloadMF prepare(VectorPayloadMF payload, int offset, int length) {
-        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+    static VectorPayloadMF prepare(VectorPayloadMF payload, int offset, Class<?> elementType, int length, boolean is_max_species) {
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(elementType, length, is_max_species);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -53,8 +53,8 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         return res;
     }
 
-    static VectorPayloadMF prepare(boolean val, int length) {
-        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+    static VectorPayloadMF prepare(boolean val, Class<?> elementType, int length, boolean is_max_species) {
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(elementType, length, is_max_species);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -73,7 +73,8 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     AbstractMask<E> uOpMF(MUnOp f) {
         int length = vspecies().laneCount();
         VectorPayloadMF bits = getBits();
-        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)(vspecies())).is_max_species();
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -94,7 +95,8 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         int length = vspecies().laneCount();
         VectorPayloadMF bits = getBits();
         VectorPayloadMF mbits = m.getBits();
-        VectorPayloadMF res = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)(vspecies())).is_max_species();
+        VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         res = Unsafe.getUnsafe().makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
@@ -39,8 +39,10 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
     /*package-private*/
     abstract VectorPayloadMF indices();
 
-    static VectorPayloadMF prepare(Class<?> elemType, int length, int[] indices, int offset, boolean is_max_species) {
-        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(elemType, length, is_max_species);
+    static <F> VectorPayloadMF prepare(int[] indices, int offset, VectorSpecies<F> species) {
+        int length = species.length();
+        boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
+        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(species.elementType(), length, isMaxShape);
         payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
         long mf_offset = payload.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -52,8 +54,10 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
         return payload;
     }
 
-    static VectorPayloadMF prepare(Class<?> elemType, int length, IntUnaryOperator f, boolean is_max_species) {
-        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(elemType, length, is_max_species);
+    static <F> VectorPayloadMF prepare(IntUnaryOperator f, VectorSpecies<F> species) {
+        int length = species.length();
+        boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
+        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(species.elementType(), length, isMaxShape);
         payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
         long offset = payload.multiFieldOffset();
         for (int i = 0; i < length; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java
@@ -39,8 +39,8 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
     /*package-private*/
     abstract VectorPayloadMF indices();
 
-    static VectorPayloadMF prepare(int length, int[] indices, int offset) {
-        VectorPayloadMF payload = VectorPayloadMF.newInstanceFactory(byte.class, length);
+    static VectorPayloadMF prepare(Class<?> elemType, int length, int[] indices, int offset, boolean is_max_species) {
+        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(elemType, length, is_max_species);
         payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
         long mf_offset = payload.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -52,8 +52,8 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
         return payload;
     }
 
-    static VectorPayloadMF prepare(int length, IntUnaryOperator f) {
-        VectorPayloadMF payload = VectorPayloadMF.newInstanceFactory(byte.class, length);
+    static VectorPayloadMF prepare(Class<?> elemType, int length, IntUnaryOperator f, boolean is_max_species) {
+        VectorPayloadMF payload = VectorPayloadMF.newShuffleInstanceFactory(elemType, length, is_max_species);
         payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
         long offset = payload.multiFieldOffset();
         for (int i = 0; i < length; i++) {
@@ -139,7 +139,8 @@ abstract class AbstractShuffle<E> extends VectorShuffle<E> {
     @ForceInline
     public final VectorShuffle<E> wrapAndRebuild(VectorPayloadMF oldIndices) {
         int length = oldIndices.length();
-        VectorPayloadMF indices = VectorPayloadMF.newInstanceFactory(byte.class, length);
+        boolean is_max_species = ((AbstractSpecies)(vspecies())).is_max_species();
+        VectorPayloadMF indices = VectorPayloadMF.newShuffleInstanceFactory(vspecies().elementType(), length, is_max_species);
         long offset = oldIndices.multiFieldOffset();
         indices = Unsafe.getUnsafe().makePrivateBuffer(indices);
         for (int i = 0; i < length; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractSpecies.java
@@ -298,6 +298,8 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
     /*package-private*/
     abstract Vector<E> fromIntValues(int[] values);
 
+    boolean is_max_species() { return vectorShape().switchKey == VectorShape.SK_Max_BIT; }
+
     /**
      * Do not use a dummy except to call methods on it when you don't
      * care about the lane values.  The main benefit of it is to
@@ -320,22 +322,22 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
         VectorSupport.VectorPayloadMF za = null;
         switch (laneType.switchKey) {
         case LaneType.SK_FLOAT:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceF(laneCount, (float[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceF(laneCount, (float[])initarr, is_max_species());
             break;
         case LaneType.SK_DOUBLE:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceD(laneCount, (double[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceD(laneCount, (double[])initarr, is_max_species());
             break;
         case LaneType.SK_BYTE:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceB(laneCount, (byte[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceB(laneCount, (byte[])initarr, is_max_species());
             break;
         case LaneType.SK_SHORT:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceS(laneCount, (short[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceS(laneCount, (short[])initarr, is_max_species());
             break;
         case LaneType.SK_INT:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceI(laneCount, (int[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceI(laneCount, (int[])initarr, is_max_species());
             break;
         case LaneType.SK_LONG:
-            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceL(laneCount, (long[])initarr);
+            za = VectorSupport.VectorPayloadMF.createVectPayloadInstanceL(laneCount, (long[])initarr, is_max_species());
             break;
         default:
             assert false : "Unsupported elemType in createVectorMF";
@@ -354,7 +356,7 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
         case LaneType.SK_SHORT:
         case LaneType.SK_INT:
         case LaneType.SK_LONG:
-            za = VectorPayloadMF.newInstanceFactory(elementType(), laneCount);
+            za = VectorPayloadMF.newVectorInstanceFactory(elementType(), laneCount, is_max_species());
             break;
         default:
             assert false : "Unsupported elemType in makeDummyVectorMF";
@@ -508,7 +510,7 @@ abstract class AbstractSpecies<E> extends VectorSupport.VectorSpecies<E>
     }
 
     AbstractMask<E> opm(FOpm f) {
-        VectorPayloadMF payload = VectorPayloadMF.newInstanceFactory(boolean.class, laneCount);
+        VectorPayloadMF payload = VectorPayloadMF.newMaskInstanceFactory(elementType(), laneCount, is_max_species());
         payload = Unsafe.getUnsafe().makePrivateBuffer(payload);
         long mOffset = payload.multiFieldOffset();
         for (int i = 0; i < laneCount; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -593,11 +593,11 @@ value class Byte128Vector extends ByteVector {
         private final VectorPayloadMF128Z payload;
 
         Byte128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Byte128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -769,11 +769,11 @@ value class Byte128Vector extends ByteVector {
         }
 
         public Byte128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Byte128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Byte128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -69,8 +69,8 @@ value class Byte128Vector extends ByteVector {
         return payload;
     }
 
-    static final Byte128Vector ZERO = new Byte128Vector(VectorPayloadMF.newInstanceFactory(byte.class, 16));
-    static final Byte128Vector IOTA = new Byte128Vector(VectorPayloadMF.createVectPayloadInstanceB(16, (byte[])(VSPECIES.iotaArray())));
+    static final Byte128Vector ZERO = new Byte128Vector(VectorPayloadMF.newVectorInstanceFactory(byte.class, 16, false));
+    static final Byte128Vector IOTA = new Byte128Vector(VectorPayloadMF.createVectPayloadInstanceB(VLENGTH, (byte[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -586,19 +586,20 @@ value class Byte128Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        private final VectorPayloadMF128Z payload;
-
         Byte128Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        private final VectorPayloadMF128Z payload;
+
         Byte128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Byte128Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -767,17 +768,18 @@ value class Byte128Vector extends ByteVector {
             assert(indexesInRange(payload));
         }
 
+        public Byte128Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Byte128Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Byte128Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Byte128Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Byte128Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -821,7 +823,7 @@ value class Byte128Vector extends ByteVector {
             Byte128Shuffle s = (Byte128Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -625,11 +625,11 @@ value class Byte256Vector extends ByteVector {
         private final VectorPayloadMF256Z payload;
 
         Byte256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Byte256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -801,11 +801,11 @@ value class Byte256Vector extends ByteVector {
         }
 
         public Byte256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Byte256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Byte256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -69,8 +69,8 @@ value class Byte256Vector extends ByteVector {
         return payload;
     }
 
-    static final Byte256Vector ZERO = new Byte256Vector(VectorPayloadMF.newInstanceFactory(byte.class, 32));
-    static final Byte256Vector IOTA = new Byte256Vector(VectorPayloadMF.createVectPayloadInstanceB(32, (byte[])(VSPECIES.iotaArray())));
+    static final Byte256Vector ZERO = new Byte256Vector(VectorPayloadMF.newVectorInstanceFactory(byte.class, 32, false));
+    static final Byte256Vector IOTA = new Byte256Vector(VectorPayloadMF.createVectPayloadInstanceB(VLENGTH, (byte[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -618,19 +618,20 @@ value class Byte256Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        private final VectorPayloadMF256Z payload;
-
         Byte256Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF256Z) payload;
         }
 
+        private final VectorPayloadMF256Z payload;
+
         Byte256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Byte256Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -799,17 +800,18 @@ value class Byte256Vector extends ByteVector {
             assert(indexesInRange(payload));
         }
 
+        public Byte256Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Byte256Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Byte256Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Byte256Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Byte256Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -853,7 +855,7 @@ value class Byte256Vector extends ByteVector {
             Byte256Shuffle s = (Byte256Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -689,11 +689,11 @@ value class Byte512Vector extends ByteVector {
         private final VectorPayloadMF512Z payload;
 
         Byte512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Byte512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -865,11 +865,11 @@ value class Byte512Vector extends ByteVector {
         }
 
         public Byte512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Byte512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Byte512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -69,8 +69,8 @@ value class Byte512Vector extends ByteVector {
         return payload;
     }
 
-    static final Byte512Vector ZERO = new Byte512Vector(VectorPayloadMF.newInstanceFactory(byte.class, 64));
-    static final Byte512Vector IOTA = new Byte512Vector(VectorPayloadMF.createVectPayloadInstanceB(64, (byte[])(VSPECIES.iotaArray())));
+    static final Byte512Vector ZERO = new Byte512Vector(VectorPayloadMF.newVectorInstanceFactory(byte.class, 64, false));
+    static final Byte512Vector IOTA = new Byte512Vector(VectorPayloadMF.createVectPayloadInstanceB(VLENGTH, (byte[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -682,19 +682,20 @@ value class Byte512Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        private final VectorPayloadMF512Z payload;
-
         Byte512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF512Z) payload;
         }
 
+        private final VectorPayloadMF512Z payload;
+
         Byte512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Byte512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -863,17 +864,18 @@ value class Byte512Vector extends ByteVector {
             assert(indexesInRange(payload));
         }
 
+        public Byte512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Byte512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Byte512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Byte512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Byte512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -917,7 +919,7 @@ value class Byte512Vector extends ByteVector {
             Byte512Shuffle s = (Byte512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -577,11 +577,11 @@ value class Byte64Vector extends ByteVector {
         private final VectorPayloadMF64Z payload;
 
         Byte64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Byte64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -753,11 +753,11 @@ value class Byte64Vector extends ByteVector {
         }
 
         public Byte64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Byte64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Byte64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -563,11 +563,11 @@ value class ByteMaxVector extends ByteVector {
         private final VectorPayloadMFMaxBZ payload;
 
         ByteMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         ByteMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -739,11 +739,11 @@ value class ByteMaxVector extends ByteVector {
         }
 
         public ByteMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public ByteMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public ByteMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Byte64Vector extends ByteVector {
+value class ByteMaxVector extends ByteVector {
     static final ByteSpecies VSPECIES =
-        (ByteSpecies) ByteVector.SPECIES_64;
+        (ByteSpecies) ByteVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Byte64Vector> VCLASS = Byte64Vector.class;
+    static final Class<ByteMaxVector> VCLASS = ByteMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Byte64Vector extends ByteVector {
 
     static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64B.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxB.class);
 
-    private final VectorPayloadMF64B payload;
+    private final VectorPayloadMFMaxB payload;
 
-    Byte64Vector(Object value) {
-        this.payload = (VectorPayloadMF64B) value;
+    ByteMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxB) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Byte64Vector extends ByteVector {
         return payload;
     }
 
-    static final Byte64Vector ZERO = new Byte64Vector(VectorPayloadMF.newVectorInstanceFactory(byte.class, 8, false));
-    static final Byte64Vector IOTA = new Byte64Vector(VectorPayloadMF.createVectPayloadInstanceB(VLENGTH, (byte[])(VSPECIES.iotaArray()), false));
+    static final ByteMaxVector ZERO = new ByteMaxVector(VectorPayloadMF.newVectorInstanceFactory(byte.class, 0, true));
+    static final ByteMaxVector IOTA = new ByteMaxVector(VectorPayloadMF.createVectPayloadInstanceB(VLENGTH, (byte[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,60 +121,60 @@ value class Byte64Vector extends ByteVector {
 
     @Override
     @ForceInline
-    public final Byte64Vector broadcast(byte e) {
-        return (Byte64Vector) super.broadcastTemplate(e);  // specialize
+    public final ByteMaxVector broadcast(byte e) {
+        return (ByteMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Byte64Vector broadcast(long e) {
-        return (Byte64Vector) super.broadcastTemplate(e);  // specialize
+    public final ByteMaxVector broadcast(long e) {
+        return (ByteMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Byte64Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Byte64Mask(payload);
+    ByteMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new ByteMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Byte64Shuffle iotaShuffle() { return Byte64Shuffle.IOTA; }
+    ByteMaxShuffle iotaShuffle() { return ByteMaxShuffle.IOTA; }
 
     @ForceInline
-    Byte64Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    ByteMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Byte64Shuffle)VectorSupport.shuffleIota(ETYPE, Byte64Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (ByteMaxShuffle)VectorSupport.shuffleIota(ETYPE, ByteMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Byte64Shuffle)VectorSupport.shuffleIota(ETYPE, Byte64Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (ByteMaxShuffle)VectorSupport.shuffleIota(ETYPE, ByteMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Byte64Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Byte64Shuffle(indexes); }
+    ByteMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new ByteMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Byte64Shuffle shuffleFromArray(int[] indexes, int i) { return new Byte64Shuffle(indexes, i); }
+    ByteMaxShuffle shuffleFromArray(int[] indexes, int i) { return new ByteMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Byte64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Byte64Shuffle(fn); }
+    ByteMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new ByteMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Byte64Vector vectorFactory(VectorPayloadMF vec) {
-        return new Byte64Vector(vec);
+    ByteMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new ByteMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte64Vector asByteVectorRaw() {
-        return (Byte64Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ value class Byte64Vector extends ByteVector {
 
     @ForceInline
     final @Override
-    Byte64Vector uOpMF(FUnOp f) {
-        return (Byte64Vector) super.uOpTemplateMF(f);  // specialize
+    ByteMaxVector uOpMF(FUnOp f) {
+        return (ByteMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Byte64Vector uOpMF(VectorMask<Byte> m, FUnOp f) {
-        return (Byte64Vector)
-            super.uOpTemplateMF((Byte64Mask)m, f);  // specialize
+    ByteMaxVector uOpMF(VectorMask<Byte> m, FUnOp f) {
+        return (ByteMaxVector)
+            super.uOpTemplateMF((ByteMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Byte64Vector bOpMF(Vector<Byte> v, FBinOp f) {
-        return (Byte64Vector) super.bOpTemplateMF((Byte64Vector)v, f);  // specialize
+    ByteMaxVector bOpMF(Vector<Byte> v, FBinOp f) {
+        return (ByteMaxVector) super.bOpTemplateMF((ByteMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Byte64Vector bOpMF(Vector<Byte> v,
+    ByteMaxVector bOpMF(Vector<Byte> v,
                      VectorMask<Byte> m, FBinOp f) {
-        return (Byte64Vector)
-            super.bOpTemplateMF((Byte64Vector)v, (Byte64Mask)m,
+        return (ByteMaxVector)
+            super.bOpTemplateMF((ByteMaxVector)v, (ByteMaxMask)m,
                                 f);  // specialize
     }
 
@@ -219,19 +219,19 @@ value class Byte64Vector extends ByteVector {
 
     @ForceInline
     final @Override
-    Byte64Vector tOpMF(Vector<Byte> v1, Vector<Byte> v2, FTriOp f) {
-        return (Byte64Vector)
-            super.tOpTemplateMF((Byte64Vector)v1, (Byte64Vector)v2,
+    ByteMaxVector tOpMF(Vector<Byte> v1, Vector<Byte> v2, FTriOp f) {
+        return (ByteMaxVector)
+            super.tOpTemplateMF((ByteMaxVector)v1, (ByteMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Byte64Vector tOpMF(Vector<Byte> v1, Vector<Byte> v2,
+    ByteMaxVector tOpMF(Vector<Byte> v1, Vector<Byte> v2,
                      VectorMask<Byte> m, FTriOp f) {
-        return (Byte64Vector)
-            super.tOpTemplateMF((Byte64Vector)v1, (Byte64Vector)v2,
-                                (Byte64Mask)m, f);  // specialize
+        return (ByteMaxVector)
+            super.tOpTemplateMF((ByteMaxVector)v1, (ByteMaxVector)v2,
+                                (ByteMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -269,64 +269,64 @@ value class Byte64Vector extends ByteVector {
 
     @Override
     @ForceInline
-    public Byte64Vector lanewise(Unary op) {
-        return (Byte64Vector) super.lanewiseTemplate(op);  // specialize
+    public ByteMaxVector lanewise(Unary op) {
+        return (ByteMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector lanewise(Unary op, VectorMask<Byte> m) {
-        return (Byte64Vector) super.lanewiseTemplate(op, Byte64Mask.class, (Byte64Mask) m);  // specialize
+    public ByteMaxVector lanewise(Unary op, VectorMask<Byte> m) {
+        return (ByteMaxVector) super.lanewiseTemplate(op, ByteMaxMask.class, (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector lanewise(Binary op, Vector<Byte> v) {
-        return (Byte64Vector) super.lanewiseTemplate(op, v);  // specialize
+    public ByteMaxVector lanewise(Binary op, Vector<Byte> v) {
+        return (ByteMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector lanewise(Binary op, Vector<Byte> v, VectorMask<Byte> m) {
-        return (Byte64Vector) super.lanewiseTemplate(op, Byte64Mask.class, v, (Byte64Mask) m);  // specialize
+    public ByteMaxVector lanewise(Binary op, Vector<Byte> v, VectorMask<Byte> m) {
+        return (ByteMaxVector) super.lanewiseTemplate(op, ByteMaxMask.class, v, (ByteMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Byte64Vector
+    @ForceInline ByteMaxVector
     lanewiseShift(VectorOperators.Binary op, int e) {
-        return (Byte64Vector) super.lanewiseShiftTemplate(op, e);  // specialize
+        return (ByteMaxVector) super.lanewiseShiftTemplate(op, e);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Byte64Vector
+    @ForceInline ByteMaxVector
     lanewiseShift(VectorOperators.Binary op, int e, VectorMask<Byte> m) {
-        return (Byte64Vector) super.lanewiseShiftTemplate(op, Byte64Mask.class, e, (Byte64Mask) m);  // specialize
+        return (ByteMaxVector) super.lanewiseShiftTemplate(op, ByteMaxMask.class, e, (ByteMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
     @ForceInline
     public final
-    Byte64Vector
+    ByteMaxVector
     lanewise(Ternary op, Vector<Byte> v1, Vector<Byte> v2) {
-        return (Byte64Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (ByteMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Byte64Vector
+    ByteMaxVector
     lanewise(Ternary op, Vector<Byte> v1, Vector<Byte> v2, VectorMask<Byte> m) {
-        return (Byte64Vector) super.lanewiseTemplate(op, Byte64Mask.class, v1, v2, (Byte64Mask) m);  // specialize
+        return (ByteMaxVector) super.lanewiseTemplate(op, ByteMaxMask.class, v1, v2, (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Byte64Vector addIndex(int scale) {
-        return (Byte64Vector) super.addIndexTemplate(scale);  // specialize
+    ByteMaxVector addIndex(int scale) {
+        return (ByteMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -341,7 +341,7 @@ value class Byte64Vector extends ByteVector {
     @ForceInline
     public final byte reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Byte> m) {
-        return super.reduceLanesTemplate(op, Byte64Mask.class, (Byte64Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, ByteMaxMask.class, (ByteMaxMask) m);  // specialized
     }
 
     @Override
@@ -354,173 +354,166 @@ value class Byte64Vector extends ByteVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, Byte64Mask.class, (Byte64Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, ByteMaxMask.class, (ByteMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Byte> toShuffle() {
-        return super.toShuffleTemplate(Byte64Shuffle.class); // specialize
+        return super.toShuffleTemplate(ByteMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Byte64Mask test(Test op) {
-        return super.testTemplate(Byte64Mask.class, op);  // specialize
+    public final ByteMaxMask test(Test op) {
+        return super.testTemplate(ByteMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Byte64Mask test(Test op, VectorMask<Byte> m) {
-        return super.testTemplate(Byte64Mask.class, op, (Byte64Mask) m);  // specialize
+    public final ByteMaxMask test(Test op, VectorMask<Byte> m) {
+        return super.testTemplate(ByteMaxMask.class, op, (ByteMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Byte64Mask compare(Comparison op, Vector<Byte> v) {
-        return super.compareTemplate(Byte64Mask.class, op, v);  // specialize
+    public final ByteMaxMask compare(Comparison op, Vector<Byte> v) {
+        return super.compareTemplate(ByteMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Byte64Mask compare(Comparison op, byte s) {
-        return super.compareTemplate(Byte64Mask.class, op, s);  // specialize
+    public final ByteMaxMask compare(Comparison op, byte s) {
+        return super.compareTemplate(ByteMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Byte64Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Byte64Mask.class, op, s);  // specialize
+    public final ByteMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(ByteMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Byte64Mask compare(Comparison op, Vector<Byte> v, VectorMask<Byte> m) {
-        return super.compareTemplate(Byte64Mask.class, op, v, (Byte64Mask) m);
+    public final ByteMaxMask compare(Comparison op, Vector<Byte> v, VectorMask<Byte> m) {
+        return super.compareTemplate(ByteMaxMask.class, op, v, (ByteMaxMask) m);
     }
 
 
     @Override
     @ForceInline
-    public Byte64Vector blend(Vector<Byte> v, VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.blendTemplate(Byte64Mask.class,
-                                (Byte64Vector) v,
-                                (Byte64Mask) m);  // specialize
+    public ByteMaxVector blend(Vector<Byte> v, VectorMask<Byte> m) {
+        return (ByteMaxVector)
+            super.blendTemplate(ByteMaxMask.class,
+                                (ByteMaxVector) v,
+                                (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector slice(int origin, Vector<Byte> v) {
-        return (Byte64Vector) super.sliceTemplate(origin, v);  // specialize
+    public ByteMaxVector slice(int origin, Vector<Byte> v) {
+        return (ByteMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector slice(int origin) {
-        return (Byte64Vector) super.sliceTemplate(origin);  // specialize
+    public ByteMaxVector slice(int origin) {
+        return (ByteMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector unslice(int origin, Vector<Byte> w, int part) {
-        return (Byte64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public ByteMaxVector unslice(int origin, Vector<Byte> w, int part) {
+        return (ByteMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector unslice(int origin, Vector<Byte> w, int part, VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.unsliceTemplate(Byte64Mask.class,
+    public ByteMaxVector unslice(int origin, Vector<Byte> w, int part, VectorMask<Byte> m) {
+        return (ByteMaxVector)
+            super.unsliceTemplate(ByteMaxMask.class,
                                   origin, w, part,
-                                  (Byte64Mask) m);  // specialize
+                                  (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector unslice(int origin) {
-        return (Byte64Vector) super.unsliceTemplate(origin);  // specialize
+    public ByteMaxVector unslice(int origin) {
+        return (ByteMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector rearrange(VectorShuffle<Byte> s) {
-        return (Byte64Vector)
-            super.rearrangeTemplate(Byte64Shuffle.class,
-                                    (Byte64Shuffle) s);  // specialize
+    public ByteMaxVector rearrange(VectorShuffle<Byte> s) {
+        return (ByteMaxVector)
+            super.rearrangeTemplate(ByteMaxShuffle.class,
+                                    (ByteMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector rearrange(VectorShuffle<Byte> shuffle,
+    public ByteMaxVector rearrange(VectorShuffle<Byte> shuffle,
                                   VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.rearrangeTemplate(Byte64Shuffle.class,
-                                    Byte64Mask.class,
-                                    (Byte64Shuffle) shuffle,
-                                    (Byte64Mask) m);  // specialize
+        return (ByteMaxVector)
+            super.rearrangeTemplate(ByteMaxShuffle.class,
+                                    ByteMaxMask.class,
+                                    (ByteMaxShuffle) shuffle,
+                                    (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector rearrange(VectorShuffle<Byte> s,
+    public ByteMaxVector rearrange(VectorShuffle<Byte> s,
                                   Vector<Byte> v) {
-        return (Byte64Vector)
-            super.rearrangeTemplate(Byte64Shuffle.class,
-                                    (Byte64Shuffle) s,
-                                    (Byte64Vector) v);  // specialize
+        return (ByteMaxVector)
+            super.rearrangeTemplate(ByteMaxShuffle.class,
+                                    (ByteMaxShuffle) s,
+                                    (ByteMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector compress(VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.compressTemplate(Byte64Mask.class,
-                                   (Byte64Mask) m);  // specialize
+    public ByteMaxVector compress(VectorMask<Byte> m) {
+        return (ByteMaxVector)
+            super.compressTemplate(ByteMaxMask.class,
+                                   (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector expand(VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.expandTemplate(Byte64Mask.class,
-                                   (Byte64Mask) m);  // specialize
+    public ByteMaxVector expand(VectorMask<Byte> m) {
+        return (ByteMaxVector)
+            super.expandTemplate(ByteMaxMask.class,
+                                   (ByteMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector selectFrom(Vector<Byte> v) {
-        return (Byte64Vector)
-            super.selectFromTemplate((Byte64Vector) v);  // specialize
+    public ByteMaxVector selectFrom(Vector<Byte> v) {
+        return (ByteMaxVector)
+            super.selectFromTemplate((ByteMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Byte64Vector selectFrom(Vector<Byte> v,
+    public ByteMaxVector selectFrom(Vector<Byte> v,
                                    VectorMask<Byte> m) {
-        return (Byte64Vector)
-            super.selectFromTemplate((Byte64Vector) v,
-                                     (Byte64Mask) m);  // specialize
+        return (ByteMaxVector)
+            super.selectFromTemplate((ByteMaxVector) v,
+                                     (ByteMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public byte lane(int i) {
-        switch(i) {
-            case 0: return laneHelper(0);
-            case 1: return laneHelper(1);
-            case 2: return laneHelper(2);
-            case 3: return laneHelper(3);
-            case 4: return laneHelper(4);
-            case 5: return laneHelper(5);
-            case 6: return laneHelper(6);
-            case 7: return laneHelper(7);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return laneHelper(i);
     }
 
     public byte laneHelper(int i) {
@@ -536,21 +529,14 @@ value class Byte64Vector extends ByteVector {
 
     @ForceInline
     @Override
-    public Byte64Vector withLane(int i, byte e) {
-        switch (i) {
-            case 0: return withLaneHelper(0, e);
-            case 1: return withLaneHelper(1, e);
-            case 2: return withLaneHelper(2, e);
-            case 3: return withLaneHelper(3, e);
-            case 4: return withLaneHelper(4, e);
-            case 5: return withLaneHelper(5, e);
-            case 6: return withLaneHelper(6, e);
-            case 7: return withLaneHelper(7, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public ByteMaxVector withLane(int i, byte e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Byte64Vector withLaneHelper(int i, byte e) {
+    public ByteMaxVector withLaneHelper(int i, byte e) {
        return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
@@ -566,22 +552,22 @@ value class Byte64Vector extends ByteVector {
 
     // Mask
 
-    static final value class Byte64Mask extends AbstractMask<Byte> {
+    static final value class ByteMaxMask extends AbstractMask<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        Byte64Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64Z) payload;
+        ByteMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxBZ) payload;
         }
 
-        private final VectorPayloadMF64Z payload;
+        private final VectorPayloadMFMaxBZ payload;
 
-        Byte64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        ByteMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Byte64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        ByteMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -603,32 +589,32 @@ value class Byte64Vector extends ByteVector {
         @ForceInline
         @Override
         public final
-        Byte64Vector toVector() {
-            return (Byte64Vector) super.toVectorTemplate();  // specialize
+        ByteMaxVector toVector() {
+            return (ByteMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Byte64Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Byte64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Byte64Mask.class, byte.class, VLENGTH, offset, limit,
-                (o, l) -> (Byte64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        ByteMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (ByteMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                ByteMaxMask.class, byte.class, VLENGTH, offset, limit,
+                (o, l) -> (ByteMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Byte64Mask not() {
+        public ByteMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Byte64Mask compress() {
-            return (Byte64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Byte64Vector.class, Byte64Mask.class, ETYPE, VLENGTH, null, this,
+        public ByteMaxMask compress() {
+            return (ByteMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                ByteMaxVector.class, ByteMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -637,32 +623,32 @@ value class Byte64Vector extends ByteVector {
 
         @Override
         @ForceInline
-        public Byte64Mask and(VectorMask<Byte> mask) {
+        public ByteMaxMask and(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
-            Byte64Mask m = (Byte64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Byte64Mask.class, null,
+            ByteMaxMask m = (ByteMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, ByteMaxMask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (ByteMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Byte64Mask or(VectorMask<Byte> mask) {
+        public ByteMaxMask or(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
-            Byte64Mask m = (Byte64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Byte64Mask.class, null,
+            ByteMaxMask m = (ByteMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, ByteMaxMask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (ByteMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Byte64Mask xor(VectorMask<Byte> mask) {
+        public ByteMaxMask xor(VectorMask<Byte> mask) {
             Objects.requireNonNull(mask);
-            Byte64Mask m = (Byte64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Byte64Mask.class, null,
+            ByteMaxMask m = (ByteMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, ByteMaxMask.class, null,
                                           byte.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Byte64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (ByteMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -670,22 +656,22 @@ value class Byte64Vector extends ByteVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Byte64Mask.class, byte.class, VLENGTH, this,
-                                                            (m) -> ((Byte64Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, ByteMaxMask.class, byte.class, VLENGTH, this,
+                                                            (m) -> ((ByteMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Byte64Mask.class, byte.class, VLENGTH, this,
-                                                            (m) -> ((Byte64Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, ByteMaxMask.class, byte.class, VLENGTH, this,
+                                                            (m) -> ((ByteMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Byte64Mask.class, byte.class, VLENGTH, this,
-                                                            (m) -> ((Byte64Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, ByteMaxMask.class, byte.class, VLENGTH, this,
+                                                            (m) -> ((ByteMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -694,8 +680,8 @@ value class Byte64Vector extends ByteVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Byte64Mask.class, byte.class, VLENGTH, this,
-                                                      (m) -> ((Byte64Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, ByteMaxMask.class, byte.class, VLENGTH, this,
+                                                      (m) -> ((ByteMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -704,8 +690,8 @@ value class Byte64Vector extends ByteVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Byte64Mask.class, byte.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Byte64Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(ByteMaxMask.class, byte.class, VLENGTH,
+                                         this, i, (m, idx) -> (((ByteMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -713,54 +699,54 @@ value class Byte64Vector extends ByteVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Byte64Mask.class, byte.class, VLENGTH,
+            return VectorSupport.test(BT_ne, ByteMaxMask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Byte64Mask) m).anyTrueHelper());
+                                         (m, __) -> ((ByteMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Byte64Mask.class, byte.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, ByteMaxMask.class, byte.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Byte64Mask) m).allTrueHelper());
+                                         (m, __) -> ((ByteMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Byte64Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Byte64Mask.class, byte.class, VLENGTH,
+        static ByteMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(ByteMaxMask.class, byte.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Byte64Mask  TRUE_MASK = new Byte64Mask(true);
-        private static final Byte64Mask FALSE_MASK = new Byte64Mask(false);
+        private static final ByteMaxMask  TRUE_MASK = new ByteMaxMask(true);
+        private static final ByteMaxMask FALSE_MASK = new ByteMaxMask(false);
 
     }
 
     // Shuffle
 
-    static final value class Byte64Shuffle extends AbstractShuffle<Byte> {
+    static final value class ByteMaxShuffle extends AbstractShuffle<Byte> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
-        private final VectorPayloadMF64B payload;
+        private final VectorPayloadMFMaxBB payload;
 
-        Byte64Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64B) payload;
+        ByteMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxBB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Byte64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public ByteMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Byte64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public ByteMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Byte64Shuffle(int[] indexes) {
+        public ByteMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -782,13 +768,13 @@ value class Byte64Vector extends ByteVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Byte64Shuffle IOTA = new Byte64Shuffle(IDENTITY);
+        static final ByteMaxShuffle IOTA = new ByteMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Byte64Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Byte64Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Byte64Vector)(((AbstractShuffle<Byte>)(s)).toVectorTemplate())));
+        public ByteMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, ByteMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((ByteMaxVector)(((AbstractShuffle<Byte>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -803,11 +789,11 @@ value class Byte64Vector extends ByteVector {
 
         @ForceInline
         @Override
-        public Byte64Shuffle rearrange(VectorShuffle<Byte> shuffle) {
-            Byte64Shuffle s = (Byte64Shuffle) shuffle;
+        public ByteMaxShuffle rearrange(VectorShuffle<Byte> shuffle) {
+            ByteMaxShuffle s = (ByteMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -816,7 +802,7 @@ value class Byte64Vector extends ByteVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Byte64Shuffle(r);
+            return new ByteMaxShuffle(r);
         }
     }
 
@@ -835,7 +821,7 @@ value class Byte64Vector extends ByteVector {
     @Override
     final
     ByteVector fromArray0(byte[] a, int offset, VectorMask<Byte> m, int offsetInRange) {
-        return super.fromArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m, offsetInRange);  // specialize
     }
 
 
@@ -851,7 +837,7 @@ value class Byte64Vector extends ByteVector {
     @Override
     final
     ByteVector fromBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m, int offsetInRange) {
-        return super.fromBooleanArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m, offsetInRange);  // specialize
+        return super.fromBooleanArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -865,7 +851,7 @@ value class Byte64Vector extends ByteVector {
     @Override
     final
     ByteVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Byte> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Byte64Mask.class, ms, offset, (Byte64Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(ByteMaxMask.class, ms, offset, (ByteMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -879,7 +865,7 @@ value class Byte64Vector extends ByteVector {
     @Override
     final
     void intoArray0(byte[] a, int offset, VectorMask<Byte> m) {
-        super.intoArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m);
+        super.intoArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m);
     }
 
 
@@ -887,14 +873,14 @@ value class Byte64Vector extends ByteVector {
     @Override
     final
     void intoBooleanArray0(boolean[] a, int offset, VectorMask<Byte> m) {
-        super.intoBooleanArray0Template(Byte64Mask.class, a, offset, (Byte64Mask) m);
+        super.intoBooleanArray0Template(ByteMaxMask.class, a, offset, (ByteMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Byte> m) {
-        super.intoMemorySegment0Template(Byte64Mask.class, ms, offset, (Byte64Mask) m);
+        super.intoMemorySegment0Template(ByteMaxMask.class, ms, offset, (ByteMaxMask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -554,11 +554,11 @@ value class Double128Vector extends DoubleVector {
         private final VectorPayloadMF16Z payload;
 
         Double128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Double128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -730,11 +730,11 @@ value class Double128Vector extends DoubleVector {
         }
 
         public Double128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Double128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Double128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -69,8 +69,8 @@ value class Double128Vector extends DoubleVector {
         return payload;
     }
 
-    static final Double128Vector ZERO = new Double128Vector(VectorPayloadMF.newInstanceFactory(double.class, 2));
-    static final Double128Vector IOTA = new Double128Vector(VectorPayloadMF.createVectPayloadInstanceD(2, (double[])(VSPECIES.iotaArray())));
+    static final Double128Vector ZERO = new Double128Vector(VectorPayloadMF.newVectorInstanceFactory(double.class, 2, false));
+    static final Double128Vector IOTA = new Double128Vector(VectorPayloadMF.createVectPayloadInstanceD(VLENGTH, (double[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -547,19 +547,20 @@ value class Double128Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        private final VectorPayloadMF16Z payload;
-
         Double128Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        private final VectorPayloadMF16Z payload;
+
         Double128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Double128Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -728,17 +729,18 @@ value class Double128Vector extends DoubleVector {
             assert(indexesInRange(payload));
         }
 
+        public Double128Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Double128Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Double128Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Double128Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Double128Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -782,7 +784,7 @@ value class Double128Vector extends DoubleVector {
             Double128Shuffle s = (Double128Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -558,11 +558,11 @@ value class Double256Vector extends DoubleVector {
         private final VectorPayloadMF32Z payload;
 
         Double256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Double256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -734,11 +734,11 @@ value class Double256Vector extends DoubleVector {
         }
 
         public Double256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Double256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Double256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -69,8 +69,8 @@ value class Double256Vector extends DoubleVector {
         return payload;
     }
 
-    static final Double256Vector ZERO = new Double256Vector(VectorPayloadMF.newInstanceFactory(double.class, 4));
-    static final Double256Vector IOTA = new Double256Vector(VectorPayloadMF.createVectPayloadInstanceD(4, (double[])(VSPECIES.iotaArray())));
+    static final Double256Vector ZERO = new Double256Vector(VectorPayloadMF.newVectorInstanceFactory(double.class, 4, false));
+    static final Double256Vector IOTA = new Double256Vector(VectorPayloadMF.createVectPayloadInstanceD(VLENGTH, (double[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -551,19 +551,20 @@ value class Double256Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        private final VectorPayloadMF32Z payload;
-
         Double256Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        private final VectorPayloadMF32Z payload;
+
         Double256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Double256Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -732,17 +733,18 @@ value class Double256Vector extends DoubleVector {
             assert(indexesInRange(payload));
         }
 
+        public Double256Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Double256Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Double256Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Double256Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Double256Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -786,7 +788,7 @@ value class Double256Vector extends DoubleVector {
             Double256Shuffle s = (Double256Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -566,11 +566,11 @@ value class Double512Vector extends DoubleVector {
         private final VectorPayloadMF64Z payload;
 
         Double512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Double512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -742,11 +742,11 @@ value class Double512Vector extends DoubleVector {
         }
 
         public Double512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Double512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Double512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -69,8 +69,8 @@ value class Double512Vector extends DoubleVector {
         return payload;
     }
 
-    static final Double512Vector ZERO = new Double512Vector(VectorPayloadMF.newInstanceFactory(double.class, 8));
-    static final Double512Vector IOTA = new Double512Vector(VectorPayloadMF.createVectPayloadInstanceD(8, (double[])(VSPECIES.iotaArray())));
+    static final Double512Vector ZERO = new Double512Vector(VectorPayloadMF.newVectorInstanceFactory(double.class, 8, false));
+    static final Double512Vector IOTA = new Double512Vector(VectorPayloadMF.createVectPayloadInstanceD(VLENGTH, (double[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -559,19 +559,20 @@ value class Double512Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        private final VectorPayloadMF64Z payload;
-
         Double512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        private final VectorPayloadMF64Z payload;
+
         Double512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Double512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -740,17 +741,18 @@ value class Double512Vector extends DoubleVector {
             assert(indexesInRange(payload));
         }
 
+        public Double512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Double512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Double512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Double512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Double512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -794,7 +796,7 @@ value class Double512Vector extends DoubleVector {
             Double512Shuffle s = (Double512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -552,11 +552,11 @@ value class Double64Vector extends DoubleVector {
         private final VectorPayloadMF8Z payload;
 
         Double64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Double64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -728,11 +728,11 @@ value class Double64Vector extends DoubleVector {
         }
 
         public Double64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Double64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Double64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -551,11 +551,11 @@ value class DoubleMaxVector extends DoubleVector {
         private final VectorPayloadMFMaxLZ payload;
 
         DoubleMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         DoubleMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -727,11 +727,11 @@ value class DoubleMaxVector extends DoubleVector {
         }
 
         public DoubleMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public DoubleMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public DoubleMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Double64Vector extends DoubleVector {
+value class DoubleMaxVector extends DoubleVector {
     static final DoubleSpecies VSPECIES =
-        (DoubleSpecies) DoubleVector.SPECIES_64;
+        (DoubleSpecies) DoubleVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Double64Vector> VCLASS = Double64Vector.class;
+    static final Class<DoubleMaxVector> VCLASS = DoubleMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Double64Vector extends DoubleVector {
 
     static final Class<Double> ETYPE = double.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64D.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxD.class);
 
-    private final VectorPayloadMF64D payload;
+    private final VectorPayloadMFMaxD payload;
 
-    Double64Vector(Object value) {
-        this.payload = (VectorPayloadMF64D) value;
+    DoubleMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxD) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Double64Vector extends DoubleVector {
         return payload;
     }
 
-    static final Double64Vector ZERO = new Double64Vector(VectorPayloadMF.newVectorInstanceFactory(double.class, 1, false));
-    static final Double64Vector IOTA = new Double64Vector(VectorPayloadMF.createVectPayloadInstanceD(VLENGTH, (double[])(VSPECIES.iotaArray()), false));
+    static final DoubleMaxVector ZERO = new DoubleMaxVector(VectorPayloadMF.newVectorInstanceFactory(double.class, 0, true));
+    static final DoubleMaxVector IOTA = new DoubleMaxVector(VectorPayloadMF.createVectPayloadInstanceD(VLENGTH, (double[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,60 +121,60 @@ value class Double64Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    public final Double64Vector broadcast(double e) {
-        return (Double64Vector) super.broadcastTemplate(e);  // specialize
+    public final DoubleMaxVector broadcast(double e) {
+        return (DoubleMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double64Vector broadcast(long e) {
-        return (Double64Vector) super.broadcastTemplate(e);  // specialize
+    public final DoubleMaxVector broadcast(long e) {
+        return (DoubleMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Double64Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Double64Mask(payload);
+    DoubleMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new DoubleMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Double64Shuffle iotaShuffle() { return Double64Shuffle.IOTA; }
+    DoubleMaxShuffle iotaShuffle() { return DoubleMaxShuffle.IOTA; }
 
     @ForceInline
-    Double64Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    DoubleMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Double64Shuffle)VectorSupport.shuffleIota(ETYPE, Double64Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (DoubleMaxShuffle)VectorSupport.shuffleIota(ETYPE, DoubleMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Double64Shuffle)VectorSupport.shuffleIota(ETYPE, Double64Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (DoubleMaxShuffle)VectorSupport.shuffleIota(ETYPE, DoubleMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Double64Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Double64Shuffle(indexes); }
+    DoubleMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new DoubleMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Double64Shuffle shuffleFromArray(int[] indexes, int i) { return new Double64Shuffle(indexes, i); }
+    DoubleMaxShuffle shuffleFromArray(int[] indexes, int i) { return new DoubleMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Double64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Double64Shuffle(fn); }
+    DoubleMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new DoubleMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Double64Vector vectorFactory(VectorPayloadMF vec) {
-        return new Double64Vector(vec);
+    DoubleMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new DoubleMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte64Vector asByteVectorRaw() {
-        return (Byte64Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ value class Double64Vector extends DoubleVector {
 
     @ForceInline
     final @Override
-    Double64Vector uOpMF(FUnOp f) {
-        return (Double64Vector) super.uOpTemplateMF(f);  // specialize
+    DoubleMaxVector uOpMF(FUnOp f) {
+        return (DoubleMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double64Vector uOpMF(VectorMask<Double> m, FUnOp f) {
-        return (Double64Vector)
-            super.uOpTemplateMF((Double64Mask)m, f);  // specialize
+    DoubleMaxVector uOpMF(VectorMask<Double> m, FUnOp f) {
+        return (DoubleMaxVector)
+            super.uOpTemplateMF((DoubleMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Double64Vector bOpMF(Vector<Double> v, FBinOp f) {
-        return (Double64Vector) super.bOpTemplateMF((Double64Vector)v, f);  // specialize
+    DoubleMaxVector bOpMF(Vector<Double> v, FBinOp f) {
+        return (DoubleMaxVector) super.bOpTemplateMF((DoubleMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double64Vector bOpMF(Vector<Double> v,
+    DoubleMaxVector bOpMF(Vector<Double> v,
                      VectorMask<Double> m, FBinOp f) {
-        return (Double64Vector)
-            super.bOpTemplateMF((Double64Vector)v, (Double64Mask)m,
+        return (DoubleMaxVector)
+            super.bOpTemplateMF((DoubleMaxVector)v, (DoubleMaxMask)m,
                                 f);  // specialize
     }
 
@@ -219,19 +219,19 @@ value class Double64Vector extends DoubleVector {
 
     @ForceInline
     final @Override
-    Double64Vector tOpMF(Vector<Double> v1, Vector<Double> v2, FTriOp f) {
-        return (Double64Vector)
-            super.tOpTemplateMF((Double64Vector)v1, (Double64Vector)v2,
+    DoubleMaxVector tOpMF(Vector<Double> v1, Vector<Double> v2, FTriOp f) {
+        return (DoubleMaxVector)
+            super.tOpTemplateMF((DoubleMaxVector)v1, (DoubleMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double64Vector tOpMF(Vector<Double> v1, Vector<Double> v2,
+    DoubleMaxVector tOpMF(Vector<Double> v1, Vector<Double> v2,
                      VectorMask<Double> m, FTriOp f) {
-        return (Double64Vector)
-            super.tOpTemplateMF((Double64Vector)v1, (Double64Vector)v2,
-                                (Double64Mask)m, f);  // specialize
+        return (DoubleMaxVector)
+            super.tOpTemplateMF((DoubleMaxVector)v1, (DoubleMaxVector)v2,
+                                (DoubleMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -269,26 +269,26 @@ value class Double64Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    public Double64Vector lanewise(Unary op) {
-        return (Double64Vector) super.lanewiseTemplate(op);  // specialize
+    public DoubleMaxVector lanewise(Unary op) {
+        return (DoubleMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector lanewise(Unary op, VectorMask<Double> m) {
-        return (Double64Vector) super.lanewiseTemplate(op, Double64Mask.class, (Double64Mask) m);  // specialize
+    public DoubleMaxVector lanewise(Unary op, VectorMask<Double> m) {
+        return (DoubleMaxVector) super.lanewiseTemplate(op, DoubleMaxMask.class, (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector lanewise(Binary op, Vector<Double> v) {
-        return (Double64Vector) super.lanewiseTemplate(op, v);  // specialize
+    public DoubleMaxVector lanewise(Binary op, Vector<Double> v) {
+        return (DoubleMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector lanewise(Binary op, Vector<Double> v, VectorMask<Double> m) {
-        return (Double64Vector) super.lanewiseTemplate(op, Double64Mask.class, v, (Double64Mask) m);  // specialize
+    public DoubleMaxVector lanewise(Binary op, Vector<Double> v, VectorMask<Double> m) {
+        return (DoubleMaxVector) super.lanewiseTemplate(op, DoubleMaxMask.class, v, (DoubleMaxMask) m);  // specialize
     }
 
 
@@ -296,24 +296,24 @@ value class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public final
-    Double64Vector
+    DoubleMaxVector
     lanewise(Ternary op, Vector<Double> v1, Vector<Double> v2) {
-        return (Double64Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (DoubleMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Double64Vector
+    DoubleMaxVector
     lanewise(Ternary op, Vector<Double> v1, Vector<Double> v2, VectorMask<Double> m) {
-        return (Double64Vector) super.lanewiseTemplate(op, Double64Mask.class, v1, v2, (Double64Mask) m);  // specialize
+        return (DoubleMaxVector) super.lanewiseTemplate(op, DoubleMaxMask.class, v1, v2, (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Double64Vector addIndex(int scale) {
-        return (Double64Vector) super.addIndexTemplate(scale);  // specialize
+    DoubleMaxVector addIndex(int scale) {
+        return (DoubleMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -328,7 +328,7 @@ value class Double64Vector extends DoubleVector {
     @ForceInline
     public final double reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Double> m) {
-        return super.reduceLanesTemplate(op, Double64Mask.class, (Double64Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, DoubleMaxMask.class, (DoubleMaxMask) m);  // specialized
     }
 
     @Override
@@ -341,167 +341,166 @@ value class Double64Vector extends DoubleVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Double> m) {
-        return (long) super.reduceLanesTemplate(op, Double64Mask.class, (Double64Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, DoubleMaxMask.class, (DoubleMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Double> toShuffle() {
-        return super.toShuffleTemplate(Double64Shuffle.class); // specialize
+        return super.toShuffleTemplate(DoubleMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Double64Mask test(Test op) {
-        return super.testTemplate(Double64Mask.class, op);  // specialize
+    public final DoubleMaxMask test(Test op) {
+        return super.testTemplate(DoubleMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double64Mask test(Test op, VectorMask<Double> m) {
-        return super.testTemplate(Double64Mask.class, op, (Double64Mask) m);  // specialize
+    public final DoubleMaxMask test(Test op, VectorMask<Double> m) {
+        return super.testTemplate(DoubleMaxMask.class, op, (DoubleMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Double64Mask compare(Comparison op, Vector<Double> v) {
-        return super.compareTemplate(Double64Mask.class, op, v);  // specialize
+    public final DoubleMaxMask compare(Comparison op, Vector<Double> v) {
+        return super.compareTemplate(DoubleMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double64Mask compare(Comparison op, double s) {
-        return super.compareTemplate(Double64Mask.class, op, s);  // specialize
+    public final DoubleMaxMask compare(Comparison op, double s) {
+        return super.compareTemplate(DoubleMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double64Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Double64Mask.class, op, s);  // specialize
+    public final DoubleMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(DoubleMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double64Mask compare(Comparison op, Vector<Double> v, VectorMask<Double> m) {
-        return super.compareTemplate(Double64Mask.class, op, v, (Double64Mask) m);
+    public final DoubleMaxMask compare(Comparison op, Vector<Double> v, VectorMask<Double> m) {
+        return super.compareTemplate(DoubleMaxMask.class, op, v, (DoubleMaxMask) m);
     }
 
 
     @Override
     @ForceInline
-    public Double64Vector blend(Vector<Double> v, VectorMask<Double> m) {
-        return (Double64Vector)
-            super.blendTemplate(Double64Mask.class,
-                                (Double64Vector) v,
-                                (Double64Mask) m);  // specialize
+    public DoubleMaxVector blend(Vector<Double> v, VectorMask<Double> m) {
+        return (DoubleMaxVector)
+            super.blendTemplate(DoubleMaxMask.class,
+                                (DoubleMaxVector) v,
+                                (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector slice(int origin, Vector<Double> v) {
-        return (Double64Vector) super.sliceTemplate(origin, v);  // specialize
+    public DoubleMaxVector slice(int origin, Vector<Double> v) {
+        return (DoubleMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector slice(int origin) {
-        return (Double64Vector) super.sliceTemplate(origin);  // specialize
+    public DoubleMaxVector slice(int origin) {
+        return (DoubleMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public DoubleMaxVector unslice(int origin, Vector<Double> w, int part) {
+        return (DoubleMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector unslice(int origin, Vector<Double> w, int part, VectorMask<Double> m) {
-        return (Double64Vector)
-            super.unsliceTemplate(Double64Mask.class,
+    public DoubleMaxVector unslice(int origin, Vector<Double> w, int part, VectorMask<Double> m) {
+        return (DoubleMaxVector)
+            super.unsliceTemplate(DoubleMaxMask.class,
                                   origin, w, part,
-                                  (Double64Mask) m);  // specialize
+                                  (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector unslice(int origin) {
-        return (Double64Vector) super.unsliceTemplate(origin);  // specialize
+    public DoubleMaxVector unslice(int origin) {
+        return (DoubleMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector rearrange(VectorShuffle<Double> s) {
-        return (Double64Vector)
-            super.rearrangeTemplate(Double64Shuffle.class,
-                                    (Double64Shuffle) s);  // specialize
+    public DoubleMaxVector rearrange(VectorShuffle<Double> s) {
+        return (DoubleMaxVector)
+            super.rearrangeTemplate(DoubleMaxShuffle.class,
+                                    (DoubleMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector rearrange(VectorShuffle<Double> shuffle,
+    public DoubleMaxVector rearrange(VectorShuffle<Double> shuffle,
                                   VectorMask<Double> m) {
-        return (Double64Vector)
-            super.rearrangeTemplate(Double64Shuffle.class,
-                                    Double64Mask.class,
-                                    (Double64Shuffle) shuffle,
-                                    (Double64Mask) m);  // specialize
+        return (DoubleMaxVector)
+            super.rearrangeTemplate(DoubleMaxShuffle.class,
+                                    DoubleMaxMask.class,
+                                    (DoubleMaxShuffle) shuffle,
+                                    (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector rearrange(VectorShuffle<Double> s,
+    public DoubleMaxVector rearrange(VectorShuffle<Double> s,
                                   Vector<Double> v) {
-        return (Double64Vector)
-            super.rearrangeTemplate(Double64Shuffle.class,
-                                    (Double64Shuffle) s,
-                                    (Double64Vector) v);  // specialize
+        return (DoubleMaxVector)
+            super.rearrangeTemplate(DoubleMaxShuffle.class,
+                                    (DoubleMaxShuffle) s,
+                                    (DoubleMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector compress(VectorMask<Double> m) {
-        return (Double64Vector)
-            super.compressTemplate(Double64Mask.class,
-                                   (Double64Mask) m);  // specialize
+    public DoubleMaxVector compress(VectorMask<Double> m) {
+        return (DoubleMaxVector)
+            super.compressTemplate(DoubleMaxMask.class,
+                                   (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector expand(VectorMask<Double> m) {
-        return (Double64Vector)
-            super.expandTemplate(Double64Mask.class,
-                                   (Double64Mask) m);  // specialize
+    public DoubleMaxVector expand(VectorMask<Double> m) {
+        return (DoubleMaxVector)
+            super.expandTemplate(DoubleMaxMask.class,
+                                   (DoubleMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector selectFrom(Vector<Double> v) {
-        return (Double64Vector)
-            super.selectFromTemplate((Double64Vector) v);  // specialize
+    public DoubleMaxVector selectFrom(Vector<Double> v) {
+        return (DoubleMaxVector)
+            super.selectFromTemplate((DoubleMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double64Vector selectFrom(Vector<Double> v,
+    public DoubleMaxVector selectFrom(Vector<Double> v,
                                    VectorMask<Double> m) {
-        return (Double64Vector)
-            super.selectFromTemplate((Double64Vector) v,
-                                     (Double64Mask) m);  // specialize
+        return (DoubleMaxVector)
+            super.selectFromTemplate((DoubleMaxVector) v,
+                                     (DoubleMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public double lane(int i) {
-        long bits;
-        switch(i) {
-            case 0: bits = laneHelper(0); break;
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        long bits = laneHelper(i);
         return Double.longBitsToDouble(bits);
     }
 
@@ -518,14 +517,14 @@ value class Double64Vector extends DoubleVector {
 
     @ForceInline
     @Override
-    public Double64Vector withLane(int i, double e) {
-        switch(i) {
-            case 0: return withLaneHelper(0, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public DoubleMaxVector withLane(int i, double e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Double64Vector withLaneHelper(int i, double e) {
+    public DoubleMaxVector withLaneHelper(int i, double e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Double.doubleToLongBits(e),
@@ -541,22 +540,22 @@ value class Double64Vector extends DoubleVector {
 
     // Mask
 
-    static final value class Double64Mask extends AbstractMask<Double> {
+    static final value class DoubleMaxMask extends AbstractMask<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        Double64Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF8Z) payload;
+        DoubleMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxLZ) payload;
         }
 
-        private final VectorPayloadMF8Z payload;
+        private final VectorPayloadMFMaxLZ payload;
 
-        Double64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        DoubleMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Double64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        DoubleMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -578,32 +577,32 @@ value class Double64Vector extends DoubleVector {
         @ForceInline
         @Override
         public final
-        Double64Vector toVector() {
-            return (Double64Vector) super.toVectorTemplate();  // specialize
+        DoubleMaxVector toVector() {
+            return (DoubleMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Double64Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Double64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Double64Mask.class, double.class, VLENGTH, offset, limit,
-                (o, l) -> (Double64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        DoubleMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (DoubleMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                DoubleMaxMask.class, double.class, VLENGTH, offset, limit,
+                (o, l) -> (DoubleMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Double64Mask not() {
+        public DoubleMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Double64Mask compress() {
-            return (Double64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Double64Vector.class, Double64Mask.class, ETYPE, VLENGTH, null, this,
+        public DoubleMaxMask compress() {
+            return (DoubleMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                DoubleMaxVector.class, DoubleMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -612,32 +611,32 @@ value class Double64Vector extends DoubleVector {
 
         @Override
         @ForceInline
-        public Double64Mask and(VectorMask<Double> mask) {
+        public DoubleMaxMask and(VectorMask<Double> mask) {
             Objects.requireNonNull(mask);
-            Double64Mask m = (Double64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Double64Mask.class, null,
+            DoubleMaxMask m = (DoubleMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, DoubleMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (DoubleMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Double64Mask or(VectorMask<Double> mask) {
+        public DoubleMaxMask or(VectorMask<Double> mask) {
             Objects.requireNonNull(mask);
-            Double64Mask m = (Double64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Double64Mask.class, null,
+            DoubleMaxMask m = (DoubleMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, DoubleMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (DoubleMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Double64Mask xor(VectorMask<Double> mask) {
+        public DoubleMaxMask xor(VectorMask<Double> mask) {
             Objects.requireNonNull(mask);
-            Double64Mask m = (Double64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Double64Mask.class, null,
+            DoubleMaxMask m = (DoubleMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, DoubleMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Double64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (DoubleMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -645,22 +644,22 @@ value class Double64Vector extends DoubleVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Double64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Double64Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, DoubleMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((DoubleMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Double64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Double64Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, DoubleMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((DoubleMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Double64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Double64Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, DoubleMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((DoubleMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -669,8 +668,8 @@ value class Double64Vector extends DoubleVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Double64Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> ((Double64Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, DoubleMaxMask.class, long.class, VLENGTH, this,
+                                                      (m) -> ((DoubleMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -679,8 +678,8 @@ value class Double64Vector extends DoubleVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Double64Mask.class, double.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Double64Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(DoubleMaxMask.class, double.class, VLENGTH,
+                                         this, i, (m, idx) -> (((DoubleMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -688,54 +687,54 @@ value class Double64Vector extends DoubleVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Double64Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_ne, DoubleMaxMask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Double64Mask) m).anyTrueHelper());
+                                         (m, __) -> ((DoubleMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Double64Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, DoubleMaxMask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Double64Mask) m).allTrueHelper());
+                                         (m, __) -> ((DoubleMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Double64Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Double64Mask.class, long.class, VLENGTH,
+        static DoubleMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(DoubleMaxMask.class, long.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Double64Mask  TRUE_MASK = new Double64Mask(true);
-        private static final Double64Mask FALSE_MASK = new Double64Mask(false);
+        private static final DoubleMaxMask  TRUE_MASK = new DoubleMaxMask(true);
+        private static final DoubleMaxMask FALSE_MASK = new DoubleMaxMask(false);
 
     }
 
     // Shuffle
 
-    static final value class Double64Shuffle extends AbstractShuffle<Double> {
+    static final value class DoubleMaxShuffle extends AbstractShuffle<Double> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
-        private final VectorPayloadMF8B payload;
+        private final VectorPayloadMFMaxLB payload;
 
-        Double64Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF8B) payload;
+        DoubleMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxLB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Double64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public DoubleMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Double64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public DoubleMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Double64Shuffle(int[] indexes) {
+        public DoubleMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -757,13 +756,13 @@ value class Double64Vector extends DoubleVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Double64Shuffle IOTA = new Double64Shuffle(IDENTITY);
+        static final DoubleMaxShuffle IOTA = new DoubleMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Double64Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Double64Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Double64Vector)(((AbstractShuffle<Double>)(s)).toVectorTemplate())));
+        public DoubleMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, DoubleMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((DoubleMaxVector)(((AbstractShuffle<Double>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -778,11 +777,11 @@ value class Double64Vector extends DoubleVector {
 
         @ForceInline
         @Override
-        public Double64Shuffle rearrange(VectorShuffle<Double> shuffle) {
-            Double64Shuffle s = (Double64Shuffle) shuffle;
+        public DoubleMaxShuffle rearrange(VectorShuffle<Double> shuffle) {
+            DoubleMaxShuffle s = (DoubleMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -791,7 +790,7 @@ value class Double64Vector extends DoubleVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Double64Shuffle(r);
+            return new DoubleMaxShuffle(r);
         }
     }
 
@@ -810,14 +809,14 @@ value class Double64Vector extends DoubleVector {
     @Override
     final
     DoubleVector fromArray0(double[] a, int offset, VectorMask<Double> m, int offsetInRange) {
-        return super.fromArray0Template(Double64Mask.class, a, offset, (Double64Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
     DoubleVector fromArray0(double[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Double> m) {
-        return super.fromArray0Template(Double64Mask.class, a, offset, indexMap, mapOffset, (Double64Mask) m);
+        return super.fromArray0Template(DoubleMaxMask.class, a, offset, indexMap, mapOffset, (DoubleMaxMask) m);
     }
 
 
@@ -833,7 +832,7 @@ value class Double64Vector extends DoubleVector {
     @Override
     final
     DoubleVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Double> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Double64Mask.class, ms, offset, (Double64Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(DoubleMaxMask.class, ms, offset, (DoubleMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -847,14 +846,14 @@ value class Double64Vector extends DoubleVector {
     @Override
     final
     void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double64Mask.class, a, offset, (Double64Mask) m);
+        super.intoArray0Template(DoubleMaxMask.class, a, offset, (DoubleMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoArray0(double[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Double> m) {
-        super.intoArray0Template(Double64Mask.class, a, offset, indexMap, mapOffset, (Double64Mask) m);
+        super.intoArray0Template(DoubleMaxMask.class, a, offset, indexMap, mapOffset, (DoubleMaxMask) m);
     }
 
 
@@ -862,7 +861,7 @@ value class Double64Vector extends DoubleVector {
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Double> m) {
-        super.intoMemorySegment0Template(Double64Mask.class, ms, offset, (Double64Mask) m);
+        super.intoMemorySegment0Template(DoubleMaxMask.class, ms, offset, (DoubleMaxMask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -372,9 +372,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     <M> DoubleVector ldOpMF(M memory, int offset,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                double.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                double.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
@@ -390,9 +391,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   VectorMask<Double> m,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                double.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                double.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -417,9 +419,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     DoubleVector ldLongOpMF(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                double.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                double.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putDouble(tpayload, vOffset + i * Double.BYTES, f.apply(memory, offset, i));
@@ -435,9 +438,10 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                                   VectorMask<Double> m,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                double.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                double.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Double>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -545,7 +549,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         int length = vspecies().length();
         VectorPayloadMF vec1 = vec();
         VectorPayloadMF vec2 = ((DoubleVector)o).vec();
-        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
+        VectorPayloadMF mbits = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -2973,11 +2978,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3268,11 +3271,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3464,11 +3465,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-            assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3581,12 +3580,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
-
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -4035,9 +4031,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         @Override
         @ForceInline
         public final DoubleVector zero() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == DoubleMaxVector.class)
-            //    return DoubleMaxVector.ZERO;
+            if ((Class<?>) vectorType() == DoubleMaxVector.class)
+               return DoubleMaxVector.ZERO;
             switch (vectorBitSize()) {
                 case 64: return Double64Vector.ZERO;
                 case 128: return Double128Vector.ZERO;
@@ -4050,9 +4045,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         @Override
         @ForceInline
         public final DoubleVector iota() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == DoubleMaxVector.class)
-            //    return DoubleMaxVector.IOTA;
+            if ((Class<?>) vectorType() == DoubleMaxVector.class)
+                return DoubleMaxVector.IOTA;
             switch (vectorBitSize()) {
                 case 64: return Double64Vector.IOTA;
                 case 128: return Double128Vector.IOTA;
@@ -4066,9 +4060,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         @Override
         @ForceInline
         public final VectorMask<Double> maskAll(boolean bit) {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == DoubleMaxVector.class)
-            //    return DoubleMaxVector.DoubleMaxMask.maskAll(bit);
+            if ((Class<?>) vectorType() == DoubleMaxVector.class)
+                return DoubleMaxVector.DoubleMaxMask.maskAll(bit);
             switch (vectorBitSize()) {
                 case 64: return Double64Vector.Double64Mask.maskAll(bit);
                 case 128: return Double128Vector.Double128Mask.maskAll(bit);
@@ -4103,8 +4096,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             case VectorShape.SK_128_BIT: return (DoubleSpecies) SPECIES_128;
             case VectorShape.SK_256_BIT: return (DoubleSpecies) SPECIES_256;
             case VectorShape.SK_512_BIT: return (DoubleSpecies) SPECIES_512;
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //case VectorShape.SK_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
+            case VectorShape.SK_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }
@@ -4138,13 +4130,11 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                             Double512Vector::new);
 
     /** Species representing {@link DoubleVector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
-    // FIXME: Enable once multi-field based MaxVector is supported.
-    /*public static final VectorSpecies<Double> SPECIES_MAX
+    public static final VectorSpecies<Double> SPECIES_MAX
         = new DoubleSpecies(VectorShape.S_Max_BIT,
                             DoubleMaxVector.class,
                             DoubleMaxVector.DoubleMaxMask.class,
                             DoubleMaxVector::new);
-     */
 
     /**
      * Preferred species for {@link DoubleVector}s.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -558,11 +558,11 @@ value class Float128Vector extends FloatVector {
         private final VectorPayloadMF32Z payload;
 
         Float128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Float128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -734,11 +734,11 @@ value class Float128Vector extends FloatVector {
         }
 
         public Float128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Float128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Float128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -69,8 +69,8 @@ value class Float128Vector extends FloatVector {
         return payload;
     }
 
-    static final Float128Vector ZERO = new Float128Vector(VectorPayloadMF.newInstanceFactory(float.class, 4));
-    static final Float128Vector IOTA = new Float128Vector(VectorPayloadMF.createVectPayloadInstanceF(4, (float[])(VSPECIES.iotaArray())));
+    static final Float128Vector ZERO = new Float128Vector(VectorPayloadMF.newVectorInstanceFactory(float.class, 4, false));
+    static final Float128Vector IOTA = new Float128Vector(VectorPayloadMF.createVectPayloadInstanceF(VLENGTH, (float[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -551,19 +551,20 @@ value class Float128Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        private final VectorPayloadMF32Z payload;
-
         Float128Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        private final VectorPayloadMF32Z payload;
+
         Float128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Float128Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -732,17 +733,18 @@ value class Float128Vector extends FloatVector {
             assert(indexesInRange(payload));
         }
 
+        public Float128Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Float128Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Float128Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Float128Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Float128Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -786,7 +788,7 @@ value class Float128Vector extends FloatVector {
             Float128Shuffle s = (Float128Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -566,11 +566,11 @@ value class Float256Vector extends FloatVector {
         private final VectorPayloadMF64Z payload;
 
         Float256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Float256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -742,11 +742,11 @@ value class Float256Vector extends FloatVector {
         }
 
         public Float256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Float256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Float256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -582,11 +582,11 @@ value class Float512Vector extends FloatVector {
         private final VectorPayloadMF128Z payload;
 
         Float512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Float512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -758,11 +758,11 @@ value class Float512Vector extends FloatVector {
         }
 
         public Float512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Float512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Float512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -69,8 +69,8 @@ value class Float512Vector extends FloatVector {
         return payload;
     }
 
-    static final Float512Vector ZERO = new Float512Vector(VectorPayloadMF.newInstanceFactory(float.class, 16));
-    static final Float512Vector IOTA = new Float512Vector(VectorPayloadMF.createVectPayloadInstanceF(16, (float[])(VSPECIES.iotaArray())));
+    static final Float512Vector ZERO = new Float512Vector(VectorPayloadMF.newVectorInstanceFactory(float.class, 16, false));
+    static final Float512Vector IOTA = new Float512Vector(VectorPayloadMF.createVectPayloadInstanceF(VLENGTH, (float[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -575,19 +575,20 @@ value class Float512Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        private final VectorPayloadMF128Z payload;
-
         Float512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        private final VectorPayloadMF128Z payload;
+
         Float512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Float512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -756,17 +757,18 @@ value class Float512Vector extends FloatVector {
             assert(indexesInRange(payload));
         }
 
+        public Float512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Float512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Float512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Float512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Float512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -810,7 +812,7 @@ value class Float512Vector extends FloatVector {
             Float512Shuffle s = (Float512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -554,11 +554,11 @@ value class Float64Vector extends FloatVector {
         private final VectorPayloadMF16Z payload;
 
         Float64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Float64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -730,11 +730,11 @@ value class Float64Vector extends FloatVector {
         }
 
         public Float64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Float64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Float64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -69,8 +69,8 @@ value class Float64Vector extends FloatVector {
         return payload;
     }
 
-    static final Float64Vector ZERO = new Float64Vector(VectorPayloadMF.newInstanceFactory(float.class, 2));
-    static final Float64Vector IOTA = new Float64Vector(VectorPayloadMF.createVectPayloadInstanceF(2, (float[])(VSPECIES.iotaArray())));
+    static final Float64Vector ZERO = new Float64Vector(VectorPayloadMF.newVectorInstanceFactory(float.class, 2, false));
+    static final Float64Vector IOTA = new Float64Vector(VectorPayloadMF.createVectPayloadInstanceF(VLENGTH, (float[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -547,19 +547,20 @@ value class Float64Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        private final VectorPayloadMF16Z payload;
-
         Float64Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        private final VectorPayloadMF16Z payload;
+
         Float64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Float64Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -728,17 +729,18 @@ value class Float64Vector extends FloatVector {
             assert(indexesInRange(payload));
         }
 
+        public Float64Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Float64Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Float64Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Float64Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Float64Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -782,7 +784,7 @@ value class Float64Vector extends FloatVector {
             Float64Shuffle s = (Float64Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -551,11 +551,11 @@ value class FloatMaxVector extends FloatVector {
         private final VectorPayloadMFMaxIZ payload;
 
         FloatMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         FloatMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -727,11 +727,11 @@ value class FloatMaxVector extends FloatVector {
         }
 
         public FloatMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public FloatMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public FloatMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Float256Vector extends FloatVector {
+value class FloatMaxVector extends FloatVector {
     static final FloatSpecies VSPECIES =
-        (FloatSpecies) FloatVector.SPECIES_256;
+        (FloatSpecies) FloatVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Float256Vector> VCLASS = Float256Vector.class;
+    static final Class<FloatMaxVector> VCLASS = FloatMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Float256Vector extends FloatVector {
 
     static final Class<Float> ETYPE = float.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256F.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxF.class);
 
-    private final VectorPayloadMF256F payload;
+    private final VectorPayloadMFMaxF payload;
 
-    Float256Vector(Object value) {
-        this.payload = (VectorPayloadMF256F) value;
+    FloatMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxF) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Float256Vector extends FloatVector {
         return payload;
     }
 
-    static final Float256Vector ZERO = new Float256Vector(VectorPayloadMF.newVectorInstanceFactory(float.class, 8, false));
-    static final Float256Vector IOTA = new Float256Vector(VectorPayloadMF.createVectPayloadInstanceF(VLENGTH, (float[])(VSPECIES.iotaArray()), false));
+    static final FloatMaxVector ZERO = new FloatMaxVector(VectorPayloadMF.newVectorInstanceFactory(float.class, 0, true));
+    static final FloatMaxVector IOTA = new FloatMaxVector(VectorPayloadMF.createVectPayloadInstanceF(VLENGTH, (float[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,60 +121,60 @@ value class Float256Vector extends FloatVector {
 
     @Override
     @ForceInline
-    public final Float256Vector broadcast(float e) {
-        return (Float256Vector) super.broadcastTemplate(e);  // specialize
+    public final FloatMaxVector broadcast(float e) {
+        return (FloatMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float256Vector broadcast(long e) {
-        return (Float256Vector) super.broadcastTemplate(e);  // specialize
+    public final FloatMaxVector broadcast(long e) {
+        return (FloatMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Float256Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Float256Mask(payload);
+    FloatMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new FloatMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Float256Shuffle iotaShuffle() { return Float256Shuffle.IOTA; }
+    FloatMaxShuffle iotaShuffle() { return FloatMaxShuffle.IOTA; }
 
     @ForceInline
-    Float256Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    FloatMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Float256Shuffle)VectorSupport.shuffleIota(ETYPE, Float256Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (FloatMaxShuffle)VectorSupport.shuffleIota(ETYPE, FloatMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Float256Shuffle)VectorSupport.shuffleIota(ETYPE, Float256Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (FloatMaxShuffle)VectorSupport.shuffleIota(ETYPE, FloatMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Float256Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Float256Shuffle(indexes); }
+    FloatMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new FloatMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Float256Shuffle shuffleFromArray(int[] indexes, int i) { return new Float256Shuffle(indexes, i); }
+    FloatMaxShuffle shuffleFromArray(int[] indexes, int i) { return new FloatMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Float256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float256Shuffle(fn); }
+    FloatMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new FloatMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Float256Vector vectorFactory(VectorPayloadMF vec) {
-        return new Float256Vector(vec);
+    FloatMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new FloatMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte256Vector asByteVectorRaw() {
-        return (Byte256Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ value class Float256Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float256Vector uOpMF(FUnOp f) {
-        return (Float256Vector) super.uOpTemplateMF(f);  // specialize
+    FloatMaxVector uOpMF(FUnOp f) {
+        return (FloatMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float256Vector uOpMF(VectorMask<Float> m, FUnOp f) {
-        return (Float256Vector)
-            super.uOpTemplateMF((Float256Mask)m, f);  // specialize
+    FloatMaxVector uOpMF(VectorMask<Float> m, FUnOp f) {
+        return (FloatMaxVector)
+            super.uOpTemplateMF((FloatMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Float256Vector bOpMF(Vector<Float> v, FBinOp f) {
-        return (Float256Vector) super.bOpTemplateMF((Float256Vector)v, f);  // specialize
+    FloatMaxVector bOpMF(Vector<Float> v, FBinOp f) {
+        return (FloatMaxVector) super.bOpTemplateMF((FloatMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float256Vector bOpMF(Vector<Float> v,
+    FloatMaxVector bOpMF(Vector<Float> v,
                      VectorMask<Float> m, FBinOp f) {
-        return (Float256Vector)
-            super.bOpTemplateMF((Float256Vector)v, (Float256Mask)m,
+        return (FloatMaxVector)
+            super.bOpTemplateMF((FloatMaxVector)v, (FloatMaxMask)m,
                                 f);  // specialize
     }
 
@@ -219,19 +219,19 @@ value class Float256Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float256Vector tOpMF(Vector<Float> v1, Vector<Float> v2, FTriOp f) {
-        return (Float256Vector)
-            super.tOpTemplateMF((Float256Vector)v1, (Float256Vector)v2,
+    FloatMaxVector tOpMF(Vector<Float> v1, Vector<Float> v2, FTriOp f) {
+        return (FloatMaxVector)
+            super.tOpTemplateMF((FloatMaxVector)v1, (FloatMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float256Vector tOpMF(Vector<Float> v1, Vector<Float> v2,
+    FloatMaxVector tOpMF(Vector<Float> v1, Vector<Float> v2,
                      VectorMask<Float> m, FTriOp f) {
-        return (Float256Vector)
-            super.tOpTemplateMF((Float256Vector)v1, (Float256Vector)v2,
-                                (Float256Mask)m, f);  // specialize
+        return (FloatMaxVector)
+            super.tOpTemplateMF((FloatMaxVector)v1, (FloatMaxVector)v2,
+                                (FloatMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -269,26 +269,26 @@ value class Float256Vector extends FloatVector {
 
     @Override
     @ForceInline
-    public Float256Vector lanewise(Unary op) {
-        return (Float256Vector) super.lanewiseTemplate(op);  // specialize
+    public FloatMaxVector lanewise(Unary op) {
+        return (FloatMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector lanewise(Unary op, VectorMask<Float> m) {
-        return (Float256Vector) super.lanewiseTemplate(op, Float256Mask.class, (Float256Mask) m);  // specialize
+    public FloatMaxVector lanewise(Unary op, VectorMask<Float> m) {
+        return (FloatMaxVector) super.lanewiseTemplate(op, FloatMaxMask.class, (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector lanewise(Binary op, Vector<Float> v) {
-        return (Float256Vector) super.lanewiseTemplate(op, v);  // specialize
+    public FloatMaxVector lanewise(Binary op, Vector<Float> v) {
+        return (FloatMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector lanewise(Binary op, Vector<Float> v, VectorMask<Float> m) {
-        return (Float256Vector) super.lanewiseTemplate(op, Float256Mask.class, v, (Float256Mask) m);  // specialize
+    public FloatMaxVector lanewise(Binary op, Vector<Float> v, VectorMask<Float> m) {
+        return (FloatMaxVector) super.lanewiseTemplate(op, FloatMaxMask.class, v, (FloatMaxMask) m);  // specialize
     }
 
 
@@ -296,24 +296,24 @@ value class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public final
-    Float256Vector
+    FloatMaxVector
     lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2) {
-        return (Float256Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (FloatMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float256Vector
+    FloatMaxVector
     lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2, VectorMask<Float> m) {
-        return (Float256Vector) super.lanewiseTemplate(op, Float256Mask.class, v1, v2, (Float256Mask) m);  // specialize
+        return (FloatMaxVector) super.lanewiseTemplate(op, FloatMaxMask.class, v1, v2, (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float256Vector addIndex(int scale) {
-        return (Float256Vector) super.addIndexTemplate(scale);  // specialize
+    FloatMaxVector addIndex(int scale) {
+        return (FloatMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -328,7 +328,7 @@ value class Float256Vector extends FloatVector {
     @ForceInline
     public final float reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Float> m) {
-        return super.reduceLanesTemplate(op, Float256Mask.class, (Float256Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, FloatMaxMask.class, (FloatMaxMask) m);  // specialized
     }
 
     @Override
@@ -341,174 +341,166 @@ value class Float256Vector extends FloatVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Float> m) {
-        return (long) super.reduceLanesTemplate(op, Float256Mask.class, (Float256Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, FloatMaxMask.class, (FloatMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Float> toShuffle() {
-        return super.toShuffleTemplate(Float256Shuffle.class); // specialize
+        return super.toShuffleTemplate(FloatMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Float256Mask test(Test op) {
-        return super.testTemplate(Float256Mask.class, op);  // specialize
+    public final FloatMaxMask test(Test op) {
+        return super.testTemplate(FloatMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float256Mask test(Test op, VectorMask<Float> m) {
-        return super.testTemplate(Float256Mask.class, op, (Float256Mask) m);  // specialize
+    public final FloatMaxMask test(Test op, VectorMask<Float> m) {
+        return super.testTemplate(FloatMaxMask.class, op, (FloatMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Float256Mask compare(Comparison op, Vector<Float> v) {
-        return super.compareTemplate(Float256Mask.class, op, v);  // specialize
+    public final FloatMaxMask compare(Comparison op, Vector<Float> v) {
+        return super.compareTemplate(FloatMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float256Mask compare(Comparison op, float s) {
-        return super.compareTemplate(Float256Mask.class, op, s);  // specialize
+    public final FloatMaxMask compare(Comparison op, float s) {
+        return super.compareTemplate(FloatMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float256Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Float256Mask.class, op, s);  // specialize
+    public final FloatMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(FloatMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float256Mask compare(Comparison op, Vector<Float> v, VectorMask<Float> m) {
-        return super.compareTemplate(Float256Mask.class, op, v, (Float256Mask) m);
+    public final FloatMaxMask compare(Comparison op, Vector<Float> v, VectorMask<Float> m) {
+        return super.compareTemplate(FloatMaxMask.class, op, v, (FloatMaxMask) m);
     }
 
 
     @Override
     @ForceInline
-    public Float256Vector blend(Vector<Float> v, VectorMask<Float> m) {
-        return (Float256Vector)
-            super.blendTemplate(Float256Mask.class,
-                                (Float256Vector) v,
-                                (Float256Mask) m);  // specialize
+    public FloatMaxVector blend(Vector<Float> v, VectorMask<Float> m) {
+        return (FloatMaxVector)
+            super.blendTemplate(FloatMaxMask.class,
+                                (FloatMaxVector) v,
+                                (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector slice(int origin, Vector<Float> v) {
-        return (Float256Vector) super.sliceTemplate(origin, v);  // specialize
+    public FloatMaxVector slice(int origin, Vector<Float> v) {
+        return (FloatMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector slice(int origin) {
-        return (Float256Vector) super.sliceTemplate(origin);  // specialize
+    public FloatMaxVector slice(int origin) {
+        return (FloatMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float256Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public FloatMaxVector unslice(int origin, Vector<Float> w, int part) {
+        return (FloatMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m) {
-        return (Float256Vector)
-            super.unsliceTemplate(Float256Mask.class,
+    public FloatMaxVector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m) {
+        return (FloatMaxVector)
+            super.unsliceTemplate(FloatMaxMask.class,
                                   origin, w, part,
-                                  (Float256Mask) m);  // specialize
+                                  (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector unslice(int origin) {
-        return (Float256Vector) super.unsliceTemplate(origin);  // specialize
+    public FloatMaxVector unslice(int origin) {
+        return (FloatMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector rearrange(VectorShuffle<Float> s) {
-        return (Float256Vector)
-            super.rearrangeTemplate(Float256Shuffle.class,
-                                    (Float256Shuffle) s);  // specialize
+    public FloatMaxVector rearrange(VectorShuffle<Float> s) {
+        return (FloatMaxVector)
+            super.rearrangeTemplate(FloatMaxShuffle.class,
+                                    (FloatMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector rearrange(VectorShuffle<Float> shuffle,
+    public FloatMaxVector rearrange(VectorShuffle<Float> shuffle,
                                   VectorMask<Float> m) {
-        return (Float256Vector)
-            super.rearrangeTemplate(Float256Shuffle.class,
-                                    Float256Mask.class,
-                                    (Float256Shuffle) shuffle,
-                                    (Float256Mask) m);  // specialize
+        return (FloatMaxVector)
+            super.rearrangeTemplate(FloatMaxShuffle.class,
+                                    FloatMaxMask.class,
+                                    (FloatMaxShuffle) shuffle,
+                                    (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector rearrange(VectorShuffle<Float> s,
+    public FloatMaxVector rearrange(VectorShuffle<Float> s,
                                   Vector<Float> v) {
-        return (Float256Vector)
-            super.rearrangeTemplate(Float256Shuffle.class,
-                                    (Float256Shuffle) s,
-                                    (Float256Vector) v);  // specialize
+        return (FloatMaxVector)
+            super.rearrangeTemplate(FloatMaxShuffle.class,
+                                    (FloatMaxShuffle) s,
+                                    (FloatMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector compress(VectorMask<Float> m) {
-        return (Float256Vector)
-            super.compressTemplate(Float256Mask.class,
-                                   (Float256Mask) m);  // specialize
+    public FloatMaxVector compress(VectorMask<Float> m) {
+        return (FloatMaxVector)
+            super.compressTemplate(FloatMaxMask.class,
+                                   (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector expand(VectorMask<Float> m) {
-        return (Float256Vector)
-            super.expandTemplate(Float256Mask.class,
-                                   (Float256Mask) m);  // specialize
+    public FloatMaxVector expand(VectorMask<Float> m) {
+        return (FloatMaxVector)
+            super.expandTemplate(FloatMaxMask.class,
+                                   (FloatMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector selectFrom(Vector<Float> v) {
-        return (Float256Vector)
-            super.selectFromTemplate((Float256Vector) v);  // specialize
+    public FloatMaxVector selectFrom(Vector<Float> v) {
+        return (FloatMaxVector)
+            super.selectFromTemplate((FloatMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float256Vector selectFrom(Vector<Float> v,
+    public FloatMaxVector selectFrom(Vector<Float> v,
                                    VectorMask<Float> m) {
-        return (Float256Vector)
-            super.selectFromTemplate((Float256Vector) v,
-                                     (Float256Mask) m);  // specialize
+        return (FloatMaxVector)
+            super.selectFromTemplate((FloatMaxVector) v,
+                                     (FloatMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public float lane(int i) {
-        int bits;
-        switch(i) {
-            case 0: bits = laneHelper(0); break;
-            case 1: bits = laneHelper(1); break;
-            case 2: bits = laneHelper(2); break;
-            case 3: bits = laneHelper(3); break;
-            case 4: bits = laneHelper(4); break;
-            case 5: bits = laneHelper(5); break;
-            case 6: bits = laneHelper(6); break;
-            case 7: bits = laneHelper(7); break;
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        int bits = laneHelper(i);
         return Float.intBitsToFloat(bits);
     }
 
@@ -525,21 +517,14 @@ value class Float256Vector extends FloatVector {
 
     @ForceInline
     @Override
-    public Float256Vector withLane(int i, float e) {
-        switch(i) {
-            case 0: return withLaneHelper(0, e);
-            case 1: return withLaneHelper(1, e);
-            case 2: return withLaneHelper(2, e);
-            case 3: return withLaneHelper(3, e);
-            case 4: return withLaneHelper(4, e);
-            case 5: return withLaneHelper(5, e);
-            case 6: return withLaneHelper(6, e);
-            case 7: return withLaneHelper(7, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public FloatMaxVector withLane(int i, float e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Float256Vector withLaneHelper(int i, float e) {
+    public FloatMaxVector withLaneHelper(int i, float e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)Float.floatToIntBits(e),
@@ -555,22 +540,22 @@ value class Float256Vector extends FloatVector {
 
     // Mask
 
-    static final value class Float256Mask extends AbstractMask<Float> {
+    static final value class FloatMaxMask extends AbstractMask<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        Float256Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64Z) payload;
+        FloatMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxIZ) payload;
         }
 
-        private final VectorPayloadMF64Z payload;
+        private final VectorPayloadMFMaxIZ payload;
 
-        Float256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        FloatMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Float256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        FloatMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -592,32 +577,32 @@ value class Float256Vector extends FloatVector {
         @ForceInline
         @Override
         public final
-        Float256Vector toVector() {
-            return (Float256Vector) super.toVectorTemplate();  // specialize
+        FloatMaxVector toVector() {
+            return (FloatMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Float256Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Float256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float256Mask.class, float.class, VLENGTH, offset, limit,
-                (o, l) -> (Float256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        FloatMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (FloatMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                FloatMaxMask.class, float.class, VLENGTH, offset, limit,
+                (o, l) -> (FloatMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Float256Mask not() {
+        public FloatMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Float256Mask compress() {
-            return (Float256Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Float256Vector.class, Float256Mask.class, ETYPE, VLENGTH, null, this,
+        public FloatMaxMask compress() {
+            return (FloatMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                FloatMaxVector.class, FloatMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -626,32 +611,32 @@ value class Float256Vector extends FloatVector {
 
         @Override
         @ForceInline
-        public Float256Mask and(VectorMask<Float> mask) {
+        public FloatMaxMask and(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
-            Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Float256Mask.class, null,
+            FloatMaxMask m = (FloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, FloatMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (FloatMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Float256Mask or(VectorMask<Float> mask) {
+        public FloatMaxMask or(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
-            Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Float256Mask.class, null,
+            FloatMaxMask m = (FloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, FloatMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (FloatMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Float256Mask xor(VectorMask<Float> mask) {
+        public FloatMaxMask xor(VectorMask<Float> mask) {
             Objects.requireNonNull(mask);
-            Float256Mask m = (Float256Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float256Mask.class, null,
+            FloatMaxMask m = (FloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, FloatMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Float256Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (FloatMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -659,22 +644,22 @@ value class Float256Vector extends FloatVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Float256Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Float256Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, FloatMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((FloatMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Float256Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Float256Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, FloatMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((FloatMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Float256Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Float256Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, FloatMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((FloatMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -683,8 +668,8 @@ value class Float256Vector extends FloatVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Float256Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> ((Float256Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, FloatMaxMask.class, int.class, VLENGTH, this,
+                                                      (m) -> ((FloatMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -693,8 +678,8 @@ value class Float256Vector extends FloatVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Float256Mask.class, float.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Float256Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(FloatMaxMask.class, float.class, VLENGTH,
+                                         this, i, (m, idx) -> (((FloatMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -702,54 +687,54 @@ value class Float256Vector extends FloatVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Float256Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_ne, FloatMaxMask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Float256Mask) m).anyTrueHelper());
+                                         (m, __) -> ((FloatMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Float256Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, FloatMaxMask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Float256Mask) m).allTrueHelper());
+                                         (m, __) -> ((FloatMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Float256Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Float256Mask.class, int.class, VLENGTH,
+        static FloatMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(FloatMaxMask.class, int.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Float256Mask  TRUE_MASK = new Float256Mask(true);
-        private static final Float256Mask FALSE_MASK = new Float256Mask(false);
+        private static final FloatMaxMask  TRUE_MASK = new FloatMaxMask(true);
+        private static final FloatMaxMask FALSE_MASK = new FloatMaxMask(false);
 
     }
 
     // Shuffle
 
-    static final value class Float256Shuffle extends AbstractShuffle<Float> {
+    static final value class FloatMaxShuffle extends AbstractShuffle<Float> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
-        private final VectorPayloadMF64B payload;
+        private final VectorPayloadMFMaxIB payload;
 
-        Float256Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64B) payload;
+        FloatMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxIB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Float256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public FloatMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Float256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public FloatMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Float256Shuffle(int[] indexes) {
+        public FloatMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -771,13 +756,13 @@ value class Float256Vector extends FloatVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Float256Shuffle IOTA = new Float256Shuffle(IDENTITY);
+        static final FloatMaxShuffle IOTA = new FloatMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Float256Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Float256Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Float256Vector)(((AbstractShuffle<Float>)(s)).toVectorTemplate())));
+        public FloatMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, FloatMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((FloatMaxVector)(((AbstractShuffle<Float>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -792,11 +777,11 @@ value class Float256Vector extends FloatVector {
 
         @ForceInline
         @Override
-        public Float256Shuffle rearrange(VectorShuffle<Float> shuffle) {
-            Float256Shuffle s = (Float256Shuffle) shuffle;
+        public FloatMaxShuffle rearrange(VectorShuffle<Float> shuffle) {
+            FloatMaxShuffle s = (FloatMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -805,7 +790,7 @@ value class Float256Vector extends FloatVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Float256Shuffle(r);
+            return new FloatMaxShuffle(r);
         }
     }
 
@@ -824,14 +809,14 @@ value class Float256Vector extends FloatVector {
     @Override
     final
     FloatVector fromArray0(float[] a, int offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromArray0Template(Float256Mask.class, a, offset, (Float256Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
     FloatVector fromArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        return super.fromArray0Template(Float256Mask.class, a, offset, indexMap, mapOffset, (Float256Mask) m);
+        return super.fromArray0Template(FloatMaxMask.class, a, offset, indexMap, mapOffset, (FloatMaxMask) m);
     }
 
 
@@ -847,7 +832,7 @@ value class Float256Vector extends FloatVector {
     @Override
     final
     FloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Float256Mask.class, ms, offset, (Float256Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(FloatMaxMask.class, ms, offset, (FloatMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -861,14 +846,14 @@ value class Float256Vector extends FloatVector {
     @Override
     final
     void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float256Mask.class, a, offset, (Float256Mask) m);
+        super.intoArray0Template(FloatMaxMask.class, a, offset, (FloatMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        super.intoArray0Template(Float256Mask.class, a, offset, indexMap, mapOffset, (Float256Mask) m);
+        super.intoArray0Template(FloatMaxMask.class, a, offset, indexMap, mapOffset, (FloatMaxMask) m);
     }
 
 
@@ -876,7 +861,7 @@ value class Float256Vector extends FloatVector {
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m) {
-        super.intoMemorySegment0Template(Float256Mask.class, ms, offset, (Float256Mask) m);
+        super.intoMemorySegment0Template(FloatMaxMask.class, ms, offset, (FloatMaxMask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -372,9 +372,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     <M> FloatVector ldOpMF(M memory, int offset,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                float.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                float.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
@@ -390,9 +391,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   VectorMask<Float> m,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                float.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                float.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -417,9 +419,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     FloatVector ldLongOpMF(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                float.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                float.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putFloat(tpayload, vOffset + i * Float.BYTES, f.apply(memory, offset, i));
@@ -435,9 +438,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                   VectorMask<Float> m,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                float.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                float.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Float>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -545,7 +549,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         int length = vspecies().length();
         VectorPayloadMF vec1 = vec();
         VectorPayloadMF vec2 = ((FloatVector)o).vec();
-        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
+        VectorPayloadMF mbits = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -3976,9 +3981,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         @Override
         @ForceInline
         public final FloatVector zero() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == FloatMaxVector.class)
-            //    return FloatMaxVector.ZERO;
+            if ((Class<?>) vectorType() == FloatMaxVector.class)
+               return FloatMaxVector.ZERO;
             switch (vectorBitSize()) {
                 case 64: return Float64Vector.ZERO;
                 case 128: return Float128Vector.ZERO;
@@ -3991,9 +3995,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         @Override
         @ForceInline
         public final FloatVector iota() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == FloatMaxVector.class)
-            //    return FloatMaxVector.IOTA;
+            if ((Class<?>) vectorType() == FloatMaxVector.class)
+                return FloatMaxVector.IOTA;
             switch (vectorBitSize()) {
                 case 64: return Float64Vector.IOTA;
                 case 128: return Float128Vector.IOTA;
@@ -4007,9 +4010,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         @Override
         @ForceInline
         public final VectorMask<Float> maskAll(boolean bit) {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == FloatMaxVector.class)
-            //    return FloatMaxVector.FloatMaxMask.maskAll(bit);
+            if ((Class<?>) vectorType() == FloatMaxVector.class)
+                return FloatMaxVector.FloatMaxMask.maskAll(bit);
             switch (vectorBitSize()) {
                 case 64: return Float64Vector.Float64Mask.maskAll(bit);
                 case 128: return Float128Vector.Float128Mask.maskAll(bit);
@@ -4044,8 +4046,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
             case VectorShape.SK_128_BIT: return (FloatSpecies) SPECIES_128;
             case VectorShape.SK_256_BIT: return (FloatSpecies) SPECIES_256;
             case VectorShape.SK_512_BIT: return (FloatSpecies) SPECIES_512;
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //case VectorShape.SK_Max_BIT: return (FloatSpecies) SPECIES_MAX;
+            case VectorShape.SK_Max_BIT: return (FloatSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }
@@ -4079,13 +4080,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
                             Float512Vector::new);
 
     /** Species representing {@link FloatVector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
-    // FIXME: Enable once multi-field based MaxVector is supported.
-    /*public static final VectorSpecies<Float> SPECIES_MAX
+    public static final VectorSpecies<Float> SPECIES_MAX
         = new FloatSpecies(VectorShape.S_Max_BIT,
                             FloatMaxVector.class,
                             FloatMaxVector.FloatMaxMask.class,
                             FloatMaxVector::new);
-     */
 
     /**
      * Preferred species for {@link FloatVector}s.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -569,11 +569,11 @@ value class Int128Vector extends IntVector {
         private final VectorPayloadMF32Z payload;
 
         Int128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Int128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -745,11 +745,11 @@ value class Int128Vector extends IntVector {
         }
 
         public Int128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Int128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Int128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -69,8 +69,8 @@ value class Int128Vector extends IntVector {
         return payload;
     }
 
-    static final Int128Vector ZERO = new Int128Vector(VectorPayloadMF.newInstanceFactory(int.class, 4));
-    static final Int128Vector IOTA = new Int128Vector(VectorPayloadMF.createVectPayloadInstanceI(4, (int[])(VSPECIES.iotaArray())));
+    static final Int128Vector ZERO = new Int128Vector(VectorPayloadMF.newVectorInstanceFactory(int.class, 4, false));
+    static final Int128Vector IOTA = new Int128Vector(VectorPayloadMF.createVectPayloadInstanceI(VLENGTH, (int[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -562,19 +562,20 @@ value class Int128Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        private final VectorPayloadMF32Z payload;
-
         Int128Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        private final VectorPayloadMF32Z payload;
+
         Int128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Int128Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -743,17 +744,18 @@ value class Int128Vector extends IntVector {
             assert(indexesInRange(payload));
         }
 
+        public Int128Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Int128Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Int128Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Int128Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Int128Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -797,7 +799,7 @@ value class Int128Vector extends IntVector {
             Int128Shuffle s = (Int128Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -577,11 +577,11 @@ value class Int256Vector extends IntVector {
         private final VectorPayloadMF64Z payload;
 
         Int256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Int256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -753,11 +753,11 @@ value class Int256Vector extends IntVector {
         }
 
         public Int256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Int256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Int256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -69,8 +69,8 @@ value class Int256Vector extends IntVector {
         return payload;
     }
 
-    static final Int256Vector ZERO = new Int256Vector(VectorPayloadMF.newInstanceFactory(int.class, 8));
-    static final Int256Vector IOTA = new Int256Vector(VectorPayloadMF.createVectPayloadInstanceI(8, (int[])(VSPECIES.iotaArray())));
+    static final Int256Vector ZERO = new Int256Vector(VectorPayloadMF.newVectorInstanceFactory(int.class, 8, false));
+    static final Int256Vector IOTA = new Int256Vector(VectorPayloadMF.createVectPayloadInstanceI(VLENGTH, (int[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -570,19 +570,20 @@ value class Int256Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        private final VectorPayloadMF64Z payload;
-
         Int256Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        private final VectorPayloadMF64Z payload;
+
         Int256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Int256Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -751,17 +752,18 @@ value class Int256Vector extends IntVector {
             assert(indexesInRange(payload));
         }
 
+        public Int256Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Int256Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Int256Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Int256Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Int256Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -805,7 +807,7 @@ value class Int256Vector extends IntVector {
             Int256Shuffle s = (Int256Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -593,11 +593,11 @@ value class Int512Vector extends IntVector {
         private final VectorPayloadMF128Z payload;
 
         Int512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Int512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -769,11 +769,11 @@ value class Int512Vector extends IntVector {
         }
 
         public Int512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Int512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Int512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -69,8 +69,8 @@ value class Int512Vector extends IntVector {
         return payload;
     }
 
-    static final Int512Vector ZERO = new Int512Vector(VectorPayloadMF.newInstanceFactory(int.class, 16));
-    static final Int512Vector IOTA = new Int512Vector(VectorPayloadMF.createVectPayloadInstanceI(16, (int[])(VSPECIES.iotaArray())));
+    static final Int512Vector ZERO = new Int512Vector(VectorPayloadMF.newVectorInstanceFactory(int.class, 16, false));
+    static final Int512Vector IOTA = new Int512Vector(VectorPayloadMF.createVectPayloadInstanceI(VLENGTH, (int[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -586,19 +586,20 @@ value class Int512Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        private final VectorPayloadMF128Z payload;
-
         Int512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        private final VectorPayloadMF128Z payload;
+
         Int512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Int512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -767,17 +768,18 @@ value class Int512Vector extends IntVector {
             assert(indexesInRange(payload));
         }
 
+        public Int512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Int512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Int512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Int512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Int512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -821,7 +823,7 @@ value class Int512Vector extends IntVector {
             Int512Shuffle s = (Int512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -565,11 +565,11 @@ value class Int64Vector extends IntVector {
         private final VectorPayloadMF16Z payload;
 
         Int64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Int64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -741,11 +741,11 @@ value class Int64Vector extends IntVector {
         }
 
         public Int64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Int64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Int64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -563,11 +563,11 @@ value class IntMaxVector extends IntVector {
         private final VectorPayloadMFMaxIZ payload;
 
         IntMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         IntMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -753,11 +753,11 @@ value class IntMaxVector extends IntVector {
         }
 
         public IntMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public IntMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public IntMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Int64Vector extends IntVector {
+value class IntMaxVector extends IntVector {
     static final IntSpecies VSPECIES =
-        (IntSpecies) IntVector.SPECIES_64;
+        (IntSpecies) IntVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Int64Vector> VCLASS = Int64Vector.class;
+    static final Class<IntMaxVector> VCLASS = IntMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Int64Vector extends IntVector {
 
     static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64I.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxI.class);
 
-    private final VectorPayloadMF64I payload;
+    private final VectorPayloadMFMaxI payload;
 
-    Int64Vector(Object value) {
-        this.payload = (VectorPayloadMF64I) value;
+    IntMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxI) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Int64Vector extends IntVector {
         return payload;
     }
 
-    static final Int64Vector ZERO = new Int64Vector(VectorPayloadMF.newVectorInstanceFactory(int.class, 2, false));
-    static final Int64Vector IOTA = new Int64Vector(VectorPayloadMF.createVectPayloadInstanceI(VLENGTH, (int[])(VSPECIES.iotaArray()), false));
+    static final IntMaxVector ZERO = new IntMaxVector(VectorPayloadMF.newVectorInstanceFactory(int.class, 0, true));
+    static final IntMaxVector IOTA = new IntMaxVector(VectorPayloadMF.createVectPayloadInstanceI(VLENGTH, (int[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,60 +121,60 @@ value class Int64Vector extends IntVector {
 
     @Override
     @ForceInline
-    public final Int64Vector broadcast(int e) {
-        return (Int64Vector) super.broadcastTemplate(e);  // specialize
+    public final IntMaxVector broadcast(int e) {
+        return (IntMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Int64Vector broadcast(long e) {
-        return (Int64Vector) super.broadcastTemplate(e);  // specialize
+    public final IntMaxVector broadcast(long e) {
+        return (IntMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Int64Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Int64Mask(payload);
+    IntMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new IntMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Int64Shuffle iotaShuffle() { return Int64Shuffle.IOTA; }
+    IntMaxShuffle iotaShuffle() { return IntMaxShuffle.IOTA; }
 
     @ForceInline
-    Int64Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    IntMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Int64Shuffle)VectorSupport.shuffleIota(ETYPE, Int64Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (IntMaxShuffle)VectorSupport.shuffleIota(ETYPE, IntMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Int64Shuffle)VectorSupport.shuffleIota(ETYPE, Int64Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (IntMaxShuffle)VectorSupport.shuffleIota(ETYPE, IntMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Int64Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Int64Shuffle(indexes); }
+    IntMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new IntMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Int64Shuffle shuffleFromArray(int[] indexes, int i) { return new Int64Shuffle(indexes, i); }
+    IntMaxShuffle shuffleFromArray(int[] indexes, int i) { return new IntMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Int64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Int64Shuffle(fn); }
+    IntMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new IntMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Int64Vector vectorFactory(VectorPayloadMF vec) {
-        return new Int64Vector(vec);
+    IntMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new IntMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte64Vector asByteVectorRaw() {
-        return (Byte64Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ value class Int64Vector extends IntVector {
 
     @ForceInline
     final @Override
-    Int64Vector uOpMF(FUnOp f) {
-        return (Int64Vector) super.uOpTemplateMF(f);  // specialize
+    IntMaxVector uOpMF(FUnOp f) {
+        return (IntMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Int64Vector uOpMF(VectorMask<Integer> m, FUnOp f) {
-        return (Int64Vector)
-            super.uOpTemplateMF((Int64Mask)m, f);  // specialize
+    IntMaxVector uOpMF(VectorMask<Integer> m, FUnOp f) {
+        return (IntMaxVector)
+            super.uOpTemplateMF((IntMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Int64Vector bOpMF(Vector<Integer> v, FBinOp f) {
-        return (Int64Vector) super.bOpTemplateMF((Int64Vector)v, f);  // specialize
+    IntMaxVector bOpMF(Vector<Integer> v, FBinOp f) {
+        return (IntMaxVector) super.bOpTemplateMF((IntMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Int64Vector bOpMF(Vector<Integer> v,
+    IntMaxVector bOpMF(Vector<Integer> v,
                      VectorMask<Integer> m, FBinOp f) {
-        return (Int64Vector)
-            super.bOpTemplateMF((Int64Vector)v, (Int64Mask)m,
+        return (IntMaxVector)
+            super.bOpTemplateMF((IntMaxVector)v, (IntMaxMask)m,
                                 f);  // specialize
     }
 
@@ -219,19 +219,19 @@ value class Int64Vector extends IntVector {
 
     @ForceInline
     final @Override
-    Int64Vector tOpMF(Vector<Integer> v1, Vector<Integer> v2, FTriOp f) {
-        return (Int64Vector)
-            super.tOpTemplateMF((Int64Vector)v1, (Int64Vector)v2,
+    IntMaxVector tOpMF(Vector<Integer> v1, Vector<Integer> v2, FTriOp f) {
+        return (IntMaxVector)
+            super.tOpTemplateMF((IntMaxVector)v1, (IntMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Int64Vector tOpMF(Vector<Integer> v1, Vector<Integer> v2,
+    IntMaxVector tOpMF(Vector<Integer> v1, Vector<Integer> v2,
                      VectorMask<Integer> m, FTriOp f) {
-        return (Int64Vector)
-            super.tOpTemplateMF((Int64Vector)v1, (Int64Vector)v2,
-                                (Int64Mask)m, f);  // specialize
+        return (IntMaxVector)
+            super.tOpTemplateMF((IntMaxVector)v1, (IntMaxVector)v2,
+                                (IntMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -269,64 +269,64 @@ value class Int64Vector extends IntVector {
 
     @Override
     @ForceInline
-    public Int64Vector lanewise(Unary op) {
-        return (Int64Vector) super.lanewiseTemplate(op);  // specialize
+    public IntMaxVector lanewise(Unary op) {
+        return (IntMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector lanewise(Unary op, VectorMask<Integer> m) {
-        return (Int64Vector) super.lanewiseTemplate(op, Int64Mask.class, (Int64Mask) m);  // specialize
+    public IntMaxVector lanewise(Unary op, VectorMask<Integer> m) {
+        return (IntMaxVector) super.lanewiseTemplate(op, IntMaxMask.class, (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector lanewise(Binary op, Vector<Integer> v) {
-        return (Int64Vector) super.lanewiseTemplate(op, v);  // specialize
+    public IntMaxVector lanewise(Binary op, Vector<Integer> v) {
+        return (IntMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector lanewise(Binary op, Vector<Integer> v, VectorMask<Integer> m) {
-        return (Int64Vector) super.lanewiseTemplate(op, Int64Mask.class, v, (Int64Mask) m);  // specialize
+    public IntMaxVector lanewise(Binary op, Vector<Integer> v, VectorMask<Integer> m) {
+        return (IntMaxVector) super.lanewiseTemplate(op, IntMaxMask.class, v, (IntMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Int64Vector
+    @ForceInline IntMaxVector
     lanewiseShift(VectorOperators.Binary op, int e) {
-        return (Int64Vector) super.lanewiseShiftTemplate(op, e);  // specialize
+        return (IntMaxVector) super.lanewiseShiftTemplate(op, e);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Int64Vector
+    @ForceInline IntMaxVector
     lanewiseShift(VectorOperators.Binary op, int e, VectorMask<Integer> m) {
-        return (Int64Vector) super.lanewiseShiftTemplate(op, Int64Mask.class, e, (Int64Mask) m);  // specialize
+        return (IntMaxVector) super.lanewiseShiftTemplate(op, IntMaxMask.class, e, (IntMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
     @ForceInline
     public final
-    Int64Vector
+    IntMaxVector
     lanewise(Ternary op, Vector<Integer> v1, Vector<Integer> v2) {
-        return (Int64Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (IntMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Int64Vector
+    IntMaxVector
     lanewise(Ternary op, Vector<Integer> v1, Vector<Integer> v2, VectorMask<Integer> m) {
-        return (Int64Vector) super.lanewiseTemplate(op, Int64Mask.class, v1, v2, (Int64Mask) m);  // specialize
+        return (IntMaxVector) super.lanewiseTemplate(op, IntMaxMask.class, v1, v2, (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Int64Vector addIndex(int scale) {
-        return (Int64Vector) super.addIndexTemplate(scale);  // specialize
+    IntMaxVector addIndex(int scale) {
+        return (IntMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -341,7 +341,7 @@ value class Int64Vector extends IntVector {
     @ForceInline
     public final int reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Integer> m) {
-        return super.reduceLanesTemplate(op, Int64Mask.class, (Int64Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, IntMaxMask.class, (IntMaxMask) m);  // specialized
     }
 
     @Override
@@ -354,167 +354,166 @@ value class Int64Vector extends IntVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, Int64Mask.class, (Int64Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, IntMaxMask.class, (IntMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Integer> toShuffle() {
-        return super.toShuffleTemplate(Int64Shuffle.class); // specialize
+        return super.toShuffleTemplate(IntMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Int64Mask test(Test op) {
-        return super.testTemplate(Int64Mask.class, op);  // specialize
+    public final IntMaxMask test(Test op) {
+        return super.testTemplate(IntMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Int64Mask test(Test op, VectorMask<Integer> m) {
-        return super.testTemplate(Int64Mask.class, op, (Int64Mask) m);  // specialize
+    public final IntMaxMask test(Test op, VectorMask<Integer> m) {
+        return super.testTemplate(IntMaxMask.class, op, (IntMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Int64Mask compare(Comparison op, Vector<Integer> v) {
-        return super.compareTemplate(Int64Mask.class, op, v);  // specialize
+    public final IntMaxMask compare(Comparison op, Vector<Integer> v) {
+        return super.compareTemplate(IntMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Int64Mask compare(Comparison op, int s) {
-        return super.compareTemplate(Int64Mask.class, op, s);  // specialize
+    public final IntMaxMask compare(Comparison op, int s) {
+        return super.compareTemplate(IntMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Int64Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Int64Mask.class, op, s);  // specialize
+    public final IntMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(IntMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Int64Mask compare(Comparison op, Vector<Integer> v, VectorMask<Integer> m) {
-        return super.compareTemplate(Int64Mask.class, op, v, (Int64Mask) m);
+    public final IntMaxMask compare(Comparison op, Vector<Integer> v, VectorMask<Integer> m) {
+        return super.compareTemplate(IntMaxMask.class, op, v, (IntMaxMask) m);
     }
 
 
     @Override
     @ForceInline
-    public Int64Vector blend(Vector<Integer> v, VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.blendTemplate(Int64Mask.class,
-                                (Int64Vector) v,
-                                (Int64Mask) m);  // specialize
+    public IntMaxVector blend(Vector<Integer> v, VectorMask<Integer> m) {
+        return (IntMaxVector)
+            super.blendTemplate(IntMaxMask.class,
+                                (IntMaxVector) v,
+                                (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector slice(int origin, Vector<Integer> v) {
-        return (Int64Vector) super.sliceTemplate(origin, v);  // specialize
+    public IntMaxVector slice(int origin, Vector<Integer> v) {
+        return (IntMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector slice(int origin) {
-        return (Int64Vector) super.sliceTemplate(origin);  // specialize
+    public IntMaxVector slice(int origin) {
+        return (IntMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector unslice(int origin, Vector<Integer> w, int part) {
-        return (Int64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public IntMaxVector unslice(int origin, Vector<Integer> w, int part) {
+        return (IntMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector unslice(int origin, Vector<Integer> w, int part, VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.unsliceTemplate(Int64Mask.class,
+    public IntMaxVector unslice(int origin, Vector<Integer> w, int part, VectorMask<Integer> m) {
+        return (IntMaxVector)
+            super.unsliceTemplate(IntMaxMask.class,
                                   origin, w, part,
-                                  (Int64Mask) m);  // specialize
+                                  (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector unslice(int origin) {
-        return (Int64Vector) super.unsliceTemplate(origin);  // specialize
+    public IntMaxVector unslice(int origin) {
+        return (IntMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector rearrange(VectorShuffle<Integer> s) {
-        return (Int64Vector)
-            super.rearrangeTemplate(Int64Shuffle.class,
-                                    (Int64Shuffle) s);  // specialize
+    public IntMaxVector rearrange(VectorShuffle<Integer> s) {
+        return (IntMaxVector)
+            super.rearrangeTemplate(IntMaxShuffle.class,
+                                    (IntMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector rearrange(VectorShuffle<Integer> shuffle,
+    public IntMaxVector rearrange(VectorShuffle<Integer> shuffle,
                                   VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.rearrangeTemplate(Int64Shuffle.class,
-                                    Int64Mask.class,
-                                    (Int64Shuffle) shuffle,
-                                    (Int64Mask) m);  // specialize
+        return (IntMaxVector)
+            super.rearrangeTemplate(IntMaxShuffle.class,
+                                    IntMaxMask.class,
+                                    (IntMaxShuffle) shuffle,
+                                    (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector rearrange(VectorShuffle<Integer> s,
+    public IntMaxVector rearrange(VectorShuffle<Integer> s,
                                   Vector<Integer> v) {
-        return (Int64Vector)
-            super.rearrangeTemplate(Int64Shuffle.class,
-                                    (Int64Shuffle) s,
-                                    (Int64Vector) v);  // specialize
+        return (IntMaxVector)
+            super.rearrangeTemplate(IntMaxShuffle.class,
+                                    (IntMaxShuffle) s,
+                                    (IntMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector compress(VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.compressTemplate(Int64Mask.class,
-                                   (Int64Mask) m);  // specialize
+    public IntMaxVector compress(VectorMask<Integer> m) {
+        return (IntMaxVector)
+            super.compressTemplate(IntMaxMask.class,
+                                   (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector expand(VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.expandTemplate(Int64Mask.class,
-                                   (Int64Mask) m);  // specialize
+    public IntMaxVector expand(VectorMask<Integer> m) {
+        return (IntMaxVector)
+            super.expandTemplate(IntMaxMask.class,
+                                   (IntMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector selectFrom(Vector<Integer> v) {
-        return (Int64Vector)
-            super.selectFromTemplate((Int64Vector) v);  // specialize
+    public IntMaxVector selectFrom(Vector<Integer> v) {
+        return (IntMaxVector)
+            super.selectFromTemplate((IntMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Int64Vector selectFrom(Vector<Integer> v,
+    public IntMaxVector selectFrom(Vector<Integer> v,
                                    VectorMask<Integer> m) {
-        return (Int64Vector)
-            super.selectFromTemplate((Int64Vector) v,
-                                     (Int64Mask) m);  // specialize
+        return (IntMaxVector)
+            super.selectFromTemplate((IntMaxVector) v,
+                                     (IntMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public int lane(int i) {
-        switch(i) {
-            case 0: return laneHelper(0);
-            case 1: return laneHelper(1);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return laneHelper(i);
     }
 
     public int laneHelper(int i) {
@@ -530,15 +529,14 @@ value class Int64Vector extends IntVector {
 
     @ForceInline
     @Override
-    public Int64Vector withLane(int i, int e) {
-        switch (i) {
-            case 0: return withLaneHelper(0, e);
-            case 1: return withLaneHelper(1, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public IntMaxVector withLane(int i, int e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Int64Vector withLaneHelper(int i, int e) {
+    public IntMaxVector withLaneHelper(int i, int e) {
        return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
@@ -554,22 +552,22 @@ value class Int64Vector extends IntVector {
 
     // Mask
 
-    static final value class Int64Mask extends AbstractMask<Integer> {
+    static final value class IntMaxMask extends AbstractMask<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        Int64Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF16Z) payload;
+        IntMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxIZ) payload;
         }
 
-        private final VectorPayloadMF16Z payload;
+        private final VectorPayloadMFMaxIZ payload;
 
-        Int64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        IntMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Int64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        IntMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -591,32 +589,32 @@ value class Int64Vector extends IntVector {
         @ForceInline
         @Override
         public final
-        Int64Vector toVector() {
-            return (Int64Vector) super.toVectorTemplate();  // specialize
+        IntMaxVector toVector() {
+            return (IntMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Int64Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Int64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Int64Mask.class, int.class, VLENGTH, offset, limit,
-                (o, l) -> (Int64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        IntMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (IntMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                IntMaxMask.class, int.class, VLENGTH, offset, limit,
+                (o, l) -> (IntMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Int64Mask not() {
+        public IntMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Int64Mask compress() {
-            return (Int64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Int64Vector.class, Int64Mask.class, ETYPE, VLENGTH, null, this,
+        public IntMaxMask compress() {
+            return (IntMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                IntMaxVector.class, IntMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -625,32 +623,32 @@ value class Int64Vector extends IntVector {
 
         @Override
         @ForceInline
-        public Int64Mask and(VectorMask<Integer> mask) {
+        public IntMaxMask and(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
-            Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Int64Mask.class, null,
+            IntMaxMask m = (IntMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, IntMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (IntMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Int64Mask or(VectorMask<Integer> mask) {
+        public IntMaxMask or(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
-            Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Int64Mask.class, null,
+            IntMaxMask m = (IntMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, IntMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (IntMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Int64Mask xor(VectorMask<Integer> mask) {
+        public IntMaxMask xor(VectorMask<Integer> mask) {
             Objects.requireNonNull(mask);
-            Int64Mask m = (Int64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Int64Mask.class, null,
+            IntMaxMask m = (IntMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, IntMaxMask.class, null,
                                           int.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Int64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (IntMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -658,22 +656,22 @@ value class Int64Vector extends IntVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Int64Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Int64Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, IntMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((IntMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Int64Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Int64Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, IntMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((IntMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Int64Mask.class, int.class, VLENGTH, this,
-                                                            (m) -> ((Int64Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, IntMaxMask.class, int.class, VLENGTH, this,
+                                                            (m) -> ((IntMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -682,8 +680,8 @@ value class Int64Vector extends IntVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Int64Mask.class, int.class, VLENGTH, this,
-                                                      (m) -> ((Int64Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, IntMaxMask.class, int.class, VLENGTH, this,
+                                                      (m) -> ((IntMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -692,8 +690,8 @@ value class Int64Vector extends IntVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Int64Mask.class, int.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Int64Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(IntMaxMask.class, int.class, VLENGTH,
+                                         this, i, (m, idx) -> (((IntMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -701,54 +699,68 @@ value class Int64Vector extends IntVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Int64Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_ne, IntMaxMask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Int64Mask) m).anyTrueHelper());
+                                         (m, __) -> ((IntMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Int64Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, IntMaxMask.class, int.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Int64Mask) m).allTrueHelper());
+                                         (m, __) -> ((IntMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Int64Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Int64Mask.class, int.class, VLENGTH,
+        static IntMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(IntMaxMask.class, int.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Int64Mask  TRUE_MASK = new Int64Mask(true);
-        private static final Int64Mask FALSE_MASK = new Int64Mask(false);
+        private static final IntMaxMask  TRUE_MASK = new IntMaxMask(true);
+        private static final IntMaxMask FALSE_MASK = new IntMaxMask(false);
 
+
+        static VectorPayloadMF maskLowerHalf() {
+            VectorPayloadMF newObj = VectorPayloadMF.newMaskInstanceFactory(ETYPE, VLENGTH, true);
+            newObj = Unsafe.getUnsafe().makePrivateBuffer(newObj);
+            long mf_offset = newObj.multiFieldOffset();
+            int len = VLENGTH >> 1;
+            for (int i = 0; i < len; i++) {
+                Unsafe.getUnsafe().putBoolean(newObj, mf_offset + i, true);
+            }
+            newObj = Unsafe.getUnsafe().finishPrivateBuffer(newObj);
+            return newObj;
+        }
+
+        static final IntMaxMask LOWER_HALF_TRUE_MASK = new IntMaxMask(maskLowerHalf());
     }
 
     // Shuffle
 
-    static final value class Int64Shuffle extends AbstractShuffle<Integer> {
+    static final value class IntMaxShuffle extends AbstractShuffle<Integer> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
-        private final VectorPayloadMF16B payload;
+        private final VectorPayloadMFMaxIB payload;
 
-        Int64Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF16B) payload;
+        IntMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxIB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Int64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public IntMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Int64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public IntMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Int64Shuffle(int[] indexes) {
+        public IntMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -770,13 +782,13 @@ value class Int64Vector extends IntVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Int64Shuffle IOTA = new Int64Shuffle(IDENTITY);
+        static final IntMaxShuffle IOTA = new IntMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Int64Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Int64Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Int64Vector)(((AbstractShuffle<Integer>)(s)).toVectorTemplate())));
+        public IntMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, IntMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((IntMaxVector)(((AbstractShuffle<Integer>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -791,11 +803,11 @@ value class Int64Vector extends IntVector {
 
         @ForceInline
         @Override
-        public Int64Shuffle rearrange(VectorShuffle<Integer> shuffle) {
-            Int64Shuffle s = (Int64Shuffle) shuffle;
+        public IntMaxShuffle rearrange(VectorShuffle<Integer> shuffle) {
+            IntMaxShuffle s = (IntMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -804,7 +816,7 @@ value class Int64Vector extends IntVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Int64Shuffle(r);
+            return new IntMaxShuffle(r);
         }
     }
 
@@ -823,14 +835,14 @@ value class Int64Vector extends IntVector {
     @Override
     final
     IntVector fromArray0(int[] a, int offset, VectorMask<Integer> m, int offsetInRange) {
-        return super.fromArray0Template(Int64Mask.class, a, offset, (Int64Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
     IntVector fromArray0(int[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Integer> m) {
-        return super.fromArray0Template(Int64Mask.class, a, offset, indexMap, mapOffset, (Int64Mask) m);
+        return super.fromArray0Template(IntMaxMask.class, a, offset, indexMap, mapOffset, (IntMaxMask) m);
     }
 
 
@@ -846,7 +858,7 @@ value class Int64Vector extends IntVector {
     @Override
     final
     IntVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Integer> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Int64Mask.class, ms, offset, (Int64Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(IntMaxMask.class, ms, offset, (IntMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -860,14 +872,14 @@ value class Int64Vector extends IntVector {
     @Override
     final
     void intoArray0(int[] a, int offset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int64Mask.class, a, offset, (Int64Mask) m);
+        super.intoArray0Template(IntMaxMask.class, a, offset, (IntMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoArray0(int[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Integer> m) {
-        super.intoArray0Template(Int64Mask.class, a, offset, indexMap, mapOffset, (Int64Mask) m);
+        super.intoArray0Template(IntMaxMask.class, a, offset, indexMap, mapOffset, (IntMaxMask) m);
     }
 
 
@@ -875,7 +887,7 @@ value class Int64Vector extends IntVector {
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Integer> m) {
-        super.intoMemorySegment0Template(Int64Mask.class, ms, offset, (Int64Mask) m);
+        super.intoMemorySegment0Template(IntMaxMask.class, ms, offset, (IntMaxMask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -555,11 +555,11 @@ value class Long128Vector extends LongVector {
         private final VectorPayloadMF16Z payload;
 
         Long128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Long128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -731,11 +731,11 @@ value class Long128Vector extends LongVector {
         }
 
         public Long128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Long128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Long128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -69,8 +69,8 @@ value class Long128Vector extends LongVector {
         return payload;
     }
 
-    static final Long128Vector ZERO = new Long128Vector(VectorPayloadMF.newInstanceFactory(long.class, 2));
-    static final Long128Vector IOTA = new Long128Vector(VectorPayloadMF.createVectPayloadInstanceL(2, (long[])(VSPECIES.iotaArray())));
+    static final Long128Vector ZERO = new Long128Vector(VectorPayloadMF.newVectorInstanceFactory(long.class, 2, false));
+    static final Long128Vector IOTA = new Long128Vector(VectorPayloadMF.createVectPayloadInstanceL(VLENGTH, (long[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -548,19 +548,20 @@ value class Long128Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        private final VectorPayloadMF16Z payload;
-
         Long128Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        private final VectorPayloadMF16Z payload;
+
         Long128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Long128Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -729,17 +730,18 @@ value class Long128Vector extends LongVector {
             assert(indexesInRange(payload));
         }
 
+        public Long128Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Long128Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Long128Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Long128Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Long128Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -783,7 +785,7 @@ value class Long128Vector extends LongVector {
             Long128Shuffle s = (Long128Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -559,11 +559,11 @@ value class Long256Vector extends LongVector {
         private final VectorPayloadMF32Z payload;
 
         Long256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Long256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -735,11 +735,11 @@ value class Long256Vector extends LongVector {
         }
 
         public Long256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Long256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Long256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -69,8 +69,8 @@ value class Long256Vector extends LongVector {
         return payload;
     }
 
-    static final Long256Vector ZERO = new Long256Vector(VectorPayloadMF.newInstanceFactory(long.class, 4));
-    static final Long256Vector IOTA = new Long256Vector(VectorPayloadMF.createVectPayloadInstanceL(4, (long[])(VSPECIES.iotaArray())));
+    static final Long256Vector ZERO = new Long256Vector(VectorPayloadMF.newVectorInstanceFactory(long.class, 4, false));
+    static final Long256Vector IOTA = new Long256Vector(VectorPayloadMF.createVectPayloadInstanceL(VLENGTH, (long[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -552,19 +552,20 @@ value class Long256Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        private final VectorPayloadMF32Z payload;
-
         Long256Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        private final VectorPayloadMF32Z payload;
+
         Long256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Long256Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -733,17 +734,18 @@ value class Long256Vector extends LongVector {
             assert(indexesInRange(payload));
         }
 
+        public Long256Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Long256Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Long256Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Long256Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Long256Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -787,7 +789,7 @@ value class Long256Vector extends LongVector {
             Long256Shuffle s = (Long256Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -567,11 +567,11 @@ value class Long512Vector extends LongVector {
         private final VectorPayloadMF64Z payload;
 
         Long512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Long512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -743,11 +743,11 @@ value class Long512Vector extends LongVector {
         }
 
         public Long512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Long512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Long512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -69,8 +69,8 @@ value class Long512Vector extends LongVector {
         return payload;
     }
 
-    static final Long512Vector ZERO = new Long512Vector(VectorPayloadMF.newInstanceFactory(long.class, 8));
-    static final Long512Vector IOTA = new Long512Vector(VectorPayloadMF.createVectPayloadInstanceL(8, (long[])(VSPECIES.iotaArray())));
+    static final Long512Vector ZERO = new Long512Vector(VectorPayloadMF.newVectorInstanceFactory(long.class, 8, false));
+    static final Long512Vector IOTA = new Long512Vector(VectorPayloadMF.createVectPayloadInstanceL(VLENGTH, (long[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -560,19 +560,20 @@ value class Long512Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        private final VectorPayloadMF64Z payload;
-
         Long512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        private final VectorPayloadMF64Z payload;
+
         Long512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Long512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -741,17 +742,18 @@ value class Long512Vector extends LongVector {
             assert(indexesInRange(payload));
         }
 
+        public Long512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Long512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Long512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Long512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Long512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -795,7 +797,7 @@ value class Long512Vector extends LongVector {
             Long512Shuffle s = (Long512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -553,11 +553,11 @@ value class Long64Vector extends LongVector {
         private final VectorPayloadMF8Z payload;
 
         Long64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Long64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -729,11 +729,11 @@ value class Long64Vector extends LongVector {
         }
 
         public Long64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Long64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Long64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -553,11 +553,11 @@ value class LongMaxVector extends LongVector {
         private final VectorPayloadMFMaxLZ payload;
 
         LongMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         LongMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -729,11 +729,11 @@ value class LongMaxVector extends LongVector {
         }
 
         public LongMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public LongMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public LongMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Long64Vector extends LongVector {
+value class LongMaxVector extends LongVector {
     static final LongSpecies VSPECIES =
-        (LongSpecies) LongVector.SPECIES_64;
+        (LongSpecies) LongVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Long64Vector> VCLASS = Long64Vector.class;
+    static final Class<LongMaxVector> VCLASS = LongMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Long64Vector extends LongVector {
 
     static final Class<Long> ETYPE = long.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64L.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxL.class);
 
-    private final VectorPayloadMF64L payload;
+    private final VectorPayloadMFMaxL payload;
 
-    Long64Vector(Object value) {
-        this.payload = (VectorPayloadMF64L) value;
+    LongMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxL) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Long64Vector extends LongVector {
         return payload;
     }
 
-    static final Long64Vector ZERO = new Long64Vector(VectorPayloadMF.newVectorInstanceFactory(long.class, 1, false));
-    static final Long64Vector IOTA = new Long64Vector(VectorPayloadMF.createVectPayloadInstanceL(VLENGTH, (long[])(VSPECIES.iotaArray()), false));
+    static final LongMaxVector ZERO = new LongMaxVector(VectorPayloadMF.newVectorInstanceFactory(long.class, 0, true));
+    static final LongMaxVector IOTA = new LongMaxVector(VectorPayloadMF.createVectPayloadInstanceL(VLENGTH, (long[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,55 +121,55 @@ value class Long64Vector extends LongVector {
 
     @Override
     @ForceInline
-    public final Long64Vector broadcast(long e) {
-        return (Long64Vector) super.broadcastTemplate(e);  // specialize
+    public final LongMaxVector broadcast(long e) {
+        return (LongMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
 
     @Override
     @ForceInline
-    Long64Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Long64Mask(payload);
+    LongMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new LongMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Long64Shuffle iotaShuffle() { return Long64Shuffle.IOTA; }
+    LongMaxShuffle iotaShuffle() { return LongMaxShuffle.IOTA; }
 
     @ForceInline
-    Long64Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    LongMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Long64Shuffle)VectorSupport.shuffleIota(ETYPE, Long64Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (LongMaxShuffle)VectorSupport.shuffleIota(ETYPE, LongMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Long64Shuffle)VectorSupport.shuffleIota(ETYPE, Long64Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (LongMaxShuffle)VectorSupport.shuffleIota(ETYPE, LongMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Long64Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Long64Shuffle(indexes); }
+    LongMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new LongMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Long64Shuffle shuffleFromArray(int[] indexes, int i) { return new Long64Shuffle(indexes, i); }
+    LongMaxShuffle shuffleFromArray(int[] indexes, int i) { return new LongMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Long64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Long64Shuffle(fn); }
+    LongMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new LongMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Long64Vector vectorFactory(VectorPayloadMF vec) {
-        return new Long64Vector(vec);
+    LongMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new LongMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte64Vector asByteVectorRaw() {
-        return (Byte64Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -182,31 +182,31 @@ value class Long64Vector extends LongVector {
 
     @ForceInline
     final @Override
-    Long64Vector uOpMF(FUnOp f) {
-        return (Long64Vector) super.uOpTemplateMF(f);  // specialize
+    LongMaxVector uOpMF(FUnOp f) {
+        return (LongMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Long64Vector uOpMF(VectorMask<Long> m, FUnOp f) {
-        return (Long64Vector)
-            super.uOpTemplateMF((Long64Mask)m, f);  // specialize
+    LongMaxVector uOpMF(VectorMask<Long> m, FUnOp f) {
+        return (LongMaxVector)
+            super.uOpTemplateMF((LongMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Long64Vector bOpMF(Vector<Long> v, FBinOp f) {
-        return (Long64Vector) super.bOpTemplateMF((Long64Vector)v, f);  // specialize
+    LongMaxVector bOpMF(Vector<Long> v, FBinOp f) {
+        return (LongMaxVector) super.bOpTemplateMF((LongMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Long64Vector bOpMF(Vector<Long> v,
+    LongMaxVector bOpMF(Vector<Long> v,
                      VectorMask<Long> m, FBinOp f) {
-        return (Long64Vector)
-            super.bOpTemplateMF((Long64Vector)v, (Long64Mask)m,
+        return (LongMaxVector)
+            super.bOpTemplateMF((LongMaxVector)v, (LongMaxMask)m,
                                 f);  // specialize
     }
 
@@ -214,19 +214,19 @@ value class Long64Vector extends LongVector {
 
     @ForceInline
     final @Override
-    Long64Vector tOpMF(Vector<Long> v1, Vector<Long> v2, FTriOp f) {
-        return (Long64Vector)
-            super.tOpTemplateMF((Long64Vector)v1, (Long64Vector)v2,
+    LongMaxVector tOpMF(Vector<Long> v1, Vector<Long> v2, FTriOp f) {
+        return (LongMaxVector)
+            super.tOpTemplateMF((LongMaxVector)v1, (LongMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Long64Vector tOpMF(Vector<Long> v1, Vector<Long> v2,
+    LongMaxVector tOpMF(Vector<Long> v1, Vector<Long> v2,
                      VectorMask<Long> m, FTriOp f) {
-        return (Long64Vector)
-            super.tOpTemplateMF((Long64Vector)v1, (Long64Vector)v2,
-                                (Long64Mask)m, f);  // specialize
+        return (LongMaxVector)
+            super.tOpTemplateMF((LongMaxVector)v1, (LongMaxVector)v2,
+                                (LongMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -264,64 +264,64 @@ value class Long64Vector extends LongVector {
 
     @Override
     @ForceInline
-    public Long64Vector lanewise(Unary op) {
-        return (Long64Vector) super.lanewiseTemplate(op);  // specialize
+    public LongMaxVector lanewise(Unary op) {
+        return (LongMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector lanewise(Unary op, VectorMask<Long> m) {
-        return (Long64Vector) super.lanewiseTemplate(op, Long64Mask.class, (Long64Mask) m);  // specialize
+    public LongMaxVector lanewise(Unary op, VectorMask<Long> m) {
+        return (LongMaxVector) super.lanewiseTemplate(op, LongMaxMask.class, (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector lanewise(Binary op, Vector<Long> v) {
-        return (Long64Vector) super.lanewiseTemplate(op, v);  // specialize
+    public LongMaxVector lanewise(Binary op, Vector<Long> v) {
+        return (LongMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector lanewise(Binary op, Vector<Long> v, VectorMask<Long> m) {
-        return (Long64Vector) super.lanewiseTemplate(op, Long64Mask.class, v, (Long64Mask) m);  // specialize
+    public LongMaxVector lanewise(Binary op, Vector<Long> v, VectorMask<Long> m) {
+        return (LongMaxVector) super.lanewiseTemplate(op, LongMaxMask.class, v, (LongMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Long64Vector
+    @ForceInline LongMaxVector
     lanewiseShift(VectorOperators.Binary op, int e) {
-        return (Long64Vector) super.lanewiseShiftTemplate(op, e);  // specialize
+        return (LongMaxVector) super.lanewiseShiftTemplate(op, e);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Long64Vector
+    @ForceInline LongMaxVector
     lanewiseShift(VectorOperators.Binary op, int e, VectorMask<Long> m) {
-        return (Long64Vector) super.lanewiseShiftTemplate(op, Long64Mask.class, e, (Long64Mask) m);  // specialize
+        return (LongMaxVector) super.lanewiseShiftTemplate(op, LongMaxMask.class, e, (LongMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
     @ForceInline
     public final
-    Long64Vector
+    LongMaxVector
     lanewise(Ternary op, Vector<Long> v1, Vector<Long> v2) {
-        return (Long64Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (LongMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Long64Vector
+    LongMaxVector
     lanewise(Ternary op, Vector<Long> v1, Vector<Long> v2, VectorMask<Long> m) {
-        return (Long64Vector) super.lanewiseTemplate(op, Long64Mask.class, v1, v2, (Long64Mask) m);  // specialize
+        return (LongMaxVector) super.lanewiseTemplate(op, LongMaxMask.class, v1, v2, (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Long64Vector addIndex(int scale) {
-        return (Long64Vector) super.addIndexTemplate(scale);  // specialize
+    LongMaxVector addIndex(int scale) {
+        return (LongMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -336,7 +336,7 @@ value class Long64Vector extends LongVector {
     @ForceInline
     public final long reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Long> m) {
-        return super.reduceLanesTemplate(op, Long64Mask.class, (Long64Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, LongMaxMask.class, (LongMaxMask) m);  // specialized
     }
 
     @Override
@@ -349,161 +349,161 @@ value class Long64Vector extends LongVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, Long64Mask.class, (Long64Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, LongMaxMask.class, (LongMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Long> toShuffle() {
-        return super.toShuffleTemplate(Long64Shuffle.class); // specialize
+        return super.toShuffleTemplate(LongMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Long64Mask test(Test op) {
-        return super.testTemplate(Long64Mask.class, op);  // specialize
+    public final LongMaxMask test(Test op) {
+        return super.testTemplate(LongMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Long64Mask test(Test op, VectorMask<Long> m) {
-        return super.testTemplate(Long64Mask.class, op, (Long64Mask) m);  // specialize
+    public final LongMaxMask test(Test op, VectorMask<Long> m) {
+        return super.testTemplate(LongMaxMask.class, op, (LongMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Long64Mask compare(Comparison op, Vector<Long> v) {
-        return super.compareTemplate(Long64Mask.class, op, v);  // specialize
+    public final LongMaxMask compare(Comparison op, Vector<Long> v) {
+        return super.compareTemplate(LongMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Long64Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Long64Mask.class, op, s);  // specialize
-    }
-
-
-    @Override
-    @ForceInline
-    public final Long64Mask compare(Comparison op, Vector<Long> v, VectorMask<Long> m) {
-        return super.compareTemplate(Long64Mask.class, op, v, (Long64Mask) m);
+    public final LongMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(LongMaxMask.class, op, s);  // specialize
     }
 
 
     @Override
     @ForceInline
-    public Long64Vector blend(Vector<Long> v, VectorMask<Long> m) {
-        return (Long64Vector)
-            super.blendTemplate(Long64Mask.class,
-                                (Long64Vector) v,
-                                (Long64Mask) m);  // specialize
+    public final LongMaxMask compare(Comparison op, Vector<Long> v, VectorMask<Long> m) {
+        return super.compareTemplate(LongMaxMask.class, op, v, (LongMaxMask) m);
+    }
+
+
+    @Override
+    @ForceInline
+    public LongMaxVector blend(Vector<Long> v, VectorMask<Long> m) {
+        return (LongMaxVector)
+            super.blendTemplate(LongMaxMask.class,
+                                (LongMaxVector) v,
+                                (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector slice(int origin, Vector<Long> v) {
-        return (Long64Vector) super.sliceTemplate(origin, v);  // specialize
+    public LongMaxVector slice(int origin, Vector<Long> v) {
+        return (LongMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector slice(int origin) {
-        return (Long64Vector) super.sliceTemplate(origin);  // specialize
+    public LongMaxVector slice(int origin) {
+        return (LongMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector unslice(int origin, Vector<Long> w, int part) {
-        return (Long64Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public LongMaxVector unslice(int origin, Vector<Long> w, int part) {
+        return (LongMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector unslice(int origin, Vector<Long> w, int part, VectorMask<Long> m) {
-        return (Long64Vector)
-            super.unsliceTemplate(Long64Mask.class,
+    public LongMaxVector unslice(int origin, Vector<Long> w, int part, VectorMask<Long> m) {
+        return (LongMaxVector)
+            super.unsliceTemplate(LongMaxMask.class,
                                   origin, w, part,
-                                  (Long64Mask) m);  // specialize
+                                  (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector unslice(int origin) {
-        return (Long64Vector) super.unsliceTemplate(origin);  // specialize
+    public LongMaxVector unslice(int origin) {
+        return (LongMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector rearrange(VectorShuffle<Long> s) {
-        return (Long64Vector)
-            super.rearrangeTemplate(Long64Shuffle.class,
-                                    (Long64Shuffle) s);  // specialize
+    public LongMaxVector rearrange(VectorShuffle<Long> s) {
+        return (LongMaxVector)
+            super.rearrangeTemplate(LongMaxShuffle.class,
+                                    (LongMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector rearrange(VectorShuffle<Long> shuffle,
+    public LongMaxVector rearrange(VectorShuffle<Long> shuffle,
                                   VectorMask<Long> m) {
-        return (Long64Vector)
-            super.rearrangeTemplate(Long64Shuffle.class,
-                                    Long64Mask.class,
-                                    (Long64Shuffle) shuffle,
-                                    (Long64Mask) m);  // specialize
+        return (LongMaxVector)
+            super.rearrangeTemplate(LongMaxShuffle.class,
+                                    LongMaxMask.class,
+                                    (LongMaxShuffle) shuffle,
+                                    (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector rearrange(VectorShuffle<Long> s,
+    public LongMaxVector rearrange(VectorShuffle<Long> s,
                                   Vector<Long> v) {
-        return (Long64Vector)
-            super.rearrangeTemplate(Long64Shuffle.class,
-                                    (Long64Shuffle) s,
-                                    (Long64Vector) v);  // specialize
+        return (LongMaxVector)
+            super.rearrangeTemplate(LongMaxShuffle.class,
+                                    (LongMaxShuffle) s,
+                                    (LongMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector compress(VectorMask<Long> m) {
-        return (Long64Vector)
-            super.compressTemplate(Long64Mask.class,
-                                   (Long64Mask) m);  // specialize
+    public LongMaxVector compress(VectorMask<Long> m) {
+        return (LongMaxVector)
+            super.compressTemplate(LongMaxMask.class,
+                                   (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector expand(VectorMask<Long> m) {
-        return (Long64Vector)
-            super.expandTemplate(Long64Mask.class,
-                                   (Long64Mask) m);  // specialize
+    public LongMaxVector expand(VectorMask<Long> m) {
+        return (LongMaxVector)
+            super.expandTemplate(LongMaxMask.class,
+                                   (LongMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector selectFrom(Vector<Long> v) {
-        return (Long64Vector)
-            super.selectFromTemplate((Long64Vector) v);  // specialize
+    public LongMaxVector selectFrom(Vector<Long> v) {
+        return (LongMaxVector)
+            super.selectFromTemplate((LongMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Long64Vector selectFrom(Vector<Long> v,
+    public LongMaxVector selectFrom(Vector<Long> v,
                                    VectorMask<Long> m) {
-        return (Long64Vector)
-            super.selectFromTemplate((Long64Vector) v,
-                                     (Long64Mask) m);  // specialize
+        return (LongMaxVector)
+            super.selectFromTemplate((LongMaxVector) v,
+                                     (LongMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public long lane(int i) {
-        switch(i) {
-            case 0: return laneHelper(0);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return laneHelper(i);
     }
 
     public long laneHelper(int i) {
@@ -519,14 +519,14 @@ value class Long64Vector extends LongVector {
 
     @ForceInline
     @Override
-    public Long64Vector withLane(int i, long e) {
-        switch (i) {
-            case 0: return withLaneHelper(0, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public LongMaxVector withLane(int i, long e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Long64Vector withLaneHelper(int i, long e) {
+    public LongMaxVector withLaneHelper(int i, long e) {
        return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
@@ -542,22 +542,22 @@ value class Long64Vector extends LongVector {
 
     // Mask
 
-    static final value class Long64Mask extends AbstractMask<Long> {
+    static final value class LongMaxMask extends AbstractMask<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        Long64Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF8Z) payload;
+        LongMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxLZ) payload;
         }
 
-        private final VectorPayloadMF8Z payload;
+        private final VectorPayloadMFMaxLZ payload;
 
-        Long64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        LongMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Long64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        LongMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -579,32 +579,32 @@ value class Long64Vector extends LongVector {
         @ForceInline
         @Override
         public final
-        Long64Vector toVector() {
-            return (Long64Vector) super.toVectorTemplate();  // specialize
+        LongMaxVector toVector() {
+            return (LongMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Long64Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Long64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Long64Mask.class, long.class, VLENGTH, offset, limit,
-                (o, l) -> (Long64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        LongMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (LongMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                LongMaxMask.class, long.class, VLENGTH, offset, limit,
+                (o, l) -> (LongMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Long64Mask not() {
+        public LongMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Long64Mask compress() {
-            return (Long64Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Long64Vector.class, Long64Mask.class, ETYPE, VLENGTH, null, this,
+        public LongMaxMask compress() {
+            return (LongMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                LongMaxVector.class, LongMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -613,32 +613,32 @@ value class Long64Vector extends LongVector {
 
         @Override
         @ForceInline
-        public Long64Mask and(VectorMask<Long> mask) {
+        public LongMaxMask and(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
-            Long64Mask m = (Long64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Long64Mask.class, null,
+            LongMaxMask m = (LongMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, LongMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (LongMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Long64Mask or(VectorMask<Long> mask) {
+        public LongMaxMask or(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
-            Long64Mask m = (Long64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Long64Mask.class, null,
+            LongMaxMask m = (LongMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, LongMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (LongMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Long64Mask xor(VectorMask<Long> mask) {
+        public LongMaxMask xor(VectorMask<Long> mask) {
             Objects.requireNonNull(mask);
-            Long64Mask m = (Long64Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Long64Mask.class, null,
+            LongMaxMask m = (LongMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, LongMaxMask.class, null,
                                           long.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Long64Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (LongMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -646,22 +646,22 @@ value class Long64Vector extends LongVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Long64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Long64Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, LongMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((LongMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Long64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Long64Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, LongMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((LongMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Long64Mask.class, long.class, VLENGTH, this,
-                                                            (m) -> ((Long64Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, LongMaxMask.class, long.class, VLENGTH, this,
+                                                            (m) -> ((LongMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -670,8 +670,8 @@ value class Long64Vector extends LongVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Long64Mask.class, long.class, VLENGTH, this,
-                                                      (m) -> ((Long64Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, LongMaxMask.class, long.class, VLENGTH, this,
+                                                      (m) -> ((LongMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -680,8 +680,8 @@ value class Long64Vector extends LongVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Long64Mask.class, long.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Long64Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(LongMaxMask.class, long.class, VLENGTH,
+                                         this, i, (m, idx) -> (((LongMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -689,54 +689,54 @@ value class Long64Vector extends LongVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Long64Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_ne, LongMaxMask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Long64Mask) m).anyTrueHelper());
+                                         (m, __) -> ((LongMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Long64Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, LongMaxMask.class, long.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Long64Mask) m).allTrueHelper());
+                                         (m, __) -> ((LongMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Long64Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Long64Mask.class, long.class, VLENGTH,
+        static LongMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(LongMaxMask.class, long.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Long64Mask  TRUE_MASK = new Long64Mask(true);
-        private static final Long64Mask FALSE_MASK = new Long64Mask(false);
+        private static final LongMaxMask  TRUE_MASK = new LongMaxMask(true);
+        private static final LongMaxMask FALSE_MASK = new LongMaxMask(false);
 
     }
 
     // Shuffle
 
-    static final value class Long64Shuffle extends AbstractShuffle<Long> {
+    static final value class LongMaxShuffle extends AbstractShuffle<Long> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
-        private final VectorPayloadMF8B payload;
+        private final VectorPayloadMFMaxLB payload;
 
-        Long64Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF8B) payload;
+        LongMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxLB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Long64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public LongMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Long64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public LongMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Long64Shuffle(int[] indexes) {
+        public LongMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -758,13 +758,13 @@ value class Long64Vector extends LongVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Long64Shuffle IOTA = new Long64Shuffle(IDENTITY);
+        static final LongMaxShuffle IOTA = new LongMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Long64Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Long64Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Long64Vector)(((AbstractShuffle<Long>)(s)).toVectorTemplate())));
+        public LongMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, LongMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((LongMaxVector)(((AbstractShuffle<Long>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -779,11 +779,11 @@ value class Long64Vector extends LongVector {
 
         @ForceInline
         @Override
-        public Long64Shuffle rearrange(VectorShuffle<Long> shuffle) {
-            Long64Shuffle s = (Long64Shuffle) shuffle;
+        public LongMaxShuffle rearrange(VectorShuffle<Long> shuffle) {
+            LongMaxShuffle s = (LongMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -792,7 +792,7 @@ value class Long64Vector extends LongVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Long64Shuffle(r);
+            return new LongMaxShuffle(r);
         }
     }
 
@@ -811,14 +811,14 @@ value class Long64Vector extends LongVector {
     @Override
     final
     LongVector fromArray0(long[] a, int offset, VectorMask<Long> m, int offsetInRange) {
-        return super.fromArray0Template(Long64Mask.class, a, offset, (Long64Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
     LongVector fromArray0(long[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Long> m) {
-        return super.fromArray0Template(Long64Mask.class, a, offset, indexMap, mapOffset, (Long64Mask) m);
+        return super.fromArray0Template(LongMaxMask.class, a, offset, indexMap, mapOffset, (LongMaxMask) m);
     }
 
 
@@ -834,7 +834,7 @@ value class Long64Vector extends LongVector {
     @Override
     final
     LongVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Long> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Long64Mask.class, ms, offset, (Long64Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(LongMaxMask.class, ms, offset, (LongMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -848,14 +848,14 @@ value class Long64Vector extends LongVector {
     @Override
     final
     void intoArray0(long[] a, int offset, VectorMask<Long> m) {
-        super.intoArray0Template(Long64Mask.class, a, offset, (Long64Mask) m);
+        super.intoArray0Template(LongMaxMask.class, a, offset, (LongMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoArray0(long[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Long> m) {
-        super.intoArray0Template(Long64Mask.class, a, offset, indexMap, mapOffset, (Long64Mask) m);
+        super.intoArray0Template(LongMaxMask.class, a, offset, indexMap, mapOffset, (LongMaxMask) m);
     }
 
 
@@ -863,7 +863,7 @@ value class Long64Vector extends LongVector {
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Long> m) {
-        super.intoMemorySegment0Template(Long64Mask.class, ms, offset, (Long64Mask) m);
+        super.intoMemorySegment0Template(LongMaxMask.class, ms, offset, (LongMaxMask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -372,9 +372,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     <M> LongVector ldOpMF(M memory, int offset,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                long.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                long.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
@@ -390,9 +391,10 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   VectorMask<Long> m,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                long.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                long.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -417,9 +419,10 @@ public abstract class LongVector extends AbstractVector<Long> {
     LongVector ldLongOpMF(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                long.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                long.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().putLong(tpayload, vOffset + i * Long.BYTES, f.apply(memory, offset, i));
@@ -435,9 +438,10 @@ public abstract class LongVector extends AbstractVector<Long> {
                                   VectorMask<Long> m,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                long.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                long.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<Long>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -545,7 +549,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         int length = vspecies().length();
         VectorPayloadMF vec1 = vec();
         VectorPayloadMF vec2 = ((LongVector)o).vec();
-        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
+        VectorPayloadMF mbits = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -3026,11 +3031,9 @@ public abstract class LongVector extends AbstractVector<Long> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3321,11 +3324,9 @@ public abstract class LongVector extends AbstractVector<Long> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3517,11 +3518,9 @@ public abstract class LongVector extends AbstractVector<Long> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-            assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -3634,12 +3633,9 @@ public abstract class LongVector extends AbstractVector<Long> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
-
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -4079,9 +4075,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         @Override
         @ForceInline
         public final LongVector zero() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == LongMaxVector.class)
-            //    return LongMaxVector.ZERO;
+            if ((Class<?>) vectorType() == LongMaxVector.class)
+               return LongMaxVector.ZERO;
             switch (vectorBitSize()) {
                 case 64: return Long64Vector.ZERO;
                 case 128: return Long128Vector.ZERO;
@@ -4094,9 +4089,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         @Override
         @ForceInline
         public final LongVector iota() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == LongMaxVector.class)
-            //    return LongMaxVector.IOTA;
+            if ((Class<?>) vectorType() == LongMaxVector.class)
+                return LongMaxVector.IOTA;
             switch (vectorBitSize()) {
                 case 64: return Long64Vector.IOTA;
                 case 128: return Long128Vector.IOTA;
@@ -4110,9 +4104,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         @Override
         @ForceInline
         public final VectorMask<Long> maskAll(boolean bit) {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == LongMaxVector.class)
-            //    return LongMaxVector.LongMaxMask.maskAll(bit);
+            if ((Class<?>) vectorType() == LongMaxVector.class)
+                return LongMaxVector.LongMaxMask.maskAll(bit);
             switch (vectorBitSize()) {
                 case 64: return Long64Vector.Long64Mask.maskAll(bit);
                 case 128: return Long128Vector.Long128Mask.maskAll(bit);
@@ -4147,8 +4140,7 @@ public abstract class LongVector extends AbstractVector<Long> {
             case VectorShape.SK_128_BIT: return (LongSpecies) SPECIES_128;
             case VectorShape.SK_256_BIT: return (LongSpecies) SPECIES_256;
             case VectorShape.SK_512_BIT: return (LongSpecies) SPECIES_512;
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //case VectorShape.SK_Max_BIT: return (LongSpecies) SPECIES_MAX;
+            case VectorShape.SK_Max_BIT: return (LongSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }
@@ -4182,13 +4174,11 @@ public abstract class LongVector extends AbstractVector<Long> {
                             Long512Vector::new);
 
     /** Species representing {@link LongVector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
-    // FIXME: Enable once multi-field based MaxVector is supported.
-    /*public static final VectorSpecies<Long> SPECIES_MAX
+    public static final VectorSpecies<Long> SPECIES_MAX
         = new LongSpecies(VectorShape.S_Max_BIT,
                             LongMaxVector.class,
                             LongMaxVector.LongMaxMask.class,
                             LongMaxVector::new);
-     */
 
     /**
      * Preferred species for {@link LongVector}s.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -577,11 +577,11 @@ value class Short128Vector extends ShortVector {
         private final VectorPayloadMF64Z payload;
 
         Short128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Short128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -753,11 +753,11 @@ value class Short128Vector extends ShortVector {
         }
 
         public Short128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Short128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Short128Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -593,11 +593,11 @@ value class Short256Vector extends ShortVector {
         private final VectorPayloadMF128Z payload;
 
         Short256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Short256Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -769,11 +769,11 @@ value class Short256Vector extends ShortVector {
         }
 
         public Short256Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Short256Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Short256Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -69,8 +69,8 @@ value class Short256Vector extends ShortVector {
         return payload;
     }
 
-    static final Short256Vector ZERO = new Short256Vector(VectorPayloadMF.newInstanceFactory(short.class, 16));
-    static final Short256Vector IOTA = new Short256Vector(VectorPayloadMF.createVectPayloadInstanceS(16, (short[])(VSPECIES.iotaArray())));
+    static final Short256Vector ZERO = new Short256Vector(VectorPayloadMF.newVectorInstanceFactory(short.class, 16, false));
+    static final Short256Vector IOTA = new Short256Vector(VectorPayloadMF.createVectPayloadInstanceS(VLENGTH, (short[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -586,19 +586,20 @@ value class Short256Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        private final VectorPayloadMF128Z payload;
-
         Short256Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        private final VectorPayloadMF128Z payload;
+
         Short256Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Short256Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -767,17 +768,18 @@ value class Short256Vector extends ShortVector {
             assert(indexesInRange(payload));
         }
 
+        public Short256Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Short256Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Short256Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Short256Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Short256Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -821,7 +823,7 @@ value class Short256Vector extends ShortVector {
             Short256Shuffle s = (Short256Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -625,11 +625,11 @@ value class Short512Vector extends ShortVector {
         private final VectorPayloadMF256Z payload;
 
         Short512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Short512Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -801,11 +801,11 @@ value class Short512Vector extends ShortVector {
         }
 
         public Short512Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Short512Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Short512Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -69,8 +69,8 @@ value class Short512Vector extends ShortVector {
         return payload;
     }
 
-    static final Short512Vector ZERO = new Short512Vector(VectorPayloadMF.newInstanceFactory(short.class, 32));
-    static final Short512Vector IOTA = new Short512Vector(VectorPayloadMF.createVectPayloadInstanceS(32, (short[])(VSPECIES.iotaArray())));
+    static final Short512Vector ZERO = new Short512Vector(VectorPayloadMF.newVectorInstanceFactory(short.class, 32, false));
+    static final Short512Vector IOTA = new Short512Vector(VectorPayloadMF.createVectPayloadInstanceS(VLENGTH, (short[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -618,19 +618,20 @@ value class Short512Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        private final VectorPayloadMF256Z payload;
-
         Short512Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF256Z) payload;
         }
 
+        private final VectorPayloadMF256Z payload;
+
         Short512Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Short512Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -799,17 +800,18 @@ value class Short512Vector extends ShortVector {
             assert(indexesInRange(payload));
         }
 
+        public Short512Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Short512Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Short512Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Short512Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Short512Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -853,7 +855,7 @@ value class Short512Vector extends ShortVector {
             Short512Shuffle s = (Short512Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -569,11 +569,11 @@ value class Short64Vector extends ShortVector {
         private final VectorPayloadMF32Z payload;
 
         Short64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         Short64Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -745,11 +745,11 @@ value class Short64Vector extends ShortVector {
         }
 
         public Short64Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public Short64Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 
         public Short64Shuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -69,8 +69,8 @@ value class Short64Vector extends ShortVector {
         return payload;
     }
 
-    static final Short64Vector ZERO = new Short64Vector(VectorPayloadMF.newInstanceFactory(short.class, 4));
-    static final Short64Vector IOTA = new Short64Vector(VectorPayloadMF.createVectPayloadInstanceS(4, (short[])(VSPECIES.iotaArray())));
+    static final Short64Vector ZERO = new Short64Vector(VectorPayloadMF.newVectorInstanceFactory(short.class, 4, false));
+    static final Short64Vector IOTA = new Short64Vector(VectorPayloadMF.createVectPayloadInstanceS(VLENGTH, (short[])(VSPECIES.iotaArray()), false));
 
     static {
         // Warm up a few species caches.
@@ -562,19 +562,20 @@ value class Short64Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        private final VectorPayloadMF32Z payload;
-
         Short64Mask(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        private final VectorPayloadMF32Z payload;
+
         Short64Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         Short64Mask(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+
 
         @ForceInline
         final @Override
@@ -743,17 +744,18 @@ value class Short64Vector extends ShortVector {
             assert(indexesInRange(payload));
         }
 
+        public Short64Shuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public Short64Shuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+
         public Short64Shuffle(int[] indexes) {
             this(indexes, 0);
         }
 
-        public Short64Shuffle(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public Short64Shuffle(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -797,7 +799,7 @@ value class Short64Vector extends ShortVector {
             Short64Shuffle s = (Short64Shuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -563,11 +563,11 @@ value class ShortMaxVector extends ShortVector {
         private final VectorPayloadMFMaxSZ payload;
 
         ShortMaxMask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         ShortMaxMask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 
 
@@ -739,11 +739,11 @@ value class ShortMaxVector extends ShortVector {
         }
 
         public ShortMaxShuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public ShortMaxShuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 
         public ShortMaxShuffle(int[] indexes) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -40,14 +40,14 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-value class Short128Vector extends ShortVector {
+value class ShortMaxVector extends ShortVector {
     static final ShortSpecies VSPECIES =
-        (ShortSpecies) ShortVector.SPECIES_128;
+        (ShortSpecies) ShortVector.SPECIES_MAX;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Short128Vector> VCLASS = Short128Vector.class;
+    static final Class<ShortMaxVector> VCLASS = ShortMaxVector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
@@ -55,12 +55,12 @@ value class Short128Vector extends ShortVector {
 
     static final Class<Short> ETYPE = short.class; // used by the JVM
 
-    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128S.class);
+    static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxS.class);
 
-    private final VectorPayloadMF128S payload;
+    private final VectorPayloadMFMaxS payload;
 
-    Short128Vector(Object value) {
-        this.payload = (VectorPayloadMF128S) value;
+    ShortMaxVector(Object value) {
+        this.payload = (VectorPayloadMFMaxS) value;
     }
 
     @ForceInline
@@ -69,8 +69,8 @@ value class Short128Vector extends ShortVector {
         return payload;
     }
 
-    static final Short128Vector ZERO = new Short128Vector(VectorPayloadMF.newVectorInstanceFactory(short.class, 8, false));
-    static final Short128Vector IOTA = new Short128Vector(VectorPayloadMF.createVectPayloadInstanceS(VLENGTH, (short[])(VSPECIES.iotaArray()), false));
+    static final ShortMaxVector ZERO = new ShortMaxVector(VectorPayloadMF.newVectorInstanceFactory(short.class, 0, true));
+    static final ShortMaxVector IOTA = new ShortMaxVector(VectorPayloadMF.createVectPayloadInstanceS(VLENGTH, (short[])(VSPECIES.iotaArray()), true));
 
     static {
         // Warm up a few species caches.
@@ -121,60 +121,60 @@ value class Short128Vector extends ShortVector {
 
     @Override
     @ForceInline
-    public final Short128Vector broadcast(short e) {
-        return (Short128Vector) super.broadcastTemplate(e);  // specialize
+    public final ShortMaxVector broadcast(short e) {
+        return (ShortMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Short128Vector broadcast(long e) {
-        return (Short128Vector) super.broadcastTemplate(e);  // specialize
+    public final ShortMaxVector broadcast(long e) {
+        return (ShortMaxVector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Short128Mask maskFromPayload(VectorPayloadMF payload) {
-        return new Short128Mask(payload);
+    ShortMaxMask maskFromPayload(VectorPayloadMF payload) {
+        return new ShortMaxMask(payload);
     }
 
     @Override
     @ForceInline
-    Short128Shuffle iotaShuffle() { return Short128Shuffle.IOTA; }
+    ShortMaxShuffle iotaShuffle() { return ShortMaxShuffle.IOTA; }
 
     @ForceInline
-    Short128Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    ShortMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Short128Shuffle)VectorSupport.shuffleIota(ETYPE, Short128Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (ShortMaxShuffle)VectorSupport.shuffleIota(ETYPE, ShortMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Short128Shuffle)VectorSupport.shuffleIota(ETYPE, Short128Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (ShortMaxShuffle)VectorSupport.shuffleIota(ETYPE, ShortMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Short128Shuffle shuffleFromBytes(VectorPayloadMF indexes) { return new Short128Shuffle(indexes); }
+    ShortMaxShuffle shuffleFromBytes(VectorPayloadMF indexes) { return new ShortMaxShuffle(indexes); }
 
     @Override
     @ForceInline
-    Short128Shuffle shuffleFromArray(int[] indexes, int i) { return new Short128Shuffle(indexes, i); }
+    ShortMaxShuffle shuffleFromArray(int[] indexes, int i) { return new ShortMaxShuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Short128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Short128Shuffle(fn); }
+    ShortMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new ShortMaxShuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Short128Vector vectorFactory(VectorPayloadMF vec) {
-        return new Short128Vector(vec);
+    ShortMaxVector vectorFactory(VectorPayloadMF vec) {
+        return new ShortMaxVector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte128Vector asByteVectorRaw() {
-        return (Byte128Vector) super.asByteVectorRawTemplate();  // specialize
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ value class Short128Vector extends ShortVector {
 
     @ForceInline
     final @Override
-    Short128Vector uOpMF(FUnOp f) {
-        return (Short128Vector) super.uOpTemplateMF(f);  // specialize
+    ShortMaxVector uOpMF(FUnOp f) {
+        return (ShortMaxVector) super.uOpTemplateMF(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Short128Vector uOpMF(VectorMask<Short> m, FUnOp f) {
-        return (Short128Vector)
-            super.uOpTemplateMF((Short128Mask)m, f);  // specialize
+    ShortMaxVector uOpMF(VectorMask<Short> m, FUnOp f) {
+        return (ShortMaxVector)
+            super.uOpTemplateMF((ShortMaxMask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Short128Vector bOpMF(Vector<Short> v, FBinOp f) {
-        return (Short128Vector) super.bOpTemplateMF((Short128Vector)v, f);  // specialize
+    ShortMaxVector bOpMF(Vector<Short> v, FBinOp f) {
+        return (ShortMaxVector) super.bOpTemplateMF((ShortMaxVector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Short128Vector bOpMF(Vector<Short> v,
+    ShortMaxVector bOpMF(Vector<Short> v,
                      VectorMask<Short> m, FBinOp f) {
-        return (Short128Vector)
-            super.bOpTemplateMF((Short128Vector)v, (Short128Mask)m,
+        return (ShortMaxVector)
+            super.bOpTemplateMF((ShortMaxVector)v, (ShortMaxMask)m,
                                 f);  // specialize
     }
 
@@ -219,19 +219,19 @@ value class Short128Vector extends ShortVector {
 
     @ForceInline
     final @Override
-    Short128Vector tOpMF(Vector<Short> v1, Vector<Short> v2, FTriOp f) {
-        return (Short128Vector)
-            super.tOpTemplateMF((Short128Vector)v1, (Short128Vector)v2,
+    ShortMaxVector tOpMF(Vector<Short> v1, Vector<Short> v2, FTriOp f) {
+        return (ShortMaxVector)
+            super.tOpTemplateMF((ShortMaxVector)v1, (ShortMaxVector)v2,
                                 f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Short128Vector tOpMF(Vector<Short> v1, Vector<Short> v2,
+    ShortMaxVector tOpMF(Vector<Short> v1, Vector<Short> v2,
                      VectorMask<Short> m, FTriOp f) {
-        return (Short128Vector)
-            super.tOpTemplateMF((Short128Vector)v1, (Short128Vector)v2,
-                                (Short128Mask)m, f);  // specialize
+        return (ShortMaxVector)
+            super.tOpTemplateMF((ShortMaxVector)v1, (ShortMaxVector)v2,
+                                (ShortMaxMask)m, f);  // specialize
     }
 
     @ForceInline
@@ -269,64 +269,64 @@ value class Short128Vector extends ShortVector {
 
     @Override
     @ForceInline
-    public Short128Vector lanewise(Unary op) {
-        return (Short128Vector) super.lanewiseTemplate(op);  // specialize
+    public ShortMaxVector lanewise(Unary op) {
+        return (ShortMaxVector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector lanewise(Unary op, VectorMask<Short> m) {
-        return (Short128Vector) super.lanewiseTemplate(op, Short128Mask.class, (Short128Mask) m);  // specialize
+    public ShortMaxVector lanewise(Unary op, VectorMask<Short> m) {
+        return (ShortMaxVector) super.lanewiseTemplate(op, ShortMaxMask.class, (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector lanewise(Binary op, Vector<Short> v) {
-        return (Short128Vector) super.lanewiseTemplate(op, v);  // specialize
+    public ShortMaxVector lanewise(Binary op, Vector<Short> v) {
+        return (ShortMaxVector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector lanewise(Binary op, Vector<Short> v, VectorMask<Short> m) {
-        return (Short128Vector) super.lanewiseTemplate(op, Short128Mask.class, v, (Short128Mask) m);  // specialize
+    public ShortMaxVector lanewise(Binary op, Vector<Short> v, VectorMask<Short> m) {
+        return (ShortMaxVector) super.lanewiseTemplate(op, ShortMaxMask.class, v, (ShortMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Short128Vector
+    @ForceInline ShortMaxVector
     lanewiseShift(VectorOperators.Binary op, int e) {
-        return (Short128Vector) super.lanewiseShiftTemplate(op, e);  // specialize
+        return (ShortMaxVector) super.lanewiseShiftTemplate(op, e);  // specialize
     }
 
     /*package-private*/
     @Override
-    @ForceInline Short128Vector
+    @ForceInline ShortMaxVector
     lanewiseShift(VectorOperators.Binary op, int e, VectorMask<Short> m) {
-        return (Short128Vector) super.lanewiseShiftTemplate(op, Short128Mask.class, e, (Short128Mask) m);  // specialize
+        return (ShortMaxVector) super.lanewiseShiftTemplate(op, ShortMaxMask.class, e, (ShortMaxMask) m);  // specialize
     }
 
     /*package-private*/
     @Override
     @ForceInline
     public final
-    Short128Vector
+    ShortMaxVector
     lanewise(Ternary op, Vector<Short> v1, Vector<Short> v2) {
-        return (Short128Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+        return (ShortMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Short128Vector
+    ShortMaxVector
     lanewise(Ternary op, Vector<Short> v1, Vector<Short> v2, VectorMask<Short> m) {
-        return (Short128Vector) super.lanewiseTemplate(op, Short128Mask.class, v1, v2, (Short128Mask) m);  // specialize
+        return (ShortMaxVector) super.lanewiseTemplate(op, ShortMaxMask.class, v1, v2, (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Short128Vector addIndex(int scale) {
-        return (Short128Vector) super.addIndexTemplate(scale);  // specialize
+    ShortMaxVector addIndex(int scale) {
+        return (ShortMaxVector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
@@ -341,7 +341,7 @@ value class Short128Vector extends ShortVector {
     @ForceInline
     public final short reduceLanes(VectorOperators.Associative op,
                                     VectorMask<Short> m) {
-        return super.reduceLanesTemplate(op, Short128Mask.class, (Short128Mask) m);  // specialized
+        return super.reduceLanesTemplate(op, ShortMaxMask.class, (ShortMaxMask) m);  // specialized
     }
 
     @Override
@@ -354,173 +354,166 @@ value class Short128Vector extends ShortVector {
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, Short128Mask.class, (Short128Mask) m);  // specialized
+        return (long) super.reduceLanesTemplate(op, ShortMaxMask.class, (ShortMaxMask) m);  // specialized
     }
 
     @ForceInline
     public VectorShuffle<Short> toShuffle() {
-        return super.toShuffleTemplate(Short128Shuffle.class); // specialize
+        return super.toShuffleTemplate(ShortMaxShuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Short128Mask test(Test op) {
-        return super.testTemplate(Short128Mask.class, op);  // specialize
+    public final ShortMaxMask test(Test op) {
+        return super.testTemplate(ShortMaxMask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Short128Mask test(Test op, VectorMask<Short> m) {
-        return super.testTemplate(Short128Mask.class, op, (Short128Mask) m);  // specialize
+    public final ShortMaxMask test(Test op, VectorMask<Short> m) {
+        return super.testTemplate(ShortMaxMask.class, op, (ShortMaxMask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Short128Mask compare(Comparison op, Vector<Short> v) {
-        return super.compareTemplate(Short128Mask.class, op, v);  // specialize
+    public final ShortMaxMask compare(Comparison op, Vector<Short> v) {
+        return super.compareTemplate(ShortMaxMask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Short128Mask compare(Comparison op, short s) {
-        return super.compareTemplate(Short128Mask.class, op, s);  // specialize
+    public final ShortMaxMask compare(Comparison op, short s) {
+        return super.compareTemplate(ShortMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Short128Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Short128Mask.class, op, s);  // specialize
+    public final ShortMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(ShortMaxMask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Short128Mask compare(Comparison op, Vector<Short> v, VectorMask<Short> m) {
-        return super.compareTemplate(Short128Mask.class, op, v, (Short128Mask) m);
+    public final ShortMaxMask compare(Comparison op, Vector<Short> v, VectorMask<Short> m) {
+        return super.compareTemplate(ShortMaxMask.class, op, v, (ShortMaxMask) m);
     }
 
 
     @Override
     @ForceInline
-    public Short128Vector blend(Vector<Short> v, VectorMask<Short> m) {
-        return (Short128Vector)
-            super.blendTemplate(Short128Mask.class,
-                                (Short128Vector) v,
-                                (Short128Mask) m);  // specialize
+    public ShortMaxVector blend(Vector<Short> v, VectorMask<Short> m) {
+        return (ShortMaxVector)
+            super.blendTemplate(ShortMaxMask.class,
+                                (ShortMaxVector) v,
+                                (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector slice(int origin, Vector<Short> v) {
-        return (Short128Vector) super.sliceTemplate(origin, v);  // specialize
+    public ShortMaxVector slice(int origin, Vector<Short> v) {
+        return (ShortMaxVector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector slice(int origin) {
-        return (Short128Vector) super.sliceTemplate(origin);  // specialize
+    public ShortMaxVector slice(int origin) {
+        return (ShortMaxVector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector unslice(int origin, Vector<Short> w, int part) {
-        return (Short128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public ShortMaxVector unslice(int origin, Vector<Short> w, int part) {
+        return (ShortMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector unslice(int origin, Vector<Short> w, int part, VectorMask<Short> m) {
-        return (Short128Vector)
-            super.unsliceTemplate(Short128Mask.class,
+    public ShortMaxVector unslice(int origin, Vector<Short> w, int part, VectorMask<Short> m) {
+        return (ShortMaxVector)
+            super.unsliceTemplate(ShortMaxMask.class,
                                   origin, w, part,
-                                  (Short128Mask) m);  // specialize
+                                  (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector unslice(int origin) {
-        return (Short128Vector) super.unsliceTemplate(origin);  // specialize
+    public ShortMaxVector unslice(int origin) {
+        return (ShortMaxVector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector rearrange(VectorShuffle<Short> s) {
-        return (Short128Vector)
-            super.rearrangeTemplate(Short128Shuffle.class,
-                                    (Short128Shuffle) s);  // specialize
+    public ShortMaxVector rearrange(VectorShuffle<Short> s) {
+        return (ShortMaxVector)
+            super.rearrangeTemplate(ShortMaxShuffle.class,
+                                    (ShortMaxShuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector rearrange(VectorShuffle<Short> shuffle,
+    public ShortMaxVector rearrange(VectorShuffle<Short> shuffle,
                                   VectorMask<Short> m) {
-        return (Short128Vector)
-            super.rearrangeTemplate(Short128Shuffle.class,
-                                    Short128Mask.class,
-                                    (Short128Shuffle) shuffle,
-                                    (Short128Mask) m);  // specialize
+        return (ShortMaxVector)
+            super.rearrangeTemplate(ShortMaxShuffle.class,
+                                    ShortMaxMask.class,
+                                    (ShortMaxShuffle) shuffle,
+                                    (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector rearrange(VectorShuffle<Short> s,
+    public ShortMaxVector rearrange(VectorShuffle<Short> s,
                                   Vector<Short> v) {
-        return (Short128Vector)
-            super.rearrangeTemplate(Short128Shuffle.class,
-                                    (Short128Shuffle) s,
-                                    (Short128Vector) v);  // specialize
+        return (ShortMaxVector)
+            super.rearrangeTemplate(ShortMaxShuffle.class,
+                                    (ShortMaxShuffle) s,
+                                    (ShortMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector compress(VectorMask<Short> m) {
-        return (Short128Vector)
-            super.compressTemplate(Short128Mask.class,
-                                   (Short128Mask) m);  // specialize
+    public ShortMaxVector compress(VectorMask<Short> m) {
+        return (ShortMaxVector)
+            super.compressTemplate(ShortMaxMask.class,
+                                   (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector expand(VectorMask<Short> m) {
-        return (Short128Vector)
-            super.expandTemplate(Short128Mask.class,
-                                   (Short128Mask) m);  // specialize
+    public ShortMaxVector expand(VectorMask<Short> m) {
+        return (ShortMaxVector)
+            super.expandTemplate(ShortMaxMask.class,
+                                   (ShortMaxMask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector selectFrom(Vector<Short> v) {
-        return (Short128Vector)
-            super.selectFromTemplate((Short128Vector) v);  // specialize
+    public ShortMaxVector selectFrom(Vector<Short> v) {
+        return (ShortMaxVector)
+            super.selectFromTemplate((ShortMaxVector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Short128Vector selectFrom(Vector<Short> v,
+    public ShortMaxVector selectFrom(Vector<Short> v,
                                    VectorMask<Short> m) {
-        return (Short128Vector)
-            super.selectFromTemplate((Short128Vector) v,
-                                     (Short128Mask) m);  // specialize
+        return (ShortMaxVector)
+            super.selectFromTemplate((ShortMaxVector) v,
+                                     (ShortMaxMask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
     public short lane(int i) {
-        switch(i) {
-            case 0: return laneHelper(0);
-            case 1: return laneHelper(1);
-            case 2: return laneHelper(2);
-            case 3: return laneHelper(3);
-            case 4: return laneHelper(4);
-            case 5: return laneHelper(5);
-            case 6: return laneHelper(6);
-            case 7: return laneHelper(7);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return laneHelper(i);
     }
 
     public short laneHelper(int i) {
@@ -536,21 +529,14 @@ value class Short128Vector extends ShortVector {
 
     @ForceInline
     @Override
-    public Short128Vector withLane(int i, short e) {
-        switch (i) {
-            case 0: return withLaneHelper(0, e);
-            case 1: return withLaneHelper(1, e);
-            case 2: return withLaneHelper(2, e);
-            case 3: return withLaneHelper(3, e);
-            case 4: return withLaneHelper(4, e);
-            case 5: return withLaneHelper(5, e);
-            case 6: return withLaneHelper(6, e);
-            case 7: return withLaneHelper(7, e);
-            default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+    public ShortMaxVector withLane(int i, short e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
+        return withLaneHelper(i, e);
     }
 
-    public Short128Vector withLaneHelper(int i, short e) {
+    public ShortMaxVector withLaneHelper(int i, short e) {
        return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
@@ -566,22 +552,22 @@ value class Short128Vector extends ShortVector {
 
     // Mask
 
-    static final value class Short128Mask extends AbstractMask<Short> {
+    static final value class ShortMaxMask extends AbstractMask<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        Short128Mask(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64Z) payload;
+        ShortMaxMask(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxSZ) payload;
         }
 
-        private final VectorPayloadMF64Z payload;
+        private final VectorPayloadMFMaxSZ payload;
 
-        Short128Mask(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+        ShortMaxMask(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
         }
 
-        Short128Mask(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+        ShortMaxMask(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
         }
 
 
@@ -603,32 +589,32 @@ value class Short128Vector extends ShortVector {
         @ForceInline
         @Override
         public final
-        Short128Vector toVector() {
-            return (Short128Vector) super.toVectorTemplate();  // specialize
+        ShortMaxVector toVector() {
+            return (ShortMaxVector) super.toVectorTemplate();  // specialize
         }
 
         @Override
         @ForceInline
         /*package-private*/
-        Short128Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Short128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Short128Mask.class, short.class, VLENGTH, offset, limit,
-                (o, l) -> (Short128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        ShortMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (ShortMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                ShortMaxMask.class, short.class, VLENGTH, offset, limit,
+                (o, l) -> (ShortMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Short128Mask not() {
+        public ShortMaxMask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Short128Mask compress() {
-            return (Short128Mask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Short128Vector.class, Short128Mask.class, ETYPE, VLENGTH, null, this,
+        public ShortMaxMask compress() {
+            return (ShortMaxMask) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                ShortMaxVector.class, ShortMaxMask.class, ETYPE, VLENGTH, null, this,
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
         }
 
@@ -637,32 +623,32 @@ value class Short128Vector extends ShortVector {
 
         @Override
         @ForceInline
-        public Short128Mask and(VectorMask<Short> mask) {
+        public ShortMaxMask and(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
-            Short128Mask m = (Short128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Short128Mask.class, null,
+            ShortMaxMask m = (ShortMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, ShortMaxMask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a & b));
+                                          (m1, m2, vm) -> (ShortMaxMask) m1.bOpMF(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Short128Mask or(VectorMask<Short> mask) {
+        public ShortMaxMask or(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
-            Short128Mask m = (Short128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Short128Mask.class, null,
+            ShortMaxMask m = (ShortMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, ShortMaxMask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a | b));
+                                          (m1, m2, vm) -> (ShortMaxMask) m1.bOpMF(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Short128Mask xor(VectorMask<Short> mask) {
+        public ShortMaxMask xor(VectorMask<Short> mask) {
             Objects.requireNonNull(mask);
-            Short128Mask m = (Short128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Short128Mask.class, null,
+            ShortMaxMask m = (ShortMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, ShortMaxMask.class, null,
                                           short.class, VLENGTH, this, m, null,
-                                          (m1, m2, vm) -> (Short128Mask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
+                                          (m1, m2, vm) -> (ShortMaxMask) m1.bOpMF(m2, (i, a, b) -> a ^ b));
         }
 
         // Mask Query operations
@@ -670,22 +656,22 @@ value class Short128Vector extends ShortVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Short128Mask.class, short.class, VLENGTH, this,
-                                                            (m) -> ((Short128Mask) m).trueCountHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, ShortMaxMask.class, short.class, VLENGTH, this,
+                                                            (m) -> ((ShortMaxMask) m).trueCountHelper());
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Short128Mask.class, short.class, VLENGTH, this,
-                                                            (m) -> ((Short128Mask) m).firstTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, ShortMaxMask.class, short.class, VLENGTH, this,
+                                                            (m) -> ((ShortMaxMask) m).firstTrueHelper());
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Short128Mask.class, short.class, VLENGTH, this,
-                                                            (m) -> ((Short128Mask) m).lastTrueHelper());
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, ShortMaxMask.class, short.class, VLENGTH, this,
+                                                            (m) -> ((ShortMaxMask) m).lastTrueHelper());
         }
 
         @Override
@@ -694,8 +680,8 @@ value class Short128Vector extends ShortVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Short128Mask.class, short.class, VLENGTH, this,
-                                                      (m) -> ((Short128Mask) m).toLongHelper());
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, ShortMaxMask.class, short.class, VLENGTH, this,
+                                                      (m) -> ((ShortMaxMask) m).toLongHelper());
         }
 
         // laneIsSet
@@ -704,8 +690,8 @@ value class Short128Vector extends ShortVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Short128Mask.class, short.class, VLENGTH,
-                                         this, i, (m, idx) -> (((Short128Mask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
+            return VectorSupport.extract(ShortMaxMask.class, short.class, VLENGTH,
+                                         this, i, (m, idx) -> (((ShortMaxMask) m).laneIsSetHelper(idx) ? 1L : 0L)) == 1L;
         }
 
         // Reductions
@@ -713,54 +699,54 @@ value class Short128Vector extends ShortVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Short128Mask.class, short.class, VLENGTH,
+            return VectorSupport.test(BT_ne, ShortMaxMask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Short128Mask) m).anyTrueHelper());
+                                         (m, __) -> ((ShortMaxMask) m).anyTrueHelper());
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Short128Mask.class, short.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, ShortMaxMask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> ((Short128Mask) m).allTrueHelper());
+                                         (m, __) -> ((ShortMaxMask) m).allTrueHelper());
         }
 
         @ForceInline
         /*package-private*/
-        static Short128Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Short128Mask.class, short.class, VLENGTH,
+        static ShortMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(ShortMaxMask.class, short.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Short128Mask  TRUE_MASK = new Short128Mask(true);
-        private static final Short128Mask FALSE_MASK = new Short128Mask(false);
+        private static final ShortMaxMask  TRUE_MASK = new ShortMaxMask(true);
+        private static final ShortMaxMask FALSE_MASK = new ShortMaxMask(false);
 
     }
 
     // Shuffle
 
-    static final value class Short128Shuffle extends AbstractShuffle<Short> {
+    static final value class ShortMaxShuffle extends AbstractShuffle<Short> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
-        private final VectorPayloadMF64B payload;
+        private final VectorPayloadMFMaxSB payload;
 
-        Short128Shuffle(VectorPayloadMF payload) {
-            this.payload = (VectorPayloadMF64B) payload;
+        ShortMaxShuffle(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMFMaxSB) payload;
             assert(VLENGTH == payload.length());
             assert(indexesInRange(payload));
         }
 
-        public Short128Shuffle(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        public ShortMaxShuffle(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
         }
 
-        public Short128Shuffle(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+        public ShortMaxShuffle(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
         }
 
-        public Short128Shuffle(int[] indexes) {
+        public ShortMaxShuffle(int[] indexes) {
             this(indexes, 0);
         }
 
@@ -782,13 +768,13 @@ value class Short128Vector extends ShortVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Short128Shuffle IOTA = new Short128Shuffle(IDENTITY);
+        static final ShortMaxShuffle IOTA = new ShortMaxShuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Short128Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Short128Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Short128Vector)(((AbstractShuffle<Short>)(s)).toVectorTemplate())));
+        public ShortMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, ShortMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((ShortMaxVector)(((AbstractShuffle<Short>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -803,11 +789,11 @@ value class Short128Vector extends ShortVector {
 
         @ForceInline
         @Override
-        public Short128Shuffle rearrange(VectorShuffle<Short> shuffle) {
-            Short128Shuffle s = (Short128Shuffle) shuffle;
+        public ShortMaxShuffle rearrange(VectorShuffle<Short> shuffle) {
+            ShortMaxShuffle s = (ShortMaxShuffle) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {
@@ -816,7 +802,7 @@ value class Short128Vector extends ShortVector {
                 Unsafe.getUnsafe().putByte(r, offset + i * Byte.BYTES, (byte) si);
             }
             r = Unsafe.getUnsafe().finishPrivateBuffer(r);
-            return new Short128Shuffle(r);
+            return new ShortMaxShuffle(r);
         }
     }
 
@@ -835,7 +821,7 @@ value class Short128Vector extends ShortVector {
     @Override
     final
     ShortVector fromArray0(short[] a, int offset, VectorMask<Short> m, int offsetInRange) {
-        return super.fromArray0Template(Short128Mask.class, a, offset, (Short128Mask) m, offsetInRange);  // specialize
+        return super.fromArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m, offsetInRange);  // specialize
     }
 
 
@@ -850,7 +836,7 @@ value class Short128Vector extends ShortVector {
     @Override
     final
     ShortVector fromCharArray0(char[] a, int offset, VectorMask<Short> m, int offsetInRange) {
-        return super.fromCharArray0Template(Short128Mask.class, a, offset, (Short128Mask) m, offsetInRange);  // specialize
+        return super.fromCharArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m, offsetInRange);  // specialize
     }
 
 
@@ -865,7 +851,7 @@ value class Short128Vector extends ShortVector {
     @Override
     final
     ShortVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Short> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Short128Mask.class, ms, offset, (Short128Mask) m, offsetInRange);  // specialize
+        return super.fromMemorySegment0Template(ShortMaxMask.class, ms, offset, (ShortMaxMask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
@@ -879,7 +865,7 @@ value class Short128Vector extends ShortVector {
     @Override
     final
     void intoArray0(short[] a, int offset, VectorMask<Short> m) {
-        super.intoArray0Template(Short128Mask.class, a, offset, (Short128Mask) m);
+        super.intoArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m);
     }
 
 
@@ -888,14 +874,14 @@ value class Short128Vector extends ShortVector {
     @Override
     final
     void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Short> m) {
-        super.intoMemorySegment0Template(Short128Mask.class, ms, offset, (Short128Mask) m);
+        super.intoMemorySegment0Template(ShortMaxMask.class, ms, offset, (ShortMaxMask) m);
     }
 
     @ForceInline
     @Override
     final
     void intoCharArray0(char[] a, int offset, VectorMask<Short> m) {
-        super.intoCharArray0Template(Short128Mask.class, a, offset, (Short128Mask) m);
+        super.intoCharArray0Template(ShortMaxMask.class, a, offset, (ShortMaxMask) m);
     }
 
     // End of specialized low-level memory operations.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -376,9 +376,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> $abstractvectortype$ ldOpMF(M memory, int offset,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                $type$.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                $type$.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
@@ -394,9 +395,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   VectorMask<$Boxtype$> m,
                                   FLdOp<M> f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                $type$.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                $type$.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -421,9 +423,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ ldLongOpMF(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                $type$.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                $type$.class, length, is_max_species));
         long vOffset = this.multiFieldOffset();
         for (int i = 0; i < length; i++) {
             Unsafe.getUnsafe().put$Type$(tpayload, vOffset + i * $Boxtype$.BYTES, f.apply(memory, offset, i));
@@ -439,9 +442,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                                   VectorMask<$Boxtype$> m,
                                   FLdLongOp f) {
         int length = vspecies().length();
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
         VectorPayloadMF tpayload =
-            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newInstanceFactory(
-                $type$.class, length));
+            Unsafe.getUnsafe().makePrivateBuffer(VectorPayloadMF.newVectorInstanceFactory(
+                $type$.class, length, is_max_species));
         VectorPayloadMF mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -549,7 +553,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         int length = vspecies().length();
         VectorPayloadMF vec1 = vec();
         VectorPayloadMF vec2 = (($abstractvectortype$)o).vec();
-        VectorPayloadMF mbits = VectorPayloadMF.newInstanceFactory(boolean.class, length);
+        boolean is_max_species = ((AbstractSpecies)vspecies()).is_max_species();
+        VectorPayloadMF mbits = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
         mbits = Unsafe.getUnsafe().makePrivateBuffer(mbits);
         long vOffset = this.multiFieldOffset();
         long mOffset = mbits.multiFieldOffset();
@@ -3784,11 +3789,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -4424,11 +4427,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -4968,11 +4969,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-            assert false : "Unhandled case for Multi-field based MaxVector";
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -5160,12 +5159,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             // indexShape is still S_MAX_BIT, but the lane count of int vector
             // is 64. So when loading index vector (IntVector), only lower half
             // of index data is needed.
-            /*vix = IntVector
+            vix = IntVector
                 .fromArray(isp, indexMap, mapOffset, IntMaxVector.IntMaxMask.LOWER_HALF_TRUE_MASK)
                 .add(offset);
-             */
-             assert false : "Unhandled case for Multi-field based MaxVector";
-
         } else {
             vix = IntVector
                 .fromArray(isp, indexMap, mapOffset)
@@ -5717,9 +5713,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @Override
         @ForceInline
         public final $abstractvectortype$ zero() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == $Type$MaxVector.class)
-            //    return $Type$MaxVector.ZERO;
+            if ((Class<?>) vectorType() == $Type$MaxVector.class)
+               return $Type$MaxVector.ZERO;
             switch (vectorBitSize()) {
                 case 64: return $Type$64Vector.ZERO;
                 case 128: return $Type$128Vector.ZERO;
@@ -5732,9 +5727,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @Override
         @ForceInline
         public final $abstractvectortype$ iota() {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == $Type$MaxVector.class)
-            //    return $Type$MaxVector.IOTA;
+            if ((Class<?>) vectorType() == $Type$MaxVector.class)
+                return $Type$MaxVector.IOTA;
             switch (vectorBitSize()) {
                 case 64: return $Type$64Vector.IOTA;
                 case 128: return $Type$128Vector.IOTA;
@@ -5748,9 +5742,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @Override
         @ForceInline
         public final VectorMask<$Boxtype$> maskAll(boolean bit) {
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //if ((Class<?>) vectorType() == $Type$MaxVector.class)
-            //    return $Type$MaxVector.$Type$MaxMask.maskAll(bit);
+            if ((Class<?>) vectorType() == $Type$MaxVector.class)
+                return $Type$MaxVector.$Type$MaxMask.maskAll(bit);
             switch (vectorBitSize()) {
                 case 64: return $Type$64Vector.$Type$64Mask.maskAll(bit);
                 case 128: return $Type$128Vector.$Type$128Mask.maskAll(bit);
@@ -5785,8 +5778,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             case VectorShape.SK_128_BIT: return ($Type$Species) SPECIES_128;
             case VectorShape.SK_256_BIT: return ($Type$Species) SPECIES_256;
             case VectorShape.SK_512_BIT: return ($Type$Species) SPECIES_512;
-            // FIXME: Enable once multi-field based MaxVector is supported.
-            //case VectorShape.SK_Max_BIT: return ($Type$Species) SPECIES_MAX;
+            case VectorShape.SK_Max_BIT: return ($Type$Species) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }
@@ -5820,13 +5812,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                             $Type$512Vector::new);
 
     /** Species representing {@link $Type$Vector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
-    // FIXME: Enable once multi-field based MaxVector is supported.
-    /*public static final VectorSpecies<$Boxtype$> SPECIES_MAX
+    public static final VectorSpecies<$Boxtype$> SPECIES_MAX
         = new $Type$Species(VectorShape.S_Max_BIT,
                             $Type$MaxVector.class,
                             $Type$MaxVector.$Type$MaxMask.class,
                             $Type$MaxVector::new);
-     */
 
     /**
      * Preferred species for {@link $Type$Vector}s.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -846,11 +846,11 @@ value class $vectortype$ extends $abstractvectortype$ {
         private final VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$Z payload;
 
         $masktype$(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         $masktype$(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, true));
+            this(prepare(val, VSPECIES));
         }
 #else[Max]
         $masktype$(VectorPayloadMF payload) {
@@ -860,11 +860,11 @@ value class $vectortype$ extends $abstractvectortype$ {
         private final VectorPayloadMF$vectorsizeinbytes$Z payload;
 
         $masktype$(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, ETYPE, VLENGTH, false));
+            this(prepare(payload, offset, VSPECIES));
         }
 
         $masktype$(boolean val) {
-            this(prepare(val, ETYPE, VLENGTH, false));
+            this(prepare(val, VSPECIES));
         }
 #end[Max]
 
@@ -1060,11 +1060,11 @@ value class $vectortype$ extends $abstractvectortype$ {
         }
 
         public $shuffletype$(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public $shuffletype$(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, true));
+            this(prepare(fn, VSPECIES));
         }
 #else[Max]
         private final VectorPayloadMF$vectorsizeinbytes$B payload;
@@ -1076,11 +1076,11 @@ value class $vectortype$ extends $abstractvectortype$ {
         }
 
         public $shuffletype$(int[] indexes, int i) {
-            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+            this(prepare(indexes, i, VSPECIES));
         }
 
         public $shuffletype$(IntUnaryOperator fn) {
-            this(prepare(ETYPE, VLENGTH, fn, false));
+            this(prepare(fn, VSPECIES));
         }
 #end[Max]
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -69,8 +69,13 @@ value class $vectortype$ extends $abstractvectortype$ {
         return payload;
     }
 
-    static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.newInstanceFactory($type$.class, $numLanes$));
-    static final $vectortype$ IOTA = new $vectortype$(VectorPayloadMF.createVectPayloadInstance$Boxinitials$($numLanes$, ($type$[])(VSPECIES.iotaArray())));
+#if[!Max]
+    static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.newVectorInstanceFactory($type$.class, $numLanes$, false));
+    static final $vectortype$ IOTA = new $vectortype$(VectorPayloadMF.createVectPayloadInstance$Boxinitials$(VLENGTH, ($type$[])(VSPECIES.iotaArray()), false));
+#else[!Max]
+    static final $vectortype$ ZERO = new $vectortype$(VectorPayloadMF.newVectorInstanceFactory($type$.class, $numLanes$, true));
+    static final $vectortype$ IOTA = new $vectortype$(VectorPayloadMF.createVectPayloadInstance$Boxinitials$(VLENGTH, ($type$[])(VSPECIES.iotaArray()), true));
+#end[!Max]
 
     static {
         // Warm up a few species caches.
@@ -833,19 +838,36 @@ value class $vectortype$ extends $abstractvectortype$ {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
 
-        private final VectorPayloadMF$vectorsizeinbytes$Z payload;
+#if[Max]
+        $masktype$(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$Z) payload;
+        }
 
+        private final VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$Z payload;
+
+        $masktype$(VectorPayloadMF payload, int offset) {
+            this(prepare(payload, offset, ETYPE, VLENGTH, true));
+        }
+
+        $masktype$(boolean val) {
+            this(prepare(val, ETYPE, VLENGTH, true));
+        }
+#else[Max]
         $masktype$(VectorPayloadMF payload) {
             this.payload = (VectorPayloadMF$vectorsizeinbytes$Z) payload;
         }
 
+        private final VectorPayloadMF$vectorsizeinbytes$Z payload;
+
         $masktype$(VectorPayloadMF payload, int offset) {
-            this(prepare(payload, offset, VLENGTH));
+            this(prepare(payload, offset, ETYPE, VLENGTH, false));
         }
 
         $masktype$(boolean val) {
-            this(prepare(val, VLENGTH));
+            this(prepare(val, ETYPE, VLENGTH, false));
         }
+#end[Max]
+
 
         @ForceInline
         final @Override
@@ -1001,7 +1023,11 @@ value class $vectortype$ extends $abstractvectortype$ {
 #if[intAndMax]
 
         static VectorPayloadMF maskLowerHalf() {
-            VectorPayloadMF newObj = VectorPayloadMF.newInstanceFactory(boolean.class, VLENGTH);
+#if[Max]
+            VectorPayloadMF newObj = VectorPayloadMF.newMaskInstanceFactory(ETYPE, VLENGTH, true);
+#else[Max]
+            VectorPayloadMF newObj = VectorPayloadMF.newMaskInstanceFactory(ETYPE, VLENGTH, false);
+#end[Max]
             newObj = Unsafe.getUnsafe().makePrivateBuffer(newObj);
             long mf_offset = newObj.multiFieldOffset();
             int len = VLENGTH >> 1;
@@ -1024,6 +1050,23 @@ value class $vectortype$ extends $abstractvectortype$ {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
 
+#if[Max]
+        private final VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$B payload;
+
+        $shuffletype$(VectorPayloadMF payload) {
+            this.payload = (VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$B) payload;
+            assert(VLENGTH == payload.length());
+            assert(indexesInRange(payload));
+        }
+
+        public $shuffletype$(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, true));
+        }
+
+        public $shuffletype$(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, true));
+        }
+#else[Max]
         private final VectorPayloadMF$vectorsizeinbytes$B payload;
 
         $shuffletype$(VectorPayloadMF payload) {
@@ -1032,17 +1075,19 @@ value class $vectortype$ extends $abstractvectortype$ {
             assert(indexesInRange(payload));
         }
 
+        public $shuffletype$(int[] indexes, int i) {
+            this(prepare(ETYPE, VLENGTH, indexes, i, false));
+        }
+
+        public $shuffletype$(IntUnaryOperator fn) {
+            this(prepare(ETYPE, VLENGTH, fn, false));
+        }
+#end[Max]
+
         public $shuffletype$(int[] indexes) {
             this(indexes, 0);
         }
 
-        public $shuffletype$(int[] indexes, int i) {
-            this(prepare(VLENGTH, indexes, i));
-        }
-
-        public $shuffletype$(IntUnaryOperator fn) {
-            this(prepare(VLENGTH, fn));
-        }
 
         @ForceInline
         @Override
@@ -1086,7 +1131,11 @@ value class $vectortype$ extends $abstractvectortype$ {
             $shuffletype$ s = ($shuffletype$) shuffle;
             VectorPayloadMF indices1 = indices();
             VectorPayloadMF indices2 = s.indices();
-            VectorPayloadMF r = VectorPayloadMF.newInstanceFactory(byte.class, VLENGTH);
+#if[Max]
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, true);
+#else[Max]
+            VectorPayloadMF r = VectorPayloadMF.newShuffleInstanceFactory(ETYPE, VLENGTH, false);
+#end[Max]
             r = Unsafe.getUnsafe().makePrivateBuffer(r);
             long offset = r.multiFieldOffset();
             for (int i = 0; i < VLENGTH; i++) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
@@ -148,8 +148,7 @@ do
   esac
 
   old_args="$args"
-  # for bits in 64 128 256 512 Max
-  for bits in 64 128 256 512
+  for bits in 64 128 256 512 Max
   do
     vectortype=${typeprefix}${Type}${bits}Vector
     masktype=${typeprefix}${Type}${bits}Mask
@@ -178,6 +177,7 @@ do
 
     if [[ "${bits}" == "Max" ]]; then
         vectorindextype="vix.getClass()"
+        vectorsizeinbytes="${bits}"
     else
         vectorindextype="Int${vectorindexbits}Vector.class"
     fi;

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -210,3 +210,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64
+
+# lworld+vector
+compiler/vectorapi/VectorReinterpretTest.java


### PR DESCRIPTION
- Patch adds MaxSpecies support for all types of vectors.
- New factory methods and VectorPayload classes for various kinds of vector, shuffle and mask payloads.
- Disable CDS archiving of VectorPayload classes.
- Summary of high level flow :-
  1/ Max species payloads encapsulate @multifield annotated field accepting -1 value as bundle size parameter.
  2/ For Vector payload bundle size is determined using maximum vector size supported by the target. 
  3/ For Shuffles and Masks payloads multifield bundle size is a function of maximum vector size and vector lane size.
  4/ Based on the dynamic bundle size parser creates a separate FieldInfo structure for each base and synthetic multifield and rest of the flow remains the same. 

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8311675](https://bugs.openjdk.org/browse/JDK-8311675): [lworld+vector] Max Species support. (**Enhancement** - P4)


### Reviewers
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer) ⚠️ Review applies to [945eb0fb](https://git.openjdk.org/valhalla/pull/931/files/945eb0fb9487f1b8b1eb0afb30ff0b209aafd71a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/931/head:pull/931` \
`$ git checkout pull/931`

Update a local copy of the PR: \
`$ git checkout pull/931` \
`$ git pull https://git.openjdk.org/valhalla.git pull/931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 931`

View PR using the GUI difftool: \
`$ git pr show -t 931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/931.diff">https://git.openjdk.org/valhalla/pull/931.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/931#issuecomment-1739797968)