### PR TITLE
8317699: [lworld+vector] Fix Vector API tests crash with "assert(vbox->is_Phi()) failed: should be phi"

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -251,7 +251,6 @@ Node* PhaseVector::expand_vbox_node_helper(Node* vbox,
                                            VectorSet &visited) {
   // JDK-8304948 shows an example that there may be a cycle in the graph.
   if (visited.test_set(vbox->_idx)) {
-    assert(vbox->is_Phi(), "should be phi");
     return vbox; // already visited
   }
 


### PR DESCRIPTION
Currently several jtreg tests under `test/jdk/jdk/jdk/incubator/vector` crash with following error:

```
A fatal error has been detected by the Java Runtime Environment:

Internal Error (valhalla/src/hotspot/share/opto/vector.cpp:257), pid=2737779, tid=2737796
assert(false) failed: should be phi

```
It happens when expanding a `VectorBoxNode` which has following inputs:

                        VectorBoxAllocate
                               |
                               |
       VectorBoxAllocate    [2 Proj]
               |             /   |
            [1 Proj]       /     |
               \         /       |
                 \     /        /
                   \ /        /
                 [2 Phi]    /
                     \    /
                       \ |
                     [1 Phi]     InlineType
                         \      /
                           \  /
                         VectorBox

The compiler will visit and expand all the inputs of the `PhiNode`, and mark them visited. If the input has been visited, it just returns without any action. And the compiler assumes the revisited node should be a PhiNode. In above graph, the first `Phi` (i.e. `[1 Phi]`) has the same input `[2 Proj]` with the second `Phi` (i.e. `[2 Phi]`). So `[2 Proj]` will be visited twice. At the second time it is visited, the assertion fails since it is not a Phi. The case is reasonable in java and the assertion can be removed.

Removing the assertion can fix the existing issue and no new issues are involved.

Jdk mainline also has the same issue, but I prefer fixing it here temporarily with following reasons:
 1) Several jtreg tests crash on this branch while pass on jdk mainline. This blocks our testing and further development.
 2) We can have more testing with this fix on this branch. And port it to jdk mainline once we think it's a mature/safe change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8317699](https://bugs.openjdk.org/browse/JDK-8317699): [lworld+vector] Fix Vector API tests crash with "assert(vbox-&gt;is_Phi()) failed: should be phi" (**Bug** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/937/head:pull/937` \
`$ git checkout pull/937`

Update a local copy of the PR: \
`$ git checkout pull/937` \
`$ git pull https://git.openjdk.org/valhalla.git pull/937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 937`

View PR using the GUI difftool: \
`$ git pr show -t 937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/937.diff">https://git.openjdk.org/valhalla/pull/937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/937#issuecomment-1754760607)