### PR TITLE
8324864: [lworld] remove non-cyclic membership checks

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5326,11 +5326,6 @@ public class Attr extends JCTree.Visitor {
         try {
             annotate.flush();
             attribClass(c);
-            if (c.type.isValueClass()) {
-                final Env<AttrContext> env = typeEnvs.get(c);
-                if (env != null && env.tree != null && env.tree.hasTag(CLASSDEF))
-                    chk.checkNonCyclicMembership((JCClassDecl)env.tree);
-            }
         } catch (CompletionFailure ex) {
             chk.completionError(pos, ex);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2432,45 +2432,6 @@ public class Check {
         }
     }
 
-    // A primitive class cannot contain a field of its own type either or indirectly.
-    void checkNonCyclicMembership(JCClassDecl tree) {
-        if (allowValueClasses) {
-            Assert.check((tree.sym.flags_field & LOCKED) == 0);
-            try {
-                tree.sym.flags_field |= LOCKED;
-                for (List<? extends JCTree> l = tree.defs; l.nonEmpty(); l = l.tail) {
-                    if (l.head.hasTag(VARDEF)) {
-                        JCVariableDecl field = (JCVariableDecl) l.head;
-                        if (cyclePossible(field.sym)) {
-                            checkNonCyclicMembership((ClassSymbol) field.type.tsym, field.pos());
-                        }
-                    }
-                }
-            } finally {
-                tree.sym.flags_field &= ~LOCKED;
-            }
-        }
-    }
-    // where
-    private void checkNonCyclicMembership(ClassSymbol c, DiagnosticPosition pos) {
-        if ((c.flags_field & LOCKED) != 0) {
-            log.error(pos, Errors.CyclicPrimitiveClassMembership(c));
-            return;
-        }
-        try {
-            c.flags_field |= LOCKED;
-            for (Symbol fld : c.members().getSymbols(s -> s.kind == VAR && cyclePossible((VarSymbol) s), NON_RECURSIVE)) {
-                checkNonCyclicMembership((ClassSymbol) fld.type.tsym, pos);
-            }
-        } finally {
-            c.flags_field &= ~LOCKED;
-        }
-    }
-        // where
-        private boolean cyclePossible(VarSymbol symbol) {
-            return false; // (symbol.flags() & STATIC) == 0 && symbol.type.isValueClass() && symbol.type.hasImplicitConstructor() && symbol.type.isNonNullable();
-        }
-
     void checkNonCyclicDecl(JCClassDecl tree) {
         CycleChecker cc = new CycleChecker();
         cc.scan(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4053,10 +4053,6 @@ compiler.err.preview.without.source.or.release=\
 compiler.misc.feature.value.classes=\
     value classes
 
-# 0: symbol
-compiler.err.cyclic.primitive.class.membership=\
-    cyclic value class membership involving {0}
-
 compiler.err.this.exposed.prematurely=\
     value class instance should not be passed around before being fully initialized
 


### PR DESCRIPTION
dropping code that was checking for non-cyclic membership for value classes with implicit constructors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8324864](https://bugs.openjdk.org/browse/JDK-8324864): [lworld] remove non-cyclic membership checks (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/982/head:pull/982` \
`$ git checkout pull/982`

Update a local copy of the PR: \
`$ git checkout pull/982` \
`$ git pull https://git.openjdk.org/valhalla.git pull/982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 982`

View PR using the GUI difftool: \
`$ git pr show -t 982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/982.diff">https://git.openjdk.org/valhalla/pull/982.diff</a>

</details>
