### PR TITLE
8319972: [lworld+vector] Enable intrinsification of Unsafe.finishPrivateBuffer.

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1864,7 +1864,6 @@ void GraphKit::set_arguments_for_java_call(CallJavaNode* call, bool is_late_inli
     if (t->is_inlinetypeptr() && !call->method()->get_Method()->mismatch() && call->method()->is_scalarized_arg(arg_num)) {
       // We don't pass inline type arguments by reference but instead pass each field of the inline type
       if (!arg->is_InlineType()) {
-        assert(_gvn.type(arg)->is_zero_type() && !t->inline_klass()->is_null_free(), "Unexpected argument type");
         arg = InlineTypeNode::make_from_oop(this, arg, t->inline_klass(), t->inline_klass()->is_null_free());
       }
       InlineTypeNode* vt = arg->as_InlineType();

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -797,7 +797,7 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       // but later decide to inline the call after the callee code also triggered allocation.
       for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
         AllocateNode* alloc = fast_out(i)->isa_Allocate();
-        if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
+        if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable && !alloc->_larval) {
           // Found a re-allocation
           Node* res = alloc->result_cast();
           if (res != nullptr && res->is_CheckCastPP()) {
@@ -1009,34 +1009,22 @@ InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi,
   return kit->gvn().transform(vt)->as_InlineType();
 }
 
-InlineTypeNode* InlineTypeNode::make_larval(GraphKit* kit, bool allocate) const {
+Node* InlineTypeNode::make_larval(GraphKit* kit) const {
   ciInlineKlass* vk = inline_klass();
-  InlineTypeNode* res = make_uninitialized(kit->gvn(), vk);
-  for (uint i = 1; i < req(); ++i) {
-    res->set_req(i, in(i));
-  }
 
-  if (allocate) {
-    // Re-execute if buffering triggers deoptimization
-    PreserveReexecuteState preexecs(kit);
-    kit->jvms()->set_should_reexecute(true);
-    Node* klass_node = kit->makecon(TypeKlassPtr::make(vk));
-    Node* alloc_oop  = kit->new_instance(klass_node, nullptr, nullptr, true);
-    AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop);
-    alloc->_larval = true;
+  // Re-execute if buffering triggers deoptimization
+  PreserveReexecuteState preexecs(kit);
+  kit->jvms()->set_should_reexecute(true);
+  Node* klass_node = kit->makecon(TypeKlassPtr::make(vk));
+  Node* alloc_oop  = kit->new_instance(klass_node, nullptr, nullptr, true);
+  AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop);
+  alloc->_larval = true;
 
-    store(kit, alloc_oop, alloc_oop, vk);
-    res->set_oop(alloc_oop);
-  }
-  // TODO 8239003
-  //res->set_type(TypeInlineType::make(vk, true));
-  res = kit->gvn().transform(res)->as_InlineType();
-  assert(!allocate || res->is_allocated(&kit->gvn()), "must be allocated");
-  return res;
+  store(kit, alloc_oop, alloc_oop, vk);
+  return alloc_oop;
 }
 
-InlineTypeNode* InlineTypeNode::finish_larval(GraphKit* kit) const {
-  Node* obj = get_oop();
+InlineTypeNode* InlineTypeNode::finish_larval(GraphKit* kit, Node* obj, const TypeInstPtr* vk) {
   Node* mark_addr = kit->basic_plus_adr(obj, oopDesc::mark_offset_in_bytes());
   Node* mark = kit->make_load(nullptr, mark_addr, TypeX_X, TypeX_X->basic_type(), MemNode::unordered);
   mark = kit->gvn().transform(new AndXNode(mark, kit->MakeConX(~markWord::larval_bit_in_place)));
@@ -1048,15 +1036,7 @@ InlineTypeNode* InlineTypeNode::finish_larval(GraphKit* kit) const {
   assert(alloc != nullptr, "must have an allocation node");
   kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
 
-  ciInlineKlass* vk = inline_klass();
-  InlineTypeNode* res = make_uninitialized(kit->gvn(), vk);
-  for (uint i = 1; i < req(); ++i) {
-    res->set_req(i, in(i));
-  }
-  // TODO 8239003
-  //res->set_type(TypeInlineType::make(vk, false));
-  res = kit->gvn().transform(res)->as_InlineType();
-  return res;
+  return InlineTypeNode::make_from_oop(kit, obj, vk->inline_klass(), !vk->maybe_null());
 }
 
 bool InlineTypeNode::is_larval(PhaseGVN* gvn) const {
@@ -1281,7 +1261,7 @@ void InlineTypeNode::remove_redundant_allocations(PhaseIdealLoop* phase) {
   // will be removed anyway and changing the memory chain will confuse other optimizations.
   for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
     AllocateNode* alloc = fast_out(i)->isa_Allocate();
-    if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable) {
+    if (alloc != nullptr && alloc->in(AllocateNode::InlineType) == this && !alloc->_is_scalar_replaceable && !alloc->_larval) {
       Node* res = alloc->result_cast();
       if (res == nullptr || !res->is_CheckCastPP()) {
         break; // No unique CheckCastPP

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -164,8 +164,8 @@ public:
   // Pass inline type as fields at a call or return
   void pass_fields(GraphKit* kit, Node* n, uint& base_input, bool in, bool null_free = true);
 
-  InlineTypeNode* make_larval(GraphKit* kit, bool allocate) const;
-  InlineTypeNode* finish_larval(GraphKit* kit) const;
+  Node* make_larval(GraphKit* kit) const;
+  static InlineTypeNode* finish_larval(GraphKit* kit, Node* obj, const TypeInstPtr* vk);
 
   // Allocation optimizations
   void remove_redundant_allocations(PhaseIdealLoop* phase);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2627,10 +2627,11 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     }
   }
 
-  if (argument(1)->is_InlineType() && is_store) {
-    InlineTypeNode* value = InlineTypeNode::make_from_oop(this, base, _gvn.type(argument(1))->inline_klass());
-    value = value->make_larval(this, false);
-    replace_in_map(argument(1), value);
+  if (_gvn.type(base)->is_inlinetypeptr() && is_store) {
+    AllocateNode* alloc = AllocateNode::Ideal_allocation(base);
+    if (alloc != nullptr) {
+      assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
+    }
   }
 
   return true;
@@ -2648,31 +2649,35 @@ bool LibraryCallKit::inline_unsafe_make_private_buffer() {
     return true;
   }
 
-  set_result(value->as_InlineType()->make_larval(this, true));
+  set_result(value->as_InlineType()->make_larval(this));
   return true;
 }
 
 bool LibraryCallKit::inline_unsafe_finish_private_buffer() {
   Node* receiver = argument(0);
   Node* buffer = argument(1);
-  if (!buffer->is_InlineType()) {
-    return false;
+  // Incoming value should be a buffer and not InlineTypeNode.
+  if (buffer->is_InlineType()) {
+     return false;
   }
-  InlineTypeNode* vt = buffer->as_InlineType();
-  if (!vt->is_allocated(&_gvn) || VectorSupport::is_vector_payload_mf(vt->inline_klass()->get_InlineKlass())) {
-    return false;
+  // Incoming value should be inline type.
+  if (!buffer->bottom_type()->is_inlinetypeptr()) {
+     return false;
   }
-  // TODO 8239003 Why is this needed?
-  if (AllocateNode::Ideal_allocation(vt->get_oop()) == nullptr) {
-    return false;
-  }
+  const TypeInstPtr* ptr = buffer->bottom_type()->isa_instptr();
 
+  // Allocation node must exist to generate IR for transitioning allocation out
+  // of larval state. Disable the intrinsic and take unsafe slow path if allocation
+  // is not reachable,  oop returned by Unsafe_finishPrivateBuffer native method
+  // will automatically rematerialize InlineTypeNode.
+  if (AllocateNode::Ideal_allocation(buffer) == nullptr) {
+    return false;
+  }
   receiver = null_check(receiver);
   if (stopped()) {
     return true;
   }
-
-  set_result(vt->finish_larval(this));
+  set_result(InlineTypeNode::finish_larval(this, buffer, ptr));
   return true;
 }
 

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2653,14 +2653,12 @@ bool LibraryCallKit::inline_unsafe_make_private_buffer() {
 bool LibraryCallKit::inline_unsafe_finish_private_buffer() {
   Node* receiver = argument(0);
   Node* buffer = argument(1);
-  // Incoming value should be a buffer and not InlineTypeNode.
-  if (buffer->is_InlineType()) {
+
+  // Incoming value should be a buffer with inline type and not InlineTypeNode.
+  if (buffer->is_InlineType() || !buffer->bottom_type()->is_inlinetypeptr()) {
      return false;
   }
-  // Incoming value should be inline type.
-  if (!buffer->bottom_type()->is_inlinetypeptr()) {
-     return false;
-  }
+
   // Allocation node must exist to generate IR for transitioning allocation out
   // of larval state. Disable the intrinsic and take unsafe slow path if allocation
   // is not reachable,  oop returned by Unsafe_finishPrivateBuffer native method

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -958,7 +958,10 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
   if (res != nullptr) { // Could be null when there are no users
     res_type = _igvn.type(res)->isa_oopptr();
   }
-
+  // Bufferes in larval state should not be scalarized.
+  if (alloc->_larval) {
+    return false;
+  }
   // Process the safepoint uses
   assert(safepoints.length() == 0 || !res_type->is_inlinetypeptr(), "Inline type allocations should not have safepoint uses");
   Unique_Node_List value_worklist;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1777,9 +1777,12 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
           // Allocate inline type in src block to be able to merge it with oop in target block
           map()->set_req(j, n->as_InlineType()->buffer(this));
         } else if (!n->is_InlineType() && t->is_inlinetypeptr()) {
-          // Scalarize null in src block to be able to merge it with inline type in target block
-          assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
-          map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
+          AllocateNode* alloc = AllocateNode::Ideal_allocation(n);
+          if (alloc == nullptr || !alloc->_larval) {
+            // Scalarize null in src block to be able to merge it with inline type in target block
+            assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
+            map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
+          }
         }
       }
     }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1777,9 +1777,11 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
           // Allocate inline type in src block to be able to merge it with oop in target block
           map()->set_req(j, n->as_InlineType()->buffer(this));
         } else if (!n->is_InlineType() && t->is_inlinetypeptr()) {
-          // Scalarize null in src block to be able to merge it with inline type in target block
-          assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
-          map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
+          // Check the value object is in larval state.
+          AllocateNode* alloc = AllocateNode::Ideal_allocation(n);
+          if (alloc != nullptr) {
+            assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
+          }
         }
       }
     }

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1777,11 +1777,9 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
           // Allocate inline type in src block to be able to merge it with oop in target block
           map()->set_req(j, n->as_InlineType()->buffer(this));
         } else if (!n->is_InlineType() && t->is_inlinetypeptr()) {
-          // Check the value object is in larval state.
-          AllocateNode* alloc = AllocateNode::Ideal_allocation(n);
-          if (alloc != nullptr) {
-            assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
-          }
+          // Scalarize null in src block to be able to merge it with inline type in target block
+          assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
+          map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
         }
       }
     }
@@ -1886,7 +1884,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       PhiNode* phi;
       if (m->is_Phi() && m->as_Phi()->region() == r) {
         phi = m->as_Phi();
-      } else if (m->is_InlineType() && m->as_InlineType()->has_phi_inputs(r)) {
+      } else if (m->is_InlineType() && n->is_InlineType() && m->as_InlineType()->has_phi_inputs(r)) {
         phi = m->as_InlineType()->get_oop()->as_Phi();
       } else {
         phi = nullptr;
@@ -1925,7 +1923,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       // It is a bug if we create a phi which sees a garbage value on a live path.
 
       // Merging two inline types?
-      if (phi != nullptr && phi->bottom_type()->is_inlinetypeptr()) {
+      if (phi != nullptr && phi->bottom_type()->is_inlinetypeptr() && m->is_InlineType() && n->is_InlineType()) {
         // Reload current state because it may have been updated by ensure_phi
         m = map()->in(j);
         InlineTypeNode* vtm = m->as_InlineType(); // Current inline type

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -38,31 +38,33 @@ import static jdk.internal.vm.vector.VectorSupport.*;
 
 abstract class AbstractMask<E> extends VectorMask<E> {
 
+    public static final Unsafe U =  Unsafe.getUnsafe();
+
     /*package-private*/
     abstract VectorPayloadMF getBits();
 
     static <F> VectorPayloadMF prepare(VectorPayloadMF payload, int offset, VectorSpecies<F> species) {
         boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
         VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(species.elementType(), species.length(), isMaxShape);
-        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        res = U.makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < species.length(); i++) {
-            boolean b = Unsafe.getUnsafe().getBoolean(payload, mOffset + i + offset);
-            Unsafe.getUnsafe().putBoolean(res, mOffset + i, b);
+            boolean b = U.getBoolean(payload, mOffset + i + offset);
+            U.putBoolean(res, mOffset + i, b);
         }
-        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        res = U.finishPrivateBuffer(res);
         return res;
     }
 
     static <F> VectorPayloadMF prepare(boolean val, VectorSpecies<F> species) {
         boolean isMaxShape  = species.vectorShape() == VectorShape.S_Max_BIT;
         VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(species.elementType(), species.length(), isMaxShape);
-        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        res = U.makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < species.length(); i++) {
-            Unsafe.getUnsafe().putBoolean(res, mOffset + i, val);
+            U.putBoolean(res, mOffset + i, val);
         }
-        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        res = U.finishPrivateBuffer(res);
         return res;
     }
 
@@ -77,13 +79,13 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         boolean is_max_species = ((AbstractSpecies)(vspecies())).is_max_species();
         VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
-        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        res = U.makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            boolean b = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
-            Unsafe.getUnsafe().putBoolean(res, mOffset + i, f.apply(i, b));
+            boolean b = U.getBoolean(bits, mOffset + i);
+            U.putBoolean(res, mOffset + i, f.apply(i, b));
         }
-        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        res = U.finishPrivateBuffer(res);
         return vspecies().maskFactory(res);
     }
 
@@ -99,14 +101,14 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF mbits = m.getBits();
         boolean is_max_species = ((AbstractSpecies)(vspecies())).is_max_species();
         VectorPayloadMF res = VectorPayloadMF.newMaskInstanceFactory(vspecies().elementType(), length, is_max_species);
-        res = Unsafe.getUnsafe().makePrivateBuffer(res);
+        res = U.makePrivateBuffer(res);
         long mOffset = res.multiFieldOffset();
         for (int i = 0; i < length; i++) {
-            boolean b = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
-            boolean mb = Unsafe.getUnsafe().getBoolean(mbits, mOffset + i);
-            Unsafe.getUnsafe().putBoolean(res, mOffset + i, f.apply(i, b, mb));
+            boolean b = U.getBoolean(bits, mOffset + i);
+            boolean mb = U.getBoolean(mbits, mOffset + i);
+            U.putBoolean(res, mOffset + i, f.apply(i, b, mb));
         }
-        res = Unsafe.getUnsafe().finishPrivateBuffer(res);
+        res = U.finishPrivateBuffer(res);
         return vspecies().maskFactory(res);
     }
 
