### PR TITLE
8315744: [lworld] SubTypeCheckNode::sub asserts with "should be not null"

### DIFF
--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -252,7 +252,7 @@ public:
   }
   Node* try_clean_mem_phi(PhaseGVN *phase);
 
-  InlineTypeNode* push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk, bool is_init);
+  InlineTypeNode* push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk);
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);


### PR DESCRIPTION
[JDK-8303279](https://bugs.openjdk.org/browse/JDK-8303279) added an assert that we now hit in Valhalla because the subtype of a `SubTypeCheckNode` is not known to be non-null. The problem is that when pushing InlineTypeNodes through Phis, we lose track of the fact that the Phi is non-null. There's some existing logic for that but it's broken.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8315744](https://bugs.openjdk.org/browse/JDK-8315744): [lworld] SubTypeCheckNode::sub asserts with "should be not null" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/944/head:pull/944` \
`$ git checkout pull/944`

Update a local copy of the PR: \
`$ git checkout pull/944` \
`$ git pull https://git.openjdk.org/valhalla.git pull/944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 944`

View PR using the GUI difftool: \
`$ git pr show -t 944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/944.diff">https://git.openjdk.org/valhalla/pull/944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/944#issuecomment-1788601066)