### PR TITLE
8325546: [lworld] Missing barrier in C1 compiled code on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -837,6 +837,10 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         f.load_argument(0, r1); // r1,: index
         int call_offset = __ call_RT(r0, noreg, CAST_FROM_FN_PTR(address, load_flat_array), r0, r1);
 
+        // Ensure the stores that initialize the buffer are visible
+        // before any subsequent store that publishes this reference.
+        __ membar(Assembler::StoreStore);
+
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_r0(sasm);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearingC1.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearingC1.java
@@ -34,6 +34,11 @@ package compiler.valhalla.inlinetypes;
  *                   --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED
  *                   --add-exports java.base/jdk.internal.value=ALL-UNNAMED
  *                   -XX:InlineFieldMaxFlatSize=-1 -XX:FlatArrayElementMaxSize=-1
+ *                   compiler.valhalla.inlinetypes.TestBufferTearingC1
+ * @run main/othervm -XX:+EnableValhalla
+ *                   --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+ *                   --add-exports java.base/jdk.internal.value=ALL-UNNAMED
+ *                   -XX:InlineFieldMaxFlatSize=-1 -XX:FlatArrayElementMaxSize=-1
  *                   -XX:TieredStopAtLevel=1
  *                   compiler.valhalla.inlinetypes.TestBufferTearingC1
  */


### PR DESCRIPTION
Similar to [JDK-8264414](https://bugs.openjdk.org/browse/JDK-8264414), a membar is required after loading from a flat array to prevent a store that publishes the buffer reference to be executed before the initializing stores have completed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325546](https://bugs.openjdk.org/browse/JDK-8325546): [lworld] Missing barrier in C1 compiled code on AArch64 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1002/head:pull/1002` \
`$ git checkout pull/1002`

Update a local copy of the PR: \
`$ git checkout pull/1002` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1002`

View PR using the GUI difftool: \
`$ git pr show -t 1002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1002.diff">https://git.openjdk.org/valhalla/pull/1002.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1002#issuecomment-1935682533)