### PR TITLE
8318117: [lw5] create a switch for null-restricted types

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -103,6 +103,7 @@ public class Lower extends TreeTranslator {
     private final boolean optimizeOuterThis;
     private final boolean useMatchException;
     private final boolean emitQDesc;
+    private final boolean allowNullRestrictedTypes;
 
     @SuppressWarnings("this-escape")
     protected Lower(Context context) {
@@ -135,6 +136,7 @@ public class Lower extends TreeTranslator {
         useMatchException = Feature.PATTERN_SWITCH.allowedInSource(source) &&
                             (preview.isEnabled() || !preview.isPreview(Feature.PATTERN_SWITCH));
         emitQDesc = options.isSet("emitQDesc") || options.isSet("enablePrimitiveClasses");
+        allowNullRestrictedTypes = options.isSet("enableNullRestrictedTypes");
     }
 
     /** The currently enclosing class.
@@ -4196,7 +4198,7 @@ public class Lower extends TreeTranslator {
             noOfDims++;
         }
         tree.elems = translate(tree.elems, types.elemtype(tree.type));
-        if (emitQDesc || tree.elemtype == null || !originalElemType.type.isNonNullable()) {
+        if (emitQDesc || !allowNullRestrictedTypes || tree.elemtype == null || !originalElemType.type.isNonNullable()) {
             result = tree;
         } else {
             Symbol elemClass = syms.getClassField(tree.elemtype.type, types);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -85,6 +85,10 @@ public class ClassWriter extends ClassFile {
      */
     private boolean emitQDesc;
 
+    /** Switch: are null-restricted types allowed
+     */
+    private boolean allowNullRestrictedTypes;
+
     /** Switch: generate CharacterRangeTable attribute.
      */
     private boolean genCrt;
@@ -198,6 +202,7 @@ public class ClassWriter extends ClassFile {
             dumpMethodModifiers = modifierFlags.indexOf('m') != -1;
         }
         emitQDesc = options.isSet("emitQDesc") || options.isSet("enablePrimitiveClasses");
+        allowNullRestrictedTypes = options.isSet("enableNullRestrictedTypes");
     }
 
     public void addExtraAttributes(ToIntFunction<Symbol> addExtraAttributes) {
@@ -958,7 +963,7 @@ public class ClassWriter extends ClassFile {
     /** Write "ImplicitCreation" attribute.
      */
     int writeImplicitCreationIfNeeded(ClassSymbol csym) {
-        if (csym.isValueClass() && csym.hasImplicitConstructor()) {
+        if (allowNullRestrictedTypes && csym.isValueClass() && csym.hasImplicitConstructor()) {
             int alenIdx = writeAttr(names.ImplicitCreation);
             int flags = ACC_DEFAULT | (csym.isSubClass(syms.looselyConsistentValueType.tsym, types) ? ACC_NON_ATOMIC : 0);
             databuf.appendChar(flags);
@@ -971,7 +976,7 @@ public class ClassWriter extends ClassFile {
     /** Write "NullRestricted" attribute.
      */
     int writeNullRestrictedIfNeeded(Symbol sym) {
-        if (sym.kind == VAR && sym.type.isNonNullable() && !sym.type.hasTag(ARRAY)) {
+        if (allowNullRestrictedTypes && sym.kind == VAR && sym.type.isNonNullable() && !sym.type.hasTag(ARRAY)) {
             int alenIdx = writeAttr(names.NullRestricted);
             endAttr(alenIdx);
             return 1;

--- a/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
@@ -128,6 +128,7 @@ public class TestValueClasses extends JavadocTester {
 
         javadoc("-d", base.resolve("out").toString(),
                 "-sourcepath", src.toString(),
+                "-XDenableNullRestrictedTypes",
                 "p");
         checkExit(Exit.OK);
 

--- a/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
+++ b/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
@@ -23,6 +23,7 @@
 
 // key: compiler.err.type.cant.be.null.restricted
 // key: compiler.err.type.cant.be.null.restricted.2
+// options: -XDenableNullRestrictedTypes
 
 public class CantBeNonNullableType {
     String! s;

--- a/test/langtools/tools/javac/diags/examples/CantImplementInterface.java
+++ b/test/langtools/tools/javac/diags/examples/CantImplementInterface.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.cant.implement.interface
+// options: -XDenableNullRestrictedTypes
 
 class CantImplementInterface implements LooselyConsistentValue {
 }

--- a/test/langtools/tools/javac/diags/examples/ImplicitConstructorWithBody.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitConstructorWithBody.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.implicit.const.cant.have.body
+// options: -XDenableNullRestrictedTypes
 
 value class ImplicitConstructorWithBody {
     public implicit ImplicitConstructorWithBody() {}

--- a/test/langtools/tools/javac/diags/examples/ImplicitMustBeInValueClass.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitMustBeInValueClass.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.implicit.const.must.be.declared.in.value.class
+// options: -XDenableNullRestrictedTypes
 
 class ImplicitMustBeInValueClass {
     public implicit ImplicitMustBeInValueClass();

--- a/test/langtools/tools/javac/diags/examples/ImplicitMustBePublic.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitMustBePublic.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.implicit.const.must.be.public
+// options: -XDenableNullRestrictedTypes
 
 value class ImplicitMustBePublic {
     implicit ImplicitMustBePublic();

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCannotBeInner.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCannotBeInner.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.value.class.with.implicit.cannot.be.inner
+// options: -XDenableNullRestrictedTypes
 
 class ValueClassWithImplicitCannotBeInner {
     value class V {

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantDeclareInitBlock.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantDeclareInitBlock.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.value.class.with.implicit.declares.init.block
+// options: -XDenableNullRestrictedTypes
 
 value class ValueClassWithImplicitCantDeclareInitBlock {
     int i;

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantHaveFieldInit.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantHaveFieldInit.java
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.err.value.class.with.implicit.instance.field.initializer
+// options: -XDenableNullRestrictedTypes
 
 value class ValueClassWithImplicitCantHaveFieldInit {
     int i = 0;

--- a/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
+++ b/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
@@ -27,7 +27,7 @@
  * @test
  * @enablePreview
  * @summary Smoke test for parsing of bang types
- * @compile NullabilityParsingTest.java
+ * @compile -XDenableNullRestrictedTypes NullabilityParsingTest.java
  */
 
 import java.util.function.*;

--- a/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
+++ b/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
@@ -89,7 +89,7 @@ public class TestValueClasses extends TestRunner {
     }
 
     @Test
-    public void TestValueClassesProcessor(Path base) throws Exception {
+    public void testValueClassesProcessor(Path base) throws Exception {
         Path src = base.resolve("src");
         Path r = src.resolve("Test");
 
@@ -127,7 +127,7 @@ public class TestValueClasses extends TestRunner {
         for (Mode mode : new Mode[] {Mode.API}) {
             List<String> log = new JavacTask(tb, mode)
                     .options("-processor", ValueClassesProcessor.class.getName(),
-                            "-XDrawDiagnostics")
+                            "-XDenableNullRestrictedTypes", "-XDrawDiagnostics")
                     .files(findJavaFiles(src))
                     .outdir(classes)
                     .run()

--- a/test/langtools/tools/javac/valhalla/primitive-classes/AsSuperTests.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/AsSuperTests.java
@@ -27,7 +27,7 @@
  * @test
  * @bug 8244712
  * @summary Javac should switch to reference projection before walking type hierarchy.
- * @compile -XDemitQDesc AsSuperTests.java
+ * @compile -XDemitQDesc -XDenableNullRestrictedTypes AsSuperTests.java
  */
 
 /* The following test "covers"/verifies that the asSuper calls in

--- a/test/langtools/tools/javac/valhalla/primitive-classes/AssortedTests.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/AssortedTests.java
@@ -27,7 +27,7 @@
  * @test
  * @bug 8222634
  * @summary Check various code snippets that were incorrectly failing to compile.
- * @compile -XDemitQDesc AssortedTests.java
+ * @compile -XDemitQDesc -XDenableNullRestrictedTypes AssortedTests.java
  */
 
 value class MyValue1 {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/AttributesTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/AttributesTest.java
@@ -28,7 +28,7 @@
  * @summary V.ref class should not inadvertently carry over attributes from V.class
  * @bug 8244713
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @compile -XDemitQDesc AttributesTest.java
+ * @compile -XDemitQDesc -XDenableNullRestrictedTypes AttributesTest.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses AttributesTest
  */
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/BogusIncompatibility.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/BogusIncompatibility.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8214299
  * @summary Strange errors from javac when mixing box and val types.
- * @compile -XDemitQDesc BogusIncompatibility.java
- * @compile -XDemitQDesc BogusIncompatibility.java
+ * @compile -XDemitQDesc -XDenableNullRestrictedTypes BogusIncompatibility.java
+ * @compile -XDemitQDesc -XDenableNullRestrictedTypes BogusIncompatibility.java
  */
 
 public class BogusIncompatibility {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CastNoNullCheckTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CastNoNullCheckTest.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @summary Check that casting to a value type involves no null check when values are not recognized in source.
- * @compile -XDenablePrimitiveClasses Point.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java
  * @compile/fail/ref=CastNoNullCheckTest.out -source 10 -XDrawDiagnostics CastNoNullCheckTest.java
  */
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CastNullCheckTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CastNullCheckTest.java
@@ -28,8 +28,8 @@
  * @bug 8215110
  * @summary Check that casting to a value type involves a null check.
  *
- * @compile -XDallowWithFieldOperator -XDenablePrimitiveClasses Point.java
- * @compile -XDallowWithFieldOperator -XDenablePrimitiveClasses CastNullCheckTest.java
+ * @compile -XDenablePrimitiveClasses Point.java
+ * @compile -XDenablePrimitiveClasses CastNullCheckTest.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses CastNullCheckTest
  * @ignore 8316628
  */

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckBadSelector.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckBadSelector.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8237067
  * @summary [lworld] Check good and bad selectors on a type name
- * @compile/fail/ref=CheckBadSelector.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckBadSelector.java
+ * @compile/fail/ref=CheckBadSelector.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckBadSelector.java
  */
 
 value final class Point {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckCyclicMembership.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckCyclicMembership.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @summary Value types may not declare fields of its own type either directly or indirectly.
- * @compile/fail/ref=CheckCyclicMembership.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckCyclicMembership.java
+ * @compile/fail/ref=CheckCyclicMembership.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckCyclicMembership.java
  */
 
 final value class CheckCyclicMembership {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFinal.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFinal.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Value types and their instance fields are implicitly final
  *
- * @compile/fail/ref=CheckFinal.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckFinal.java
+ * @compile/fail/ref=CheckFinal.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckFinal.java
  */
 
 value class CheckFinal { // implicitly final

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlags.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlags.java
@@ -27,7 +27,7 @@
  * @test
  * @summary Check value flag in class file
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @compile -XDallowWithFieldOperator -XDenablePrimitiveClasses Point.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java
  * @run main CheckFlags
  */
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableCycles.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableCycles.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Check for cycles through fields declared flattenable.
  *
- * @compile/fail/ref=CheckFlattenableCycles.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckFlattenableCycles.java
+ * @compile/fail/ref=CheckFlattenableCycles.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckFlattenableCycles.java
  */
 
 final value class CheckFlattenableCycles {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableFlagFromClass.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableFlagFromClass.java
@@ -2,8 +2,8 @@
  * @test /nodynamiccopyright/
  * @bug 8197911
  * @summary Check that valueness is deduced from class files and has the appropriate effect.
- * @compile -XDenablePrimitiveClasses FlattenableFlagFromClass.java
- * @compile/fail/ref=CheckFlattenableFlagFromClass.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckFlattenableFlagFromClass.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes FlattenableFlagFromClass.java
+ * @compile/fail/ref=CheckFlattenableFlagFromClass.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckFlattenableFlagFromClass.java
  */
 
 public class CheckFlattenableFlagFromClass {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableSyntheticFields.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckFlattenableSyntheticFields.java
@@ -28,7 +28,7 @@
  * @bug 8207330
  * @summary Check that flattenable flag is set for synthetic fields as needed.
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @compile -XDenablePrimitiveClasses CheckFlattenableSyntheticFields.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckFlattenableSyntheticFields.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses CheckFlattenableSyntheticFields
  */
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckIdentityHash.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckIdentityHash.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8237071
  * @summary Totalize System.identityHashCode for inline types.
- * @compile -XDenablePrimitiveClasses CheckIdentityHash.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckIdentityHash.java
  */
 
 final value class CheckIdentityHash {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckIdentityHash01.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckIdentityHash01.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8237071
  * @summary Totalize System.identityHashCode for inline types.
- * @compile -XDenablePrimitiveClasses CheckIdentityHash01.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckIdentityHash01.java
  */
 import static java.lang.System.*;
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckLocalClasses.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckLocalClasses.java
@@ -28,7 +28,7 @@
  * @bug 8211910
  * @summary [lworld] Reinstate support for local value classes.
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @compile -XDenablePrimitiveClasses CheckLocalClasses.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckLocalClasses.java
  * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses CheckLocalClasses
  */
 

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckMakeDefault.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckMakeDefault.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Check various semantic constraints on value creation via default
  *
- * @compile/fail/ref=CheckMakeDefault.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckMakeDefault.java
+ * @compile/fail/ref=CheckMakeDefault.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckMakeDefault.java
  */
 value final class Point {
     value interface I { int x = 10; } // Error

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckMultiDimensionalArrayStore.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckMultiDimensionalArrayStore.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @summary Check null store into multidimensional array
- * @compile/fail/ref=CheckMultiDimensionalArrayStore.out -XDrawDiagnostics -XDdev -XDenablePrimitiveClasses CheckMultiDimensionalArrayStore.java
+ * @compile/fail/ref=CheckMultiDimensionalArrayStore.out -XDrawDiagnostics -XDdev -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckMultiDimensionalArrayStore.java
  */
 
 public class CheckMultiDimensionalArrayStore {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullAssign.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullAssign.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary Assignment of null to value types should be disallowed.
  *
- * @compile/fail/ref=CheckNullAssign.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckNullAssign.java
+ * @compile/fail/ref=CheckNullAssign.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckNullAssign.java
  */
 
 final value class CheckNullAssign {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullCastable.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullCastable.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @summary null cannot be casted to and compared with value types.
  *
- * @compile/fail/ref=CheckNullCastable.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckNullCastable.java
+ * @compile/fail/ref=CheckNullCastable.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckNullCastable.java
  */
 
 value final class CheckNullCastable {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckNullWithQuestion.java
@@ -27,7 +27,7 @@
  * @test
  * @bug 8222634
  * @summary Check null assignment/comparisons against VT.ref
- * @compile -XDenablePrimitiveClasses CheckNullWithQuestion.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckNullWithQuestion.java
  */
 
 value class CheckNullWithQuestion {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckQuestionInMessages.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckQuestionInMessages.java
@@ -3,7 +3,7 @@
  * @bug 8222790
  * @summary javac diagnostics don't discriminate between inline types and there nullable projection types.
  *
- * @compile/fail/ref=CheckQuestionInMessages.out -XDrawDiagnostics -XDenablePrimitiveClasses CheckQuestionInMessages.java
+ * @compile/fail/ref=CheckQuestionInMessages.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckQuestionInMessages.java
  */
 
 import java.util.List;

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckStaticFinalAssign.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckStaticFinalAssign.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @summary Check that a static final field may not be modified in a value factory
- * @compile/fail/ref=CheckStaticFinalAssign.out -XDrawDiagnostics -XDdev -XDenablePrimitiveClasses CheckStaticFinalAssign.java
+ * @compile/fail/ref=CheckStaticFinalAssign.out -XDrawDiagnostics -XDdev -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckStaticFinalAssign.java
  */
 
 value final class CheckStaticFinalAssign {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckSuperCompileOnly.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckSuperCompileOnly.java
@@ -27,8 +27,8 @@
  * @test
  * @summary Check that value types have their super types wired to be j.l.Object
  *
- * @compile -XDallowWithFieldOperator -XDenablePrimitiveClasses Point.java
- * @compile -XDenablePrimitiveClasses CheckSuperCompileOnly.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CheckSuperCompileOnly.java
  */
 
 public class CheckSuperCompileOnly {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CompilesJustFine.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CompilesJustFine.java
@@ -27,7 +27,7 @@
  * @test
  * @bug 8222555 8222553
  * @summary Prove that code suspected of not compiling actually compiles fine.
- * @compile -XDenablePrimitiveClasses CompilesJustFine.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes CompilesJustFine.java
  */
 
 class CompilesFine {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/ConstantPropagationTest.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/ConstantPropagationTest.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Check constant propagation behavior
  * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
- * @compile -XDenablePrimitiveClasses ConstantPropagationTest.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes ConstantPropagationTest.java
  * @run main/othervm -Xverify:none -XX:+EnableValhalla -XX:+EnablePrimitiveClasses ConstantPropagationTest
  * @modules jdk.compiler
  */

--- a/test/langtools/tools/javac/valhalla/primitive-classes/ConsumeUnifiedClass.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/ConsumeUnifiedClass.java
@@ -27,9 +27,9 @@
  * @test
  * @bug 8266466
  * @summary Enhance javac to consume unified primitive class files, also see that we lose nullability information with separate compilation
- * @compile/fail/ref=ConsumeUnifiedClass.out -XDrawDiagnostics -XDenablePrimitiveClasses Point.java Rectangle.java ConsumeUnifiedClass.java
- * @compile -XDallowWithFieldOperator -XDenablePrimitiveClasses Point.java Rectangle.java
- * @compile/fail/ref=ConsumeUnifiedClass2.out -XDrawDiagnostics -XDenablePrimitiveClasses ConsumeUnifiedClass.java
+ * @compile/fail/ref=ConsumeUnifiedClass.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java Rectangle.java ConsumeUnifiedClass.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java Rectangle.java
+ * @compile/fail/ref=ConsumeUnifiedClass2.out -XDrawDiagnostics -XDenablePrimitiveClasses -XDenableNullRestrictedTypes ConsumeUnifiedClass.java
  */
 
 public value class ConsumeUnifiedClass {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/Point.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/Point.java
@@ -27,7 +27,7 @@
  * @test
  * @summary Test basic syntax of values
  *
- * @compile -XDenablePrimitiveClasses Point.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes Point.java
  */
 
 value class Point {

--- a/test/langtools/tools/javac/valhalla/primitive-classes/QPointConsumer.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/QPointConsumer.java
@@ -25,8 +25,8 @@
  * @test
  * @bug 8212615
  * @summary ClassReader has trouble coping with 'Q' types.
- * @compile -XDenablePrimitiveClasses QPointConsumer.java
- * @compile -XDenablePrimitiveClasses QPointConsumer.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes QPointConsumer.java
+ * @compile -XDenablePrimitiveClasses -XDenableNullRestrictedTypes QPointConsumer.java
  */
 
 class QPointConsumer {

--- a/test/langtools/tools/javac/valhalla/value-objects/ArrayCreationWithQuestion.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ArrayCreationWithQuestion.java
@@ -27,6 +27,8 @@
  * @summary Check array creation with V and V.ref
  * @modules jdk.compiler/com.sun.tools.javac.util jdk.jdeps/com.sun.tools.javap
  * @modules jdk.compiler
+ * @compile -XDenableNullRestrictedTypes ArrayCreationWithQuestion.java
+ * @run main ArrayCreationWithQuestion
  */
 
 import java.io.PrintWriter;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -775,114 +775,121 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
     }
 
     public void testImplicitConstructor() {
-        assertOK(
-                """
-                value class V {
-                    public implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.implicit.const.must.be.public",
-                """
-                value class V {
-                    implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.implicit.const.cant.have.body",
-                """
-                value class V {
-                    public implicit V() {}
-                }
-                """
-        );
-        assertFail("compiler.err.implicit.const.must.be.public",
-                """
-                value class V {
-                    private implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.implicit.const.must.be.public",
-                """
-                value class V {
-                    protected implicit V();
-                }
-                """
-        );
-
-        assertFail("compiler.err.already.defined",
-                """
-                value class V {
-                    public implicit V();
-                    public V() {}
-                }
-                """
-        );
-
-        assertFail("compiler.err.implicit.const.must.be.declared.in.value.class",
-                """
-                class V {
-                    public implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
-                """
-                class Outer {
+        String[] previousOptions = getCompileOptions();
+        try {
+            String[] testOptions = {"-XDenableNullRestrictedTypes"};
+            setCompileOptions(testOptions);
+            assertOK(
+                    """
                     value class V {
                         public implicit V();
                     }
-                }
-                """
-        );
-        assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
-                """
-                class Outer {
-                    new value class V() {
+                    """
+            );
+            assertFail("compiler.err.implicit.const.must.be.public",
+                    """
+                    value class V {
+                        implicit V();
+                    }
+                    """
+            );
+            assertFail("compiler.err.implicit.const.cant.have.body",
+                    """
+                    value class V {
+                        public implicit V() {}
+                    }
+                    """
+            );
+            assertFail("compiler.err.implicit.const.must.be.public",
+                    """
+                    value class V {
+                        private implicit V();
+                    }
+                    """
+            );
+            assertFail("compiler.err.implicit.const.must.be.public",
+                    """
+                    value class V {
+                        protected implicit V();
+                    }
+                    """
+            );
+
+            assertFail("compiler.err.already.defined",
+                    """
+                    value class V {
                         public implicit V();
-                    };
-                }
-                """
-        );
-        assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
-                """
-                class Outer {
-                    void m() {
+                        public V() {}
+                    }
+                    """
+            );
+
+            assertFail("compiler.err.implicit.const.must.be.declared.in.value.class",
+                    """
+                    class V {
+                        public implicit V();
+                    }
+                    """
+            );
+            assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
+                    """
+                    class Outer {
                         value class V {
                             public implicit V();
                         }
                     }
-                }
-                """
-        );
-        assertFail("compiler.err.cyclic.primitive.class.membership",
-                """
-                value class V {
-                    V! v;
-                    public implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.value.class.with.implicit.instance.field.initializer",
-                """
-                value class V {
-                    String s = "";
-                    public implicit V();
-                }
-                """
-        );
-        assertFail("compiler.err.value.class.with.implicit.declares.init.block",
-                """
-                value class V {
-                    String s;
-                    {
-                        s = "";
+                    """
+            );
+            assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
+                    """
+                    class Outer {
+                        new value class V() {
+                            public implicit V();
+                        };
                     }
-                    public implicit V();
-                }
-                """
-        );
+                    """
+            );
+            assertFail("compiler.err.value.class.with.implicit.cannot.be.inner",
+                    """
+                    class Outer {
+                        void m() {
+                            value class V {
+                                public implicit V();
+                            }
+                        }
+                    }
+                    """
+            );
+            assertFail("compiler.err.cyclic.primitive.class.membership",
+                    """
+                    value class V {
+                        V! v;
+                        public implicit V();
+                    }
+                    """
+            );
+            assertFail("compiler.err.value.class.with.implicit.instance.field.initializer",
+                    """
+                    value class V {
+                        String s = "";
+                        public implicit V();
+                    }
+                    """
+            );
+            assertFail("compiler.err.value.class.with.implicit.declares.init.block",
+                    """
+                    value class V {
+                        String s;
+                        {
+                            s = "";
+                        }
+                        public implicit V();
+                    }
+                    """
+            );
+        } finally {
+            setCompileOptions(previousOptions);
+        }
     }
 
     private File findClassFileOrFail(File dir, String name) {
@@ -919,73 +926,87 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
     }
 
     public void testClassAttributes() throws Exception {
-        String code =
-                """
-                value class V0 {
-                    public implicit V0();
-                }
-
-                value class V1 {
-                    V0! f1;
-                    V0 f2;
-                    V0[]! f3;
-                    public implicit V1();
-                }
-
-                value class V2 {
-                    public V2() {}
-                }
-                """;
-
-        File dir = assertOK(true, code);
-
-        // test for V1
-        ClassFile classFile = ClassFile.read(findClassFileOrFail(dir, "V1.class"));
-
-        Field field1 = classFile.fields[0];
-        findAttributeOrFail(field1.attributes, NullRestricted_attribute.class, 1);
-        Field field2 = classFile.fields[1];
+        String[] previousOptions = getCompileOptions();
         try {
-            findAttributeOrFail(field2.attributes, NullRestricted_attribute.class, 1);
-            throw new AssertionError("NullRestricted attribute shouldn't be here");
-        } catch (Throwable t) {
-            // good
-        }
-        Field field3 = classFile.fields[2];
-        checkAttributeNotPresent(field3.attributes, NullRestricted_attribute.class);
-        findAttributeOrFail(classFile.attributes, ImplicitCreation_attribute.class, 1);
+            String[] testOptions = {"-XDenableNullRestrictedTypes"};
+            setCompileOptions(testOptions);
+            String code =
+                    """
+                    value class V0 {
+                        public implicit V0();
+                    }
+    
+                    value class V1 {
+                        V0! f1;
+                        V0 f2;
+                        V0[]! f3;
+                        public implicit V1();
+                    }
+    
+                    value class V2 {
+                        public V2() {}
+                    }
+                    """;
 
-        classFile = ClassFile.read(findClassFileOrFail(dir, "V2.class"));
-        try {
+            File dir = assertOK(true, code);
+
+            // test for V1
+            ClassFile classFile = ClassFile.read(findClassFileOrFail(dir, "V1.class"));
+
+            Field field1 = classFile.fields[0];
+            findAttributeOrFail(field1.attributes, NullRestricted_attribute.class, 1);
+            Field field2 = classFile.fields[1];
+            try {
+                findAttributeOrFail(field2.attributes, NullRestricted_attribute.class, 1);
+                throw new AssertionError("NullRestricted attribute shouldn't be here");
+            } catch (Throwable t) {
+                // good
+            }
+            Field field3 = classFile.fields[2];
+            checkAttributeNotPresent(field3.attributes, NullRestricted_attribute.class);
             findAttributeOrFail(classFile.attributes, ImplicitCreation_attribute.class, 1);
-            throw new AssertionError("ImplicitCreation attribute shouldn't be here");
-        } catch (Throwable t) {
-            // good
+
+            classFile = ClassFile.read(findClassFileOrFail(dir, "V2.class"));
+            try {
+                findAttributeOrFail(classFile.attributes, ImplicitCreation_attribute.class, 1);
+                throw new AssertionError("ImplicitCreation attribute shouldn't be here");
+            } catch (Throwable t) {
+                // good
+            }
+        } finally {
+            setCompileOptions(previousOptions);
         }
     }
 
     public void testImplementingLooselyConsistentValue() {
-        assertFail("compiler.err.cant.implement.interface",
-                """
-                class V implements LooselyConsistentValue {} // not a value class
-                """
-        );
-        assertFail("compiler.err.cant.implement.interface",
-                """
-                value class V implements LooselyConsistentValue {} // no implicit constructor
-                """
-        );
-        assertOK(
-                """
-                abstract class V implements LooselyConsistentValue {}  // not concrete value class
-                """
-        );
-        assertOK(
-                """
-                value class V implements LooselyConsistentValue { // concrete value class with implicit constructor
-                    public implicit V();
-                }
-                """
-        );
+        String[] previousOptions = getCompileOptions();
+        try {
+            String[] testOptions = {"-XDenableNullRestrictedTypes"};
+            setCompileOptions(testOptions);
+            assertFail("compiler.err.cant.implement.interface",
+                    """
+                    class V implements LooselyConsistentValue {} // not a value class
+                    """
+            );
+            assertFail("compiler.err.cant.implement.interface",
+                    """
+                    value class V implements LooselyConsistentValue {} // no implicit constructor
+                    """
+            );
+            assertOK(
+                    """
+                    abstract class V implements LooselyConsistentValue {}  // not concrete value class
+                    """
+            );
+            assertOK(
+                    """
+                    value class V implements LooselyConsistentValue { // concrete value class with implicit constructor
+                        public implicit V();
+                    }
+                    """
+            );
+        } finally {
+            setCompileOptions(previousOptions);
+        }
     }
 }

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -935,14 +935,14 @@ public class ValueObjectCompilationTests extends CompilationTestCase {
                     value class V0 {
                         public implicit V0();
                     }
-    
+
                     value class V1 {
                         V0! f1;
                         V0 f2;
                         V0[]! f3;
                         public implicit V1();
                     }
-    
+
                     value class V2 {
                         public V2() {}
                     }


### PR DESCRIPTION
switch for opt-in for null restricted types features

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8318117](https://bugs.openjdk.org/browse/JDK-8318117): [lw5] create a switch for null-restricted types (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/940/head:pull/940` \
`$ git checkout pull/940`

Update a local copy of the PR: \
`$ git checkout pull/940` \
`$ git pull https://git.openjdk.org/valhalla.git pull/940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 940`

View PR using the GUI difftool: \
`$ git pr show -t 940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/940.diff">https://git.openjdk.org/valhalla/pull/940.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/940#issuecomment-1773253689)