### PR TITLE
8325560: [lworld] Aarch64 interpreter is missing a membar on flat array access

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -828,6 +828,9 @@ void TemplateTable::aaload()
     __ b(done);
     __ bind(is_flat_array);
     __ call_VM(r0, CAST_FROM_FN_PTR(address, InterpreterRuntime::value_array_load), r0, r1);
+    // Ensure the stores to copy the inline field contents are visible
+    // before any subsequent store that publishes this reference.
+    __ membar(Assembler::StoreStore);
     __ bind(done);
   } else {
     __ add(r1, r1, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);


### PR DESCRIPTION
Add missing membar in the aarch64 interpreter when reading a value from a flat array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325560](https://bugs.openjdk.org/browse/JDK-8325560): [lworld] Aarch64 interpreter is missing a membar on flat array access (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1004/head:pull/1004` \
`$ git checkout pull/1004`

Update a local copy of the PR: \
`$ git checkout pull/1004` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1004`

View PR using the GUI difftool: \
`$ git pr show -t 1004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1004.diff">https://git.openjdk.org/valhalla/pull/1004.diff</a>

</details>
