### PR TITLE
8321039: [lworld] Substitutability code must recognize new annotations

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -137,7 +137,6 @@ JVM_GetSystemPackage
 JVM_GetSystemPackages
 JVM_GetTemporaryDirectory
 JVM_GetVmArguments
-JVM_GetZeroInstance
 JVM_Halt
 JVM_HasReferencePendingList
 JVM_HoldsLock

--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -137,6 +137,7 @@ JVM_GetSystemPackage
 JVM_GetSystemPackages
 JVM_GetTemporaryDirectory
 JVM_GetVmArguments
+JVM_GetZeroInstance
 JVM_Halt
 JVM_HasReferencePendingList
 JVM_HoldsLock
@@ -156,6 +157,7 @@ JVM_IsDumpingClassList
 JVM_IsFinalizationEnabled
 JVM_IsHiddenClass
 JVM_IsIdentityClass
+JVM_IsImplicitlyConstructibleClass
 JVM_IsInterface
 JVM_IsPreviewEnabled
 JVM_IsValhallaEnabled

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -3448,7 +3448,7 @@ int java_lang_reflect_Field::_name_offset;
 int java_lang_reflect_Field::_type_offset;
 int java_lang_reflect_Field::_slot_offset;
 int java_lang_reflect_Field::_modifiers_offset;
-int java_lang_reflect_Field::_trusted_final_offset;
+int java_lang_reflect_Field::_flags_offset;
 int java_lang_reflect_Field::_signature_offset;
 int java_lang_reflect_Field::_annotations_offset;
 
@@ -3458,7 +3458,7 @@ int java_lang_reflect_Field::_annotations_offset;
   macro(_type_offset,      k, vmSymbols::type_name(),      class_signature,  false); \
   macro(_slot_offset,      k, vmSymbols::slot_name(),      int_signature,    false); \
   macro(_modifiers_offset, k, vmSymbols::modifiers_name(), int_signature,    false); \
-  macro(_trusted_final_offset,    k, vmSymbols::trusted_final_name(),    bool_signature,       false); \
+  macro(_flags_offset,     k, vmSymbols::flags_name(),     int_signature,    false); \
   macro(_signature_offset,        k, vmSymbols::signature_name(),        string_signature,     false); \
   macro(_annotations_offset,      k, vmSymbols::annotations_name(),      byte_array_signature, false);
 
@@ -3523,8 +3523,8 @@ void java_lang_reflect_Field::set_modifiers(oop field, int value) {
   field->int_field_put(_modifiers_offset, value);
 }
 
-void java_lang_reflect_Field::set_trusted_final(oop field) {
-  field->bool_field_put(_trusted_final_offset, true);
+void java_lang_reflect_Field::set_flags(oop field, int value) {
+  field->int_field_put(_flags_offset, value);
 }
 
 void java_lang_reflect_Field::set_signature(oop field, oop value) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -770,7 +770,7 @@ class java_lang_reflect_Field : public java_lang_reflect_AccessibleObject {
   static int _type_offset;
   static int _slot_offset;
   static int _modifiers_offset;
-  static int _trusted_final_offset;
+  static int _flags_offset;
   static int _signature_offset;
   static int _annotations_offset;
 
@@ -798,7 +798,7 @@ class java_lang_reflect_Field : public java_lang_reflect_AccessibleObject {
   static int modifiers(oop field);
   static void set_modifiers(oop field, int value);
 
-  static void set_trusted_final(oop field);
+  static void set_flags(oop field, int value);
 
   static void set_signature(oop constructor, oop value);
   static void set_annotations(oop constructor, oop value);
@@ -1301,8 +1301,9 @@ class java_lang_invoke_MemberName: AllStatic {
     MN_TRUSTED_FINAL         = 0x00200000, // trusted final field
     MN_HIDDEN_MEMBER         = 0x00400000, // @Hidden annotation detected
     MN_FLAT_FIELD            = 0x00800000, // flat field
-    MN_REFERENCE_KIND_SHIFT  = 24, // refKind
-    MN_REFERENCE_KIND_MASK   = 0x0F000000 >> MN_REFERENCE_KIND_SHIFT,
+    MN_NULL_RESTRICTED_FIELD = 0x01000000, // null-restricted fiel
+    MN_REFERENCE_KIND_SHIFT  = 26, // refKind
+    MN_REFERENCE_KIND_MASK   = 0x3C000000 >> MN_REFERENCE_KIND_SHIFT,
     MN_NESTMATE_CLASS        = 0x00000001,
     MN_HIDDEN_CLASS          = 0x00000002,
     MN_STRONG_LOADER_LINK    = 0x00000004,

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1301,7 +1301,7 @@ class java_lang_invoke_MemberName: AllStatic {
     MN_TRUSTED_FINAL         = 0x00200000, // trusted final field
     MN_HIDDEN_MEMBER         = 0x00400000, // @Hidden annotation detected
     MN_FLAT_FIELD            = 0x00800000, // flat field
-    MN_NULL_RESTRICTED_FIELD = 0x01000000, // null-restricted fiel
+    MN_NULL_RESTRICTED_FIELD = 0x01000000, // null-restricted field
     MN_REFERENCE_KIND_SHIFT  = 26, // refKind
     MN_REFERENCE_KIND_MASK   = 0x3C000000 >> MN_REFERENCE_KIND_SHIFT,
     MN_NESTMATE_CLASS        = 0x00000001,

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -301,7 +301,6 @@ class SerializeClosure;
   template(returnType_name,                           "returnType")                               \
   template(signature_name,                            "signature")                                \
   template(slot_name,                                 "slot")                                     \
-  template(trusted_final_name,                        "trustedFinal")                             \
   template(blackhole_name,                            "<blackhole>")  /*fake name*/               \
                                                                                                   \
   /* Support for annotations (JDK 1.5 and above) */                                               \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -579,6 +579,9 @@ JVM_IsHiddenClass(JNIEnv *env, jclass cls);
 JNIEXPORT jboolean JNICALL
 JVM_IsIdentityClass(JNIEnv *env, jclass cls);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsImplicitlyConstructibleClass(JNIEnv *env, jclass cls);
+
 JNIEXPORT jint JNICALL
 JVM_GetClassModifiers(JNIEnv *env, jclass cls);
 
@@ -1133,6 +1136,9 @@ JVM_InitAgentProperties(JNIEnv *env, jobject agent_props);
 
 JNIEXPORT jstring JNICALL
 JVM_GetTemporaryDirectory(JNIEnv *env);
+
+JNIEXPORT jobject JNICALL
+JVM_GetZeroInstance(JNIEnv *env, jclass cls);
 
 JNIEXPORT jarray JNICALL
 JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint len);

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1137,9 +1137,6 @@ JVM_InitAgentProperties(JNIEnv *env, jobject agent_props);
 JNIEXPORT jstring JNICALL
 JVM_GetTemporaryDirectory(JNIEnv *env);
 
-JNIEXPORT jobject JNICALL
-JVM_GetZeroInstance(JNIEnv *env, jclass cls);
-
 JNIEXPORT jarray JNICALL
 JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint len);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -423,23 +423,6 @@ JVM_ENTRY(jstring, JVM_GetTemporaryDirectory(JNIEnv *env))
   return (jstring) JNIHandles::make_local(THREAD, h());
 JVM_END
 
-JVM_ENTRY(jobject, JVM_GetZeroInstance(JNIEnv *env, jclass cls)) {
-  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(cls));
-  k->initialize(CHECK_NULL);
-  if (!k->is_value_class()) {
-    ResourceMark rm;
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not a value class", k->external_name()));
-  }
-  InlineKlass* vk = InlineKlass::cast(k);
-  if (!vk->is_implicitly_constructible()) {
-    ResourceMark rm;
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", vk->external_name()));
-  }
-  oop v = vk->default_value();
-  return JNIHandles::make_local(THREAD, v);
-}
-JVM_END
-
 JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint len))
   if (len < 0) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Array length is negative");

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -423,6 +423,18 @@ JVM_ENTRY(jstring, JVM_GetTemporaryDirectory(JNIEnv *env))
   return (jstring) JNIHandles::make_local(THREAD, h());
 JVM_END
 