@@ -116,7 +118,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < vspecies().laneCount(); i++) {
-            arr[idx++] = Unsafe.getUnsafe().getBoolean(bits, mOffset + i);
+            arr[idx++] = U.getBoolean(bits, mOffset + i);
         }
     }
 
@@ -216,7 +218,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
     /*package-private*/
     boolean laneIsSetHelper(int idx) {
         VectorPayloadMF bits = getBits();
-        return Unsafe.getUnsafe().getBoolean(bits, bits.multiFieldOffset() + idx);
+        return U.getBoolean(bits, bits.multiFieldOffset() + idx);
     }
 
     /*package-private*/
@@ -225,7 +227,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < length(); i++) {
-            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return true;
+            if (U.getBoolean(bits, mOffset + i)) return true;
         }
         return false;
     }
@@ -236,7 +238,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < length(); i++) {
-            if (!Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return false;
+            if (!U.getBoolean(bits, mOffset + i)) return false;
         }
         return true;
     }
@@ -247,7 +249,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < length(); i++) {
-            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) c++;
+            if (U.getBoolean(bits, mOffset + i)) c++;
         }
         return c;
     }
@@ -257,7 +259,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < length(); i++) {
-            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return i;
+            if (U.getBoolean(bits, mOffset + i)) return i;
         }
         return length();
     }
