### PR TITLE
8326879: [lworld] IncompatibleClassChangeError on `value record` extending java.lang.Record

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/YearMonth.java \
     java/time/Year.java \
     java/time/Period.java \
+    java/lang/Record.java \
     #
 
 java.base-VALUE-CLASS-FILES := \
@@ -53,7 +54,8 @@ $(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUECLASS_REPLACEMENTS, \
     SOURCE_BASE_DIR := $(TOPDIR)/src/java.base/share/classes, \
     OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/gensrc-valueclasses/java.base/, \
     REPLACEMENTS := \
-        public final class => public final value class, \
+        public final class => public final value class ; \
+        public abstract class => public abstract value class, \
 ))
 
 TARGETS += $(JAVA_BASE_VALUECLASS_REPLACEMENTS)

--- a/test/jdk/java/io/Serializable/records/BasicRecordSer.java
+++ b/test/jdk/java/io/Serializable/records/BasicRecordSer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,10 @@
 
 /*
  * @test
- * @bug 8246774
+ * @bug 8246774 8326879
  * @summary Basic test that serializes and deserializes a number of records
  * @run testng BasicRecordSer
+ * @run testng/othervm -XX:+EnableValhalla BasicRecordSer
  * @run testng/othervm/java.security.policy=empty_security.policy BasicRecordSer
  */
 

--- a/test/jdk/java/io/Serializable/records/RecordClassTest.java
+++ b/test/jdk/java/io/Serializable/records/RecordClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,10 @@
 
 /*
  * @test
- * @bug 8246774
+ * @bug 8246774 8326879
  * @summary Basic tests for serializing and deserializing record classes
  * @run testng RecordClassTest
+ * @run testng/othervm -XX:+EnableValhalla RecordClassTest
  * @run testng/othervm/java.security.policy=empty_security.policy RecordClassTest
  */
 

--- a/test/jdk/java/lang/reflect/records/IsRecordTest.java
+++ b/test/jdk/java/lang/reflect/records/IsRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,12 @@
 
 /*
  * @test
- * @bug 8255560
+ * @bug 8255560 8326879
  * @summary Class::isRecord should check that the current class is final and not abstract
  * @modules java.base/jdk.internal.org.objectweb.asm
  * @library /test/lib
  * @run testng/othervm IsRecordTest
+ * @run testng/othervm -XX:+EnableValhalla IsRecordTest
  * @run testng/othervm/java.security.policy=allPermissions.policy IsRecordTest
  */
 

--- a/test/jdk/java/lang/reflect/records/RecordReflectionTest.java
+++ b/test/jdk/java/lang/reflect/records/RecordReflectionTest.java
@@ -23,10 +23,11 @@
 
 /*
  * @test
- * @bug 8235369 8235550 8247444
+ * @bug 8235369 8235550 8247444 8326879
  * @summary reflection test for records
  * @compile RecordReflectionTest.java
  * @run testng/othervm RecordReflectionTest
+ * @run testng/othervm -XX:+EnableValhalla RecordReflectionTest
  * @run testng/othervm/java.security.policy=allPermissions.policy RecordReflectionTest
  */
 

--- a/test/jdk/valhalla/valuetypes/UseValueClassTest.java
+++ b/test/jdk/valhalla/valuetypes/UseValueClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,7 @@ public class UseValueClassTest {
                 Year.class,
                 YearMonth.class,
                 ZonedDateTime.class,
+                Record.class,
         };
         return Arrays.stream(classes, 0, classes.length);
     }


### PR DESCRIPTION
"value records" implicitly extend the abstract class java.lang.Record.
Class loading throws IncompatibleClassChangeError if java.lang.Record is not marked as "abstract value class".

The tests affected are:

valhalla/valuetypes/ObjectMethods.java: test Object methods on value classes
valhalla/valuetypes/ObjectMethodsViaCondy.java: Test ObjectMethods::bootstrap call via condy 

The solution is to add java.lang.Record to the set of classes that are modified for --enable-preview to be `value` classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326879](https://bugs.openjdk.org/browse/JDK-8326879): [lworld] IncompatibleClassChangeError on `value record` extending java.lang.Record (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1027/head:pull/1027` \
`$ git checkout pull/1027`

Update a local copy of the PR: \
`$ git checkout pull/1027` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1027`

View PR using the GUI difftool: \
`$ git pr show -t 1027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1027.diff">https://git.openjdk.org/valhalla/pull/1027.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1027#issuecomment-1969608823)