### PR TITLE
8319945: [lworld+vector] Fix vector api jtreg crash with "-XX:-EnableVectorSupport"

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -426,6 +426,17 @@ ciField* ciInstanceKlass::get_field_by_offset(int field_offset, bool is_static) 
       if (field_off > field_offset)
         break;
       // could do binary search or check bins, but probably not worth it
+
+      if (field->secondary_fields_count() > 1) {
+        for (int j = 0; j < field->secondary_fields_count() - 1; j++) {
+          ciField* sec_field = static_cast<ciMultiField*>(field)->secondary_fields()->at(j);
+          int sec_field_offset = sec_field->offset_in_bytes();
+          if (sec_field_offset == field_offset)
+            return sec_field;
+          if (sec_field_offset > field_offset)
+            return nullptr;
+        }
+      }
     }
     return nullptr;
   }


### PR DESCRIPTION
Several vector api jtreg tests crash with `"-XX:-EnableVectorSupport"`
when running on machines that the operations of vector payload can
be vectorized.

Here is the log:

```
 Internal Error (valhalla/src/hotspot/share/opto/library_call.cpp:2465), pid=467482, tid=467499
 assert(bt == alias_type->basic_type() || bt == T_PRIMITIVE_OBJECT) failed: should match

 JRE version: OpenJDK Runtime Environment (22.0) (fastdebug build 22-internal-git-5b2fa0aab)
 Java VM: OpenJDK 64-Bit Server VM (fastdebug 22-internal-git-5b2fa0aab, mixed mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
 Problematic frame:
 V [[libjvm.so](http://libjvm.so/)+0x11b1738] LibraryCallKit::inline_unsafe_access(bool, BasicType, LibraryCallKit::AccessKind, bool)+0x13e8
```

The reason is the matched field of the given offset in the vector
payload is not found when using Usafe's access methods. And the root
cause is when the operations of the multifields are vectorizable in
C2, only the multifield base is added into the holder klass's non-static
fields list in ci stage. Hence when accessing other multifields by
Unsafe's get/put methods (which is the fall-back java implementation of
current vector operations), the fields cannot be found with the given
field offset.

This issue is involved by [JDK-8314980](https://bugs.openjdk.java.net/browse/JDK-8314980) (see [1]), which refactors the
multfields parsing in ci stage. The special handling for multifields
in `ciInstanceKlass::get_field_by_offset` is removed. Adding it back
can fix this issue.

This patch also reverted the special consideration for multifields when
printing out the JVM state in a safepoint. It is not needed anymore,
because the fields of an `InlineTypeNode` in C2 is always consistent
with the holder klass's non-static fields after [JDK-8314980](https://bugs.openjdk.java.net/browse/JDK-8314980).

[1] https://github.com/openjdk/valhalla/pull/918

Verified with Vector API jtreg tests with `-XX:-EnableVectorSupport`, and all tests clean.