### PR TITLE
8316742: [lworld] Intrinsify Unsafe::isFlattenedArray()

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -102,6 +102,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/jdk.internal.classfile.instruction=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile.components=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.classfile.impl=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -618,6 +618,8 @@ class methodHandle;
   do_intrinsic(_copyMemory,               jdk_internal_misc_Unsafe,     copyMemory_name, copyMemory_signature,         F_RN)     \
    do_name(     copyMemory_name,                                        "copyMemory0")                                           \
    do_signature(copyMemory_signature,                                   "(Ljava/lang/Object;JLjava/lang/Object;JJ)V")            \
+  do_intrinsic(_isFlattenedArray,         jdk_internal_misc_Unsafe,     isFlattenedArray_name, class_boolean_signature, F_RN)    \
+   do_name(     isFlattenedArray_name,                                  "isFlattenedArray")                                      \
   do_intrinsic(_loadFence,                jdk_internal_misc_Unsafe,     loadFence_name, loadFence_signature,           F_R)      \
    do_name(     loadFence_name,                                         "loadFence")                                             \
    do_alias(    loadFence_signature,                                    void_method_signature)                                   \
@@ -630,8 +632,6 @@ class methodHandle;
   do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_RN)     \
    do_name(     fullFence_name,                                         "fullFence")                                             \
    do_alias(    fullFence_signature,                                    void_method_signature)                                   \
-  do_intrinsic(_isFlattenedArray,         jdk_internal_misc_Unsafe,     isFlattenedArray_name, class_boolean_signature, F_RN)    \
-   do_name(     isFlattenedArray_name,                                  "isFlattenedArray")                                      \
                                                                                                                         \
   /* Custom branch frequencies profiling support for JSR292 */                                                          \
   do_class(java_lang_invoke_MethodHandleImpl,               "java/lang/invoke/MethodHandleImpl")                        \

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -630,6 +630,8 @@ class methodHandle;
   do_intrinsic(_fullFence,                jdk_internal_misc_Unsafe,     fullFence_name, fullFence_signature,           F_RN)     \
    do_name(     fullFence_name,                                         "fullFence")                                             \
    do_alias(    fullFence_signature,                                    void_method_signature)                                   \
+  do_intrinsic(_isFlattenedArray,         jdk_internal_misc_Unsafe,     isFlattenedArray_name, class_boolean_signature, F_RN)    \
+   do_name(     isFlattenedArray_name,                                  "isFlattenedArray")                                      \
                                                                                                                         \
   /* Custom branch frequencies profiling support for JSR292 */                                                          \
   do_class(java_lang_invoke_MethodHandleImpl,               "java/lang/invoke/MethodHandleImpl")                        \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -697,7 +697,6 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_storeFence:
   case vmIntrinsics::_storeStoreFence:
   case vmIntrinsics::_fullFence:
-  case vmIntrinsics::_isFlattenedArray:
   case vmIntrinsics::_currentCarrierThread:
   case vmIntrinsics::_currentThread:
   case vmIntrinsics::_setCurrentThread:
@@ -712,6 +711,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_nanoTime:
   case vmIntrinsics::_allocateInstance:
   case vmIntrinsics::_allocateUninitializedArray:
+  case vmIntrinsics::_isFlattenedArray:
   case vmIntrinsics::_newArray:
   case vmIntrinsics::_getLength:
   case vmIntrinsics::_copyOf:

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -697,6 +697,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_storeFence:
   case vmIntrinsics::_storeStoreFence:
   case vmIntrinsics::_fullFence:
