### PR TITLE
8320225: [lworld] TestBasicFunctionality::test20 fails intermittently because it does not correctly handle coalescing of subword stores

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -466,9 +466,7 @@ public class TestBasicFunctionality {
     // correctly allocated.
     @Test
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        // Initializing stores are captured by InitializeNode::capture_store, converted
-        // to raw stores and then merged by InitializeNode::coalesce_subword_stores.
-        counts = {ALLOC, "= 1", compiler.lib.ir_framework.IRNode.STORE_L, "= 7"},
+        counts = {ALLOC, "= 1"},
         failOn = {LOAD})
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
         counts = {ALLOC, "= 2"},

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -466,7 +466,9 @@ public class TestBasicFunctionality {
     // correctly allocated.
     @Test
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
-        counts = {ALLOC, "= 1", STORE, "= 1"},  // InitializeNode::coalesce_subword_stores merges stores
+        // Initializing stores are captured by InitializeNode::capture_store, converted
+        // to raw stores and then merged by InitializeNode::coalesce_subword_stores.
+        counts = {ALLOC, "= 1", compiler.lib.ir_framework.IRNode.STORE_L, "= 7"},
         failOn = {LOAD})
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
         counts = {ALLOC, "= 2"},


### PR DESCRIPTION
`TestBasicFunctionality::test20` fails intermittently if one of the randomly chosen field values of a value object is zero because that will lead to slightly different type information for the captured stores that initialize the object. 

Passing case:
```
299  StoreP  === 330 375 285 290  [[ 302 304 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw;
304  StoreL  === 330 299 289 302  [[ 308 ]]  @null  Memory: @rawptr:BotPTR, idx=Raw;
308  StoreNKlass  === 330 304 306 331  [[ 316 ]]  @null  Memory: @rawptr:BotPTR, idx=Raw;
316  StoreI  === 330 308 315 57  [[ 280 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw;
311  StoreL  === 279 280 309 310  [[ 246 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw; !orig=[245],3161 !jvms: MyValue1::<vnew> @ bci:82 (line 57) MyValue1::setV4 @ bci:40 (line 178) MyValue1::createWithFieldsInline @ bci:106 (line 89) TestBasicFunctionality::test20 @ bci:6 (line 475)
246  StoreL  === 279 311 254 188  [[ 314 ]]  @compiler/valhalla/inlinetypes/MyValue2 (compiler/valhalla/inlinetypes/MyInterface):exact+24 *, name=l, idx=11;  Memory: @rawptr:BotPTR, idx=Raw; !orig=3166 !jvms: MyValue1::<vnew> @ bci:82 (line 57) MyValue1::setV4 @ bci:40 (line 178) MyValue1::createWithFieldsInline @ bci:106 (line 89) TestBasicFunctionality::test20 @ bci:6 (line 475)
314  StoreL  === 279 246 312 313  [[ 231 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw; !orig=[248],3178 !jvms: MyValue1::<vnew> @ bci:82 (line 57) MyValue1::setV4 @ bci:40 (line 178) MyValue1::createWithFieldsInline @ bci:106 (line 89) TestBasicFunctionality::test20 @ bci:6 (line 475)
```

Failing case:
```
300  StoreP  === 337 384 286 291  [[ 303 305 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw;
305  StoreL  === 337 300 290 303  [[ 309 ]]  @null  Memory: @rawptr:BotPTR, idx=Raw;
309  StoreNKlass  === 337 305 307 338  [[ 317 ]]  @null  Memory: @rawptr:BotPTR, idx=Raw;
317  StoreI  === 337 309 316 57  [[ 343 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw;
343  StoreL  === 337 317 322 184  [[ 281 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw; !orig=[323]
312  StoreL  === 280 281 310 311  [[ 315 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw; !orig=[248],3163 !jvms: MyValue1::<vnew> @ bci:82 (line 57) MyValue1::setV4 @ bci:40 (line 178) MyValue1::createWithFieldsInline @ bci:106 (line 89) TestBasicFunctionality::test20 @ bci:6 (line 475)
315  StoreL  === 280 312 313 314  [[ 234 ]]  @rawptr:BotPTR, idx=Raw;  Memory: @rawptr:BotPTR, idx=Raw; !orig=[250],3180 !jvms: MyValue1::<vnew> @ bci:82 (line 57) MyValue1::setV4 @ bci:40 (line 178) MyValue1::createWithFieldsInline @ bci:106 (line 89) TestBasicFunctionality::test20 @ bci:6 (line 475)
``` 

In the failing case, the `343  StoreL` is a zeroing store that's separated from the other non-zero `StoreL` by a memory Phi and thus not detected as a store to field `l`. The fix is to make the test more robust by matching on the number of `STORE_L` instead.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8320225](https://bugs.openjdk.org/browse/JDK-8320225): [lworld] TestBasicFunctionality::test20 fails intermittently because it does not correctly handle coalescing of subword stores (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/957/head:pull/957` \
`$ git checkout pull/957`

Update a local copy of the PR: \
`$ git checkout pull/957` \
`$ git pull https://git.openjdk.org/valhalla.git pull/957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 957`

View PR using the GUI difftool: \
`$ git pr show -t 957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/957.diff">https://git.openjdk.org/valhalla/pull/957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/957#issuecomment-1820662849)