### PR TITLE
8239003: [lworld] C2 should respect larval state when scalarizing

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -27,6 +27,7 @@
 #include "ci/ciInlineKlass.hpp"
 #include "ci/ciUtilities.hpp"
 #include "classfile/javaClasses.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "ci/ciObjArray.hpp"
 #include "asm/register.hpp"
 #include "compiler/compileLog.hpp"
@@ -1954,6 +1955,15 @@ Node* GraphKit::set_results_for_java_call(CallJavaNode* call, bool separate_io_p
       if (type->is_inlinetypeptr()) {
         ret = InlineTypeNode::make_from_oop(this, ret, type->inline_klass(), type->inline_klass()->is_null_free());
       }
+      Node* receiver = !call->method()->is_static() ? call->in(TypeFunc::Parms) : nullptr;
+      if (ret->is_InlineType() &&
+          receiver && receiver->bottom_type()->isa_instptr() &&
+          receiver->bottom_type()->is_instptr()->instance_klass()->name()->get_symbol() == vmSymbols::jdk_internal_misc_Unsafe() &&
+          call->method()->name()->get_symbol() == vmSymbols::makePrivateBuffer_name()) {
+        // Re-buffer scalarized InlineTypeNodes returned from makePrivateBuffer
+        // and transition the allocation into larval state.
+        ret = ret->as_InlineType()->make_larval(this);
+      }
     }
   }
 
@@ -3455,7 +3465,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
           assert(safe_for_replace, "must be");
           obj = null_check(obj);
         }
-        assert(stopped() || !toop->is_inlinetypeptr() || obj->is_InlineType(), "should have been scalarized");
+        assert(stopped() || !toop->is_inlinetypeptr() || obj->is_InlineType() || obj->bottom_type()->is_inlinetypeptr(), "should have been scalarized");
         return obj;
       case Compile::SSC_always_false:
         if (null_free) {

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -147,8 +147,8 @@ public:
   // Pass inline type as fields at a call or return
   void pass_fields(GraphKit* kit, Node* n, uint& base_input, bool in, bool null_free = true);
 
-  InlineTypeNode* make_larval(GraphKit* kit, bool allocate) const;
-  InlineTypeNode* finish_larval(GraphKit* kit) const;
+  Node* make_larval(GraphKit* kit) const;
+  static InlineTypeNode* finish_larval(GraphKit* kit, Node* obj, const TypeInstPtr* vk);
 
   // Allocation optimizations
   void remove_redundant_allocations(PhaseIdealLoop* phase);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2331,6 +2331,17 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
   assert(Unsafe_field_offset_to_byte_offset(11) == 11,
          "fieldOffset must be byte-scaled");
 
+  if (_gvn.type(base)->is_inlinetypeptr() && is_store) {
+    // FIXME: Larval bit check is needed to preserve the semantics of value
+    // objects which can be mutated only if its _larval bit is set. Since
+    // the oop is not always an AllocateNode, we have to find an utility way
+    // to check the larval state for all kind of oops.
+    AllocateNode* alloc = AllocateNode::Ideal_allocation(base);
+    if (alloc != nullptr) {
+      assert(alloc->_larval, "InlineType instance must be in _larval state for unsafe put operation.\n");
+    }
+  }
+
   ciInlineKlass* inline_klass = nullptr;
   if (is_flat) {
     const TypeInstPtr* cls = _gvn.type(argument(4))->isa_instptr();
@@ -2608,12 +2619,6 @@ bool LibraryCallKit::inline_unsafe_access(bool is_store, const BasicType type, c
     }
   }
 
-  if (argument(1)->is_InlineType() && is_store) {
-    InlineTypeNode* value = InlineTypeNode::make_from_oop(this, base, _gvn.type(argument(1))->inline_klass());
-    value = value->make_larval(this, false);
-    replace_in_map(argument(1), value);
-  }
-
   return true;
 }
 
@@ -2629,31 +2634,29 @@ bool LibraryCallKit::inline_unsafe_make_private_buffer() {
     return true;
   }
 
