### PR TITLE
8325343: [lworld] java/lang/reflect/Proxy/ClassRestrictions.java fails with NPE

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -875,7 +875,7 @@ public class Proxy implements java.io.Serializable {
                 type = Class.forName(c.getName(), false, ld);
             } catch (ClassNotFoundException e) {
             }
-            if (PrimitiveClass.asPrimaryType(type) != PrimitiveClass.asPrimaryType(c)) {
+            if (type == null || PrimitiveClass.asPrimaryType(type) != PrimitiveClass.asPrimaryType(c)) {
                 throw new IllegalArgumentException(c.getName() +
                         " referenced from a method is not visible from class loader: " + JLA.getLoaderNameID(ld));
             }


### PR DESCRIPTION
Trivial 1-line fix is to check if the type is found or not before calling `PrimitiveClass::asPrimaryType`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325343](https://bugs.openjdk.org/browse/JDK-8325343): [lworld] java/lang/reflect/Proxy/ClassRestrictions.java fails with NPE (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/996/head:pull/996` \
`$ git checkout pull/996`

Update a local copy of the PR: \
`$ git checkout pull/996` \
`$ git pull https://git.openjdk.org/valhalla.git pull/996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 996`

View PR using the GUI difftool: \
`$ git pr show -t 996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/996.diff">https://git.openjdk.org/valhalla/pull/996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/996#issuecomment-1930508698)