### PR TITLE
8317658: [lworld] TemplateTable::withfield() does not correctly load the ResolvedFieldEntry

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3292,8 +3292,7 @@ void TemplateTable::withfield() {
   Register cache = LP64_ONLY(c_rarg1) NOT_LP64(rcx);
   Register index = LP64_ONLY(c_rarg2) NOT_LP64(rdx);
 
-  resolve_cache_and_index(f2_byte, cache, index, sizeof(u2));
-  __ load_field_entry(cache, index);
+  resolve_cache_and_index_for_field(f2_byte, cache, index);
 
   __ lea(rax, at_tos());
   __ call_VM(rbx, CAST_FROM_FN_PTR(address, InterpreterRuntime::withfield), cache, rax);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -272,6 +272,7 @@ JRT_ENTRY(void, InterpreterRuntime::aconst_init(JavaThread* current, ConstantPoo
 JRT_END
 
 JRT_ENTRY(int, InterpreterRuntime::withfield(JavaThread* current, ResolvedFieldEntry* entry, uintptr_t ptr))
+  assert(entry->is_valid(), "Invalid ResolvedFieldEntry");
   oop obj = nullptr;
   int recv_offset = type2size[as_BasicType((TosState)entry->tos_state())];
   assert(frame::interpreter_frame_expression_stack_direction() == -1, "currently is -1 on all platforms");
@@ -396,6 +397,7 @@ JRT_ENTRY(void, InterpreterRuntime::uninitialized_static_inline_type_field(JavaT
   // The code below tries to load and initialize the field's class again before returning the default value.
   // If the field was not initialized because of an error, an exception should be thrown.
   // If the class is being initialized, the default value is returned.
+  assert(entry->is_valid(), "Invalid ResolvedFieldEntry");
   instanceHandle mirror_h(THREAD, (instanceOop)mirror);
   InstanceKlass* klass = entry->field_holder();
   u2 index = entry->field_index();
@@ -1428,6 +1430,7 @@ JRT_END
 JRT_ENTRY(void, InterpreterRuntime::post_field_access(JavaThread* current, oopDesc* obj,
                                                       ResolvedFieldEntry *entry))
 
+  assert(entry->is_valid(), "Invalid ResolvedFieldEntry");
   // check the access_flags for the field in the klass
 
   InstanceKlass* ik = entry->field_holder();
@@ -1452,6 +1455,7 @@ JRT_END
 JRT_ENTRY(void, InterpreterRuntime::post_field_modification(JavaThread* current, oopDesc* obj,
                                                             ResolvedFieldEntry *entry, jvalue *value))
 
+  assert(entry->is_valid(), "Invalid ResolvedFieldEntry");
   InstanceKlass* ik = entry->field_holder();
 
   // check the access_flags for the field in the klass

--- a/src/hotspot/share/oops/resolvedFieldEntry.cpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.cpp
@@ -24,6 +24,9 @@
 
 #include "precompiled.hpp"
 #include "resolvedFieldEntry.hpp"
+#include "interpreter/bytecodes.hpp"
+#include "oops/instanceOop.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 void ResolvedFieldEntry::print_on(outputStream* st) const {
   st->print_cr("Field Entry:");
@@ -43,6 +46,15 @@ void ResolvedFieldEntry::print_on(outputStream* st) const {
   st->print_cr(" - Is Null Free Inline Type: %d", is_null_free_inline_type());
   st->print_cr(" - Get Bytecode: %s", Bytecodes::name((Bytecodes::Code)get_code()));
   st->print_cr(" - Put Bytecode: %s", Bytecodes::name((Bytecodes::Code)put_code()));
+}
+
+bool ResolvedFieldEntry::is_valid() const {
+  return field_holder()->is_instance_klass() &&
+    field_offset() >= instanceOopDesc::base_offset_in_bytes() && field_offset() < 0x7fffffff &&
+    as_BasicType((TosState)tos_state()) != T_ILLEGAL &&
+    _flags < (1 << (max_flag_shift + 1)) &&
+    (get_code() == 0 || get_code() == Bytecodes::_getstatic || get_code() == Bytecodes::_getfield) &&
+    (put_code() == 0 || put_code() == Bytecodes::_putstatic || put_code() == Bytecodes::_putfield || put_code() == Bytecodes::_withfield);
 }
 
 void ResolvedFieldEntry::remove_unshareable_info() {

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -74,6 +74,7 @@ public:
       is_final_shift        = 1, // unused
       is_flat_shift         = 2,
       is_null_free_inline_type_shift = 3,
+      max_flag_shift = is_null_free_inline_type_shift,
   };
 
   // Getters
@@ -136,6 +137,7 @@ public:
     // These must be set after the other fields
     set_bytecode(&_get_code, b1);
     set_bytecode(&_put_code, b2);
+    assert(is_valid(), "invalid");
   }
 
   // CDS
@@ -150,6 +152,8 @@ public:
   static ByteSize type_offset()         { return byte_offset_of(ResolvedFieldEntry, _tos_state);    }
   static ByteSize flags_offset()        { return byte_offset_of(ResolvedFieldEntry, _flags);        }
 
+  // Debug help
+  bool is_valid() const;
 };
 
 #endif //SHARE_OOPS_RESOLVEDFIELDENTRY_HPP

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -72,16 +72,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
 compiler/gcbarriers/TestZGCBarrierElision.java#ZGen 8313737 generic-all
-compiler/valhalla/inlinetypes/TestArrays.java 8313667 generic-all
-compiler/valhalla/inlinetypes/TestBasicFunctionality.java 8317140 linux-x64
-compiler/valhalla/inlinetypes/TestCallingConvention.java 8317142 generic-all
-compiler/valhalla/inlinetypes/TestCallingConventionC1.java 8317143 generic-all
-compiler/valhalla/inlinetypes/TestC1.java 8317143 generic-all
-compiler/valhalla/inlinetypes/TestLWorld.java 8317145 linux-x64,windows-x64
-compiler/valhalla/inlinetypes/TestLWorldProfiling.java 8317146 linux-x64
-compiler/valhalla/inlinetypes/TestNullableArrays.java 8317147 linux-x64
-compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java 8317148 linux-x64
-compiler/valhalla/inlinetypes/TestValueClasses.java 8317149 generic-all
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Ensure ResolvedFieldEntry is correctly loaded

More testing might well be in order, but we are more than likely to remove `withfield` . To make up for the testing, using `assert(entry->is_valid())` upon passing to the interpreter runtime is useful for avoiding bugs in future changes to the hand-rolled assembler, that can be error prone when holding a lot of registers (e.g. `putfield`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8317658](https://bugs.openjdk.org/browse/JDK-8317658): [lworld] TemplateTable::withfield() does not correctly load the ResolvedFieldEntry (**Bug** - P2)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/936/head:pull/936` \
`$ git checkout pull/936`

Update a local copy of the PR: \
`$ git checkout pull/936` \
`$ git pull https://git.openjdk.org/valhalla.git pull/936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 936`

View PR using the GUI difftool: \
`$ git pr show -t 936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/936.diff">https://git.openjdk.org/valhalla/pull/936.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/936#issuecomment-1752745223)