### PR TITLE
8320815: [lworld+vector] Fix vector API jtreg crashes with "-XX:InlineFieldMaxFlatSize=0"

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -301,22 +301,9 @@ bool InlineTypeNode::field_is_null_free(uint index) const {
   return field->is_null_free();
 }
 
-static bool is_vector_payload(ciKlass* klass) {
-  return klass->is_subclass_of(ciEnv::current()->vector_VectorPayload_klass());
-}
-
-static bool is_vector_payload_mf(ciKlass* klass) {
-  return klass->is_subclass_of(ciEnv::current()->vector_VectorPayloadMF_klass());
-}
-
 void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_List& worklist, SafePointNode* sfpt) {
   ciInlineKlass* vk = inline_klass();
   uint nfields = vk->nof_nonstatic_fields();
-  if (is_vector_payload_mf(vk)) {
-     assert(field_count() == nfields, "");
-  } else if (is_vector_payload(vk)) {
-     assert(field_value(0)->as_InlineType()->field_count() == nfields, "");
-  }
   JVMState* jvms = sfpt->jvms();
   // Replace safepoint edge by SafePointScalarObjectNode and add field values
   assert(jvms != nullptr, "missing JVMS");

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -853,6 +853,12 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
   sobj->init_req(0, C->root());
   transform_later(sobj);
 
+  if (iklass && iklass->is_inlinetype()) {
+    // Value object has two additional inputs before the non-static fields
+    sfpt->add_req(_igvn.intcon(1));
+    sfpt->add_req(_igvn.intcon(alloc->_larval ? 1 : 0));
+  }
+
   // Scan object's fields adding an input to the safepoint for each field.
   for (int j = 0; j < nfields; j++) {
     intptr_t offset;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1251,7 +1251,7 @@ Node* LoadNode::Identity(PhaseGVN* phase) {
       offset > oopDesc::klass_offset_in_bytes()) {
     Node* value = base->as_InlineType()->field_value_by_offset((int)offset, true);
     if (value != nullptr) {
-      if (Opcode() == Op_LoadN) {
+      if (Opcode() == Op_LoadN && !base->is_VectorBox()) {
         // Encode oop value if we are loading a narrow oop
         assert(!phase->type(value)->isa_narrowoop(), "should already be decoded");
         value = phase->transform(new EncodePNode(value, bottom_type()));


### PR DESCRIPTION
Current Vector API jtreg crashes with `-XX:InlineFieldMaxFlatSize=0` with several kinds of issues. This option makes all the value object fields can not be flattened.

This patch fixes them with following main changes:

 1) Remove the fields count check for `Vector/VectorPayload` objects when scalaring the value objects across safepoints. The check on vector objects fails when its payload field is not flattened (see [1]). The check is not right and can be removed.

 2) Insert two additional inputs of `InlineTypeNode` to safepoint when creating the `SafePointScalarObjectNode` for a value object. This is missing when compiler handles an allocation merge with inline type. It causes the assertion [2] fails.

 3) Forbit optimizing a `LoadN` to `EncodeP (InlineType)`, if the `InlineType` is the payload field of `VectorBox`. This fixes the
assertion failure [3].

When loading from an `InlineType`, C2 compiler tries to look for its field value with the matching offset. If the matched field is a
flattened value object, its field with the matching offset is searched recursively. Otherwise, the field itself is used. After the field
value is found, the load can be saved, and the field value is used as the replacement. If it is an object loading (i.e. `LoadN`), the
matched field value is expected to be a valid oop.

The issue happens when the address base is `VectorBox` and the matched field is a non-flattened `InlineType`. Since `VectorBox` is expanded lately, its memory and the memory for the field are not allocated at this moment. Optimizing `LoadN` to `EncodeP` with the un-allocated `InlineType` makes it possible to the miss the buffer.

 4) Explicitly check whether the payload field is flattened when expanding `VectorBox`. Allocate the buffer and store the vector value to the memory if the payload is not flattened.

The similar operations are handled in `InlineTypeNode::store()` before. But the graph is more complex and not right for some vector API cases. We hit assertion [4].

Tests: All tests pass with `-XX:InlineFieldMaxFlatSize=0` now. And no new regressions are found.

[1] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/opto/inlinetypenode.cpp#L318
[2] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/opto/output.cpp#L812
[3] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/opto/compile.cpp#L2050
[4] https://github.com/openjdk/valhalla/blob/lworld%2Bvector/src/hotspot/share/opto/inlinetypenode.cpp#L1269

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8320815](https://bugs.openjdk.org/browse/JDK-8320815): [lworld+vector] Fix vector API jtreg crashes with "-XX:InlineFieldMaxFlatSize=0" (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/958/head:pull/958` \
`$ git checkout pull/958`

Update a local copy of the PR: \
`$ git checkout pull/958` \
`$ git pull https://git.openjdk.org/valhalla.git pull/958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 958`

View PR using the GUI difftool: \
`$ git pr show -t 958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/958.diff">https://git.openjdk.org/valhalla/pull/958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/958#issuecomment-1838100801)