### PR TITLE
8324980: [lworld] removing dead code plus gratuitous differences with jdk/master

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -67,7 +67,6 @@ public class MemberEnter extends JCTree.Visitor {
     private final Types types;
     private final Names names;
     private final DeferredLintHandler deferredLintHandler;
-    private final boolean allowValueClasses;
 
     public static MemberEnter instance(Context context) {
         MemberEnter instance = context.get(memberEnterKey);
@@ -89,8 +88,6 @@ public class MemberEnter extends JCTree.Visitor {
         source = Source.instance(context);
         names = Names.instance(context);
         deferredLintHandler = DeferredLintHandler.instance(context);
-        Source source = Source.instance(context);
-        allowValueClasses = Source.Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     /** Construct method type from method signature.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -106,7 +106,6 @@ public class Resolve {
     JCDiagnostic.Factory diags;
     public final boolean allowModules;
     public final boolean allowRecords;
-    public final boolean allowValueClasses;
     private final boolean compactMethodDiags;
     private final boolean allowLocalVariableTypeInference;
     private final boolean allowYieldStatement;
@@ -149,7 +148,6 @@ public class Resolve {
         allowModules = Feature.MODULES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         dumpMethodReferenceSearchResults = options.isSet("debug.dumpMethodReferenceSearchResults");
-        allowValueClasses = Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     /** error symbols, which are returned when resolution fails
@@ -471,10 +469,11 @@ public class Resolve {
     private boolean notOverriddenIn(Type site, Symbol sym) {
         if (sym.kind != MTH || sym.isConstructor() || sym.isStatic())
             return true;
-
-        Symbol s2 = ((MethodSymbol)sym).implementation(site.tsym, types, true);
-        return (s2 == null || s2 == sym || sym.owner == s2.owner || (sym.owner.isInterface() && s2.owner == syms.objectType.tsym) ||
-                !types.isSubSignature(types.memberType(site, s2), types.memberType(site, sym)));
+        else {
+            Symbol s2 = ((MethodSymbol)sym).implementation(site.tsym, types, true);
+            return (s2 == null || s2 == sym || sym.owner == s2.owner || (sym.owner.isInterface() && s2.owner == syms.objectType.tsym) ||
+                    !types.isSubSignature(types.memberType(site, s2), types.memberType(site, sym)));
+        }
     }
     //where
         /** Is given protected symbol accessible if it is selected from given site
@@ -4274,7 +4273,6 @@ public class Resolve {
             }
             boolean truncatedDiag = candidatesMap.size() != filteredCandidates.size();
             if (filteredCandidates.size() > 1) {
-                boolean isConstructor = names.isInit(name);
                 JCDiagnostic err = diags.create(dkind,
                         null,
                         truncatedDiag ?

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -141,8 +141,6 @@ public class ClassWriter extends ClassFile {
     /** The name table. */
     private final Names names;
 
-    private final Symtab syms;
-
     /** Access to files. */
     private final JavaFileManager fileManager;
 
@@ -177,7 +175,6 @@ public class ClassWriter extends ClassFile {
         check = Check.instance(context);
         fileManager = context.get(JavaFileManager.class);
         poolWriter = Gen.instance(context).poolWriter;
-        syms = Symtab.instance(context);
 
         verbose        = options.isSet(VERBOSE);
         genCrt         = options.isSet(XJCOV);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -2274,8 +2274,7 @@ public class Gen extends JCTree.Visitor {
         if (!tree.clazz.type.isPrimitive() &&
            !types.isSameType(tree.expr.type, tree.clazz.type) &&
            types.asSuper(tree.expr.type, tree.clazz.type.tsym) == null) {
-            checkDimension(tree.pos(), tree.clazz.type);
-            code.emitop2(checkcast, tree.clazz.type, PoolWriter::putClass);
+            code.emitop2(checkcast, checkDimension(tree.pos(), tree.clazz.type), PoolWriter::putClass);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4056,10 +4056,6 @@ compiler.misc.feature.value.classes=\
 compiler.err.this.exposed.prematurely=\
     value class instance should not be passed around before being fully initialized
 
-# 0: type
-compiler.err.generic.parameterization.with.primitive.class=\
-    Inferred type {0} involves generic parameterization by a primitive class
-
 # 0: type, 1: type
 compiler.err.value.type.has.identity.super.type=\
     The identity type {1} cannot be a supertype of the value type {0}

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -226,7 +226,3 @@ compiler.warn.proc.use.proc.or.implicit
 
 # Value Objects
 compiler.misc.feature.value.classes
-
-# Primitive Classes
-compiler.err.cyclic.primitive.class.membership
-compiler.err.generic.parameterization.with.primitive.class


### PR DESCRIPTION
removing differences originated from old, dead code, making preparations to simplify a future merge with jdk/master

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8324980](https://bugs.openjdk.org/browse/JDK-8324980): [lworld] removing dead code plus gratuitous differences with jdk/master (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/983/head:pull/983` \
`$ git checkout pull/983`

Update a local copy of the PR: \
`$ git checkout pull/983` \
`$ git pull https://git.openjdk.org/valhalla.git pull/983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 983`

View PR using the GUI difftool: \
`$ git pr show -t 983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/983.diff">https://git.openjdk.org/valhalla/pull/983.diff</a>

</details>
