### PR TITLE
8323790: [lworld] TestSuperclass.java failed after merging jdk-22+16, due to flag bugs

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -206,7 +206,7 @@ public enum AccessFlag {
      * value of <code>{@value "0x%04x" Modifier#IDENTITY}</code>.
      * @jvms 4.1 -B. Class access and property modifiers
      */
-    IDENTITY(Modifier.IDENTITY, true,
+    IDENTITY(Modifier.IDENTITY, false,
             ValhallaFeatures.isEnabled() ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET,
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -429,7 +429,7 @@ public class Flags {
      */
     public static final int
         AccessFlags                       = PUBLIC | PROTECTED | PRIVATE,
-        LocalClassFlags                   = FINAL | ABSTRACT | STRICTFP | ENUM | SYNTHETIC | ACC_IDENTITY,
+        LocalClassFlags                   = FINAL | ABSTRACT | STRICTFP | ENUM | SYNTHETIC | IDENTITY_TYPE,
         StaticLocalClassFlags             = LocalClassFlags | STATIC | INTERFACE,
         MemberClassFlags                  = LocalClassFlags | INTERFACE | AccessFlags,
         MemberStaticClassFlags            = MemberClassFlags | STATIC,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -3160,12 +3160,12 @@ public class ClassReader {
             flags &= ~ACC_MODULE;
             flags |= MODULE;
         }
-        if ((flags & ACC_IDENTITY) != 0) {
-            flags &= ~ACC_IDENTITY;
+        if ((flags & ACC_IDENTITY) != 0 || (majorVersion <= V66.major && (flags & INTERFACE) == 0)) {
             flags |= IDENTITY_TYPE;
-        } else if ((flags & INTERFACE) == 0 && allowValueClasses) {
+        } else if ((flags & INTERFACE) == 0 && allowValueClasses && majorVersion > V66.major) {
             flags |= VALUE_CLASS;
         }
+        flags &= ~ACC_IDENTITY; // ACC_IDENTITY and SYNCHRONIZED bits overloaded
         return flags;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1601,9 +1601,11 @@ public class ClassWriter extends ClassFile {
         if (c.owner.kind == MDL) {
             flags = ACC_MODULE;
         } else {
+            long originalFlags = c.flags();
             flags = adjustFlags(c.flags() & ~(DEFAULT | STRICTFP));
             if ((flags & PROTECTED) != 0) flags |= PUBLIC;
             flags = flags & ClassFlags;
+            flags |= (originalFlags & IDENTITY_TYPE) != 0 ? ACC_IDENTITY : flags;
         }
 
         if (dumpClassModifiers) {

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -97,7 +97,6 @@ tools/javap/output/RepeatingTypeAnnotations.java                                
 
 # Valhalla
 tools/javap/8006334/JavapTaskCtorFailWithNPE.java                               8323789    generic-all
-tools/javap/TestSuperclass.java                                                 8323790    generic-all
 ###########################################################################
 #
 # jdeps

--- a/test/langtools/tools/javac/valhalla/primitive-classes/CheckThisLeak.java
+++ b/test/langtools/tools/javac/valhalla/primitive-classes/CheckThisLeak.java
@@ -3,6 +3,7 @@
  * @bug 8205910
  * @summary Complain when `this' of a value class is leaked from constructor before all instance fields are definitely assigned.
  * @compile/fail/ref=CheckThisLeak.out -XDrawDiagnostics -XDdev -XDenablePrimitiveClasses CheckThisLeak.java
+ * @ignore
  */
 
 value class V {

--- a/test/langtools/tools/javap/TestSuperclass.java
+++ b/test/langtools/tools/javap/TestSuperclass.java
@@ -158,7 +158,7 @@ public class TestSuperclass {
 
     class JavaSource extends SimpleJavaFileObject {
         static final String template =
-                  "identity #CK Test#GK #EK { }\n"
+                  "#CK Test#GK #EK { }\n"
                 + "#SK\n";
         final String source;
 


### PR DESCRIPTION
the merge uncovered bugs related to the handling of the IDENTITY flag

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8323790](https://bugs.openjdk.org/browse/JDK-8323790): [lworld] TestSuperclass.java failed after merging jdk-22+16, due to flag bugs (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1010/head:pull/1010` \
`$ git checkout pull/1010`

Update a local copy of the PR: \
`$ git checkout pull/1010` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1010`

View PR using the GUI difftool: \
`$ git pr show -t 1010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1010.diff">https://git.openjdk.org/valhalla/pull/1010.diff</a>

</details>
