### PR TITLE
8326707: [lworld] Remove VALUE modifier from Modifier and AccessFlag

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -664,7 +664,6 @@ public final class Class<T> implements java.io.Serializable,
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public boolean isValue() {
         if (isPrimitive() || isArray() || isInterface()) return false;
-
         return (this.getModifiers() & Modifier.IDENTITY) == 0;
     }
 

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -654,17 +654,18 @@ public final class Class<T> implements java.io.Serializable,
 
     /**
      * {@return {@code true} if this {@code Class} object represents a value
-     * class or interface; otherwise {@code false}}
+     * class; otherwise {@code false}}
      *
-     * If this {@code Class} object represents an array type, a primitive type, or
-     * {@code void}, then this method returns {@code false}.
+     * If this {@code Class} object represents an array type, an interface,
+     * a primitive type, or {@code void}, then this method returns {@code false}.
      *
      * @since Valhalla
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public boolean isValue() {
-        if (isPrimitive() || isArray() || isInterface()) return false;
-        return (this.getModifiers() & Modifier.IDENTITY) == 0;
+         if (isPrimitive() | isArray() | isInterface())
+             return false;
+        return ((getModifiers() & Modifier.IDENTITY) == 0);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/AbstractValidatingLambdaMetafactory.java
@@ -199,13 +199,6 @@ import static sun.invoke.util.Wrapper.isWrapperType;
                     interfaceClass.getName()));
         }
 
-        if (interfaceClass.isIdentity() || interfaceClass.isValue()) {
-            throw new LambdaConversionException(String.format(
-                    "%s is %s interface",
-                    interfaceClass.getName(),
-                    interfaceClass.isIdentity() ? "an identity" : "a value"));
-        }
-
         for (Class<?> c : altInterfaces) {
             if (!c.isInterface()) {
                 throw new LambdaConversionException(String.format(

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -265,14 +265,6 @@ public enum AccessFlag {
                  }),
 
     /**
-     * The access flag {@code ACC_VALUE}, corresponding to the
-     * source modifier {@link Modifier#VALUE value}, with a mask
-     * value of <code>{@value "0x%04x" Modifier#VALUE}</code>.
-     * @jvms 4.1 -B. Class access and property modifiers
-     */
-    VALUE(Modifier.VALUE, true, Set.of(Location.CLASS, Location.INNER_CLASS), null),
-
-    /**
      * The access flag {@code ACC_VOLATILE}, corresponding to the
      * source modifier {@link Modifier#VOLATILE volatile}, with a mask
      * value of <code>{@value "0x%04x" Modifier#VOLATILE}</code>.
@@ -702,7 +694,7 @@ public enum AccessFlag {
     private static class LocationToFlags {
         private static Map<Location, Set<AccessFlag>> locationToFlags =
             Map.ofEntries(entry(Location.CLASS,
-                                Set.of(PUBLIC, FINAL, IDENTITY, VALUE,
+                                Set.of(PUBLIC, FINAL, IDENTITY,
                                        INTERFACE, ABSTRACT,
                                        SYNTHETIC, ANNOTATION,
                                        ENUM, AccessFlag.MODULE)),
@@ -716,7 +708,7 @@ public enum AccessFlag {
                                        BRIDGE, VARARGS, NATIVE,
                                        ABSTRACT, STRICT, SYNTHETIC)),
                           entry(Location.INNER_CLASS,
-                                Set.of(PUBLIC, PRIVATE, PROTECTED, IDENTITY, VALUE,
+                                Set.of(PUBLIC, PRIVATE, PROTECTED, IDENTITY,
                                        STATIC, FINAL, INTERFACE, ABSTRACT,
                                        SYNTHETIC, ANNOTATION, ENUM)),
                           entry(Location.METHOD_PARAMETER,

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,18 +156,18 @@ public class Modifier {
     }
 
     /**
-     * Return {@code true} if the integer argument includes the
-     * {@code value} modifier, {@code false} otherwise.
+     * Return {@code true} if the integer argument does not include the
+     * {@code identity} modifier, {@code false} otherwise.
      *
      * @apiNote {@code isValue} should only be called with the modifiers
      * of a {@linkplain Class#getModifiers() class}.
      *
      * @param   mod a set of modifiers
-     * @return {@code true} if {@code mod} includes the
-     * {@code value} modifier; {@code false} otherwise.
+     * @return {@code true} if {@code mod} does not include the
+     * {@code identity} modifier; {@code false} otherwise.
      */
     public static boolean isValue(int mod) {
-        return (mod & IDENTITY) == 0;
+        return !isIdentity(mod);
     }
 
     /**
@@ -334,13 +334,6 @@ public class Modifier {
      * modifier.
      */
     public static final int IDENTITY         = 0x00000020;
-
-    /**
-     * The {@code int} value representing the {@code value}
-     * modifier.
-     * @see AccessFlag#VALUE
-     */
-   public static final int VALUE            = 0x00000040;
 
     /**
      * The {@code int} value representing the {@code volatile}

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -113,7 +113,7 @@ public class ObjectMethods {
 
     static Stream<Arguments> identitiesData() {
         return Stream.of(
-                Arguments.of(new Object(), false, false),
+                Arguments.of(new Object(), true, false),
                 Arguments.of("String", true, false),
                 Arguments.of(String.class, true, false),
                 Arguments.of(Object.class, true, false),


### PR DESCRIPTION
Remove the VALUE modifier in Modifier.java and AccessFlag.java.
Update Class.isValue() to be false for primitive, array, and interface classes and otherwise be ~ACC_IDENTITY in the modifiers.