### PR TITLE
8298659: [lworld] ValueObject isSubstutitable comparison of float/double should use raw bits

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,8 +179,12 @@ public class ObjectMethods {
     private static boolean eq(char a, char b) { return a == b; }
     private static boolean eq(int a, int b) { return a == b; }
     private static boolean eq(long a, long b) { return a == b; }
-    private static boolean eq(float a, float b) { return Float.compare(a, b) == 0; }
-    private static boolean eq(double a, double b) { return Double.compare(a, b) == 0; }
+    private static boolean eq(float a, float b) {
+        return Float.floatToRawIntBits(a) == Float.floatToRawIntBits(b);
+    }
+    private static boolean eq(double a, double b) {
+        return Double.doubleToRawLongBits(a) == Double.doubleToRawLongBits(b);
+    }
     private static boolean eq(boolean a, boolean b) { return a == b; }
 
     /** Get the method handle for combining two values of a given type */

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -662,13 +662,9 @@ final class ValueObjectMethods {
      * <li>If {@code a} and {@code b} are both values of the same builtin primitive type,
      *     this method returns {@code a == b} with the following exception:
      *     <ul>
-     *     <li> If {@code a} and {@code b} both represent {@code NaN},
-     *          this method returns {@code true}, even though {@code NaN == NaN}
-     *          has the value {@code false}.
-     *     <li> If {@code a} is floating point positive zero while {@code b} is
-     *          floating point negative zero, or vice versa, this method
-     *          returns {@code false}, even though {@code +0.0 == -0.0} has
-     *          the value {@code true}.
+     *     <li> For primitive types {@code float} and {@code double} the
+     *          comparison uses the raw bits corresponding to {@link Float#floatToRawIntBits(float)}
+     *          and {@link Double#doubleToRawLongBits(double)} respectively.
      *     </ul>
      * <li>If {@code a} and {@code b} are both instances of the same reference type,
      *     this method returns {@code a == b}.
@@ -712,8 +708,8 @@ final class ValueObjectMethods {
      * @return {@code true} if the arguments are substitutable to each other;
      *         {@code false} otherwise.
      * @param <T> type
-     * @see Float#equals(Object)
-     * @see Double#equals(Object)
+     * @see Float#floatToRawIntBits(float)
+     * @see Double#doubleToRawLongBits(double)
      */
     private static <T> boolean isSubstitutable(T a, Object b) {
         if (VERBOSE) {
@@ -753,8 +749,8 @@ final class ValueObjectMethods {
      *     returns a method handle testing the two arguments are the same value,
      *     i.e. {@code a == b}.
      * <li>If {@code T} is {@code float} or {@code double}, this method
-     *     returns a method handle representing {@link Float#equals(Object)} or
-     *     {@link Double#equals(Object)} respectively.
+     *     returns a method handle representing {@link Float#floatToRawIntBits(float)} or
+     *     {@link Double#doubleToRawLongBits(double)} respectively.
      * <li>If {@code T} is a reference type that is not {@code Object} and not an
      *     interface, this method returns a method handle testing
      *     the two arguments are the same reference, i.e. {@code a == b}.

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,6 +91,32 @@ public class SubstitutabilityTest {
         }
     }
 
+    @ImplicitlyConstructible
+    static value class MyFloat {
+        public static float NaN1 = Float.intBitsToFloat(0x7ff00001);
+        public static float NaN2 = Float.intBitsToFloat(0x7ff00002);
+        float x;
+        MyFloat(float x) {
+            this.x = x;
+        }
+        public String toString() {
+            return Float.toString(x);
+        }
+    }
+
+    @ImplicitlyConstructible
+    static value class MyDouble {
+        public static double NaN1 = Double.longBitsToDouble(0x7ff0000000000001L);
+        public static double NaN2 = Double.longBitsToDouble(0x7ff0000000000002L);
+        double x;
+        MyDouble(double x) {
+            this.x = x;
+        }
+        public String toString() {
+            return Double.toString(x);
+        }
+    }
+
     static Stream<Arguments> substitutableCases() {
         Point p1 = new Point(10, 10);
         Point p2 = new Point(20, 20);
@@ -101,6 +127,10 @@ public class SubstitutabilityTest {
         MyValue2 value3 = new MyValue2(3);
         MyValue[] va = new MyValue[1];
         return Stream.of(
+                Arguments.of(new MyFloat(1.0f), new MyFloat(1.0f)),
+                Arguments.of(new MyDouble(1.0), new MyDouble(1.0)),
+                Arguments.of(new MyFloat(Float.NaN), new MyFloat(Float.NaN)),
+                Arguments.of(new MyDouble(Double.NaN), new MyDouble(Double.NaN)),
                 Arguments.of(p1, new Point(10, 10)),
                 Arguments.of(p2, new Point(20, 20)),
                 Arguments.of(l1, new Line(10,10, 20,20)),
@@ -121,6 +151,10 @@ public class SubstitutabilityTest {
         MyValue[] va = new MyValue[] { ValueClass.zeroInstance(MyValue.class) };
         Object[] oa = new Object[] { va };
         return Stream.of(
+                Arguments.of(new MyFloat(1.0f), new MyFloat(2.0f)),
+                Arguments.of(new MyDouble(1.0), new MyDouble(2.0)),
+                Arguments.of(new MyFloat(MyFloat.NaN1), new MyFloat(MyFloat.NaN2)),
+                Arguments.of(new MyDouble(MyDouble.NaN1), new MyDouble(MyDouble.NaN2)),
                 Arguments.of(new Point(10, 10), new Point(20, 20)),
                 /*
                  * Verify ValueObjectMethods::isSubstitutable that does not


### PR DESCRIPTION
Update the substitutability implementation to match the new JLS for JEP 401.
Float and double values should be compared for equality using the raw bits.