### PR TITLE
8326862: [lworld] javac is rejecting value records

### DIFF
--- a/src/java.base/share/classes/java/lang/Record.java
+++ b/src/java.base/share/classes/java/lang/Record.java
@@ -87,6 +87,7 @@ package java.lang;
  * @jls 8.10 Record Types
  * @since 16
  */
+@jdk.internal.ValueBased
 public abstract class Record {
     /**
      * Constructor for record classes to call.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2675,7 +2675,7 @@ public class Check {
         Type identitySuper = null, valueSuper = null;
         for (Type t : types.closure(c)) {
             if (t != c) {
-                if ((t.tsym.flags() & IDENTITY_TYPE) != 0)
+                if ((t.tsym.flags() & IDENTITY_TYPE) != 0 && (t.tsym.flags() & VALUE_BASED) == 0)
                     identitySuper = t;
                 else if ((t.tsym.flags() & VALUE_CLASS) != 0)
                     valueSuper = t;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -138,6 +138,10 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     static abstract value class V extends ConcreteSuperType {}  // Error: concrete super.
                 }
                 """);
+        assertOK(
+                """
+                value record Point(int x, int y) {}
+                """);
     }
 
     @Test


### PR DESCRIPTION
code like:
```
value record Point(int x, int y) {}
```

is being rejected by javac. `java.lang.Record` should be considered a value class.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326862](https://bugs.openjdk.org/browse/JDK-8326862): [lworld] javac is rejecting value records (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1022/head:pull/1022` \
`$ git checkout pull/1022`

Update a local copy of the PR: \
`$ git checkout pull/1022` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1022`

View PR using the GUI difftool: \
`$ git pr show -t 1022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1022.diff">https://git.openjdk.org/valhalla/pull/1022.diff</a>

</details>