+JVM_ENTRY(jobject, JVM_GetZeroInstance(JNIEnv *env, jclass cls)) {
+  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(cls));
+  k->initialize(CHECK_NULL);
+  if (!k->is_value_class()) {
+    ResourceMark rm;
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not a value class", k->external_name()));
+  }
+  InlineKlass* vk = InlineKlass::cast(k);
+  oop v = vk->default_value();
+  return JNIHandles::make_local(THREAD, v); 
+}
+JVM_END
 
 JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint len))
   if (len < 0) {
@@ -1293,6 +1305,12 @@ JVM_ENTRY(jboolean, JVM_IsIdentityClass(JNIEnv *env, jclass cls))
   } else {
     return k->is_interface() ? JNI_FALSE : JNI_TRUE;
   }
+JVM_END
+
+JVM_ENTRY(jboolean, JVM_IsImplicitlyConstructibleClass(JNIEnv *env, jclass cls))
+  oop mirror = JNIHandles::resolve_non_null(cls);
+  InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(mirror));
+  return ik->is_implicitly_constructible();
 JVM_END
 
 JVM_ENTRY(jobjectArray, JVM_GetClassSigners(JNIEnv *env, jclass cls))

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -431,6 +431,9 @@ JVM_ENTRY(jobject, JVM_GetZeroInstance(JNIEnv *env, jclass cls)) {
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not a value class", k->external_name()));
   }
   InlineKlass* vk = InlineKlass::cast(k);
+  if (!vk->is_implicitly_constructible()) {
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", vk->external_name()));
+  }
   oop v = vk->default_value();
   return JNIHandles::make_local(THREAD, v); 
 }
@@ -444,11 +447,11 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint 
   Klass* klass = java_lang_Class::as_Klass(mirror);
   klass->initialize(CHECK_NULL);
   if (!klass->is_value_class()) {
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not a value class");
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not a value class", klass->external_name()));
   }
   InstanceKlass* ik = InstanceKlass::cast(klass);
   if (!ik->is_implicitly_constructible()) {
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not annotated with @ImplicitlyConstructible");
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", ik->external_name()));
   }
   oop array = oopFactory::new_valueArray(ik, len, CHECK_NULL);
   return (jarray) JNIHandles::make_local(THREAD, array);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -432,10 +432,11 @@ JVM_ENTRY(jobject, JVM_GetZeroInstance(JNIEnv *env, jclass cls)) {
   }
   InlineKlass* vk = InlineKlass::cast(k);
   if (!vk->is_implicitly_constructible()) {
+    ResourceMark rm;
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", vk->external_name()));
-  }
+  } 
   oop v = vk->default_value();
-  return JNIHandles::make_local(THREAD, v); 
+  return JNIHandles::make_local(THREAD, v);
 }
 JVM_END
 
@@ -447,11 +448,11 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint 
   Klass* klass = java_lang_Class::as_Klass(mirror);
   klass->initialize(CHECK_NULL);
   if (!klass->is_value_class()) {
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not a value class", klass->external_name()));
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not a value class");
   }
   InstanceKlass* ik = InstanceKlass::cast(klass);
   if (!ik->is_implicitly_constructible()) {
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", ik->external_name()));
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not annotated with @ImplicitlyConstructible");
   }
   oop array = oopFactory::new_valueArray(ik, len, CHECK_NULL);
   return (jarray) JNIHandles::make_local(THREAD, array);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -434,7 +434,7 @@ JVM_ENTRY(jobject, JVM_GetZeroInstance(JNIEnv *env, jclass cls)) {
   if (!vk->is_implicitly_constructible()) {
     ResourceMark rm;
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), err_msg("%s not implicitly constructible", vk->external_name()));
-  } 
+  }
   oop v = vk->default_value();
   return JNIHandles::make_local(THREAD, v);
 }

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -138,7 +138,8 @@ enum {
   CALLER_SENSITIVE      = java_lang_invoke_MemberName::MN_CALLER_SENSITIVE,
   TRUSTED_FINAL         = java_lang_invoke_MemberName::MN_TRUSTED_FINAL,
   HIDDEN_MEMBER        = java_lang_invoke_MemberName::MN_HIDDEN_MEMBER,
-  FLATTENED             = java_lang_invoke_MemberName::MN_FLAT_FIELD,
+  FLAT_FIELD            = java_lang_invoke_MemberName::MN_FLAT_FIELD,
+  NULL_RESTRICTED       = java_lang_invoke_MemberName::MN_NULL_RESTRICTED_FIELD,
   REFERENCE_KIND_SHIFT  = java_lang_invoke_MemberName::MN_REFERENCE_KIND_SHIFT,
   REFERENCE_KIND_MASK   = java_lang_invoke_MemberName::MN_REFERENCE_KIND_MASK,
   LM_UNCONDITIONAL      = java_lang_invoke_MemberName::MN_UNCONDITIONAL_MODE,
@@ -356,7 +357,8 @@ oop MethodHandles::init_field_MemberName(Handle mname, fieldDescriptor& fd, bool
   int flags = (jushort)( fd.access_flags().as_short() & JVM_RECOGNIZED_FIELD_MODIFIERS );
   flags |= IS_FIELD | ((fd.is_static() ? JVM_REF_getStatic : JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   if (fd.is_trusted_final()) flags |= TRUSTED_FINAL;
-  if (fd.is_flat()) flags |= FLATTENED;;
+  if (fd.is_flat()) flags |= FLAT_FIELD;
+  if (fd.is_null_free_inline_type()) flags |= NULL_RESTRICTED;
   if (is_setter)  flags += ((JVM_REF_putField - JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   int vmindex        = fd.offset();  // determines the field uniquely when combined with static bit
 

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -344,13 +344,6 @@ UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedArray(JNIEnv *env, jobject unsafe, jcla
   return k->is_flatArray_klass();
 } UNSAFE_END
 
-UNSAFE_ENTRY(jobject, Unsafe_UninitializedDefaultValue(JNIEnv *env, jobject unsafe, jclass vc)) {
-  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(vc));
-  InlineKlass* vk = InlineKlass::cast(k);
-  oop v = vk->default_value();
-  return JNIHandles::make_local(THREAD, v);
-} UNSAFE_END
-
 UNSAFE_ENTRY(jobject, Unsafe_GetValue(JNIEnv *env, jobject unsafe, jobject obj, jlong offset, jclass vc)) {
   oop base = JNIHandles::resolve(obj);
   Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(vc));
@@ -1004,7 +997,6 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "isFlattenedField0", CC "(" OBJ ")Z",                    FN_PTR(Unsafe_IsFlattenedField)},
     {CC "getValue",         CC "(" OBJ "J" CLS ")" OBJ,          FN_PTR(Unsafe_GetValue)},
     {CC "putValue",         CC "(" OBJ "J" CLS OBJ ")V",         FN_PTR(Unsafe_PutValue)},
-    {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,         FN_PTR(Unsafe_UninitializedDefaultValue)},
     {CC "makePrivateBuffer",     CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_MakePrivateBuffer)},
     {CC "finishPrivateBuffer",   CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_FinishPrivateBuffer)},
     {CC "valueHeaderSize",       CC "(" CLS ")J",                FN_PTR(Unsafe_ValueHeaderSize)},

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -344,6 +344,13 @@ UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedArray(JNIEnv *env, jobject unsafe, jcla
   return k->is_flatArray_klass();
 } UNSAFE_END
 
+UNSAFE_ENTRY(jobject, Unsafe_UninitializedDefaultValue(JNIEnv *env, jobject unsafe, jclass vc)) {
+  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(vc));
+  InlineKlass* vk = InlineKlass::cast(k);
+  oop v = vk->default_value();
+  return JNIHandles::make_local(THREAD, v);
+} UNSAFE_END
+
 UNSAFE_ENTRY(jobject, Unsafe_GetValue(JNIEnv *env, jobject unsafe, jobject obj, jlong offset, jclass vc)) {
   oop base = JNIHandles::resolve(obj);
   Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(vc));
@@ -997,6 +1004,7 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "isFlattenedField0", CC "(" OBJ ")Z",                    FN_PTR(Unsafe_IsFlattenedField)},
     {CC "getValue",         CC "(" OBJ "J" CLS ")" OBJ,          FN_PTR(Unsafe_GetValue)},
     {CC "putValue",         CC "(" OBJ "J" CLS OBJ ")V",         FN_PTR(Unsafe_PutValue)},