@@ -267,7 +269,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = length() - 1; i >= 0; i--) {
-            if (Unsafe.getUnsafe().getBoolean(bits, mOffset + i)) return i;
+            if (U.getBoolean(bits, mOffset + i)) return i;
         }
         return -1;
     }
@@ -279,7 +281,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorPayloadMF bits = getBits();
         long mOffset = bits.multiFieldOffset();
         for (int i = 0; i < length(); i++) {
-            res = Unsafe.getUnsafe().getBoolean(bits, mOffset + i) ? res | set : res;
+            res = U.getBoolean(bits, mOffset + i) ? res | set : res;
             set = set << 1;
         }
         return res;

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -30,6 +30,7 @@ import jdk.internal.vm.vector.VectorSupport;
 
 import java.nio.ByteOrder;
 import java.util.function.IntUnaryOperator;
+import jdk.internal.misc.Unsafe;
 
 import static jdk.incubator.vector.VectorOperators.*;
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -79,6 +80,8 @@ abstract class AbstractVector<E> extends Vector<E> {
 
     /*package-private*/
     abstract long multiFieldOffset();
+
+    static final Unsafe U = Unsafe.getUnsafe();
 
     @Override
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -57,8 +57,6 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      */
     public ByteVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfByte ELEMENT_LAYOUT = ValueLayout.JAVA_BYTE.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -57,8 +57,6 @@ public abstract class DoubleVector extends AbstractVector<Double> {
      */
     public DoubleVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfDouble ELEMENT_LAYOUT = ValueLayout.JAVA_DOUBLE.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -57,8 +57,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     public FloatVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfFloat ELEMENT_LAYOUT = ValueLayout.JAVA_FLOAT.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -57,8 +57,6 @@ public abstract class IntVector extends AbstractVector<Integer> {
      */
     public IntVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfInt ELEMENT_LAYOUT = ValueLayout.JAVA_INT.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -57,8 +57,6 @@ public abstract class LongVector extends AbstractVector<Long> {
      */
     public LongVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfLong ELEMENT_LAYOUT = ValueLayout.JAVA_LONG.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -57,8 +57,6 @@ public abstract class ShortVector extends AbstractVector<Short> {
      */
     public ShortVector() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.OfShort ELEMENT_LAYOUT = ValueLayout.JAVA_SHORT.withByteAlignment(1);
 
     @ForceInline

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -61,8 +61,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     public $abstractvectortype$() {}
 
-    static final Unsafe U = Unsafe.getUnsafe();
-
     static final ValueLayout.Of$Type$ ELEMENT_LAYOUT = ValueLayout.JAVA_$TYPE$.withByteAlignment(1);
 
     @ForceInline

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -213,3 +213,4 @@ vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription
 
 # lworld+vector
 compiler/vectorapi/VectorReinterpretTest.java
+compiler/vectorapi/reshape/TestVectorReinterpret.java

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -405,7 +405,7 @@ public class TestIntrinsics {
 
     MyValue1 test22_vt;
     @Test
-    @IR(failOn = {CALL_UNSAFE, ALLOC})
+    @IR(failOn = {CALL_UNSAFE})
     public void test22(MyValue1 v) {
         v = U.makePrivateBuffer(v);
         U.putInt(v, X_OFFSET, rI);


### PR DESCRIPTION
Re-enabling intrinsification of Unsafe.finishPrivateBuffer to fix performance degradation seen in Vector API JMH micro benchmarks. It's intrinsifation was disabled to fix incorrectness caused due to missing inductive InlineType Phi node in loops with Unsafe.put* operations. Since Unsafe.put* APIs returns a void hence JVM state is not altered and ciTypeFlow dataflow analysis does not encounter a inductive definition in the loop, due to this C2 parser misses creating an inductive phi node on
encountering [loop header block](https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/opto/parse1.cpp#L696). 

In order to maintain IR compliance with ciTypeFlow analysis C2 should prevent scalarizing value object b/w make and finish private buffer calls.

New behavior of unsafe inline expanders
1) makePrivate: Receive InlineTypeNode input and return initialized buffer in larval state.
2) finishPrivateBuffer: Receive value object buffer input and return rematerialize InlineTypeNode in non-larval state.

This may result into creation of unbalanced phi node at control flow merges where one of the phi input may InlineTypeNode and other is a buffer of compatible value type, but the IR still remains valid.

In addition compiler is now preventing elimination of allocation in larval state.

Validation Status:-
  - All the VectorAPI and Valhalla JTREG tests are now passing at various AVX level with / wo -XX:+DoptimizeALot.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8319972](https://bugs.openjdk.org/browse/JDK-8319972): [lworld+vector] Enable intrinsification of Unsafe.finishPrivateBuffer. (**Enhancement** - P4)


### Reviewers
 * [Xiaohong Gong](https://openjdk.org/census#xgong) (@XiaohongGong - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/952/head:pull/952` \
`$ git checkout pull/952`

Update a local copy of the PR: \
`$ git checkout pull/952` \
`$ git pull https://git.openjdk.org/valhalla.git pull/952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 952`

View PR using the GUI difftool: \
`$ git pr show -t 952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/952.diff">https://git.openjdk.org/valhalla/pull/952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/952#issuecomment-1810416359)