### PR TITLE
8326867: [lworld] remove Q-descriptor support from jdk.experimental.bytecode test library

### DIFF
--- a/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/OldInstructionHelper.java
+++ b/test/jdk/java/lang/invoke/common/test/java/lang/invoke/lib/OldInstructionHelper.java
@@ -47,8 +47,6 @@ import java.util.function.Function;
 import static java.lang.invoke.MethodType.fromMethodDescriptorString;
 import static java.lang.invoke.MethodType.methodType;
 
-import jdk.internal.value.PrimitiveClass;
-
 /**
  * 8308778: Temporarily keep the old bytecode API, but needs removing when Valhalla support is added to classfile API
  */
@@ -292,19 +290,12 @@ public class OldInstructionHelper {
             }
 
             @Override
-            public boolean isInlineClass(String desc) {
-                Class<?> aClass = symbol(desc);
-                return aClass != null && PrimitiveClass.isPrimitiveValueType(aClass);
-            }
-
-            @Override
             public Class<?> symbol(String desc) {
                 try {
                     if (desc.startsWith("[")) {
                         return Class.forName(desc.replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
                     } else {
-                        Class<?> c = Class.forName(basicTypeHelper.symbol(desc).replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
-                        return basicTypeHelper.isInlineClass(desc) ? PrimitiveClass.asValueType(c) : PrimitiveClass.asPrimaryType(c);
+                        return Class.forName(basicTypeHelper.symbol(desc).replaceAll("/", "."), true, lookup.lookupClass().getClassLoader());
                     }
                 } catch (ReflectiveOperationException ex) {
                     throw new AssertionError(ex);

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/BasicTypeHelper.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/BasicTypeHelper.java
@@ -46,26 +46,16 @@ public class BasicTypeHelper implements TypeHelper<String, String> {
     }
 
     @Override
-    public boolean isInlineClass(String t) {
-        return t.charAt(0) == 'Q' && t.endsWith(";");
-    }
-
-    @Override
     public String type(String s) {
         return "L" + s + ";";
     }
 
-    @Override
-    public String valueType(String s) {
-        return "Q" + s + ";";
-    }
 
     @Override
     public TypeTag tag(String s) {
         switch (s.charAt(0)) {
             case '[':
             case 'L':
-            case 'Q':
                 return TypeTag.A;
             case 'B':
             case 'C':
@@ -154,7 +144,6 @@ public class BasicTypeHelper implements TypeHelper<String, String> {
                         ch++;
                         return "[" + next();
                     case 'L':
-                    case 'Q':
                         StringBuilder builder = new StringBuilder();
                         while (curr != ';') {
                             builder.append(curr);

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/CodeBuilder.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/CodeBuilder.java
@@ -173,24 +173,21 @@ public class CodeBuilder<S, T, E, C extends CodeBuilder<S, T, E, C>> extends Att
 
     public C anewarray(S array) {
         emitOp(Opcode.ANEWARRAY, array);
-        int poolIdx = (typeHelper.isInlineClass(typeHelper.type(array))) ?
-            poolHelper.putInlineClass(array) : poolHelper.putClass(array);
+        int poolIdx = poolHelper.putClass(array);
         code.writeChar(poolIdx);
         return thisBuilder();
     }
 
     public C checkcast(S target) {
         emitOp(Opcode.CHECKCAST);
-        int poolIdx = (typeHelper.isInlineClass(typeHelper.type(target))) ?
-            poolHelper.putInlineClass(target) : poolHelper.putClass(target);
+        int poolIdx = poolHelper.putClass(target);
         code.writeChar(poolIdx);
         return thisBuilder();
     }
 
     public C instanceof_(S target) {
         emitOp(Opcode.INSTANCEOF);
-        int poolIdx = (typeHelper.isInlineClass(typeHelper.type(target))) ?
-            poolHelper.putInlineClass(target) : poolHelper.putClass(target);
+        int poolIdx = poolHelper.putClass(target);
         code.writeChar(poolIdx);
         return thisBuilder();
     }
@@ -1162,8 +1159,7 @@ public class CodeBuilder<S, T, E, C extends CodeBuilder<S, T, E, C>> extends Att
                     } else {
                         //TODO: uninit this, top?
                         stackmaps.writeByte(7);
-                        stackmaps.writeChar(typeHelper.isInlineClass(t) ?
-                            poolHelper.putInlineClass(typeHelper.symbol(t)) : poolHelper.putClass(typeHelper.symbol(t)));
+                        stackmaps.writeChar(poolHelper.putClass(typeHelper.symbol(t)));
                     }
                     break;
                 default:

--- a/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/TypeHelper.java
+++ b/test/jdk/lib/testlibrary/bytecode/jdk/experimental/bytecode/TypeHelper.java
@@ -84,24 +84,6 @@ public interface TypeHelper<S, T> {
     T type(S s);
 
     /**
-     * Return true if the parameter is a value type.
-     *
-     * @param t the type descreiptor
-     * @return true if the given type is a value type
-     */
-    boolean isInlineClass(T t);
-
-    /**
-     * For a symbol that corresponds to a value type, return the type descriptor.
-     *
-     * @param s the symbol
-     * @return the type descriptor
-     */
-    default T valueType(S s) {
-        return type(s);
-    }
-
-    /**
      * Return the symbol corresponding to a type descriptor.
      *
      * @param type the type descriptor


### PR DESCRIPTION
VM valhalla tests are using `jdk.experimental.bytecode` test library. These tests should be converted to use the new ClassFile API.

This PR removes Q-descriptor support from `jdk.experimental.bytecode` test library as an interim fix.  The test library is not updated to support JEP 401 properly and instead JDK-8308778  will ClassFile API to support Valhalla. 

With this patch, 31 `hotspot_valhalla_runtime` tests pass when running with -Xint.  2 test failures remain to be investigated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326867](https://bugs.openjdk.org/browse/JDK-8326867): [lworld] remove Q-descriptor support from jdk.experimental.bytecode test library (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1023/head:pull/1023` \
`$ git checkout pull/1023`

Update a local copy of the PR: \
`$ git checkout pull/1023` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1023`

View PR using the GUI difftool: \
`$ git pr show -t 1023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1023.diff">https://git.openjdk.org/valhalla/pull/1023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1023#issuecomment-1967494720)