-  set_result(value->as_InlineType()->make_larval(this, true));
+  set_result(value->as_InlineType()->make_larval(this));
   return true;
 }
 
 bool LibraryCallKit::inline_unsafe_finish_private_buffer() {
   Node* receiver = argument(0);
   Node* buffer = argument(1);
-  if (!buffer->is_InlineType()) {
-    return false;
-  }
-  InlineTypeNode* vt = buffer->as_InlineType();
-  if (!vt->is_allocated(&_gvn)) {
-    return false;
-  }
-  // TODO 8239003 Why is this needed?
-  if (AllocateNode::Ideal_allocation(vt->get_oop()) == nullptr) {
-    return false;
+
+  // Incoming value should be a buffer with inline type and not InlineTypeNode.
+  if (buffer->is_InlineType() || !buffer->bottom_type()->is_inlinetypeptr()) {
+     return false;
   }
 
-  receiver = null_check(receiver);
-  if (stopped()) {
-    return true;
+  // Allocation node must exist to generate IR for transitioning allocation out
+  // of larval state. Disable the intrinsic and take unsafe slow path if allocation
+  // is not reachable,  oop returned by Unsafe_finishPrivateBuffer native method
+  // will automatically rematerialize InlineTypeNode.
+  if (AllocateNode::Ideal_allocation(buffer) == nullptr) {
+     return false;
   }
 
-  set_result(vt->finish_larval(this));
+  const TypeInstPtr* ptr = buffer->bottom_type()->isa_instptr();
+  set_result(InlineTypeNode::finish_larval(this, buffer, ptr));
   return true;
 }
 

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -959,6 +959,11 @@ bool PhaseMacroExpand::scalar_replacement(AllocateNode *alloc, GrowableArray <Sa
     res_type = _igvn.type(res)->isa_oopptr();
   }
 
+  // Bufferes in larval state should not be scalarized.
+  if (alloc->_larval) {
+    return false;
+  }
+
   // Process the safepoint uses
   assert(safepoints.length() == 0 || !res_type->is_inlinetypeptr(), "Inline type allocations should not have safepoint uses");
   Unique_Node_List value_worklist;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1769,9 +1769,12 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
           // Allocate inline type in src block to be able to merge it with oop in target block
           map()->set_req(j, n->as_InlineType()->buffer(this));
         } else if (!n->is_InlineType() && t->is_inlinetypeptr()) {
-          // Scalarize null in src block to be able to merge it with inline type in target block
-          assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
-          map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
+          AllocateNode* alloc = AllocateNode::Ideal_allocation(n);
+          if (alloc == nullptr || !alloc->_larval) {
+            // Scalarize null in src block to be able to merge it with inline type in target block
+            assert(gvn().type(n)->is_zero_type(), "Should have been scalarized");
+            map()->set_req(j, InlineTypeNode::make_null(gvn(), t->inline_klass()));
+          }
         }
       }
     }
