### PR TITLE
8320296: [lworld] Fix profiling at array store subtype checks in Valhalla

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -318,8 +318,9 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void profile_switch_default(Register mdp);
   void profile_switch_case(Register index_in_scratch, Register mdp,
                            Register scratch2);
-  void profile_array(Register mdp, Register array, Register tmp);
-  void profile_element(Register mdp, Register element, Register tmp);
+  template <class ArrayData> void profile_array_type(Register mdp, Register array, Register tmp);
+  void profile_multiple_element_types(Register mdp, Register element, Register tmp, Register tmp2);
+  void profile_element_type(Register mdp, Register element, Register tmp);
   void profile_acmp(Register mdp, Register left, Register right, Register tmp);
 
   void profile_obj_type(Register obj, const Address& mdo_addr);

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -817,7 +817,7 @@ void TemplateTable::aaload()
   // r0: array
   // r1: index
   index_check(r0, r1); // leaves index in r1, kills rscratch1
-  __ profile_array(r2, r0, r4);
+  __ profile_array_type<ArrayLoadData>(r2, r0, r4);
   if (UseFlatArray) {
     Label is_flat_array, done;
 
@@ -833,7 +833,7 @@ void TemplateTable::aaload()
     __ add(r1, r1, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
     do_oop_load(_masm, Address(r0, r1, Address::uxtw(LogBytesPerHeapOop)), r0, IS_ARRAY);
   }
-  __ profile_element(r2, r0, r4);
+  __ profile_element_type(r2, r0, r4);
 }
 
 void TemplateTable::baload()
