### PR TITLE
8315745: [lworld] "Meet Not Symmetric" failures

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -56,11 +56,10 @@ const Type::Offset Type::Offset::bottom(Type::OffsetBot);
 
 const Type::Offset Type::Offset::meet(const Type::Offset other) const {
   // Either is 'TOP' offset?  Return the other offset!
-  int offset = other._offset;
-  if (_offset == OffsetTop) return Offset(offset);
-  if (offset == OffsetTop) return Offset(_offset);
+  if (_offset == OffsetTop) return other;
+  if (other._offset == OffsetTop) return *this;
   // If either is different, return 'BOTTOM' offset
-  if (_offset != offset) return bottom;
+  if (_offset != other._offset) return bottom;
   return Offset(_offset);
 }
 
@@ -4987,7 +4986,13 @@ const TypeAryPtr* TypeAryPtr::cast_to_not_flat(bool not_flat) const {
   }
   assert(!not_flat || !is_flat(), "inconsistency");
   const TypeAry* new_ary = TypeAry::make(elem(), size(), is_stable(), is_flat(), not_flat, is_not_null_free());
-  return make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset, _instance_id, _speculative, _inline_depth, _is_autobox_cache);
+  const TypeAryPtr* res = make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset, _instance_id, _speculative, _inline_depth, _is_autobox_cache);
+  // We keep the speculative part if it contains information about flat-/nullability.
+  // Make sure it's removed if it's not better than the non-speculative type anymore.
+  if (res->speculative() == res->remove_speculative()) {
+    return res->remove_speculative();
+  }
+  return res;
 }
 
 //-------------------------------cast_to_not_null_free-------------------------
@@ -4999,6 +5004,8 @@ const TypeAryPtr* TypeAryPtr::cast_to_not_null_free(bool not_null_free) const {
   const TypeAry* new_ary = TypeAry::make(elem(), size(), is_stable(), is_flat(), /* not_flat= */ not_null_free ? true : is_not_flat(), not_null_free);
   const TypeAryPtr* res = make(ptr(), const_oop(), new_ary, klass(), klass_is_exact(), _offset, _field_offset,
                                _instance_id, _speculative, _inline_depth, _is_autobox_cache);
+  // We keep the speculative part if it contains information about flat-/nullability.
+  // Make sure it's removed if it's not better than the non-speculative type anymore.
   if (res->speculative() == res->remove_speculative()) {
     return res->remove_speculative();
   }
@@ -5206,7 +5213,7 @@ const Type *TypeAryPtr::xmeet_helper(const Type *t) const {
       } else if (below_centerline(ptr)) {
         // Result is in a non-flat representation
         off = Offset(flat_offset()).meet(Offset(tap->flat_offset()));
-        field_off = Offset::bottom;
+        field_off = (field_off == Offset::top) ? Offset::top : Offset::bottom;
       } else if (flat_offset() == tap->flat_offset()) {
         off = Offset(!is_flat() ? offset() : tap->offset());
         field_off = !is_flat() ? field_offset() : tap->field_offset();


### PR DESCRIPTION
The following two independent issues showed up with stress testing.

```
=== Meet Not Symmetric ===
t   =                   not flat:not null free:narrowoop: java/lang/Object:BotPTR *[int:0..max-2] (java/lang/Cloneable,java/io/Serializable):NotNull:exact *
this=                   flat:not flat:not null free:top[int:0..max-2] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+bot):null_free *,iid=top (inline_depth=1)
mt=(t meet this)=       not flat:not null free:narrowoop: java/lang/Object:BotPTR *[int:0..max-2] (java/lang/Cloneable,java/io/Serializable):NotNull:exact *
t_dual=                 stable:flat:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max-2..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:exact:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop)
this_dual=              stable:bottom[int:max-2..0] (java/lang/Cloneable,java/io/Serializable):NotNull * (inline_depth=-1)
mt_dual=                stable:flat:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max-2..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:exact:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop)
mt_dual meet t_dual=    stable:flat:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max-2..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:exact:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop)
mt_dual meet this_dual= stable:bottom[int:max-2..0] (java/lang/Cloneable,java/io/Serializable):NotNull * (inline_depth=-1)
```

The problem is that `mt_dual meet this_dual != this_dual` with `mt_dual->_field_offset == TOP` and `this_dual->_field_offset == TOP` because the `_field_offset` of the result is `BOTTOM`. The fix is to adjust the code in `TypeAryPtr::xmeet_helper` to not set the field offset from `TOP` to `BOTTOM`.

```
=== Meet Not Symmetric ===
t   =                   stable:flat:not null free:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop) (speculative=stable:flat:not null free:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop))
this=                   stable:flat:not flat:not null free:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop) (speculative=stable:flat:not null free:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop))
mt=(t meet this)=       stable:flat:not null free:narrowoop: java/lang/Object:TopPTR *,iid=top (inline_depth=InlineDepthTop)[int:max..0] (java/lang/Cloneable,java/io/Serializable):AnyNull:flat(+top):null_free *,iid=top (inline_depth=InlineDepthTop)
t_dual=                 not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull * (speculative=not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull *)
this_dual=              narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull * (speculative=not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull *)
mt_dual=                not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull *
mt_dual meet t_dual=    not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull *
mt_dual meet this_dual= narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull * (speculative=not flat:narrowoop: java/lang/Object:BotPTR *[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull *)
```

The problem is that `mt_dual meet t_dual != this_dual` because the speculative type is lost. The problem is already that for `t` the speculative type is equivalent to the non-speculative type. Since we keep the speculative part if it contains information about flat-/nullability (see [JDK-8222221](https://bugs.openjdk.org/browse/JDK-8222221)), we need to make sure it's removed if it's not better than the non-speculative type anymore and this check was missing in `TypeAryPtr::cast_to_not_flat`.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8315745](https://bugs.openjdk.org/browse/JDK-8315745): [lworld] "Meet Not Symmetric" failures (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/943/head:pull/943` \
`$ git checkout pull/943`

Update a local copy of the PR: \
`$ git checkout pull/943` \
`$ git pull https://git.openjdk.org/valhalla.git pull/943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 943`

View PR using the GUI difftool: \
`$ git pr show -t 943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/943.diff">https://git.openjdk.org/valhalla/pull/943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/943#issuecomment-1787743957)