### PR TITLE
8325578: [lworld] removing references to primitive, vnew in javax.lang.model

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -139,12 +139,10 @@ public interface ExecutableElement extends Element, Parameterizable {
 
     /**
      * {@return the simple name of a constructor, method, or
-     * initializer}  For a constructor, the name {@code "<init>"} or
-     * initializer} For a constructor, the name {@code "<init>"} is
-     * returned, for a value class static factory method, the name
-     * {@code "<vnew>"} is returned, for a static initializer, the
-     * name {@code "<clinit>"} is returned, and for an anonymous class
-     * or instance initializer, an {@linkplain Name##empty_name empty name} is
+     * initializer}  For a constructor, the name {@code "<init>"} is
+     * returned, for a static initializer, the name {@code "<clinit>"}
+     * is returned, and for an anonymous class or instance
+     * initializer, an {@linkplain Name##empty_name empty name} is
      * returned.
      */
     @Override

--- a/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Modifier.java
@@ -60,7 +60,6 @@ public enum Modifier {
      * @since 1.8
      */
      DEFAULT,
-
     /** The modifier {@code static} */          STATIC,
 
     /**
@@ -78,12 +77,6 @@ public enum Modifier {
             return "non-sealed";
         }
     },
-
-    /**
-     * The modifier {@code primitive}
-     * @since 18
-     */
-    PRIMITIVE,
 
     /**
      * The modifier {@code value}


### PR DESCRIPTION
removing references to primitive and vnew

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325578](https://bugs.openjdk.org/browse/JDK-8325578): [lworld] removing references to primitive, vnew in javax.lang.model (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1005/head:pull/1005` \
`$ git checkout pull/1005`

Update a local copy of the PR: \
`$ git checkout pull/1005` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1005`

View PR using the GUI difftool: \
`$ git pr show -t 1005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1005.diff">https://git.openjdk.org/valhalla/pull/1005.diff</a>

</details>