+  case vmIntrinsics::_isFlattenedArray:
   case vmIntrinsics::_currentCarrierThread:
   case vmIntrinsics::_currentThread:
   case vmIntrinsics::_setCurrentThread:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -509,6 +509,7 @@ bool LibraryCallKit::try_to_inline(int predicate) {
   case vmIntrinsics::_writebackPostSync0:       return inline_unsafe_writebackSync0(false);
   case vmIntrinsics::_allocateInstance:         return inline_unsafe_allocate();
   case vmIntrinsics::_copyMemory:               return inline_unsafe_copyMemory();
+  case vmIntrinsics::_isFlattenedArray:         return inline_unsafe_isFlattenedArray();
   case vmIntrinsics::_getLength:                return inline_native_getLength();
   case vmIntrinsics::_copyOf:                   return inline_array_copyOf(false);
   case vmIntrinsics::_copyOfRange:              return inline_array_copyOf(true);
@@ -5260,6 +5261,16 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
 }
 
 #undef XTOP
+
+//----------------------inline_unsafe_isFlattenedArray-------------------
+// public native boolean Unsafe.isFlattenedArray(Class<?> arrayClass);
+bool LibraryCallKit::inline_unsafe_isFlattenedArray() {
+  Node* cls = argument(1); // TODO: null check on cls? or assume this is never null?
+  Node* kls = load_klass_from_mirror(cls, false, nullptr, 0); // TODO: null check on kls? primitive handling (e.g. int.class)? array check? (see generate_array_guard and _isArray implementation)
+  Node* result = flat_array_test(kls);
+  set_result(result);
+  return true;
+}
 
 //------------------------clone_coping-----------------------------------
 // Helper function for inline_native_clone.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5265,8 +5265,10 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
 //----------------------inline_unsafe_isFlattenedArray-------------------
 // public native boolean Unsafe.isFlattenedArray(Class<?> arrayClass);
 bool LibraryCallKit::inline_unsafe_isFlattenedArray() {
-  Node* cls = argument(1); // TODO: null check on cls? or assume this is never null?
-  Node* kls = load_klass_from_mirror(cls, false, nullptr, 0); // TODO: null check on kls? primitive handling (e.g. int.class)? array check? (see generate_array_guard and _isArray implementation)
+  // Unsafe.isFlattenedArray assumes arrayClass is neither null nor a primitive
+  // class (e.g. int.class). It can however be a non-array class.
+  Node* cls = argument(1); // cls cannot be null.
+  Node* kls = load_klass_from_mirror(cls, false, nullptr, 0); // TODO: null check on kls? array check? (see generate_array_guard and _isArray implementation)
   Node* result = flat_array_test(kls);
   set_result(result);
   return true;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5264,7 +5264,8 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
 
 //----------------------inline_unsafe_isFlattenedArray-------------------
 // public native boolean Unsafe.isFlattenedArray(Class<?> arrayClass);
-// This method assumes arrayClass is neither null not a primitive class.
+// This method exploits assumptions made by the native implementation
+// (arrayClass is neither null nor primitive) to avoid unnecessary null checks.
 bool LibraryCallKit::inline_unsafe_isFlattenedArray() {
   Node* cls = argument(1);
   Node* p = basic_plus_adr(cls, java_lang_Class::klass_offset());

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4103,16 +4103,30 @@ bool LibraryCallKit::inline_native_Class_query(vmIntrinsics::ID id) {
   case vmIntrinsics::_isFlattenedArray:
     array_ctrl = generate_array_guard(kls, region);
     if (array_ctrl != nullptr) {
-      // If the array guard is taken, cast klass as an array and test whether it
-      // is flattened (the cast is necessary to meet the assumptions of
-      // PhaseMacroExpand::expand_flatarraycheck_node()).
-      const Type* array_kls_type =
-        TypeAryKlassPtr::make(TypePtr::NotNull, Type::BOTTOM, nullptr,
-                              Type::Offset::bottom, false, false, false);
-      Node* cast = new CastPPNode(kls, array_kls_type);
-      cast->init_req(0, array_ctrl);
-      Node* array_kls = _gvn.transform(cast);
-      Node* is_flattened = flat_array_test(array_kls);
+      Node* is_flattened;
+      if (UseNewCode) {
+        // Expand subset of FlatArrayCheck node directly.
+        // TODO: factor out into own function to be reused in macro expansion.
+        // See GraphKit::array_lh_test().
+        Node* lh_addr = basic_plus_adr(kls, in_bytes(Klass::layout_helper_offset()));
+        Node* lh_val = _gvn.transform(LoadNode::make(_gvn, nullptr, C->immutable_memory(),
+                                                     lh_addr, lh_addr->bottom_type()->is_ptr(),
+                                                     TypeInt::INT, T_INT, MemNode::unordered));
+        Node* masked = _gvn.transform(new AndINode(lh_val, intcon(Klass::_lh_array_tag_flat_value_bit_inplace)));
+        is_flattened = _gvn.transform(new Conv2BNode(masked));
+      } else {
+        // Generate a FlatArrayCheck node to be macro-expanded.
+        // If the array guard is taken, cast klass as an array and test whether
+        // it is flattened (the cast is necessary to meet the assumptions of
+        // PhaseMacroExpand::expand_flatarraycheck_node()).
+        const Type* array_kls_type =
+          TypeAryKlassPtr::make(TypePtr::NotNull, Type::BOTTOM, nullptr,
+                                Type::Offset::bottom, false, false, false);
+        Node* cast = new CastPPNode(kls, array_kls_type);
+        cast->init_req(0, array_ctrl);
+        Node* array_kls = _gvn.transform(cast);
+        is_flattened = flat_array_test(array_kls);
+      }
       phi->add_req(is_flattened);
     }
     // If we fall through, it's a plain class and not a flattened array.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5264,7 +5264,7 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
 
 //----------------------inline_unsafe_isFlattenedArray-------------------
 // public native boolean Unsafe.isFlattenedArray(Class<?> arrayClass);
-// This method exploits assumptions made by the native implementation
+// This intrinsic exploits assumptions made by the native implementation
 // (arrayClass is neither null nor primitive) to avoid unnecessary null checks.
 bool LibraryCallKit::inline_unsafe_isFlattenedArray() {
   Node* cls = argument(1);

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -251,7 +251,6 @@ class LibraryCallKit : public GraphKit {
   bool inline_unsafe_writeback0();
   bool inline_unsafe_writebackSync0(bool is_pre);
   bool inline_unsafe_copyMemory();
-  bool inline_unsafe_isFlattenedArray();
   bool inline_unsafe_make_private_buffer();
   bool inline_unsafe_finish_private_buffer();
 

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -251,6 +251,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_unsafe_writeback0();
   bool inline_unsafe_writebackSync0(bool is_pre);
   bool inline_unsafe_copyMemory();
+  bool inline_unsafe_isFlattenedArray();
   bool inline_unsafe_make_private_buffer();
   bool inline_unsafe_finish_private_buffer();
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2827,8 +2827,15 @@ void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
       lhs = _igvn.transform(new OrINode(lhs, lh_val));
     }
     Node* masked = transform_later(new AndINode(lhs, intcon(Klass::_lh_array_tag_flat_value_bit_inplace)));
-    Node* cmp = transform_later(new CmpINode(masked, intcon(0)));
-    Node* bol = transform_later(new BoolNode(cmp, BoolTest::eq));
+    Node* bol;
+    if (UseNewCode) {
+      Node* cmp = transform_later(new CmpINode(masked, intcon(0)));
+      bol = transform_later(new BoolNode(cmp, BoolTest::eq));
+    } else {
+      // This is required to satisfy the matcher in cases the result (bol) is
+      // used by other nodes than If.
+      bol = transform_later(new Conv2BNode(masked));
+    }
     Node* old_bol = check->unique_out();
     _igvn.replace_node(old_bol, bol);
     _igvn.replace_node(check, C->top());

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2819,7 +2819,7 @@ void PhaseMacroExpand::expand_flatarraycheck_node(FlatArrayCheckNode* check) {
         Node* klass_adr = basic_plus_adr(array_or_klass, oopDesc::klass_offset_in_bytes());
         klass = transform_later(LoadKlassNode::make(_igvn, nullptr, C->immutable_memory(), klass_adr, TypeInstPtr::KLASS, TypeInstKlassPtr::OBJECT));
       } else {
-        assert(t->isa_aryklassptr(), "Unexpected input type");
+        assert(t->isa_klassptr(), "Unexpected input type");
         klass = array_or_klass;
       }
       Node* lh_addr = basic_plus_adr(klass, in_bytes(Klass::layout_helper_offset()));

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -223,10 +223,7 @@ final class VarHandles {
         int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
 
         if (!componentType.isPrimitive()) {
-            // the redundant componentType.isPrimitiveValueType() check is
-            // there to minimize the performance impact to non-value array.
-            // It should be removed when Unsafe::isFlattenedArray is intrinsified.
-            return maybeAdapt(PrimitiveClass.isPrimitiveValueType(componentType) && UNSAFE.isFlattenedArray(arrayClass)
+            return maybeAdapt(UNSAFE.isFlattenedArray(arrayClass)
                 ? new VarHandleValues.Array(aoffset, ashift, arrayClass)
                 : new VarHandleReferences.Array(aoffset, ashift, arrayClass));
         }

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -194,6 +194,7 @@ public final class Unsafe {
     /**
      * Returns true if the given class is a flattened array.
      */
+    @IntrinsicCandidate
     public native boolean isFlattenedArray(Class<?> arrayClass);
 
     /**

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,7 +71,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
-compiler/gcbarriers/TestZGCBarrierElision.java#ZGen 8313737 generic-all
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1658,5 +1658,39 @@ public class TestIntrinsics {
         Test80Value1 v = new Test80Value1();
         Field field = PrimitiveClass.asValueType(Test80Value1.class).getDeclaredField("v");
         Asserts.assertEQ(test80(v, U.isFlattened(field), U.objectFieldOffset(field)), v.v);
+    }
+
+    // Test correctness of the Unsafe::isFlattenedArray intrinsic
+    @Test
+    public boolean test81(Class<?> cls) {
+        return U.isFlattenedArray(cls);
+    }
+
+    @Run(test = "test81")
+    public void test81_verifier() {
+        Asserts.assertEQ(test81(MyValue1[].class), TEST33_FLATTENED_ARRAY, "test81_1 failed");
+        Asserts.assertFalse(test81(String[].class), "test81_2 failed");
+        Asserts.assertFalse(test81(String.class), "test81_3 failed");
+        Asserts.assertFalse(test81(int[].class), "test81_4 failed");
+    }
+
+    // Verify that Unsafe::isFlattenedArray checks with statically known classes
+    // are folded
+    @Test
+    @IR(failOn = {LOADK})
+    public boolean test82() {
+        boolean check1 = U.isFlattenedArray(MyValue1[].class);
+        if (!TEST33_FLATTENED_ARRAY) {
+            check1 = !check1;
+        }
+        boolean check2 = !U.isFlattenedArray(String[].class);
+        boolean check3 = !U.isFlattenedArray(String.class);
+        boolean check4 = !U.isFlattenedArray(int[].class);
+        return check1 && check2 && check3 && check4;
+    }
+
+    @Run(test = "test82")
+    public void test82_verifier() {
+        Asserts.assertTrue(test82(), "test82 failed");
     }
 }

--- a/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
@@ -64,32 +64,32 @@ public class IsFlattenedArray {
     }
 
     @Benchmark
-    public boolean testKnownFlatClass() {
+    public boolean testKnownFlattenedClass() {
         return U.isFlattenedArray(Point[].class);
     }
 
     @Benchmark
-    public boolean testKnownNonFlatClass() {
+    public boolean testKnownNonFlattenedClass() {
         return U.isFlattenedArray(String[].class);
     }
 
     @Benchmark
-    public boolean testUnknownFlatClass(ClassState state) {
+    public boolean testUnknownFlattenedClass(ClassState state) {
         return U.isFlattenedArray(state.flattenedArrayClass);
     }
 
     @Benchmark
-    public boolean testUnknownNonFlatClass(ClassState state) {
+    public boolean testUnknownNonFlattenedClass(ClassState state) {
         return U.isFlattenedArray(state.nonFlattenedArrayClass);
     }
 
     @Benchmark
-    public void setKnownFlatArrayElement(ClassState state) {
+    public void setKnownFlattenedArrayElement(ClassState state) {
         flattenedArrayVarHandle.set(state.flattenedArray, state.arrayIndex, state.flatElement);
     }
 
     @Benchmark
-    public void setKnownNonFlatArrayElement(ClassState state) {
+    public void setKnownNonFlattenedArrayElement(ClassState state) {
         nonFlattenedArrayVarHandle.set(state.nonFlattenedArray, state.arrayIndex, state.nonFlatElement);
     }
 
@@ -97,6 +97,12 @@ public class IsFlattenedArray {
     public void setUnknownArrayElement(ClassState state) {
         objectArrayVarHandle.set(state.objectArray, state.arrayIndex, state.objectElement);
     }
+
+    @Benchmark
+    public VarHandle makeArrayVarHandle() {
+        return MethodHandles.arrayElementVarHandle(Object[].class);
+    }
+
 }
 
 primitive class Point {

--- a/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
@@ -40,26 +40,16 @@ import jdk.internal.misc.Unsafe;
 public class IsFlattenedArray {
 
     private static final Unsafe U = Unsafe.getUnsafe();
-    private static final VarHandle flattenedArrayVarHandle =
-        MethodHandles.arrayElementVarHandle(Point[].class);
-    private static final VarHandle nonFlattenedArrayVarHandle =
-        MethodHandles.arrayElementVarHandle(String[].class);
     private static final VarHandle objectArrayVarHandle =
         MethodHandles.arrayElementVarHandle(Object[].class);
 
     @State(Scope.Benchmark)
     public static class ClassState {
         public Class flattenedArrayClass = Point[].class;
-        public Point[] flattenedArray = new Point[10];
-        public Point flatElement = new Point(0, 0);
-
         public Class nonFlattenedArrayClass = String[].class;
-        public String[] nonFlattenedArray = new String[10];
-        public String nonFlatElement = new String("hej");
 
         public Object[] objectArray = new Object[10];
         public Object objectElement = new Object();
-
         public int arrayIndex = 0;
     }
 
@@ -84,17 +74,7 @@ public class IsFlattenedArray {
     }
 
     @Benchmark
-    public void setKnownFlattenedArrayElement(ClassState state) {
-        flattenedArrayVarHandle.set(state.flattenedArray, state.arrayIndex, state.flatElement);
-    }
-
-    @Benchmark
-    public void setKnownNonFlattenedArrayElement(ClassState state) {
-        nonFlattenedArrayVarHandle.set(state.nonFlattenedArray, state.arrayIndex, state.nonFlatElement);
-    }
-
-    @Benchmark
-    public void setUnknownArrayElement(ClassState state) {
+    public void setArrayElement(ClassState state) {
         objectArrayVarHandle.set(state.objectArray, state.arrayIndex, state.objectElement);
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.valhalla.intrinsics;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.TimeUnit;
+import jdk.internal.misc.Unsafe;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 1,
+      jvmArgsAppend = {"--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
+                       "-XX:+EnableValhalla", "-XX:+EnablePrimitiveClasses"})
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class IsFlattenedArray {
+
+    private static final Unsafe U = Unsafe.getUnsafe();
+    private static final VarHandle flattenedArrayVarHandle =
+        MethodHandles.arrayElementVarHandle(Point[].class);
+    private static final VarHandle nonFlattenedArrayVarHandle =
+        MethodHandles.arrayElementVarHandle(String[].class);
+    private static final VarHandle objectArrayVarHandle =
+        MethodHandles.arrayElementVarHandle(Object[].class);
+
+    @State(Scope.Benchmark)
+    public static class ClassState {
+        public Class flattenedArrayClass = Point[].class;
+        public Point[] flattenedArray = new Point[10];
+        public Point flatElement = new Point(0, 0);
+
+        public Class nonFlattenedArrayClass = String[].class;
+        public String[] nonFlattenedArray = new String[10];
+        public String nonFlatElement = new String("hej");
+
+        public Object[] objectArray = new Object[10];
+        public Object objectElement = new Object();
+
+        public int arrayIndex = 0;
+    }
+
+    @Benchmark
+    public boolean testKnownFlatClass() {
+        return U.isFlattenedArray(Point[].class);
+    }
+
+    @Benchmark
+    public boolean testKnownNonFlatClass() {
+        return U.isFlattenedArray(String[].class);
+    }
+
+    @Benchmark
+    public boolean testUnknownFlatClass(ClassState state) {
+        return U.isFlattenedArray(state.flattenedArrayClass);
+    }
+
+    @Benchmark
+    public boolean testUnknownNonFlatClass(ClassState state) {
+        return U.isFlattenedArray(state.nonFlattenedArrayClass);
+    }
+
+    @Benchmark
+    public void setKnownFlatArrayElement(ClassState state) {
+        flattenedArrayVarHandle.set(state.flattenedArray, state.arrayIndex, state.flatElement);
+    }
+
+    @Benchmark
+    public void setKnownNonFlatArrayElement(ClassState state) {
+        nonFlattenedArrayVarHandle.set(state.nonFlattenedArray, state.arrayIndex, state.nonFlatElement);
+    }
+
+    @Benchmark
+    public void setUnknownArrayElement(ClassState state) {
+        objectArrayVarHandle.set(state.objectArray, state.arrayIndex, state.objectElement);
+    }
+}
+
+primitive class Point {
+    int x;
+    int y;
+    public Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
This changeset introduces a compiler intrinsic for `jdk.internal.misc.Unsafe::isFlattenedArray(Class<?> arrayClass)`. The intrinsic reuses C2's `FlatArrayCheckNode`, and exploits the assumptions made by the native implementation (`arrayClass` is non-null and non-primitive) to avoid unnecessary null checks. Reusing `FlatArrayCheckNode` in this different context requires small generalizations of its macro expansion logic.

Additionally, the changeset removes a no-longer-needed check in `java.lang.invoke.VarHandles::makeArrayElementHandle(Class<?> arrayClass)` and re-enables the `compiler.gcbarriers::TestZGCBarrierElision` tests (whose failures were caused by the introduction of calls to `isFlattenedArray` inhibiting barrier optimizations).

Local experiments with the included micro-benchmarks show that the changeset:
- speeds up direct calls to `isFlattenedArray` by between 24x and 48x depending on whether the tested class is known to C2,
- speeds up `java.lang.invoke.VarHandle.set(Object... args)` by an order of magnitude, and
- preserves the performance of `java.lang.invoke.MethodHandles.arrayElementVarHandle(Class<?> arrayClass)` despite the simplification of the underlying `java.lang.invoke.VarHandles::makeArrayElementHandle(Class<?> arrayClass)` method.

Complete results are attached [here](https://github.com/openjdk/valhalla/files/12927498/results.ods).


#### Testing
- tier1-5 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode)

**Acknowledgments:** thanks to Tobias Hartmann for discussions on earlier versions of this changeset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8316742](https://bugs.openjdk.org/browse/JDK-8316742): [lworld] Intrinsify Unsafe::isFlattenedArray() (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/938/head:pull/938` \
`$ git checkout pull/938`

Update a local copy of the PR: \
`$ git checkout pull/938` \
`$ git pull https://git.openjdk.org/valhalla.git pull/938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 938`

View PR using the GUI difftool: \
`$ git pr show -t 938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/938.diff">https://git.openjdk.org/valhalla/pull/938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/938#issuecomment-1766148290)