### PR TITLE
8320080: [lworld] SubTypeCheckNode::sub asserts with "should be not null"

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -770,6 +770,7 @@ void StaticFieldPrinter::do_field_helper(fieldDescriptor* fd, oop mirror, bool i
       _out->print(INT64_FORMAT, *(int64_t*)&d);
       break;
     }
+    case T_PRIMITIVE_OBJECT: // fall-through
     case T_ARRAY:  // fall-through
     case T_OBJECT:
       if (!fd->is_null_free_inline_type()) {

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -1091,6 +1091,7 @@ class CompileReplay : public StackObj {
       }
       case T_ARRAY:
       case T_OBJECT:
+      case T_PRIMITIVE_OBJECT:
         if (!fd->is_null_free_inline_type()) {
           JavaThread* THREAD = JavaThread::current();
           bool res = _replay->process_staticfield_reference(string_value, _vt, fd, THREAD);

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -111,6 +111,9 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     Node* cast = clone();
     cast->set_req(1, vt->get_oop());
     vt = vt->clone()->as_InlineType();
+    if (!_type->maybe_null()) {
+      vt->as_InlineType()->set_is_init(*phase);
+    }
     vt->set_oop(phase->transform(cast));
     return vt;
   }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2868,4 +2868,21 @@ public class TestNullableInlineTypes {
         Asserts.assertEQ(test102(false), new CircularValue1(CircularValue1.default));
         Asserts.assertEQ(test102(true), null);
     }
+
+    // Might be incrementally inlined
+    public static Object hide(Object obj) {
+        return (MyValue1.ref)obj;
+    }
+
+    // Test that the ConstraintCastNode::Ideal transformation propagates null-free information
+    @Test
+    public MyValue1.ref test103() {
+        Object obj = hide(null);
+        return (MyValue1.ref)obj;
+    }
+
+    @Run(test = "test103")
+    public void test103_verifier() {
+        Asserts.assertEQ(test103(), null);
+    }
 }


### PR DESCRIPTION
Similar to [JDK-8315744](https://bugs.openjdk.org/browse/JDK-8315744), we hit an assert because the subtype of a SubTypeCheckNode is not known to be non-null. The problem is that when pushing casts up through InlineTypeNodes in `ConstraintCastNode::Ideal`, we lose track of the null-free information.

I also re-added still required `T_PRIMITIVE_OBJECT` in the compiler replay implementation that I accidentally removed with https://git.openjdk.org/valhalla/pull/946.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8320080](https://bugs.openjdk.org/browse/JDK-8320080): [lworld] SubTypeCheckNode::sub asserts with "should be not null" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/956/head:pull/956` \
`$ git checkout pull/956`

Update a local copy of the PR: \
`$ git checkout pull/956` \
`$ git pull https://git.openjdk.org/valhalla.git pull/956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 956`

View PR using the GUI difftool: \
`$ git pr show -t 956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/956.diff">https://git.openjdk.org/valhalla/pull/956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/956#issuecomment-1818887852)