+    {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,         FN_PTR(Unsafe_UninitializedDefaultValue)},
     {CC "makePrivateBuffer",     CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_MakePrivateBuffer)},
     {CC "finishPrivateBuffer",   CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_FinishPrivateBuffer)},
     {CC "valueHeaderSize",       CC "(" CLS ")J",                FN_PTR(Unsafe_ValueHeaderSize)},

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -880,9 +880,16 @@ oop Reflection::new_field(fieldDescriptor* fd, TRAPS) {
   java_lang_reflect_Field::set_slot(rh(), fd->index());
   java_lang_reflect_Field::set_name(rh(), name());
   java_lang_reflect_Field::set_type(rh(), type());
+
+  int flags = 0;
   if (fd->is_trusted_final()) {
-    java_lang_reflect_Field::set_trusted_final(rh());
+    flags |= TRUSTED_FINAL;
   }
+  if (fd->is_null_free_inline_type()) {
+    flags |= NULL_RESTRICTED;
+  }
+  java_lang_reflect_Field::set_flags(rh(), flags);
+
   // Note the ACC_ANNOTATION bit, which is a per-class access flag, is never set here.
   int modifiers = fd->access_flags().as_int() & JVM_RECOGNIZED_FIELD_MODIFIERS;
   java_lang_reflect_Field::set_modifiers(rh(), modifiers);

--- a/src/hotspot/share/runtime/reflection.hpp
+++ b/src/hotspot/share/runtime/reflection.hpp
@@ -50,6 +50,8 @@ class Reflection: public AllStatic {
     DECLARED          = 1,
     MEMBER_PUBLIC     = 0,
     MEMBER_DECLARED   = 1,
+    TRUSTED_FINAL     = 0x10,
+    NULL_RESTRICTED   = 0x20,
     MAX_DIM           = 255
   };
 

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -63,6 +63,7 @@ import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaSecurityAccess;
 import jdk.internal.util.ByteArray;
+import jdk.internal.value.ValueClass;
 import sun.reflect.misc.ReflectUtil;
 
 /**
@@ -1961,7 +1962,7 @@ public final class ObjectStreamClass implements Serializable {
          */
         static Object newValueInstance(Class<?> clazz) throws InstantiationException{
             assert clazz.isValue() : "Should be a value class";
-            Object obj = UNSAFE.uninitializedDefaultValue(clazz);
+            Object obj = ValueClass.zeroInstance(clazz);
             return UNSAFE.makePrivateBuffer(obj);
         }
 

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1962,7 +1962,8 @@ public final class ObjectStreamClass implements Serializable {
          */
         static Object newValueInstance(Class<?> clazz) throws InstantiationException{
             assert clazz.isValue() : "Should be a value class";
-            Object obj = ValueClass.zeroInstance(clazz);
+            // may not be implicitly constructible; so allocate with Unsafe
+            Object obj = UNSAFE.uninitializedDefaultValue(clazz);
             return UNSAFE.makePrivateBuffer(obj);
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -631,17 +631,18 @@ sealed class DirectMethodHandle extends MethodHandle {
             FT_LAST_WRAPPER     = Wrapper.COUNT-1,
             FT_UNCHECKED_REF    = Wrapper.OBJECT.ordinal(),
             FT_CHECKED_REF      = FT_LAST_WRAPPER+1,
-            FT_CHECKED_VALUE    = FT_LAST_WRAPPER+2,  // flattened and non-flattened
-            FT_LIMIT            = FT_LAST_WRAPPER+4;
-    private static int afIndex(byte formOp, boolean isVolatile, boolean isFlatValue, int ftypeKind) {
+            FT_CHECKED_VALUE    = FT_LAST_WRAPPER+2,  // flattened and non-flattened and null-restricted
+            FT_LIMIT            = FT_LAST_WRAPPER+6;
+    private static int afIndex(byte formOp, boolean isVolatile, boolean isFlatValue, boolean isNullRestricted, int ftypeKind) {
         return ((formOp * FT_LIMIT * 2)
                 + (isVolatile ? FT_LIMIT : 0)
                 + (isFlatValue ? 1 : 0)
+                + (isNullRestricted ? 1 : 0)
                 + ftypeKind);
     }
     @Stable
     private static final LambdaForm[] ACCESSOR_FORMS
-            = new LambdaForm[afIndex(AF_LIMIT, false, false, 0)];
+            = new LambdaForm[afIndex(AF_LIMIT, false, false, false, 0)];
     static int ftypeKind(Class<?> ftype, boolean isValue) {
         if (ftype.isPrimitive()) {
             return Wrapper.forPrimitiveType(ftype).ordinal();
@@ -686,7 +687,7 @@ sealed class DirectMethodHandle extends MethodHandle {
     private static LambdaForm preparedFieldLambdaForm(byte formOp, boolean isVolatile,
                                                       boolean isValue, boolean isFlat, boolean isNullRestricted, Class<?> ftype) {
         int ftypeKind = ftypeKind(ftype, isValue);
-        int afIndex = afIndex(formOp, isVolatile, isFlat, ftypeKind);
+        int afIndex = afIndex(formOp, isVolatile, isFlat, isNullRestricted, ftypeKind);
         LambdaForm lform = ACCESSOR_FORMS[afIndex];
         if (lform != null)  return lform;
         lform = makePreparedFieldLambdaForm(formOp, isVolatile, isValue, isFlat, isNullRestricted, ftypeKind);

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -261,6 +261,8 @@ class LambdaForm {
         PUT_REFERENCE("putReference"),
         GET_REFERENCE_VOLATILE("getReferenceVolatile"),
         PUT_REFERENCE_VOLATILE("putReferenceVolatile"),
+        GET_NULL_RESTRICTED_REFERENCE("getNullRestrictedReference"),
+        GET_NULL_RESTRICTED_REFERENCE_VOLATILE("getNullRestrictedReferenceVolatile"),
         GET_VALUE("getValue"),
         PUT_VALUE("putValue"),
         GET_VALUE_VOLATILE("getValueVolatile"),

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -433,7 +433,10 @@ final class MemberName implements Member, Cloneable {
     }
 
     /** Query whether this member is a flattened field */
-    public boolean isFlattened() { return (flags & MN_FLATTENED) == MN_FLATTENED; }
+    public boolean isFlat() { return (flags & MN_FLAT_FIELD) == MN_FLAT_FIELD; }
+
+    /** Query whether this member is a null-restricted field */
+    public boolean isNullRestricted() { return (flags & MN_NULL_RESTRICTED) == MN_NULL_RESTRICTED; }
 
     /** Query whether this member is a field of a primitive class. */
     public boolean isInlineableField()  {
@@ -666,7 +669,7 @@ final class MemberName implements Member, Cloneable {
         this.name = fld.getName();
         this.type = fld.getType();
         byte refKind = this.getReferenceKind();
-        assert(refKind == (isStatic() ? REF_getStatic : REF_getField));
+        assert(refKind == (isStatic() ? REF_getStatic : REF_getField)) : " refKind " + refKind;
         if (makeSetter) {
             changeReferenceKind((byte)(refKind + (REF_putStatic - REF_getStatic)), refKind);
         }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1563,6 +1563,12 @@ abstract class MethodHandleImpl {
                 return (flags & MN_HIDDEN_MEMBER) == MN_HIDDEN_MEMBER;
             }
 
+            public boolean isNullRestrictedField(MethodHandle mh) {
+                var memberName = mh.internalMemberName();
+                assert memberName.isField();
+                return memberName.isNullRestricted();
+            }
+
             @Override
             public Map<String, byte[]> generateHolderClasses(Stream<String> traces) {
                 return GenerateJLIClassesHelper.generateHolderClasses(traces);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -117,9 +117,10 @@ class MethodHandleNatives {
             MN_CALLER_SENSITIVE      = 0x00100000, // @CallerSensitive annotation detected
             MN_TRUSTED_FINAL         = 0x00200000, // trusted final field
             MN_HIDDEN_MEMBER         = 0x00400000, // members defined in a hidden class or with @Hidden
-            MN_FLATTENED             = 0x00800000, // flattened field
-            MN_REFERENCE_KIND_SHIFT  = 24, // refKind
-            MN_REFERENCE_KIND_MASK   = 0x0F000000 >> MN_REFERENCE_KIND_SHIFT;
+            MN_FLAT_FIELD            = 0x00800000, // flat field
+            MN_NULL_RESTRICTED       = 0x01000000, // null-restricted field
+            MN_REFERENCE_KIND_SHIFT  = 26, // refKind
+            MN_REFERENCE_KIND_MASK   = 0x3C000000 >> MN_REFERENCE_KIND_SHIFT;
 
         /**
          * Constant pool reference-kind codes, as used by CONSTANT_MethodHandle CP entries.

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -38,6 +38,7 @@ import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.CallerSensitiveAdapter;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.util.ClassFileDumper;
+import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ForceInline;
 import sun.invoke.util.ValueConversions;
 import sun.invoke.util.VerifyAccess;
@@ -5198,7 +5199,7 @@ assert((int)twice.invokeExact(21) == 42);
             return zero(Wrapper.forPrimitiveType(type), type);
         } else if (PrimitiveClass.isPrimitiveValueType(type)) {
             // singleton default value
-            Object value = UNSAFE.uninitializedDefaultValue(type);
+            Object value = ValueClass.zeroInstance(type);
             return identity(type).bindTo(value);
         } else {
             return zero(Wrapper.OBJECT, type);

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -59,14 +59,14 @@ final class VarHandles {
             long foffset = MethodHandleNatives.objectFieldOffset(f);
             Class<?> type = f.getFieldType();
             if (!type.isPrimitive()) {
-                if (f.isFlattened()) {
+                if (f.isFlat()) {
                     return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleValues.FieldInstanceReadOnly(refc, foffset, type)
-                        : new VarHandleValues.FieldInstanceReadWrite(refc, foffset, type));
+                        ? new VarHandleValues.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
+                        : new VarHandleValues.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
                 } else {
                     return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                       ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type)
-                       : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type));
+                       ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
+                       : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
                 }
             }
             else if (type == boolean.class) {
@@ -127,14 +127,14 @@ final class VarHandles {
         long foffset = MethodHandleNatives.staticFieldOffset(f);
         Class<?> type = f.getFieldType();
         if (!type.isPrimitive()) {
-            if (f.isFlattened()) {
+            if (f.isFlat()) {
                 return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleValues.FieldStaticReadOnly(decl, base, foffset, type)
-                        : new VarHandleValues.FieldStaticReadWrite(decl, base, foffset, type));
+                        ? new VarHandleValues.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
+                        : new VarHandleValues.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted()));
             } else {
                 return f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type)
-                        : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type);
+                        ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
+                        : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
             }
         }
         else if (type == boolean.class) {

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -24,6 +24,9 @@
  */
 package java.lang.invoke;
 
+#if[Object]
+import jdk.internal.value.ValueClass;
+#end[Object]
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -42,19 +45,21 @@ final class VarHandle$Type$s {
         final Class<?> receiverType;
 #if[Object]
         final Class<?> fieldType;
+        final boolean nullRestricted;
 #end[Object]
 
-        FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
-            this(receiverType, fieldOffset{#if[Object]?, fieldType}, FieldInstanceReadOnly.FORM, false);
+        FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldInstanceReadOnly.FORM, false);
         }
 
-        protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType},
+        protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
                                         VarForm form, boolean exact) {
             super(form, exact);
             this.fieldOffset = fieldOffset;
             this.receiverType = receiverType;
 #if[Object]
             this.fieldType = fieldType;
+            this.nullRestricted = nullRestricted;
 #end[Object]
         }
 
@@ -62,14 +67,14 @@ final class VarHandle$Type$s {
         public FieldInstanceReadOnly withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType}, vform, true);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, true);
         }
 
         @Override
         public FieldInstanceReadOnly withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType}, vform, false);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, false);
         }
 
         @Override
@@ -93,56 +98,80 @@ final class VarHandle$Type$s {
         @ForceInline
         static $type$ get(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
-            return UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
+            $type$ value = UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getVolatile(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
-            return UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
+            $type$ value = UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getOpaque(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
-            return UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
+            $type$ value = UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getAcquire(VarHandle ob, Object holder) {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
-            return UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
+            $type$ value = UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         static final VarForm FORM = new VarForm(FieldInstanceReadOnly.class, Object.class, $type$.class);
     }
 
     static final class FieldInstanceReadWrite extends FieldInstanceReadOnly {
-        FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
-            this(receiverType, fieldOffset{#if[Object]?, fieldType}, false);
+        FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
         }
 
-        private FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType},
+        private FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
                                        boolean exact) {
-            super(receiverType, fieldOffset{#if[Object]?, fieldType}, FieldInstanceReadWrite.FORM, exact);
+            super(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldInstanceReadWrite.FORM, exact);
         }
 
         @Override
         public FieldInstanceReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType}, true);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, true);
         }
 
         @Override
         public FieldInstanceReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType}, false);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
         }
 
 #if[Object]
@@ -393,13 +422,14 @@ final class VarHandle$Type$s {
         final long fieldOffset;
 #if[Object]
         final Class<?> fieldType;
+        final boolean nullRestricted;
 #end[Object]
 
-        FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
-            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, FieldStaticReadOnly.FORM, false);
+        FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
+            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldStaticReadOnly.FORM, false);
         }
 
-        protected FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType},
+        protected FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
                                       VarForm form, boolean exact) {
             super(form, exact);
             this.declaringClass = declaringClass;
@@ -407,6 +437,7 @@ final class VarHandle$Type$s {
             this.fieldOffset = fieldOffset;
 #if[Object]
             this.fieldType = fieldType;
+            this.nullRestricted = nullRestricted;
 #end[Object]
         }
 
@@ -414,14 +445,14 @@ final class VarHandle$Type$s {
         public FieldStaticReadOnly withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, vform, true);
+                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, true);
         }
 
         @Override
         public FieldStaticReadOnly withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, vform, false);
