### PR TITLE
8326839: [lworld] Aarch64 interpreter still prevents new bytecode to be used with value classes

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3874,7 +3874,6 @@ void TemplateTable::_new() {
   __ get_unsigned_2_byte_index_at_bcp(r3, 1);
   Label slow_case;
   Label done;
-  Label is_not_value;
   Label initialize_header;
 
   __ get_cpool_and_tags(r4, r0);
@@ -3890,14 +3889,6 @@ void TemplateTable::_new() {
 
   // get InstanceKlass
   __ load_resolved_klass_at_offset(r4, r3, r4, rscratch1);
-
-  __ ldrb(rscratch1, Address(r4, InstanceKlass::kind_offset()));
-  __ cmp(rscratch1, (u1)Klass::InlineKlassKind);
-  __ br(Assembler::NE, is_not_value);
-
-  __ call_VM(noreg, CAST_FROM_FN_PTR(address, InterpreterRuntime::throw_InstantiationError));
-
-  __ bind(is_not_value);
 
   // make sure klass is initialized & doesn't have finalizer
   // make sure klass is fully initialized

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypeCreation.java
@@ -46,6 +46,7 @@ public class InlineTypeCreation {
         testLong8();
         testPerson();
         StaticSelf.test();
+        testUnresolvedAndResolvedNew();
     }
 
     void testPoint() {
@@ -91,4 +92,19 @@ public class InlineTypeCreation {
         }
 
     }
+
+    static value class MyPoint {
+         int x,y;
+         MyPoint(int x, int y) {
+             this.x = x;
+             this.y = y;
+         }
+     }
+
+    // Two instantiations of the same class to exercise both the unresolved and resolved paths
+    // in bytecode 'new' implementation
+    void testUnresolvedAndResolvedNew(){
+         MyPoint p1 = new MyPoint(10, 20);
+         MyPoint p2 = new MyPoint(20, 20);
+     }
 }


### PR DESCRIPTION
Small fix on aarch64 template interpreter: bytecode `new` was still rejecting value classes but this behavior is now allowed by JEP 401. The issue occurred only when `new` operates on a resolved constant pool entry.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326839](https://bugs.openjdk.org/browse/JDK-8326839): [lworld] Aarch64 interpreter still prevents new bytecode to be used with value classes (**Bug** - P2)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1021/head:pull/1021` \
`$ git checkout pull/1021`

Update a local copy of the PR: \
`$ git checkout pull/1021` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1021`

View PR using the GUI difftool: \
`$ git pr show -t 1021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1021.diff">https://git.openjdk.org/valhalla/pull/1021.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1021#issuecomment-1966821576)