@@ -1876,7 +1879,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       PhiNode* phi;
       if (m->is_Phi() && m->as_Phi()->region() == r) {
         phi = m->as_Phi();
-      } else if (m->is_InlineType() && m->as_InlineType()->has_phi_inputs(r)) {
+      } else if (m->is_InlineType() && n->is_InlineType() && m->as_InlineType()->has_phi_inputs(r)) {
         phi = m->as_InlineType()->get_oop()->as_Phi();
       } else {
         phi = nullptr;
@@ -1915,7 +1918,7 @@ void Parse::merge_common(Parse::Block* target, int pnum) {
       // It is a bug if we create a phi which sees a garbage value on a live path.
 
       // Merging two inline types?
-      if (phi != nullptr && phi->bottom_type()->is_inlinetypeptr()) {
+      if (phi != nullptr && phi->bottom_type()->is_inlinetypeptr() && m->is_InlineType() && n->is_InlineType()) {
         // Reload current state because it may have been updated by ensure_phi
         m = map()->in(j);
         InlineTypeNode* vtm = m->as_InlineType(); // Current inline type

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptInLarvalState.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestDeoptInLarvalState.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8239003
+ * @summary C2 should respect larval state when scalarizing
+ * @modules java.base/jdk.internal.misc
+ * @library /testlibrary /test/lib
+ * @compile TestDeoptInLarvalState.java
+ * @run main/othervm/timeout=300 -Xbatch -XX:CompileThresholdScaling=0.3 -XX:+UnlockDiagnosticVMOptions -XX:+PrintDeoptimizationDetails -XX:CompileOnly=compiler.valhalla.inlinetypes.TestDeoptInLarvalState::test1 --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED  compiler.valhalla.inlinetypes.TestDeoptInLarvalState
+ * @run main/othervm/timeout=300 -Xbatch -XX:CompileThresholdScaling=0.3 -XX:+UnlockDiagnosticVMOptions -XX:+PrintCompilation -XX:CompileOnly=compiler.valhalla.inlinetypes.TestDeoptInLarvalState::test2 -XX:CompileCommand=DontInline,compiler.valhalla.inlinetypes.TestDeoptInLarvalState::cleanup --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED  compiler.valhalla.inlinetypes.TestDeoptInLarvalState
+ * @run main/othervm/timeout=300 -Xbatch -XX:CompileThresholdScaling=0.3 -XX:+UnlockDiagnosticVMOptions -XX:+PrintDeoptimizationDetails -XX:CompileOnly=compiler.valhalla.inlinetypes.TestDeoptInLarvalState::test2 --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED  compiler.valhalla.inlinetypes.TestDeoptInLarvalState
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.misc.Unsafe;
+
+value class Pair {
+    public double d1, d2;
+    public Pair(double d1, double d2) {
+        this.d1 = d1;
+        this.d2 = d2;
+    }
+}
+
+public class TestDeoptInLarvalState {
+    static final long OFFSET = 16;
+
+    public static Pair cleanup(Pair p) {
+        return Unsafe.getUnsafe().finishPrivateBuffer(p);
+    }
+
+    public static double test1(double value, int iter) {
+        Pair p = Unsafe.getUnsafe().makePrivateBuffer(new Pair(10.0, 20.0));
+        Unsafe.getUnsafe().putDouble(p, OFFSET, value);
+        if (iter == 5000) {
+           throw new RuntimeException("test1 : Failed to update p with value = " + p.d1);
+        }
+        p = Unsafe.getUnsafe().finishPrivateBuffer(p);
+        return p.d1 + p.d2;
+    }
+
+    public static double test2(double value, int iter) {
+        Pair p = Unsafe.getUnsafe().makePrivateBuffer(new Pair(10.0, 20.0));
+        Unsafe.getUnsafe().putDouble(p, OFFSET, value);
+        if (iter == 5000) {
+           throw new RuntimeException("test2 : Failed to update p with value = " + p.d1);
+        }
+        p = cleanup(p);
+        return p.d1 + p.d2;
+    }
+
+    public static void main(String[] args) {
+        double res = 0.0;
+        try {
+            for (int i = 0; i < 10000; i++) {
+                res += test1((double)i, i);
+            }
+            System.out.println("[res]" + res);
+        } catch (Exception e) {
+            System.out.println("Caught Exception: " + e);
+        }
+        try {
+            for (int i = 0; i < 10000; i++) {
+                res += test2((double)i, i);
+            }
+            System.out.println("[res]" + res);
+        } catch (Exception e) {
+            System.out.println("Caught Exception: " + e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -405,7 +405,7 @@ public class TestIntrinsics {
 
     MyValue1 test22_vt;
     @Test
-    @IR(failOn = {CALL_UNSAFE, ALLOC})
+    @IR(failOn = {CALL_UNSAFE})
     public void test22(MyValue1 v) {
         v = U.makePrivateBuffer(v);
         U.putInt(v, X_OFFSET, rI);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMaskedUnsafePutInLoop.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMaskedUnsafePutInLoop.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8239003
+ * @summary C2 should respect larval state when scalarizing
+ * @modules java.base/jdk.internal.misc
+ * @library /testlibrary /test/lib
+ * @compile -XDenablePrimitiveClasses TestMaskedUnsafePutInLoop.java
+ * @run main/othervm/timeout=300 -XX:-TieredCompilation -Xbatch -XX:+EnablePrimitiveClasses --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+ *                               -XX:+UnlockDiagnosticVMOptions compiler.valhalla.inlinetypes.TestMaskedUnsafePutInLoop
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import jdk.internal.misc.Unsafe;
+
+public class TestMaskedUnsafePutInLoop {
+     primitive class Pair {
+         final double d1, d2;
+         public Pair(double d1, double d2) {
+             this.d1 = d1;
+             this.d2 = d2;
+         }
+     }
+
+     static final long[] OFFSETS = new long[] { 16, 24 };
+
+     public static Pair helper(double[] values, boolean[] mask) {
+         Pair p = Unsafe.getUnsafe().makePrivateBuffer(Pair.default);
+
+         for (int i = 0; i < OFFSETS.length; i++) {
+             if (mask[i]) {
+                 Unsafe.getUnsafe().putDouble(p, OFFSETS[i], values[i]);
+             }
+         }
+         return Unsafe.getUnsafe().finishPrivateBuffer(p);
+    }
+
+
+    public static double test(double[] values, boolean[] mask) {
+         Pair p = helper(values, mask);
+         return p.d1 + p.d2;
+    }
+
+    public static void main(String[] args) {
+        double[] values = new double[] { 1.0, 2.0 };
+        boolean[] mask = new boolean[] { true, false };
+
+        double d = 0.0;
+        for (int i = 0; i < 10000; i++) {
+            d += test(values, mask);
+        }
+        if (d != 10000.0) {
+            throw new AssertionError("Incorrect Result expected(10000.0) != actual(" + d + ")");
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMaskedUnsafePutInLoop.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMaskedUnsafePutInLoop.java
@@ -38,7 +38,7 @@ import jdk.internal.misc.Unsafe;
 
 public class TestMaskedUnsafePutInLoop {
      primitive class Pair {
-         final double d1, d2;
+         double d1, d2;
          public Pair(double d1, double d2) {
              this.d1 = d1;
              this.d2 = d2;


### PR DESCRIPTION
Hi All,

Patch addresses issues around unsafe updates to value objects within a loop and larval state preservation by suppressing
scalarization of value objects in larval state.

Since Unsafe.put* APIs returns a void, hence it does not alter JVM state. Due to this ciTypeFlow dataflow analysis does
not encounter an inductive definition corresponding to updated value object within the loop, due to this C2 parser misses
creating an inductive phi node on encountering loop header block.

In order to maintain IR compliance with ciTypeFlow analysis C2 should prevent scalarizing value object b/w make and finish
private buffer calls.

New behavior of unsafe inline expanders

* makePrivate: Receive InlineTypeNode input and return initialized buffer in larval state.
* finishPrivateBuffer: Receive value object buffer input and return rematerialize InlineTypeNode in non-larval state.
  This may result into creation of unbalanced phi node at control flow merges where one of the phi input may InlineTypeNode
  and other is a buffer of compatible value type, but the IR still remains valid.

In addition compiler is now preventing elimination of allocation in larval state.

Validation Status:-

All the Valhalla JTREG tests are passing at various AVX level with / wo -XX:+DoptimizeALot.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Issue
 * [JDK-8239003](https://bugs.openjdk.org/browse/JDK-8239003): [lworld] C2 should respect larval state when scalarizing (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/964/head:pull/964` \
`$ git checkout pull/964`

Update a local copy of the PR: \
`$ git checkout pull/964` \
`$ git pull https://git.openjdk.org/valhalla.git pull/964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 964`

View PR using the GUI difftool: \
`$ git pr show -t 964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/964.diff">https://git.openjdk.org/valhalla/pull/964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/964#issuecomment-1864490316)