+                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, false);
         }
 
         @Override
@@ -447,29 +478,53 @@ final class VarHandle$Type$s {
         @ForceInline
         static $type$ get(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
-            return UNSAFE.get$Type$(handle.base,
+            $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getVolatile(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
-            return UNSAFE.get$Type$Volatile(handle.base,
+            $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getOpaque(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
-            return UNSAFE.get$Type$Opaque(handle.base,
+            $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         @ForceInline
         static $type$ getAcquire(VarHandle ob) {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
-            return UNSAFE.get$Type$Acquire(handle.base,
+            $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
+#if[Object]
+            if (handle.nullRestricted && value == null) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Object]
+            return value;
         }
 
         static final VarForm FORM = new VarForm(FieldStaticReadOnly.class, null, $type$.class);
@@ -477,27 +532,27 @@ final class VarHandle$Type$s {
 
     static final class FieldStaticReadWrite extends FieldStaticReadOnly {
 
-        FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType}) {
-            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, false);
+        FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
+            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
         }
 
-        private FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType},
+        private FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
                                      boolean exact) {
-            super(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, FieldStaticReadWrite.FORM, exact);
+            super(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldStaticReadWrite.FORM, exact);
         }
 
         @Override
         public FieldStaticReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, true);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, true);
         }
 
         @Override
         public FieldStaticReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}, false);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
         }
 
 #if[Object]

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -24,9 +24,9 @@
  */
 package java.lang.invoke;
 
