### PR TITLE
8317415: [lworld] Preload_attribute needs moving to jdk.internal.classfile.attribute

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -78,8 +78,6 @@ tools/javac/varargs/warning/Warn5.java                                          
 
 # javac Valhalla
 tools/javac/Diagnostics/8043251/T8043251.java                                   8301662    generic-all
-tools/javac/annotations/SyntheticParameters.java                                8317415    generic-all
-tools/javac/annotations/typeAnnotations/classfile/SyntheticParameters.java      8317415    generic-all
 
 tools/javac/valhalla/primitive-classes/ArrayCreationWithQuestion.java 8323785    generic-all
 tools/javac/valhalla/primitive-classes/BoxValCastTest.java            8323785    generic-all

--- a/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
+++ b/test/langtools/lib/annotations/annotations/classfile/ClassfileInspector.java
@@ -1211,11 +1211,6 @@ public class ClassfileInspector {
             }
             default -> {}
         }
-
-        @Override
-        public Void visitPreload(Preload_attribute attr, T p) {
-            return null;
-        }
     }
 
     private void paramMatcher(Attribute<?> attr, ExpectedParameterAnnotation expected) {


### PR DESCRIPTION
mostly a merge issue

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8317415](https://bugs.openjdk.org/browse/JDK-8317415): [lworld] Preload_attribute needs moving to jdk.internal.classfile.attribute (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1008/head:pull/1008` \
`$ git checkout pull/1008`

Update a local copy of the PR: \
`$ git checkout pull/1008` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1008`

View PR using the GUI difftool: \
`$ git pr show -t 1008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1008.diff">https://git.openjdk.org/valhalla/pull/1008.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1008#issuecomment-1947665264)