@@ -1129,8 +1129,8 @@ void TemplateTable::aastore() {
 
   index_check(r3, r2);     // kills r1
 
-  __ profile_array(r4, r3, r5);
-  __ profile_element(r4, r0, r5);
+  __ profile_array_type<ArrayStoreData>(r4, r3, r5);
+  __ profile_multiple_element_types(r4, r0, r5, r6);
 
   __ add(r4, r2, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
   Address element_address(r3, r4, Address::uxtw(LogBytesPerHeapOop));

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1863,9 +1863,9 @@ void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
 // function is recursive, to generate the required tree structured code.
 // It's the interpreter, so we are trading off code space for speed.
 // See below for example code.
-void
-InterpreterMacroAssembler::record_klass_in_profile_helper(Register receiver, Register mdp, Register reg2, int start_row,
-                                                          Label &done) {
+void InterpreterMacroAssembler::record_klass_in_profile_helper(Register receiver, Register mdp,
+                                                               Register reg2, int start_row,
+                                                               Label& done) {
   if (TypeProfileWidth == 0) {
     increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
   } else {

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1843,7 +1843,7 @@ void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
     }
 
     // Record the receiver type.
-    record_klass_in_profile(receiver, mdp, reg2, true);
+    record_klass_in_profile(receiver, mdp, reg2);
     bind(skip_receiver_profile);
 
     // The method data pointer needs to be updated to reflect the new target.
@@ -1863,10 +1863,9 @@ void InterpreterMacroAssembler::profile_virtual_call(Register receiver,
 // function is recursive, to generate the required tree structured code.
 // It's the interpreter, so we are trading off code space for speed.
 // See below for example code.
-void InterpreterMacroAssembler::record_klass_in_profile_helper(
-                                        Register receiver, Register mdp,
-                                        Register reg2, int start_row,
-                                        Label& done, bool is_virtual_call) {
+void
+InterpreterMacroAssembler::record_klass_in_profile_helper(Register receiver, Register mdp, Register reg2, int start_row,
+                                                          Label &done) {
   if (TypeProfileWidth == 0) {
     increment_mdp_data_at(mdp, in_bytes(CounterData::count_offset()));
   } else {
@@ -1970,13 +1969,11 @@ void InterpreterMacroAssembler::record_item_in_profile_helper(Register item, Reg
 //   }
 //   done:
 
-void InterpreterMacroAssembler::record_klass_in_profile(Register receiver,
-                                                        Register mdp, Register reg2,
-                                                        bool is_virtual_call) {
+void InterpreterMacroAssembler::record_klass_in_profile(Register receiver, Register mdp, Register reg2) {
   assert(ProfileInterpreter, "must be profiling");
   Label done;
 
-  record_klass_in_profile_helper(receiver, mdp, reg2, 0, done, is_virtual_call);
+  record_klass_in_profile_helper(receiver, mdp, reg2, 0, done);
 
   bind (done);
 }
@@ -2053,7 +2050,7 @@ void InterpreterMacroAssembler::profile_typecheck(Register mdp, Register klass, 
       mdp_delta = in_bytes(VirtualCallData::virtual_call_data_size());
 
       // Record the object type.
-      record_klass_in_profile(klass, mdp, reg2, false);
+      record_klass_in_profile(klass, mdp, reg2);
       NOT_LP64(assert(reg2 == rdi, "we know how to fix this blown reg");)
       NOT_LP64(restore_locals();)         // Restore EDI
     }
@@ -2115,9 +2112,9 @@ void InterpreterMacroAssembler::profile_switch_case(Register index,
   }
 }
 
-void InterpreterMacroAssembler::profile_array(Register mdp,
-                                              Register array,
-                                              Register tmp) {
+template <class ArrayData> void InterpreterMacroAssembler::profile_array_type(Register mdp,
+                                                                              Register array,
+                                                                              Register tmp) {
   if (ProfileInterpreter) {
     Label profile_continue;
 
@@ -2125,19 +2122,19 @@ void InterpreterMacroAssembler::profile_array(Register mdp,
     test_method_data_pointer(mdp, profile_continue);
 
     mov(tmp, array);
-    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayLoadStoreData::array_offset())));
+    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayData::array_offset())));
 
     Label not_flat;
     test_non_flat_array_oop(array, tmp, not_flat);
 
-    set_mdp_flag_at(mdp, ArrayLoadStoreData::flat_array_byte_constant());
+    set_mdp_flag_at(mdp, ArrayData::flat_array_byte_constant());
 
     bind(not_flat);
 
     Label not_null_free;
     test_non_null_free_array_oop(array, tmp, not_null_free);
 
-    set_mdp_flag_at(mdp, ArrayLoadStoreData::null_free_array_byte_constant());
+    set_mdp_flag_at(mdp, ArrayData::null_free_array_byte_constant());
 
     bind(not_null_free);
 
@@ -2145,9 +2142,45 @@ void InterpreterMacroAssembler::profile_array(Register mdp,
   }
 }
 
-void InterpreterMacroAssembler::profile_element(Register mdp,
-                                                Register element,
-                                                Register tmp) {
+template void InterpreterMacroAssembler::profile_array_type<ArrayLoadData>(Register mdp,
+                                                                           Register array,
+                                                                           Register tmp);
+template void InterpreterMacroAssembler::profile_array_type<ArrayStoreData>(Register mdp,
+                                                                            Register array,
+                                                                            Register tmp);
+
+
+void InterpreterMacroAssembler::profile_multiple_element_types(Register mdp, Register element, Register tmp, const Register tmp2) {
+  if (ProfileInterpreter) {
+    Label profile_continue;
+
+    // If no method data exists, go to profile_continue.
+    test_method_data_pointer(mdp, profile_continue);
+
+    Label done, update;
+    testptr(element, element);
+    jccb(Assembler::notZero, update);
+    set_mdp_flag_at(mdp, BitData::null_seen_byte_constant());
+    jmp(done);
+
+    bind(update);
+    load_klass(tmp, element, rscratch1);
+
+    // Record the object type.
+    record_klass_in_profile(tmp, mdp, tmp2);
+
+    bind(done);
+
+    // The method data pointer needs to be updated.
+    update_mdp_by_constant(mdp, in_bytes(ArrayStoreData::array_store_data_size()));
+
+    bind(profile_continue);
+  }
+}
+
+void InterpreterMacroAssembler::profile_element_type(Register mdp,
+                                                     Register element,
+                                                     Register tmp) {
   if (ProfileInterpreter) {
     Label profile_continue;
 
@@ -2155,10 +2188,10 @@ void InterpreterMacroAssembler::profile_element(Register mdp,
     test_method_data_pointer(mdp, profile_continue);
 
     mov(tmp, element);
-    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayLoadStoreData::element_offset())));
+    profile_obj_type(tmp, Address(mdp, in_bytes(ArrayLoadData::element_offset())));
 
     // The method data pointer needs to be updated.
-    update_mdp_by_constant(mdp, in_bytes(ArrayLoadStoreData::array_load_store_data_size()));
+    update_mdp_by_constant(mdp, in_bytes(ArrayLoadData::array_load_data_size()));
 
     bind(profile_continue);
   }

--- a/src/hotspot/cpu/x86/interp_masm_x86.hpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.hpp
@@ -274,11 +274,8 @@ class InterpreterMacroAssembler: public MacroAssembler {
                         Register test_value_out,
                         Label& not_equal_continue);
 
-  void record_klass_in_profile(Register receiver, Register mdp,
-                               Register reg2, bool is_virtual_call);
-  void record_klass_in_profile_helper(Register receiver, Register mdp,
-                                      Register reg2, int start_row,
-                                      Label& done, bool is_virtual_call);
+  void record_klass_in_profile(Register receiver, Register mdp, Register reg2);
+  void record_klass_in_profile_helper(Register receiver, Register mdp, Register reg2, int start_row, Label &done);
   void record_item_in_profile_helper(Register item, Register mdp, Register reg2, int start_row,
                                      Label& done, int total_rows,
                                      OffsetFunction item_offset_fn,
@@ -303,8 +300,10 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void profile_switch_default(Register mdp);
   void profile_switch_case(Register index_in_scratch, Register mdp,
                            Register scratch2);
-  void profile_array(Register mdp, Register array, Register tmp);
-  void profile_element(Register mdp, Register element, Register tmp);
+  template <class ArrayData> void profile_array_type(Register mdp, Register array, Register tmp);
+
+  void profile_multiple_element_types(Register mdp, Register element, Register tmp, const Register tmp2);
+  void profile_element_type(Register mdp, Register element, Register tmp);
   void profile_acmp(Register mdp, Register left, Register right, Register tmp);
 
   // Debugging

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -836,7 +836,7 @@ void TemplateTable::aaload() {
   Register index = rax;
 
   index_check(array, index); // kills rbx
-  __ profile_array(rbx, array, rcx);
+  __ profile_array_type<ArrayLoadData>(rbx, array, rcx);
   if (UseFlatArray) {
     Label is_flat_array, done;
     __ test_flat_array_oop(array, rbx, is_flat_array);
@@ -858,7 +858,7 @@ void TemplateTable::aaload() {
                 rax,
                 IS_ARRAY);
   }
-  __ profile_element(rbx, rax, rcx);
+  __ profile_element_type(rbx, rax, rcx);
 }
 
 void TemplateTable::baload() {
@@ -1157,8 +1157,8 @@ void TemplateTable::aastore() {
 
   index_check_without_pop(rdx, rcx);     // kills rbx
 
-  __ profile_array(rdi, rdx, rbx);
-  __ profile_element(rdi, rax, rbx);
+  __ profile_array_type<ArrayStoreData>(rdi, rdx, rbx);
+  __ profile_multiple_element_types(rdi, rax, rbx, rcx);
 
   __ testptr(rax, rax);
   __ jcc(Assembler::zero, is_null);

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -495,9 +495,9 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void profile_parameters(Base* x);
   void profile_parameters_at_call(ProfileCall* x);
   void profile_flags(ciMethodData* md, ciProfileData* load_store, int flag, LIR_Condition condition = lir_cond_always);
-  void profile_null_free_array(LIRItem array, ciMethodData* md, ciArrayLoadStoreData* load_store);
-  void profile_array_type(AccessIndexed* x, ciMethodData*& md, ciArrayLoadStoreData*& load_store);
-  void profile_element_type(Value element, ciMethodData* md, ciArrayLoadStoreData* load_store);
+  template <class ArrayData> void profile_null_free_array(LIRItem array, ciMethodData* md, ArrayData* load_store);
+  template <class ArrayData> void profile_array_type(AccessIndexed* x, ciMethodData*& md, ArrayData*& load_store);
+  void profile_element_type(Value element, ciMethodData* md, ciArrayLoadData* load_store);
   bool profile_inline_klass(ciMethodData* md, ciProfileData* data, Value value, int flag);
   LIR_Opr mask_boolean(LIR_Opr array, LIR_Opr value, CodeEmitInfo*& null_check_info);
 

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -356,8 +356,10 @@ ciProfileData* ciMethodData::data_from(DataLayout* data_layout) {
     return new ciVirtualCallTypeData(data_layout);
   case DataLayout::parameters_type_data_tag:
     return new ciParametersTypeData(data_layout);
-  case DataLayout::array_load_store_data_tag:
-    return new ciArrayLoadStoreData(data_layout);
+  case DataLayout::array_store_data_tag:
+    return new ciArrayStoreData(data_layout);
+  case DataLayout::array_load_data_tag:
+    return new ciArrayLoadData(data_layout);
   case DataLayout::acmp_data_tag:
     return new ciACmpData(data_layout);
   };
@@ -755,12 +757,17 @@ void ciMethodData::dump_replay_data(outputStream* out) {
       } else if (pdata->is_CallTypeData()) {
           ciCallTypeData* call_type_data = (ciCallTypeData*)pdata;
           dump_replay_data_call_type_helper<ciCallTypeData>(out, round, count, call_type_data);
-      } else if (pdata->is_ArrayLoadStoreData()) {
-        ciArrayLoadStoreData* array_load_store_data = (ciArrayLoadStoreData*)pdata;
-        dump_replay_data_type_helper(out, round, count, array_load_store_data, ciArrayLoadStoreData::array_offset(),
-                                     array_load_store_data->array()->valid_type());
-        dump_replay_data_type_helper(out, round, count, array_load_store_data, ciArrayLoadStoreData::element_offset(),
-                                     array_load_store_data->element()->valid_type());
+      } else if (pdata->is_ArrayStoreData()) {
+        ciArrayStoreData* array_store_data = (ciArrayStoreData*)pdata;
+        dump_replay_data_type_helper(out, round, count, array_store_data, ciArrayStoreData::array_offset(),
+                                     array_store_data->array()->valid_type());
+//        dump_replay_data_receiver_type_helper<ciArrayLoadStoreData>(out, round, count, array_store_data);
+      } else if (pdata->is_ArrayLoadData()) {
+        ciArrayLoadData* array_load_data = (ciArrayLoadData*)pdata;
+        dump_replay_data_type_helper(out, round, count, array_load_data, ciArrayLoadData::array_offset(),
+                                     array_load_data->array()->valid_type());
+        dump_replay_data_type_helper(out, round, count, array_load_data, ciArrayLoadData::element_offset(),
+                                     array_load_data->element()->valid_type());
       } else if (pdata->is_ACmpData()) {
         ciACmpData* acmp_data = (ciACmpData*)pdata;
         dump_replay_data_type_helper(out, round, count, acmp_data, ciACmpData::left_offset(),
@@ -924,7 +931,17 @@ void ciSpeculativeTrapData::print_data_on(outputStream* st, const char* extra) c
   st->cr();
 }
 
-void ciArrayLoadStoreData::print_data_on(outputStream* st, const char* extra) const {
+void ciArrayStoreData::print_data_on(outputStream* st, const char* extra) const {
+  print_shared(st, "ciArrayLoadStoreData", extra);
+  tab(st, true);
+  st->print("array");
+  array()->print_data_on(st);
+  tab(st, true);
+  st->print("element");
+  print_receiver_data_on(st);
+}
+
+void ciArrayLoadData::print_data_on(outputStream* st, const char* extra) const {
   print_shared(st, "ciArrayLoadStoreData", extra);
   tab(st, true);
   st->print("array");

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -761,7 +761,7 @@ void ciMethodData::dump_replay_data(outputStream* out) {
         ciArrayStoreData* array_store_data = (ciArrayStoreData*)pdata;
         dump_replay_data_type_helper(out, round, count, array_store_data, ciArrayStoreData::array_offset(),
                                      array_store_data->array()->valid_type());
-//        dump_replay_data_receiver_type_helper<ciArrayLoadStoreData>(out, round, count, array_store_data);
+        dump_replay_data_receiver_type_helper<ciArrayStoreData>(out, round, count, array_store_data);
       } else if (pdata->is_ArrayLoadData()) {
         ciArrayLoadData* array_load_data = (ciArrayLoadData*)pdata;
         dump_replay_data_type_helper(out, round, count, array_load_data, ciArrayLoadData::array_offset(),

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -362,22 +362,42 @@ public:
 #endif
 };
 
-class ciArrayLoadStoreData : public ArrayLoadStoreData {
-public:
-  ciArrayLoadStoreData(DataLayout* layout) : ArrayLoadStoreData(layout) {}
+class ciArrayStoreData : public ArrayStoreData {
+  // Fake multiple inheritance...  It's a ciReceiverTypeData also.
+  ciReceiverTypeData* rtd_super() const { return (ciReceiverTypeData*) this; }
 
-  ciSingleTypeEntry* array() const { return (ciSingleTypeEntry*)ArrayLoadStoreData::array(); }
-  ciSingleTypeEntry* element() const { return (ciSingleTypeEntry*)ArrayLoadStoreData::element(); }
+public:
+  ciArrayStoreData(DataLayout* layout) : ArrayStoreData(layout) {}
+
+  ciSingleTypeEntry* array() const { return (ciSingleTypeEntry*)ArrayStoreData::array(); }
 
   virtual void translate_from(const ProfileData* data) {
-    array()->translate_type_data_from(data->as_ArrayLoadStoreData()->array());
-    element()->translate_type_data_from(data->as_ArrayLoadStoreData()->element());
+    array()->translate_type_data_from(data->as_ArrayStoreData()->array());
+    rtd_super()->translate_receiver_data_from(data);
   }
 
 #ifndef PRODUCT
   void print_data_on(outputStream* st, const char* extra = nullptr) const;
 #endif
 };
+
+class ciArrayLoadData : public ArrayLoadData {
+public:
+  ciArrayLoadData(DataLayout* layout) : ArrayLoadData(layout) {}
+
+  ciSingleTypeEntry* array() const { return (ciSingleTypeEntry*)ArrayLoadData::array(); }
+  ciSingleTypeEntry* element() const { return (ciSingleTypeEntry*)ArrayLoadData::element(); }
+
+  virtual void translate_from(const ProfileData* data) {
+    array()->translate_type_data_from(data->as_ArrayLoadData()->array());
+    element()->translate_type_data_from(data->as_ArrayLoadData()->element());
+  }
+
+#ifndef PRODUCT
+  void print_data_on(outputStream* st, const char* extra = nullptr) const;
+#endif
+};
+
 
 class ciACmpData : public ACmpData {
 public:

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -376,6 +376,9 @@ public:
     rtd_super()->translate_receiver_data_from(data);
   }
 
+  ciKlass* receiver(uint row) {
+    return rtd_super()->receiver(row);
+  }
 #ifndef PRODUCT
   void print_data_on(outputStream* st, const char* extra = nullptr) const;
 #endif

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -637,7 +637,7 @@
   declare_constant(DataLayout::virtual_call_type_data_tag)                \
   declare_constant(DataLayout::parameters_type_data_tag)                  \
   declare_constant(DataLayout::speculative_trap_data_tag)                 \
-  declare_constant(DataLayout::array_load_store_data_tag)                 \
+  declare_constant(DataLayout::array_store_data_tag)                      \
   declare_constant(DataLayout::acmp_data_tag)                             \
                                                                           \
   declare_constant(Deoptimization::Unpack_deopt)                          \

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -638,6 +638,7 @@
   declare_constant(DataLayout::parameters_type_data_tag)                  \
   declare_constant(DataLayout::speculative_trap_data_tag)                 \
   declare_constant(DataLayout::array_store_data_tag)                      \
+  declare_constant(DataLayout::array_load_data_tag)                       \
   declare_constant(DataLayout::acmp_data_tag)                             \
                                                                           \
   declare_constant(Deoptimization::Unpack_deopt)                          \

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -130,7 +130,8 @@ public:
     virtual_call_type_data_tag,
     parameters_type_data_tag,
     speculative_trap_data_tag,
-    array_load_store_data_tag,
+    array_store_data_tag,
+    array_load_data_tag,
     acmp_data_tag
   };
 
@@ -263,6 +264,7 @@ class     CounterData;
 class       ReceiverTypeData;
 class         VirtualCallData;
 class           VirtualCallTypeData;
+class         ArrayStoreData;
 class       RetData;
 class       CallTypeData;
 class   JumpData;
@@ -273,7 +275,7 @@ class     MultiBranchData;
 class     ArgInfoData;
 class     ParametersTypeData;
 class   SpeculativeTrapData;
-class   ArrayLoadStoreData;
+class   ArrayLoadData;
 
 // ProfileData
 //
@@ -402,7 +404,8 @@ public:
   virtual bool is_VirtualCallTypeData()const { return false; }
   virtual bool is_ParametersTypeData() const { return false; }
   virtual bool is_SpeculativeTrapData()const { return false; }
-  virtual bool is_ArrayLoadStoreData() const { return false; }
+  virtual bool is_ArrayStoreData() const { return false; }
+  virtual bool is_ArrayLoadData() const { return false; }
   virtual bool is_ACmpData()           const { return false; }
 
 
@@ -462,9 +465,13 @@ public:
     assert(is_SpeculativeTrapData(), "wrong type");
     return is_SpeculativeTrapData() ? (SpeculativeTrapData*)this : nullptr;
   }
-  ArrayLoadStoreData* as_ArrayLoadStoreData() const {
-    assert(is_ArrayLoadStoreData(), "wrong type");
-    return is_ArrayLoadStoreData() ? (ArrayLoadStoreData*)this : nullptr;
+  ArrayStoreData* as_ArrayStoreData() const {
+    assert(is_ArrayStoreData(), "wrong type");
+    return is_ArrayStoreData() ? (ArrayStoreData*)this : nullptr;
+  }
+  ArrayLoadData* as_ArrayLoadData() const {
+    assert(is_ArrayLoadData(), "wrong type");
+    return is_ArrayLoadData() ? (ArrayLoadData*)this : nullptr;
   }
   ACmpData* as_ACmpData() const {
     assert(is_ACmpData(), "wrong type");
@@ -505,11 +512,12 @@ protected:
   enum : u1 {
     // null_seen:
     //  saw a null operand (cast/aastore/instanceof)
-      null_seen_flag              = DataLayout::first_flag + 0
+      null_seen_flag              = DataLayout::first_flag + 0,
 #if INCLUDE_JVMCI
     // bytecode threw any exception
-    , exception_seen_flag         = null_seen_flag + 1
+      exception_seen_flag         = null_seen_flag + 1,
 #endif
+      last_bit_data_flag
   };
   enum { bit_cell_count = 0 };  // no additional data fields needed.
 public:
@@ -530,7 +538,7 @@ public:
 
   // The null_seen flag bit is specially known to the interpreter.
   // Consulting it allows the compiler to avoid setting up null_check traps.
-  bool null_seen()     { return flag_at(null_seen_flag); }
+  bool null_seen() const  { return flag_at(null_seen_flag); }
   void set_null_seen()    { set_flag_at(null_seen_flag); }
 
 #if INCLUDE_JVMCI
@@ -1116,7 +1124,8 @@ public:
   ReceiverTypeData(DataLayout* layout) : CounterData(layout) {
     assert(layout->tag() == DataLayout::receiver_type_data_tag ||
            layout->tag() == DataLayout::virtual_call_data_tag ||
-           layout->tag() == DataLayout::virtual_call_type_data_tag, "wrong type");
+           layout->tag() == DataLayout::virtual_call_type_data_tag ||
+           layout->tag() == DataLayout::array_store_data_tag, "wrong type");
   }
 
   virtual bool is_ReceiverTypeData() const { return true; }
@@ -1837,7 +1846,69 @@ public:
   virtual void print_data_on(outputStream* st, const char* extra = nullptr) const;
 };
 
-class ArrayLoadStoreData : public ProfileData {
+class ArrayStoreData : public ReceiverTypeData {
+private:
+  enum {
+    flat_array_flag = BitData::last_bit_data_flag,
+    null_free_array_flag = flat_array_flag + 1,
+  };
+
+  SingleTypeEntry _array;
+
+public:
+  ArrayStoreData(DataLayout* layout) :
+    ReceiverTypeData(layout),
+    _array(ReceiverTypeData::static_cell_count()) {
+    assert(layout->tag() == DataLayout::array_store_data_tag, "wrong type");
+    _array.set_profile_data(this);
+  }
+
+  const SingleTypeEntry* array() const {
+    return &_array;
+  }
+
+  virtual bool is_ArrayStoreData() const { return true; }
+
+  static int static_cell_count() {
+    return ReceiverTypeData::static_cell_count() + SingleTypeEntry::static_cell_count();
+  }
+
+  virtual int cell_count() const {
+    return static_cell_count();
+  }
+
+  void set_flat_array() { set_flag_at(flat_array_flag); }
+  bool flat_array() const { return flag_at(flat_array_flag); }
+
+  void set_null_free_array() { set_flag_at(null_free_array_flag); }
+  bool null_free_array() const { return flag_at(null_free_array_flag); }
+
+  // Code generation support
+  static int flat_array_byte_constant() {
+    return flag_number_to_constant(flat_array_flag);
+  }
+
+  static int null_free_array_byte_constant() {
+    return flag_number_to_constant(null_free_array_flag);
+  }
+
+  static ByteSize array_offset() {
+    return cell_offset(ReceiverTypeData::static_cell_count());
+  }
+
+  virtual void clean_weak_klass_links(bool always_clean) {
+    ReceiverTypeData::clean_weak_klass_links(always_clean);
+    _array.clean_weak_klass_links(always_clean);
+  }
+
+  static ByteSize array_store_data_size() {
+    return cell_offset(static_cell_count());
+  }
+
+  virtual void print_data_on(outputStream* st, const char* extra = nullptr) const;
+};
+
+class ArrayLoadData : public ProfileData {
 private:
   enum {
     flat_array_flag = DataLayout::first_flag,
@@ -1848,11 +1919,11 @@ private:
   SingleTypeEntry _element;
 
 public:
-  ArrayLoadStoreData(DataLayout* layout) :
+  ArrayLoadData(DataLayout* layout) :
     ProfileData(layout),
     _array(0),
     _element(SingleTypeEntry::static_cell_count()) {
-    assert(layout->tag() == DataLayout::array_load_store_data_tag, "wrong type");
+    assert(layout->tag() == DataLayout::array_load_data_tag, "wrong type");
     _array.set_profile_data(this);
     _element.set_profile_data(this);
   }
@@ -1865,7 +1936,7 @@ public:
     return &_element;
   }
 
-  virtual bool is_ArrayLoadStoreData() const { return true; }
+  virtual bool is_ArrayLoadData() const { return true; }
 
   static int static_cell_count() {
     return SingleTypeEntry::static_cell_count() * 2;
@@ -1903,7 +1974,7 @@ public:
     _element.clean_weak_klass_links(always_clean);
   }
 
-  static ByteSize array_load_store_data_size() {
+  static ByteSize array_load_data_size() {
     return cell_offset(static_cell_count());
   }
 

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3144,9 +3144,6 @@ bool GraphKit::seems_never_null(Node* obj, ciProfileData* data, bool& speculatin
     assert(java_bc() == Bytecodes::_checkcast ||
            java_bc() == Bytecodes::_instanceof ||
            java_bc() == Bytecodes::_aastore, "MDO must collect null_seen bit here");
-    if (java_bc() == Bytecodes::_aastore) {
-      return ((ciArrayLoadStoreData*)data->as_ArrayLoadStoreData())->element()->ptr_kind() == ProfileNeverNull;
-    }
     return !data->as_BitData()->null_seen();
   }
   speculating = false;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
@@ -105,7 +105,8 @@ final class HotSpotMethodData implements MetaspaceObject {
             new VirtualCallTypeData(this, config.dataLayoutVirtualCallTypeDataTag),
             new UnknownProfileData(this, config.dataLayoutParametersTypeDataTag),
             new UnknownProfileData(this, config.dataLayoutSpeculativeTrapDataTag),
-            new UnknownProfileData(this, config.dataLayoutArrayLoadStoreDataTag),
+            new UnknownProfileData(this, config.dataLayoutArrayLoadDataTag),
+            new UnknownProfileData(this, config.dataLayoutArrayStoreDataTag),
             new UnknownProfileData(this, config.dataLayoutACmpDataTag),
         };
         // @formatter:on

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
@@ -105,8 +105,8 @@ final class HotSpotMethodData implements MetaspaceObject {
             new VirtualCallTypeData(this, config.dataLayoutVirtualCallTypeDataTag),
             new UnknownProfileData(this, config.dataLayoutParametersTypeDataTag),
             new UnknownProfileData(this, config.dataLayoutSpeculativeTrapDataTag),
-            new UnknownProfileData(this, config.dataLayoutArrayLoadDataTag),
             new UnknownProfileData(this, config.dataLayoutArrayStoreDataTag),
+            new UnknownProfileData(this, config.dataLayoutArrayLoadDataTag),
             new UnknownProfileData(this, config.dataLayoutACmpDataTag),
         };
         // @formatter:on

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -302,7 +302,8 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int dataLayoutVirtualCallTypeDataTag = getConstant("DataLayout::virtual_call_type_data_tag", Integer.class);
     final int dataLayoutParametersTypeDataTag = getConstant("DataLayout::parameters_type_data_tag", Integer.class);
     final int dataLayoutSpeculativeTrapDataTag = getConstant("DataLayout::speculative_trap_data_tag", Integer.class);
-    final int dataLayoutArrayLoadStoreDataTag = getConstant("DataLayout::array_load_store_data_tag", Integer.class);
+    final int dataLayoutArrayLoadDataTag = getConstant("DataLayout::array_load_data_tag", Integer.class);
+    final int dataLayoutArrayStoreDataTag = getConstant("DataLayout::array_store_data_tag", Integer.class);
     final int dataLayoutACmpDataTag = getConstant("DataLayout::acmp_data_tag", Integer.class);
 
     final int bciProfileWidth = getFlag("BciProfileWidth", Integer.class);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,8 +73,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
-compiler/c2/irTests/ProfileAtTypeCheck.java 8320296 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
The issue is that the way valhalla collects profile data at `aastore` is different from what mainline does. It used to not matter because mainline didn't use part of the data it collects but that has changed. In mainline, no profile data is collected for `aaload` and every `aastore` has a `ReceiverTypeData` entry. In valhalla, `aaload` and `aastore` both make use of a `ArrayLoadStoreData` that's unrelated to `ReceiverTypeData`. What I propose to fix this is that `aaload` and `aastore` each have their own profile data structure: `ArrayLoadData` and `ArrayStoreData` . `ArrayLoadData` is identical to `ArrayLoadStoreData`  so there's no change to profile collection code for `aaload`. `ArrayStoreData` is a subclass of `ReceiverTypeData` so profile data collection has to be adjusted. The reason for not having the same data structure for `aaload` and `aastore` is that it made fixing the profile collection code easier and increasing the number of types collected by  `ReceiverTypeData` (if we ever want to do that) would not cause a lot of unused data to be collected at `aaload`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8320296](https://bugs.openjdk.org/browse/JDK-8320296): [lworld] Fix profiling at array store subtype checks in Valhalla (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/962/head:pull/962` \
`$ git checkout pull/962`

Update a local copy of the PR: \
`$ git checkout pull/962` \
`$ git pull https://git.openjdk.org/valhalla.git pull/962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 962`

View PR using the GUI difftool: \
`$ git pr show -t 962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/962.diff">https://git.openjdk.org/valhalla/pull/962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/962#issuecomment-1855428521)