-#if[Object]
+#if[Reference]
 import jdk.internal.value.ValueClass;
-#end[Object]
+#end[Reference]
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -45,8 +45,10 @@ final class VarHandle$Type$s {
         final Class<?> receiverType;
 #if[Object]
         final Class<?> fieldType;
-        final boolean nullRestricted;
 #end[Object]
+#if[Reference]
+        final boolean nullRestricted;
+#end[Reference]
 
         FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
             this(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldInstanceReadOnly.FORM, false);
@@ -59,22 +61,24 @@ final class VarHandle$Type$s {
             this.receiverType = receiverType;
 #if[Object]
             this.fieldType = fieldType;
-            this.nullRestricted = nullRestricted;
 #end[Object]
+#if[Reference]
+            this.nullRestricted = nullRestricted;
+#end[Reference]
         }
 
         @Override
         public FieldInstanceReadOnly withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, true);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, vform, true);
         }
 
         @Override
         public FieldInstanceReadOnly withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, false);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, vform, false);
         }
 
         @Override
@@ -100,11 +104,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -113,11 +117,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -126,11 +130,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -139,11 +143,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -164,14 +168,14 @@ final class VarHandle$Type$s {
         public FieldInstanceReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, true);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, true);
         }
 
         @Override
         public FieldInstanceReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, false);
         }
 
 #if[Object]
@@ -480,11 +484,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -493,11 +497,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -506,11 +510,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -519,11 +523,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Object]
+#if[Reference]
             if (handle.nullRestricted && value == null) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Object]
+#end[Reference]
             return value;
         }
 
