### PR TITLE
8324117: [lworld] C1 hits "Can not patch access to flat field" assert after JDK-8320437

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1685,11 +1685,6 @@ void LIRGenerator::do_StoreField(StoreField* x) {
   }
 #endif
 
-  if (!inline_type_field_access_prolog(x)) {
-    // Field store will always deopt due to unloaded field or holder klass
-    return;
-  }
-
   if (x->needs_null_check() &&
       (needs_patching ||
        MacroAssembler::needs_explicit_null_check(x->offset()))) {
@@ -2076,30 +2071,6 @@ LIR_Opr LIRGenerator::access_atomic_add_at(DecoratorSet decorators, BasicType ty
   }
 }
 
-bool LIRGenerator::inline_type_field_access_prolog(AccessField* x) {
-  ciField* field = x->field();
-  assert(!field->is_flat(), "Flattened field access should have been expanded");
-  // Deoptimize if the access is non-static and requires patching (holder not loaded
-  // or not accessible) because then we only have partial field information and the
-  // field could be flat (see ciField constructor).
-  bool could_be_flat = field->type()->is_inlinetype() && InlineFieldMaxFlatSize >= 0 &&
-                       !x->is_static() && x->needs_patching();
-  // Deoptimize if we load from a static field with an uninitialized type because we
-  // need to throw an exception if initialization of the type failed.
-  // TODO 8325106 It seems that this fix for JDK-8273594 is not needed anymore or our tests don't trigger the issue anymore
-  bool not_initialized = false && x->is_static() && x->as_LoadField() != nullptr &&
-      !field->type()->as_instance_klass()->is_initialized();
-  if (could_be_flat || not_initialized) {
-    CodeEmitInfo* info = state_for(x, x->state_before());
-    CodeStub* stub = new DeoptimizeStub(new CodeEmitInfo(info),
-                                        Deoptimization::Reason_unloaded,
-                                        Deoptimization::Action_make_not_entrant);
-    __ jump(stub);
-    return false;
-  }
-  return true;
-}
-
 void LIRGenerator::do_LoadField(LoadField* x) {
   bool needs_patching = x->needs_patching();
   bool is_volatile = x->field()->is_volatile();
@@ -2128,13 +2099,6 @@ void LIRGenerator::do_LoadField(LoadField* x) {
                   x->is_static() ?  "static" : "field", x->printable_bci());
   }
 #endif
-
-  if (!inline_type_field_access_prolog(x)) {
-    // Field load will always deopt due to unloaded field or holder klass
-    LIR_Opr result = rlock_result(x, field_type);
-    __ move(LIR_OprFact::oopConst(nullptr), result);
-    return;
-  }
 
   bool stress_deopt = StressLoopInvariantCodeMotion && info && info->deoptimize_on_exception();
   if (x->needs_null_check() &&

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -276,7 +276,6 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_vectorizedMismatch(Intrinsic* x);
   void do_blackhole(Intrinsic* x);
 
-  bool inline_type_field_access_prolog(AccessField* x);
   void access_flat_array(bool is_load, LIRItem& array, LIRItem& index, LIRItem& obj_item, ciField* field = nullptr, int offset = 0);
   void access_sub_element(LIRItem& array, LIRItem& index, LIR_Opr& result, ciField* field, int sub_offset);
   LIR_Opr get_and_load_element_address(LIRItem& array, LIRItem& index);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1090,6 +1090,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
   BasicType patch_field_type = T_ILLEGAL;
   bool deoptimize_for_volatile = false;
   bool deoptimize_for_atomic = false;
+  bool deoptimize_for_flat = false;
   int patch_field_offset = -1;
   Klass* init_klass = nullptr; // klass needed by load_klass_patching code
   Klass* load_klass = nullptr; // klass needed by load_klass_patching code
@@ -1106,7 +1107,6 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
     constantPoolHandle constants(current, caller_method->constants());
     LinkResolver::resolve_field_access(result, constants, field_access.index(), caller_method, Bytecodes::java_code(code), CHECK);
     patch_field_offset = result.offset();
-    assert(!result.is_flat(), "Can not patch access to flat field");
 
     // If we're patching a field which is volatile then at compile it
     // must not have been know to be volatile, so the generated code
@@ -1133,6 +1133,11 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
 
     patch_field_type = result.field_type();
     deoptimize_for_atomic = (AlwaysAtomicAccesses && (patch_field_type == T_DOUBLE || patch_field_type == T_LONG));
+
+    // The field we are patching is flat. Deoptimize and regenerate
+    // the compiled code which can't handle the layout of the flat
+    // field because it was unknown at compile time.
+    deoptimize_for_flat = result.is_flat();
 
   } else if (load_klass_or_mirror_patch_id) {
     Klass* k = nullptr;
@@ -1219,7 +1224,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
     ShouldNotReachHere();
   }
 
-  if (deoptimize_for_volatile || deoptimize_for_atomic) {
+  if (deoptimize_for_volatile || deoptimize_for_atomic || deoptimize_for_flat) {
     // At compile time we assumed the field wasn't volatile/atomic but after
     // loading it turns out it was volatile/atomic so we have to throw the
     // compiled code out and let it be regenerated.
@@ -1229,6 +1234,9 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
       }
       if (deoptimize_for_atomic) {
         tty->print_cr("Deoptimizing for patching atomic field reference");
+      }
+      if (deoptimize_for_flat) {
+        tty->print_cr("Deoptimizing for patching flat field reference");
       }
     }
 


### PR DESCRIPTION
Current code assumes that even if the holder is not loaded, we always know at compile time if a field type is an inline type. That's not guaranteed after the removal of Q-types and as a result we hit an assert when trying to patch a flat field at runtime.

I don't remember why we had this complicated code before but we can simply deopt at runtime when we detect the flat field during patching. The code will then be re-compiled.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8324117](https://bugs.openjdk.org/browse/JDK-8324117): [lworld] C1 hits "Can not patch access to flat field" assert after JDK-8320437 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/994/head:pull/994` \
`$ git checkout pull/994`

Update a local copy of the PR: \
`$ git checkout pull/994` \
`$ git pull https://git.openjdk.org/valhalla.git pull/994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 994`

View PR using the GUI difftool: \
`$ git pr show -t 994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/994.diff">https://git.openjdk.org/valhalla/pull/994.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/994#issuecomment-1930188634)