### PR TITLE
8326048: [lworld] LibraryCallKit::arraycopy_restore_alloc_state needs to handle _newNullRestrictedArray intrinsic

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -242,6 +242,7 @@ int InlineKlass::collect_fields(GrowableArray<SigEntry>* sig, int base_off) {
   for (JavaFieldStream fs(this); !fs.done(); fs.next()) {
     if (fs.access_flags().is_static()) continue;
     int offset = base_off + fs.offset() - (base_off > 0 ? first_field_offset() : 0);
+    // TODO 8284443 Use different heuristic to decide what should be scalarized in the calling convention
     if (fs.is_flat()) {
       // Resolve klass of flat field and recursively collect fields
       Klass* vk = get_inline_type_field_klass(fs.index());

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -1104,6 +1104,9 @@ public:
 // High-level array allocation
 //
 class AllocateArrayNode : public AllocateNode {
+private:
+  bool _null_free;
+
 public:
   AllocateArrayNode(Compile* C, const TypeFunc* atype, Node* ctrl, Node* mem, Node* abio, Node* size, Node* klass_node,
                     Node* initial_test, Node* count_val, Node* valid_length_test,
@@ -1116,7 +1119,9 @@ public:
     set_req(AllocateNode::ValidLengthTest, valid_length_test);
     init_req(AllocateNode::DefaultValue,  default_value);
     init_req(AllocateNode::RawDefaultValue, raw_default_value);
+    _null_free = false;
   }
+  virtual uint size_of() const { return sizeof(*this); }
   virtual int Opcode() const;
 
   // Dig the length operand out of a array allocation site.
@@ -1135,6 +1140,9 @@ public:
     return (allo == nullptr || !allo->is_AllocateArray())
            ? nullptr : allo->as_AllocateArray();
   }
+
+  void set_null_free() { _null_free = true; }
+  bool is_null_free() const { return _null_free; }
 };
 
 //------------------------------AbstractLockNode-----------------------------------

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -702,7 +702,7 @@ class GraphKit : public Phase {
 
   // Do a null check on the receiver as it would happen before the call to
   // callee (with all arguments still on the stack).
-  Node* null_check_receiver_before_call(ciMethod* callee, bool replace_value = true) {
+  Node* null_check_receiver_before_call(ciMethod* callee) {
     assert(!callee->is_static(), "must be a virtual method");
     // Callsite signature can be different from actual method being called (i.e _linkTo* sites).
     // Use callsite signature always.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4422,8 +4422,6 @@ Node* LibraryCallKit::generate_array_guard_common(Node* kls, RegionNode* region,
 //-----------------------inline_newNullRestrictedArray--------------------------
 // public static native Object[] newNullRestrictedArray(Class<?> componentType, int length);
 bool LibraryCallKit::inline_newNullRestrictedArray() {
-  // TODO 8325106
-  // Improve this and add required runtime checks
   Node* componentType = argument(0);
   Node* length = argument(1);
 
@@ -4438,6 +4436,8 @@ bool LibraryCallKit::inline_newNullRestrictedArray() {
         if (array_klass->is_loaded() && array_klass->element_klass()->as_inline_klass()->is_initialized()) {
           const TypeKlassPtr* array_klass_type = TypeKlassPtr::make(array_klass, Type::trust_interfaces);
           Node* obj = new_array(makecon(array_klass_type), length, 0);  // no arguments to push
+          AllocateArrayNode* alloc = AllocateArrayNode::Ideal_array_allocation(obj);
+          alloc->set_null_free();
           set_result(obj);
           return true;
         }
@@ -5577,12 +5577,6 @@ JVMState* LibraryCallKit::arraycopy_restore_alloc_state(AllocateArrayNode* alloc
       }
 
       if (no_interfering_store) {
-        // TODO 8325106
-        // TestArrays::test94 hits an assert because we create a wrong JVMState for before the newNullRestrictedArray intrinsic because above code does not account for the class argument on stack in addition to the size
-        // See https://github.com/openjdk/jdk/commit/5a478ef7759e64da6d17426673700ff0d9c66b33
-        // Check why this isn't optimized for Array.newInstance(MyValue.class, 10);
-        // Re-enable IR matching in TestArrays::test29 and TestNullableArrays::test29 and deopt checks in TestArrayCopyNoInitDeopt
-        return nullptr;
         SafePointNode* sfpt = create_safepoint_with_state_before_array_allocation(alloc);
 
         JVMState* saved_jvms = jvms();
@@ -5608,12 +5602,23 @@ SafePointNode* LibraryCallKit::create_safepoint_with_state_before_array_allocati
   for (uint i = 0; i < size; i++) {
     sfpt->init_req(i, alloc->in(i));
   }
+  int adjustment = 1;
+  if (alloc->is_null_free()) {
+    // A null-free, tightly coupled array allocation can only come from LibraryCallKit::inline_newNullRestrictedArray
+    // which requires both the component type and the array length on stack for re-execution. Re-create and push
+    // the component type.
+    ciArrayKlass* klass = alloc->in(AllocateNode::KlassNode)->bottom_type()->is_aryklassptr()->exact_klass()->as_array_klass();
+    ciInstance* instance = klass->component_mirror_instance();
+    const TypeInstPtr* t_instance = TypeInstPtr::make(instance);
+    sfpt->ins_req(old_jvms->stkoff() + old_jvms->sp(), makecon(t_instance));
+    adjustment++;
+  }
   // re-push array length for deoptimization
-  sfpt->ins_req(old_jvms->stkoff() + old_jvms->sp(), alloc->in(AllocateNode::ALength));
-  old_jvms->set_sp(old_jvms->sp()+1);
-  old_jvms->set_monoff(old_jvms->monoff()+1);
-  old_jvms->set_scloff(old_jvms->scloff()+1);
-  old_jvms->set_endoff(old_jvms->endoff()+1);
+  sfpt->ins_req(old_jvms->stkoff() + old_jvms->sp() + adjustment - 1, alloc->in(AllocateNode::ALength));
+  old_jvms->set_sp(old_jvms->sp() + adjustment);
+  old_jvms->set_monoff(old_jvms->monoff() + adjustment);
+  old_jvms->set_scloff(old_jvms->scloff() + adjustment);
+  old_jvms->set_endoff(old_jvms->endoff() + adjustment);
   old_jvms->set_should_reexecute(true);
 
   sfpt->set_i_o(map()->i_o());

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1214,7 +1214,7 @@ SafePointNode* Parse::create_entry_map() {
   // If this is an inlined method, we may have to do a receiver null check.
   if (_caller->has_method() && is_normal_parse() && !method()->is_static()) {
     GraphKit kit(_caller);
-    kit.null_check_receiver_before_call(method(), false);
+    kit.null_check_receiver_before_call(method());
     _caller = kit.transfer_exceptions_into_jvms();
     if (kit.stopped()) {
       _exits.add_exception_states_from(_caller);

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInitDeopt.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyNoInitDeopt.java
@@ -111,8 +111,7 @@ public class TestArrayCopyNoInitDeopt {
 
             // should deoptimize for type check
             if (!deoptimize(method_m1, src_obj)) {
-                // TODO 8325106 Currently disabled in LibraryCallKit::arraycopy_restore_alloc_state
-                // throw new RuntimeException("m1 not deoptimized");
+                throw new RuntimeException("m1 not deoptimized");
             }
 
             WHITE_BOX.enqueueMethodForCompilation(method_m1, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
@@ -142,8 +141,7 @@ public class TestArrayCopyNoInitDeopt {
 
                 // should deoptimize for speculative type check
                 if (!deoptimize(method_m2, src_obj)) {
-                    // TODO 8325106 Currently disabled in LibraryCallKit::arraycopy_restore_alloc_state
-                    // throw new RuntimeException("m2 not deoptimized");
+                    throw new RuntimeException("m2 not deoptimized");
                 }
 
                 WHITE_BOX.enqueueMethodForCompilation(method_m2, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
@@ -154,8 +152,7 @@ public class TestArrayCopyNoInitDeopt {
 
                 // should deoptimize for actual type check
                 if (!deoptimize(method_m2, src_obj)) {
-                    // TODO 8325106 Currently disabled in LibraryCallKit::arraycopy_restore_alloc_state
-                    // throw new RuntimeException("m2 not deoptimized");
+                    throw new RuntimeException("m2 not deoptimized");
                 }
 
                 WHITE_BOX.enqueueMethodForCompilation(method_m2, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -764,13 +764,10 @@ public class TestArrays {
     // TODO 8227588: shouldn't this have the same IR matching rules as test6?
     // @Test(failOn = ALLOC + ALLOCA + LOOP + LOAD + STORE + TRAP)
     @Test
-    // TODO 8325106 Currently disabled in LibraryCallKit::arraycopy_restore_alloc_state
-    /*
     @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
         failOn = {ALLOCA, LOOP, LOAD, TRAP})
     @IR(applyIf = {"FlatArrayElementMaxSize", "!= -1"},
         failOn = {ALLOCA, LOOP, TRAP})
-    */
     public MyValue2 test29(MyValue2[] src) {
         MyValue2[] dst = (MyValue2[])ValueClass.newNullRestrictedArray(MyValue2.class, 10);
         System.arraycopy(src, 0, dst, 0, 10);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1647,4 +1647,28 @@ public class TestIntrinsics {
     public void test82_verifier() {
         Asserts.assertTrue(test82(), "test82 failed");
     }
+
+    // Test that LibraryCallKit::arraycopy_move_allocation_here works as expected
+    @Test
+    public MyValue1 test83(Object[] src) {
+        MyValue1[] dst = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 10);
+        System.arraycopy(src, 0, dst, 0, 10);
+        return dst[0];
+    }
+
+    @Run(test = "test83")
+    public void test83_verifier(RunInfo info) {
+        if (info.isWarmUp()) {
+            MyValue1[] src = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 10);
+            Asserts.assertEQ(test83(src), src[0]);
+        } else {
+            // Trigger deoptimization to verify that re-execution works
+            try {
+                test83(new Integer[10]);
+                throw new RuntimeException("No NullPointerException thrown");
+            } catch (NullPointerException npe) {
+                // Expected
+            }
+        }
+    }
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableArrays.java
@@ -901,8 +901,7 @@ public class TestNullableArrays {
     // non escaping allocations
     // TODO 8227588: shouldn't this have the same IR matching rules as test6?
     @Test
-    // TODO 8325106 Currently disabled in LibraryCallKit::arraycopy_restore_alloc_state
-    //@IR(failOn = {ALLOCA, LOOP, TRAP})
+    @IR(failOn = {ALLOCA, LOOP, TRAP})
     public MyValue2 test29(MyValue2[] src) {
         MyValue2[] dst = new MyValue2[10];
         System.arraycopy(src, 0, dst, 0, 10);
@@ -2819,7 +2818,7 @@ public class TestNullableArrays {
         }
     }
 
-    // TODO 8325106 Fails with "matching stack sizes" in Scenario 5 with -XX:TypeProfileLevel=222
+    // TODO 8325632 Fails with "matching stack sizes" in Scenario 5 with -XX:TypeProfileLevel=222
     /*
     // Test that allocation is not replaced by non-dominating allocation
     @ForceInline

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2806,8 +2806,6 @@ public class TestNullableInlineTypes {
         }
     }
 
-    // TODO 8325106 fix assert in InlineTypeNode::merge_with
-/*
     // Same as test98 but with circularity in class of flattened field
     @Test
     public CircularValue2 test99(CircularValue2 val) {
@@ -2821,7 +2819,7 @@ public class TestNullableInlineTypes {
         CircularValue2 res = test99(val2);
         Asserts.assertEQ(res.val, val1);
     }
-*/
+
     @ImplicitlyConstructible
     @LooselyConsistentValue
     static value class CircularValue3 {


### PR DESCRIPTION
Follow-up from [JDK-8325106](https://bugs.openjdk.org/browse/JDK-8325106): We hit an assert because we create a wrong JVMState in `LibraryCallKit::arraycopy_restore_alloc_state` for re-executing the `newNullRestrictedArray` intrinsic because the code does not account for the class argument on stack in addition to the size.

I also fixed an independent issue with handling circularity.

Best regards,
Tobias