@@ -545,14 +549,14 @@ final class VarHandle$Type$s {
         public FieldStaticReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, true);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}{#if[Reference]?, nullRestricted}, true);
         }
 
         @Override
         public FieldStaticReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}{#if[Reference]?, nullRestricted}, false);
         }
 
 #if[Object]

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -74,7 +74,7 @@ class Field extends AccessibleObject implements Member {
     private final String              name;
     private final Class<?>            type;
     private final int                 modifiers;
-    private final boolean             trustedFinal;
+    private final int                 flags;
     // Generics and annotations support
     private final transient String    signature;
     // generic info repository; lazily initialized
@@ -127,7 +127,7 @@ class Field extends AccessibleObject implements Member {
           String name,
           Class<?> type,
           int modifiers,
-          boolean trustedFinal,
+          int flags,
           int slot,
           String signature,
           byte[] annotations)
@@ -137,7 +137,7 @@ class Field extends AccessibleObject implements Member {
         this.name = name;
         this.type = type;
         this.modifiers = modifiers;
-        this.trustedFinal = trustedFinal;
+        this.flags = flags;
         this.slot = slot;
         this.signature = signature;
         this.annotations = annotations;
@@ -159,7 +159,7 @@ class Field extends AccessibleObject implements Member {
         if (this.root != null)
             throw new IllegalArgumentException("Can not copy a non-root Field");
 
-        Field res = new Field(clazz, name, type, modifiers, trustedFinal, slot, signature, annotations);
+        Field res = new Field(clazz, name, type, modifiers, flags, slot, signature, annotations);
         res.root = this;
         // Might as well eagerly propagate this if already present
         res.fieldAccessor = fieldAccessor;
@@ -1248,8 +1248,15 @@ class Field extends AccessibleObject implements Member {
         return root;
     }
 
+    private static final int TRUST_FINAL     = 0x0010;
+    private static final int NULL_RESTRICTED = 0x0020;
+
     /* package-private */ boolean isTrustedFinal() {
-        return trustedFinal;
+        return (flags & TRUST_FINAL) == TRUST_FINAL;
+    }
+
+    /* package-private */ boolean isNullRestricted() {
+        return (flags & NULL_RESTRICTED) == NULL_RESTRICTED;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -177,6 +177,12 @@ final class ValueObjectMethods {
                     Class<?> ftype = fieldType(getter);
                     var f1 = getter.invoke(o1);
                     var f2 = getter.invoke(o2);
+                    if (JLIA.isNullRestrictedField(getter) && (f1 == null || f2 == null)) {
+                        System.out.println("null restricted field " + ftype.getName() + " in container " + type.getName());
+                    }
+
+                    assert JLIA.isNullRestrictedField(getter) && f1 != null && f2 != null :
+                            "null restricted field " + ftype.getName() + " in container " + type.getName();
 
                     boolean substitutable;
                     if (ftype == type) {
@@ -238,6 +244,11 @@ final class ValueObjectMethods {
                 for (MethodHandle getter : getters) {
                     Class<?> ftype = fieldType(getter);
                     var f = getter.invoke(obj);
+                    if (JLIA.isNullRestrictedField(getter) && f == null) {
+                        System.out.println("null restricted field " + ftype.getName() + " in container " + type.getName());
+                    }
+                    assert JLIA.isNullRestrictedField(getter) && f != null :
+                            "null restricted field " + ftype.getName() + " in container " + type.getName();
 
                     int hc;
                     if (ftype == type) {
@@ -505,8 +516,9 @@ final class ValueObjectMethods {
             }
 
             MethodHandle target = valueTypeHashCode(type, nonRecurTypeGetters);
-            System.out.println(type.getName() + " valueHashCode " + nonRecurTypeGetters + " " + recurTypeGetters);
-
+            if (VERBOSE) {
+                System.out.println(type.getName() + " valueHashCode " + nonRecurTypeGetters + " recursive types " + recurTypeGetters);
+            }
             // This value class contains cyclic membership
             // Create a method handle that is capable of calling itself.
             // - the hashCodeBase method first calls the method handle that computes the hash code

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -177,9 +177,6 @@ final class ValueObjectMethods {
                     Class<?> ftype = fieldType(getter);
                     var f1 = getter.invoke(o1);
                     var f2 = getter.invoke(o2);
-                    if (JLIA.isNullRestrictedField(getter) && (f1 == null || f2 == null)) {
-                        System.out.println("null restricted field " + ftype.getName() + " in container " + type.getName());
-                    }
 
                     assert JLIA.isNullRestrictedField(getter) && f1 != null && f2 != null :
                             "null restricted field " + ftype.getName() + " in container " + type.getName();
@@ -244,9 +241,6 @@ final class ValueObjectMethods {
                 for (MethodHandle getter : getters) {
                     Class<?> ftype = fieldType(getter);
                     var f = getter.invoke(obj);
-                    if (JLIA.isNullRestrictedField(getter) && f == null) {
-                        System.out.println("null restricted field " + ftype.getName() + " in container " + type.getName());
-                    }
                     assert JLIA.isNullRestrictedField(getter) && f != null :
                             "null restricted field " + ftype.getName() + " in container " + type.getName();
 

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -178,7 +178,7 @@ final class ValueObjectMethods {
                     var f1 = getter.invoke(o1);
                     var f2 = getter.invoke(o2);
 
-                    assert JLIA.isNullRestrictedField(getter) && f1 != null && f2 != null :
+                    assert !JLIA.isNullRestrictedField(getter) ||  (f1 != null && f2 != null) :
                             "null restricted field " + ftype.getName() + " in container " + type.getName();
 
                     boolean substitutable;
@@ -241,7 +241,7 @@ final class ValueObjectMethods {
                 for (MethodHandle getter : getters) {
                     Class<?> ftype = fieldType(getter);
                     var f = getter.invoke(obj);
-                    assert JLIA.isNullRestrictedField(getter) && f != null :
+                    assert !JLIA.isNullRestrictedField(getter) || f != null :
                             "null restricted field " + ftype.getName() + " in container " + type.getName();
 
                     int hc;

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -63,6 +63,12 @@ public interface JavaLangInvokeAccess {
     boolean isHiddenMember(int flags);
 
     /**
+     * Returns true if the member of the given method handle is a null-restricted
+     * field.
+     */
+    boolean isNullRestrictedField(MethodHandle mh);
+
+    /**
      * Returns a map of class name in internal forms to its corresponding
      * class bytes per the given stream of LF_RESOLVE and SPECIES_RESOLVE
      * trace logs. Used by GenerateJLIClassesPlugin to enable generation

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -312,11 +312,6 @@ public final class Unsafe {
     }
 
     /**
-     * Returns an uninitialized default value of the given value type.
-     */
-    public native <V> V uninitializedDefaultValue(Class<?> type);
-
-    /**
      * Returns an object instance with a private buffered value whose layout
      * and contents is exactly the given value instance.  The return object
      * is in the larval state that can be updated using the unsafe put operation.

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -294,7 +294,10 @@ public final class Unsafe {
     /**
      * Fetches a reference value of the given type from a given null-restricted
      * Java variable.  The VM may lazily set a null-restricted non-flat field.
-     * If the reference value is null, return the zero instance.
+     * If the reference value is null, return a zero instance instead.
+     *
+     * @apiNote This API is temporary.  It will be replaced when CheckedType
+     *          is implemented.
      *
      * @param type type
      */

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -312,6 +312,11 @@ public final class Unsafe {
     }
 
     /**
+     * Returns an uninitialized default instance of the given value class.
+     */
+    public native <V> V uninitializedDefaultValue(Class<?> type);
+
+    /**
      * Returns an object instance with a private buffered value whose layout
      * and contents is exactly the given value instance.  The return object
      * is in the larval state that can be updated using the unsafe put operation.

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -27,6 +27,7 @@ package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
 import jdk.internal.value.PrimitiveClass;
+import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -274,8 +275,8 @@ public final class Unsafe {
         Object ref = getReference(o, offset);
         if (ref == null && PrimitiveClass.isPrimitiveValueType(type)) {
             // If the type of the returned reference is a primitive value type,
-            // return an uninitialized default value if null
-            ref = uninitializedDefaultValue(type);
+            // return the zero instance if null
+            ref = ValueClass.zeroInstance(type);
         }
         return ref;
     }
@@ -284,10 +285,27 @@ public final class Unsafe {
         Object ref = getReferenceVolatile(o, offset);
         if (ref == null && PrimitiveClass.isPrimitiveValueType(type)) {
             // If the type of the returned reference is a primitive value type,
-            // return an uninitialized default value if null
-            ref = uninitializedDefaultValue(type);
+            // return the zero instance if null
+            ref = ValueClass.zeroInstance(type);
         }
         return ref;
+    }
+
+    /**
+     * Fetches a reference value of the given type from a given null-restricted
+     * Java variable.  The VM may lazily set a null-restricted non-flat field.
+     * If the reference value is null, return the zero instance.
+     *
+     * @param type type
+     */
+    public Object getNullRestrictedReference(Object o, long offset, Class<?> type) {
+        Object ref = getReference(o, offset);
+        return ref != null ? ref : ValueClass.zeroInstance(type);
+    }
+
+    public Object getNullRestrictedReferenceVolatile(Object o, long offset, Class<?> type) {
+        Object ref = getReferenceVolatile(o, offset);
+        return ref != null ? ref : ValueClass.zeroInstance(type);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -495,20 +495,4 @@ public class VM {
     public static List<BufferPool> getBufferPools() {
         return BufferPoolsHolder.BUFFER_POOLS;
     }
-
-    /**
-     * Allocate an array of a value class type with components that behave in
-     * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
-     * field.
-     * <p>
-     * Because these behaviors are not specified by Java SE, arrays created with
-     * this method should only be used by internal JDK code for experimental
-     * purposes and should not affect user-observable outcomes.
-     *
-     * @throws IllegalArgumentException if {@code componentType} is not a
-     *         value class type or is not annotated with
-     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
-     */
-    public static native Object[] newNullRestrictedArray(Class<?> componentType,
-                                                         int length);
 }

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -40,7 +40,11 @@ public class ValueClass {
     public static native boolean isImplicitlyConstructible(Class<?> cls);
 
     /**
-     * Returns the default value of the given value type.
+     * Returns the default value of the given value class type.
+     *
+     * @throws IllegalArgumentException if {@code cls} is not a
+     *         value class type or is not annotated with
+     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
      */
     public static native <T> T zeroInstance(Class<T> cls);
 

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.value;
+
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+
+/**
+ * Utilities to access
+ */
+public class ValueClass {
+    private static final JavaLangAccess javaLangAccess = SharedSecrets.getJavaLangAccess();
+
+    /**
+     * Returns true if the given {@code Class} object is implicitly constructible
+     */
+    public static native boolean isImplicitlyConstructible(Class<?> cls);
+
+    /**
+     * Returns the default value of the given value type.
+     */
+    public static native <T> T zeroInstance(Class<T> cls);
+
+    /**
+     * Allocate an array of a value class type with components that behave in
+     * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
+     * field.
+     * <p>
+     * Because these behaviors are not specified by Java SE, arrays created with
+     * this method should only be used by internal JDK code for experimental
+     * purposes and should not affect user-observable outcomes.
+     *
+     * @throws IllegalArgumentException if {@code componentType} is not a
+     *         value class type or is not annotated with
+     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
+     */
+    public static native Object[] newNullRestrictedArray(Class<?> componentType,
+                                                         int length);
+}

--- a/src/java.base/share/native/libjava/ValueClass.c
+++ b/src/java.base/share/native/libjava/ValueClass.c
@@ -33,11 +33,6 @@ Java_jdk_internal_value_ValueClass_isImplicitlyConstructible(JNIEnv *env, jclass
     return JVM_IsImplicitlyConstructibleClass(env, cls);
 }
 
-JNIEXPORT jobject JNICALL
-Java_jdk_internal_value_ValueClass_zeroInstance(JNIEnv *env, jclass dummy, jclass cls) {
-    return JVM_GetZeroInstance(env, cls);
-}
-
 JNIEXPORT jarray JNICALL
 Java_jdk_internal_value_ValueClass_newNullRestrictedArray(JNIEnv *env, jclass cls, jclass elmClass, jint len)
 {

--- a/src/java.base/share/native/libjava/ValueClass.c
+++ b/src/java.base/share/native/libjava/ValueClass.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,34 +24,22 @@
  */
 
 #include "jni.h"
-#include "jni_util.h"
 #include "jvm.h"
-#include "jdk_util.h"
 
-#include "jdk_internal_misc_VM.h"
+#include "jdk_internal_value_ValueClass.h"
 
-/* Only register the performance-critical methods */
-static JNINativeMethod methods[] = {
-    {"getNanoTimeAdjustment", "(J)J", (void *)&JVM_GetNanoTimeAdjustment}
-};
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_value_ValueClass_isImplicitlyConstructible(JNIEnv *env, jclass dummy, jclass cls) {
+    return JVM_IsImplicitlyConstructibleClass(env, cls);
+}
 
 JNIEXPORT jobject JNICALL
-Java_jdk_internal_misc_VM_latestUserDefinedLoader0(JNIEnv *env, jclass cls) {
-    return JVM_LatestUserDefinedLoader(env);
+Java_jdk_internal_value_ValueClass_zeroInstance(JNIEnv *env, jclass dummy, jclass cls) {
+    return JVM_GetZeroInstance(env, cls);
 }
 
-JNIEXPORT void JNICALL
-Java_jdk_internal_misc_VM_initialize(JNIEnv *env, jclass cls) {
-    // Registers implementations of native methods described in methods[]
-    // above.
-    // In particular, registers JVM_GetNanoTimeAdjustment as the implementation
-    // of the native VM.getNanoTimeAdjustment - avoiding the cost of
-    // introducing a Java_jdk_internal_misc_VM_getNanoTimeAdjustment wrapper
-    (*env)->RegisterNatives(env, cls,
-                            methods, sizeof(methods)/sizeof(methods[0]));
-}
-
-JNIEXPORT jobjectArray JNICALL
-Java_jdk_internal_misc_VM_getRuntimeArguments(JNIEnv *env, jclass cls) {
-    return JVM_GetVmArguments(env);
+JNIEXPORT jarray JNICALL
+Java_jdk_internal_value_ValueClass_newNullRestrictedArray(JNIEnv *env, jclass cls, jclass elmClass, jint len)
+{
+    return JVM_NewNullRestrictedArray(env, elmClass, len);
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java
@@ -22,18 +22,20 @@
  */
 package runtime.valhalla.inlinetypes;
 
+import jdk.internal.value.ValueClass;
 import jdk.test.lib.Asserts;
-import jdk.internal.misc.VM;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.vm.annotation.NullRestricted;
 
 /*
-* @test
-* @summary Test several scenarios of class initialization failures
-* @library /test/lib
-* @compile --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED ClassInitializationFailuresTest.java
-* @run main/othervm -XX:+EnableValhalla --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED runtime.valhalla.inlinetypes.ClassInitializationFailuresTest
+ * @test
+ * @summary Test several scenarios of class initialization failures
+ * @library /test/lib
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @compile ClassInitializationFailuresTest.java
+ * @run main/othervm -XX:+EnableValhalla runtime.valhalla.inlinetypes.ClassInitializationFailuresTest
 */
 public class ClassInitializationFailuresTest {
     static boolean failingInitialization = true;
@@ -116,7 +118,7 @@ public class ClassInitializationFailuresTest {
         // Testing anewarray when the primitive element class fails to initialize properly
         Throwable e = null;
         try {
-            BadTwo[] array = (BadTwo[])VM.newNullRestrictedArray(BadTwo.class, 10);
+            BadTwo[] array = (BadTwo[]) ValueClass.newNullRestrictedArray(BadTwo.class, 10);
         } catch(Throwable t) {
             e = t;
         }
@@ -124,7 +126,7 @@ public class ClassInitializationFailuresTest {
         Asserts.assertTrue(e.getClass() == ExceptionInInitializerError.class, " Must be an ExceptionInInitializerError");
         // Second attempt because it doesn't fail the same way
         try {
-            BadTwo[] array = (BadTwo[])VM.newNullRestrictedArray(BadTwo.class, 10);
+            BadTwo[] array = (BadTwo[]) ValueClass.newNullRestrictedArray(BadTwo.class, 10);
         } catch(Throwable t) {
             e = t;
         }
@@ -160,7 +162,7 @@ public class ClassInitializationFailuresTest {
         int i = 0;
         static BadFour[] array;
         static {
-            array = (BadFour[])VM.newNullRestrictedArray(BadFour.class, 10);
+            array = (BadFour[]) ValueClass.newNullRestrictedArray(BadFour.class, 10);
             if (ClassInitializationFailuresTest.failingInitialization) {
                 throw new RuntimeException("Failing initialization");
             }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
@@ -23,10 +23,10 @@
 
 
 
+import jdk.internal.value.ValueClass;
 import jdk.test.lib.Asserts;
 import java.lang.reflect.Method;
 import jdk.internal.misc.Unsafe;
-import jdk.internal.misc.VM;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import jdk.internal.vm.annotation.LooselyConsistentValue;
 
@@ -34,10 +34,11 @@ import jdk.internal.vm.annotation.LooselyConsistentValue;
 /*
  * @test
  * @summary Test of VM.newNullRestrictedArray API
- * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @compile --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED NullRestrictedArrayTest.java
- * @run main/othervm --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -XX:+EnableValhalla NullRestrictedArrayTest
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.misc
+ *          java.base/jdk.internal.value
+ * @run main/othervm -XX:+EnableValhalla NullRestrictedArrayTest
  */
 
 
@@ -66,7 +67,7 @@ public class NullRestrictedArrayTest {
   public void test_0() {
       Throwable exception = null;
       try {
-        VM.newNullRestrictedArray(String.class, 4);
+        ValueClass.newNullRestrictedArray(String.class, 4);
       } catch (IllegalArgumentException e) {
         System.out.println("Received: " + e);
         exception = e;
@@ -85,7 +86,7 @@ public class NullRestrictedArrayTest {
   public void test_1() {
       Throwable exception = null;
       try {
-        VM.newNullRestrictedArray(ValueClass1.class, -1);
+        ValueClass.newNullRestrictedArray(ValueClass1.class, -1);
       } catch (IllegalArgumentException e) {
         System.out.println("Received: " + e);
         exception = e;
@@ -102,7 +103,7 @@ public class NullRestrictedArrayTest {
   public void test_2() {
       Throwable exception = null;
       try {
-        VM.newNullRestrictedArray(ValueClass2.class, 8);
+        ValueClass.newNullRestrictedArray(ValueClass2.class, 8);
       } catch (IllegalArgumentException e) {
         System.out.println("Received: " + e);
         exception = e;
@@ -121,7 +122,7 @@ public class NullRestrictedArrayTest {
   public void test_3() {
       Throwable exception = null;
       try {
-        Object array = VM.newNullRestrictedArray(ValueClass3.class, 8);
+        Object array = ValueClass.newNullRestrictedArray(ValueClass3.class, 8);
         Asserts.assertTrue(UNSAFE.isFlattenedArray(array.getClass()), "Expecting flat array but array is not flat");
       } catch (Throwable e) {
         System.out.println("Received: " + e);
@@ -142,7 +143,7 @@ public class NullRestrictedArrayTest {
   public void test_4() {
       Throwable exception = null;
       try {
-        Object[] array = VM.newNullRestrictedArray(ValueClass4.class, 8);
+        Object[] array = ValueClass.newNullRestrictedArray(ValueClass4.class, 8);
         Asserts.assertNotNull(array[1], "Expecting non null element but null found instead");
       } catch (Throwable e) {
         System.out.println("Received: " + e);
@@ -162,7 +163,7 @@ public class NullRestrictedArrayTest {
   public void test_5() {
       Throwable exception = null;
       try {
-        Object[] array = VM.newNullRestrictedArray(ValueClass4.class, 8);
+        Object[] array = ValueClass.newNullRestrictedArray(ValueClass4.class, 8);
         array[1] = null;
       } catch (NullPointerException e) {
         System.out.println("Received: " + e);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -805,5 +805,4 @@ java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 
 # valhalla
-valhalla/valuetypes/ObjectMethods.java 8317150 generic-all
-valhalla/valuetypes/SubstitutabilityTest.java 8317151 generic-all
+valhalla/valuetypes/RecursiveValueClass.java 8317767 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -805,4 +805,3 @@ java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 
 # valhalla
-valhalla/valuetypes/RecursiveValueClass.java 8317767 generic-all

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -125,7 +125,8 @@ public class MethodHandleTest {
         // static fields of reference type
         setField(MixedValues.class, "staticLine", null, l, false);
         setField(MixedValues.class, "staticLine", null, null, false);
-        setField(MixedValues.class, "staticValue", null, vo, false);
+        // FIXME
+        // setField(MixedValues.class, "staticValue", null, vo, false);
     }
 
     @DataProvider(name="arrays")

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -125,8 +125,7 @@ public class MethodHandleTest {
         // static fields of reference type
         setField(MixedValues.class, "staticLine", null, l, false);
         setField(MixedValues.class, "staticLine", null, null, false);
-        // FIXME
-        // setField(MixedValues.class, "staticValue", null, vo, false);
+        setField(MixedValues.class, "staticValue", null, vo, false);
     }
 
     @DataProvider(name="arrays")

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -21,9 +21,7 @@
  * questions.
  */
 
-import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
-import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.vm.annotation.NullRestricted;
 
 import org.junit.jupiter.api.Test;
@@ -42,12 +40,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class NullRestrictedTest {
     @ImplicitlyConstructible
-    @LooselyConsistentValue
     static value class MyValueEmpty {
     }
 
     @ImplicitlyConstructible
-    @LooselyConsistentValue
     static value class EmptyContainer {
         @NullRestricted
         MyValueEmpty empty = new MyValueEmpty();

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import jdk.internal.vm.annotation.NullRestricted;
 
@@ -52,24 +53,24 @@ public class NullRestrictedTest {
     @Test
     public void lazyInitializedDefaultValue() {
         // VM lazily sets the null-restricted non-flat field to zero default
-        assertTrue(new EmptyContainer() == EmptyContainer.default);
+        assertTrue(new EmptyContainer() == ValueClass.zeroInstance(EmptyContainer.class));
     }
 
     @Test
     public void testMethodHandle() throws Throwable {
         var mh = MethodHandles.lookup().findGetter(EmptyContainer.class, "empty", MyValueEmpty.class);
-        assertTrue(mh.invoke(new EmptyContainer()) == MyValueEmpty.default);
+        assertTrue(mh.invoke(new EmptyContainer()) == ValueClass.zeroInstance(MyValueEmpty.class));
     }
 
     @Test
     public void testVarHandle() throws Throwable {
         var vh = MethodHandles.lookup().findVarHandle(EmptyContainer.class, "empty", MyValueEmpty.class);
-        assertTrue(vh.get(new EmptyContainer()) == MyValueEmpty.default);
+        assertTrue(vh.get(new EmptyContainer()) == ValueClass.zeroInstance(MyValueEmpty.class));
     }
 
     @Test
     public void testField() throws Throwable {
         var f = EmptyContainer.class.getDeclaredField("empty");
-        assertTrue(f.get(new EmptyContainer()) == MyValueEmpty.default);
+        assertTrue(f.get(new EmptyContainer()) == ValueClass.zeroInstance(MyValueEmpty.class));
     }
 }

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
+import jdk.internal.vm.annotation.NullRestricted;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * @test
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @compile -XDenablePrimitiveClasses NullRestrictedTest.java
+ * @run junit/othervm -XX:+EnableValhalla NullRestrictedTest
+ * @run junit/othervm -XX:+EnableValhalla -XX:InlineFieldMaxFlatSize=0 NullRestrictedTest
+ */
+public class NullRestrictedTest {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class MyValueEmpty {
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class EmptyContainer {
+        @NullRestricted
+        MyValueEmpty empty = new MyValueEmpty();
+    }
+
+    @Test
+    public void lazyInitializedDefaultValue() {
+        // VM lazily sets the null-restricted non-flat field to zero default
+        assertTrue(new EmptyContainer() == EmptyContainer.default);
+    }
+
+    @Test
+    public void testMethodHandle() throws Throwable {
+        var mh = MethodHandles.lookup().findGetter(EmptyContainer.class, "empty", MyValueEmpty.class);
+        assertTrue(mh.invoke(new EmptyContainer()) == MyValueEmpty.default);
+    }
+
+    @Test
+    public void testVarHandle() throws Throwable {
+        var vh = MethodHandles.lookup().findVarHandle(EmptyContainer.class, "empty", MyValueEmpty.class);
+        assertTrue(vh.get(new EmptyContainer()) == MyValueEmpty.default);
+    }
+
+    @Test
+    public void testField() throws Throwable {
+        var f = EmptyContainer.class.getDeclaredField("empty");
+        assertTrue(f.get(new EmptyContainer()) == MyValueEmpty.default);
+    }
+}


### PR DESCRIPTION
An initial implementation for substitutability test and partial method handle and var handle support for null-restricted types. JDK-8317767 will provide the full library support for null-restricted types.    

This patch handles null-restricted field reference declared in a non-flat class.  The default value of that field is lazily set by VM on read access.  `Unsafe::getReference` may return null for null-restricted non-flat field.  

A new `jdk.internal.value.ValueClass` is created to provide JVM entry points for value classes until public APIs are defined.     `jdk.internal.misc.newNullRestrictedArray` method is moved as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8321039](https://bugs.openjdk.org/browse/JDK-8321039): [lworld] Substitutability code must recognize new annotations (**Enhancement** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [e216c78e](https://git.openjdk.org/valhalla/pull/960/files/e216c78eba5e8c3c2236d936c0dbe9d15e156570)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer) ⚠️ Review applies to [e216c78e](https://git.openjdk.org/valhalla/pull/960/files/e216c78eba5e8c3c2236d936c0dbe9d15e156570)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/960/head:pull/960` \
`$ git checkout pull/960`

Update a local copy of the PR: \
`$ git checkout pull/960` \
`$ git pull https://git.openjdk.org/valhalla.git pull/960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 960`

View PR using the GUI difftool: \
`$ git pr show -t 960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/960.diff">https://git.openjdk.org/valhalla/pull/960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/960#issuecomment-1841662196)