### PR TITLE
[lworld] Disable IR rule for TestLWorld::test113_sharp

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3311,8 +3311,9 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(failOn = {ALLOC_G, MEMBAR},
-        counts = {PREDICATE_TRAP, "= 1"})
+    @IR(failOn = {ALLOC_G, MEMBAR})
+        // TODO 8326401
+        // counts = {PREDICATE_TRAP, "= 1"})
     public long test113_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {


### PR DESCRIPTION
Disable the IR rule due to [JDK-8326401](https://bugs.openjdk.org/browse/JDK-8326401).

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1013/head:pull/1013` \
`$ git checkout pull/1013`

Update a local copy of the PR: \
`$ git checkout pull/1013` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1013`

View PR using the GUI difftool: \
`$ git pr show -t 1013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1013.diff">https://git.openjdk.org/valhalla/pull/1013.diff</a>

</details>
