### PR TITLE
8318903: [lw5] null-restricted storage API points

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
@@ -577,4 +577,20 @@ public class VMSupport {
         }
         return length;
     }
+
+    /**
+     * Allocate an array of a value class type with components that behave in
+     * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
+     * field.
+     * <p>
+     * Because these behaviors are not specified by Java SE, arrays created with
+     * this method should only be used by internal JDK code for experimental
+     * purposes and should not affect user-observable outcomes.
+     *
+     * @throws IllegalArgumentException if {@code componentType} is not a
+     *         value class type or is not annotated with
+     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
+     */
+    public static native Object[] newNullRestrictedArray(Class<?> componentType,
+                                                         int length);
 }

--- a/src/java.base/share/classes/jdk/internal/vm/annotation/ImplicitlyConstructible.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/ImplicitlyConstructible.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * An implicitly-constructible value class is a class that authorizes the JVM
+ * to create its <em>zero instance</em>, where all instance fields are set to
+ * their default values (0, {@code null}, etc.), without any code execution.
+ * Any superclasses other than {@code Object} are also expected to be marked
+ * {@code @ImplicitlyConstructible}.
+ * <p>
+ * The HotSpot VM depends on this annotation being present to properly
+ * initialize {@link NullRestricted} fields and arrays of a value class type.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ImplicitlyConstructible {
+}

--- a/src/java.base/share/classes/jdk/internal/vm/annotation/LooselyConsistentValue.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/LooselyConsistentValue.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * A loosely-consistent value class is a class that is willing to tolerate
+ * data corruption when fields or arrays storing instances of the class are
+ * updated under race. Specifically, a value object read from such a field may
+ * contain combinations of field values that were never set by a previous
+ * constructor invocation.
+ * <p>
+ * Users of a class with this annotation take responsibility for ensuring the
+ * integrity of their data by avoiding race conditions.
+ * <p>
+ * The HotSpot VM uses this annotation to enable non-atomic strategies for
+ * reading and writing to flattened fields and arrays of the annotated class's
+ * type.
+ * <p>
+ * Because these behaviors are not specified by Java SE, this annotation should
+ * only be used by internal JDK code for experimental purposes and should not
+ * affect user-observable outcomes.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LooselyConsistentValue {
+}

--- a/src/java.base/share/classes/jdk/internal/vm/annotation/NullRestricted.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/NullRestricted.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * A null-restricted field is a field that does not store {@code null}.
+ * The type of the field is expected to be a value class type with the
+ * {@link ImplicitlyConstructible} annotation. The initial value of the field
+ * is the zero instance of the given class, and attempts to write {@code null}
+ * to the field will throw an exception.
+ * <p>
+ * The HotSpot VM uses this annotation to enable flattened encodings for the
+ * field that would otherwise be impossible.
+ * <p>
+ * Because these behaviors are not specified by Java SE, this annotation should
+ * only be used by internal JDK classes for experimental purposes and should not
+ * affect user-observable outcomes.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullRestricted {
+}


### PR DESCRIPTION
internal null-restricted storage API points

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8318903](https://bugs.openjdk.org/browse/JDK-8318903): [lw5] null-restricted storage API points (**Bug** - P4)


### Contributors
 * Dan Smith `<dlsmith@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/942/head:pull/942` \
`$ git checkout pull/942`

Update a local copy of the PR: \
`$ git checkout pull/942` \
`$ git pull https://git.openjdk.org/valhalla.git pull/942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 942`

View PR using the GUI difftool: \
`$ git pr show -t 942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/942.diff">https://git.openjdk.org/valhalla/pull/942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/942#issuecomment-1781361781)