### PR TITLE
8325398: [lworld] C1 should not patch null restricted field stores

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -1056,4 +1056,28 @@ public class TestUnloadedInlineTypeField {
     public void test27_verifier() {
         Asserts.assertEQ(test27(), 0);
     }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class MyValue28 {
+        @NullRestricted
+        static MyValue28 field1;
+    }
+
+    // Test null store to null restricted field with unloaded holder
+    @Test
+    public static void test28() {
+        MyValue28.field1 = null;
+    }
+
+    @Run(test = "test28")
+    @Warmup(0) // Make sure that MyValue28 is not loaded
+    public void test28_verifier() {
+        try {
+            test28();
+            throw new RuntimeException("No exception thrown");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
 }


### PR DESCRIPTION
Follow-up from https://git.openjdk.org/valhalla/pull/994: We also need to deopt when patching a null-free field store because the compiled code is missing the null check.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325398](https://bugs.openjdk.org/browse/JDK-8325398): [lworld] C1 should not patch null restricted field stores (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/997/head:pull/997` \
`$ git checkout pull/997`

Update a local copy of the PR: \
`$ git checkout pull/997` \
`$ git pull https://git.openjdk.org/valhalla.git pull/997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 997`

View PR using the GUI difftool: \
`$ git pr show -t 997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/997.diff">https://git.openjdk.org/valhalla/pull/997.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/997#issuecomment-1931866760)