### PR TITLE
8322573: [lworld] Add null-restricted value class array support in core reflection

### DIFF
--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -273,9 +273,14 @@ void Reflection::array_set(jvalue* value, arrayOop a, int index, BasicType value
   if (!a->is_within_bounds(index)) {
     THROW(vmSymbols::java_lang_ArrayIndexOutOfBoundsException());
   }
+
   if (a->is_objArray()) {
     if (value_type == T_OBJECT) {
       oop obj = cast_to_oop(value->l);
+      if (a->is_null_free_array() && obj == nullptr) {
+         THROW_MSG(vmSymbols::java_lang_NullPointerException(), "null-restricted array");
+      }
+
       if (obj != nullptr) {
         Klass* element_klass = ObjArrayKlass::cast(a->klass())->element_klass();
         if (!obj->is_a(element_klass)) {

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -183,13 +183,19 @@ public class MethodHandleTest {
         MethodHandle setter = MethodHandles.arrayElementSetter(array.getClass());
         MethodHandle getter = MethodHandles.arrayElementGetter(array.getClass());
         VarHandle vh = MethodHandles.arrayElementVarHandle(arrayClass);
+        Class<?> componentType = arrayClass.getComponentType();
 
         for (int i=0; i < ARRAY_SIZE; i++) {
-            setter.invoke(array, i, element);
+            var v = getter.invoke(array, i);
+            if (nullRestricted) {
+                assertTrue(v == ValueClass.zeroInstance(componentType));
+            } else {
+                assertTrue(v == null);
+            }
         }
         for (int i=0; i < ARRAY_SIZE; i++) {
-            Object v = (Object)getter.invoke(array, i);
-            assertEquals(v, element);
+            setter.invoke(array, i, element);
+            assertTrue(getter.invoke(array, i) == element);
         }
         // set an array element to null
         if (nullRestricted) {

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -34,7 +34,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import jdk.internal.value.ValueClass;
@@ -142,7 +141,7 @@ public class Reflection {
         // set elements
         for (int i = 0; i < array.length; i++) {
             Array.set(array, i, element);
-            assertEquals(element, Array.get(array, i));
+            assertTrue(Array.get(array, i) == element);
         }
 
         Arrays.setAll(array, i -> array[i]);


### PR DESCRIPTION
This patch fixes `Array::set` that if `null` is set on an element of a null-restricted arra, NPE will be thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8322573](https://bugs.openjdk.org/browse/JDK-8322573): [lworld] Add null-restricted value class array support in core reflection (**Enhancement** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/965/head:pull/965` \
`$ git checkout pull/965`

Update a local copy of the PR: \
`$ git checkout pull/965` \
`$ git pull https://git.openjdk.org/valhalla.git pull/965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 965`

View PR using the GUI difftool: \
`$ git pr show -t 965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/965.diff">https://git.openjdk.org/valhalla/pull/965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/965#issuecomment-1865276397)