### PR TITLE
8323781: [lworld] Synchronization on inline type does not throw IllegalMonitorStateException with lightweight locking

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -7147,6 +7147,11 @@ void MacroAssembler::lightweight_lock(Register obj, Register hdr, Register t1, R
 
   // Load (object->mark() | 1) into hdr
   orr(hdr, hdr, markWord::unlocked_value);
+  if (EnableValhalla) {
+    // Mask inline_type bit such that we go to the slow path if object is an inline type
+    andr(hdr, hdr, ~((int) markWord::inline_type_bit_in_place));
+  }
+
   // Clear lock-bits, into t2
   eor(t2, hdr, markWord::unlocked_value);
   // Try to swing header from unlocked to locked

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -10588,6 +10588,10 @@ void MacroAssembler::lightweight_lock(Register obj, Register hdr, Register threa
   movptr(tmp, hdr);
   // Set unlocked_value bit.
   orptr(hdr, markWord::unlocked_value);
+  if (EnableValhalla) {
+    // Mask inline_type bit such that we go to the slow path if object is an inline type
+    andptr(hdr, ~((int) markWord::inline_type_bit_in_place));
+  }
   lock();
   cmpxchgptr(tmp, Address(obj, oopDesc::mark_offset_in_bytes()));
   jcc(Assembler::notEqual, slow);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,9 +73,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
-compiler/valhalla/inlinetypes/TestIntrinsics.java 8323781 generic-all
-compiler/valhalla/inlinetypes/TestLWorld.java 8323781 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
[JDK-8315880](https://bugs.openjdk.org/browse/JDK-8315880) sets `LM_LIGHTWEIGHT` as new default locking mode which revealed an existing bug after the merge of jdk-22+16 (triggers already before the merge by explicitly setting `-XX:LockingMode=2`). JDK-8315880 was backed out again in jdk-22+24 ([JDK-8319253](https://bugs.openjdk.org/browse/JDK-8319253)). But the backout is not yet merged in. The REDO [JDK-8319251](https://bugs.openjdk.org/browse/JDK-8319251) is still open. Maybe we need to add some runs in the CI in the future which test all three locking modes.

This patch fixes a problem in the newly added lightweight locking code ([JDK-8291555](https://bugs.openjdk.org/browse/8291555)) where we forgot to mask the inline type bit in the mark word. This patch fixes that and unlists the problemlisted tests.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8323781](https://bugs.openjdk.org/browse/JDK-8323781): [lworld] Synchronization on inline type does not throw IllegalMonitorStateException with lightweight locking (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/972/head:pull/972` \
`$ git checkout pull/972`

Update a local copy of the PR: \
`$ git checkout pull/972` \
`$ git pull https://git.openjdk.org/valhalla.git pull/972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 972`

View PR using the GUI difftool: \
`$ git pr show -t 972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/972.diff">https://git.openjdk.org/valhalla/pull/972.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/972#issuecomment-1898074984)