### PR TITLE
8327080: [lworld] Update Valhalla micros to JEP 401

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -779,10 +779,10 @@ ifeq ($(BUILD_JTREG_TEST_THREAD_FACTORY), true)
   ))
 endif
 
-# $(eval $(call SetupTarget, build-microbenchmark, \
-#     MAKEFILE := test/BuildMicrobenchmark, \
-#     DEPS := interim-langtools exploded-image, \
-# ))
+$(eval $(call SetupTarget, build-microbenchmark, \
+    MAKEFILE := test/BuildMicrobenchmark, \
+    DEPS := interim-langtools exploded-image, \
+))
 
 ################################################################################
 # Run tests
@@ -1280,9 +1280,9 @@ ifeq ($(BUILD_JTREG_TEST_THREAD_FACTORY), true)
   test-image: test-image-test-thread-factory
 endif
 
-# ifneq ($(JMH_CORE_JAR), )
-#   test-image: build-microbenchmark
-# endif
+ifneq ($(JMH_CORE_JAR), )
+  test-image: build-microbenchmark
+endif
 
 ################################################################################
 

--- a/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class Inline64byte extends AckermannBase {
                 + ack_value(new Q64byte(X3), new Q64byte(Y3)).longValue();
     }
 
-    private static Q64byte.ref ack_ref(Q64byte.ref x, Q64byte.ref y) {
+    private static Q64byte ack_ref(Q64byte x, Q64byte y) {
         return x.longValue() == 0 ?
                 new Q64byte(y.longValue() + 1) :
                 (y.longValue() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class Inline64int extends AckermannBase {
                 + ack_value(new Q64int(X3), new Q64int(Y3)).longValue();
     }
 
-    private static Q64int.ref ack_ref(Q64int.ref x, Q64int.ref y) {
+    private static Q64int ack_ref(Q64int x, Q64int y) {
         return x.longValue() == 0 ?
                 new Q64int(y.longValue() + 1) :
                 (y.longValue() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/ackermann/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class Inline64long extends AckermannBase {
                 + ack_value(new Q64long(X3), new Q64long(Y3)).longValue();
     }
 
-    private static Q64long.ref ack_ref(Q64long.ref x, Q64long.ref y) {
+    private static Q64long ack_ref(Q64long x, Q64long y) {
         return x.longValue() == 0 ?
                 new Q64long(y.longValue() + 1) :
                 (y.longValue() == 0 ?

--- a/test/micro/org/openjdk/bench/valhalla/acmp/array/InlineIsCmpBranch64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/acmp/array/InlineIsCmpBranch64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class InlineIsCmpBranch64byte extends StatesQ64byte {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int cmp_Ref(Q64byte.ref[] objects1, Q64byte.ref[] objects2) {
+    private static int cmp_Ref(Q64byte[] objects1, Q64byte[] objects2) {
         int s = 0;
         for (int i = 0; i < SIZE; i++) {
             if (objects1[i] == objects2[i]) {

--- a/test/micro/org/openjdk/bench/valhalla/acmp/array/InlineIsCmpBranch64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/acmp/array/InlineIsCmpBranch64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class InlineIsCmpBranch64long extends StatesQ64long {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    private static int cmp_Ref(Q64long.ref[] objects1, Q64long.ref[] objects2) {
+    private static int cmp_Ref(Q64long[] objects1, Q64long[] objects2) {
         int s = 0;
         for (int i = 0; i < SIZE; i++) {
             if (objects1[i] == objects2[i]) {

--- a/test/micro/org/openjdk/bench/valhalla/acmp/array/StatesQ64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/acmp/array/StatesQ64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class StatesQ64byte {
 
     @State(Scope.Thread)
     public abstract static class RefState {
-        Q64byte.ref[] arr1, arr2;
+        Q64byte[] arr1, arr2;
     }
 
     @State(Scope.Thread)
@@ -171,8 +171,8 @@ public class StatesQ64byte {
     public static class RefState00 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64byte.ref[SIZE];
-            arr2 = new Q64byte.ref[SIZE];
+            arr1 = new Q64byte[SIZE];
+            arr2 = new Q64byte[SIZE];
             populate(arr1, arr2, 0);
         }
     }
@@ -180,8 +180,8 @@ public class StatesQ64byte {
     public static class RefState25 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64byte.ref[SIZE];
-            arr2 = new Q64byte.ref[SIZE];
+            arr1 = new Q64byte[SIZE];
+            arr2 = new Q64byte[SIZE];
             populate(arr1, arr2, 25);
         }
     }
@@ -189,8 +189,8 @@ public class StatesQ64byte {
     public static class RefState50 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64byte.ref[SIZE];
-            arr2 = new Q64byte.ref[SIZE];
+            arr1 = new Q64byte[SIZE];
+            arr2 = new Q64byte[SIZE];
             populate(arr1, arr2, 50);
         }
     }
@@ -198,8 +198,8 @@ public class StatesQ64byte {
     public static class RefState75 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64byte.ref[SIZE];
-            arr2 = new Q64byte.ref[SIZE];
+            arr1 = new Q64byte[SIZE];
+            arr2 = new Q64byte[SIZE];
             populate(arr1, arr2, 75);
         }
     }
@@ -207,8 +207,8 @@ public class StatesQ64byte {
     public static class RefState100 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64byte.ref[SIZE];
-            arr2 = new Q64byte.ref[SIZE];
+            arr1 = new Q64byte[SIZE];
+            arr2 = new Q64byte[SIZE];
             populate(arr1, arr2, 100);
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/acmp/array/StatesQ64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/acmp/array/StatesQ64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class StatesQ64long {
 
     @State(Scope.Thread)
     public abstract static class RefState {
-        Q64long.ref[] arr1, arr2;
+        Q64long[] arr1, arr2;
     }
 
     @State(Scope.Thread)
@@ -171,8 +171,8 @@ public class StatesQ64long {
     public static class RefState00 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64long.ref[SIZE];
-            arr2 = new Q64long.ref[SIZE];
+            arr1 = new Q64long[SIZE];
+            arr2 = new Q64long[SIZE];
             populate(arr1, arr2, 0);
         }
     }
@@ -180,8 +180,8 @@ public class StatesQ64long {
     public static class RefState25 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64long.ref[SIZE];
-            arr2 = new Q64long.ref[SIZE];
+            arr1 = new Q64long[SIZE];
+            arr2 = new Q64long[SIZE];
             populate(arr1, arr2, 25);
         }
     }
@@ -189,8 +189,8 @@ public class StatesQ64long {
     public static class RefState50 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64long.ref[SIZE];
-            arr2 = new Q64long.ref[SIZE];
+            arr1 = new Q64long[SIZE];
+            arr2 = new Q64long[SIZE];
             populate(arr1, arr2, 50);
         }
     }
@@ -198,8 +198,8 @@ public class StatesQ64long {
     public static class RefState75 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64long.ref[SIZE];
-            arr2 = new Q64long.ref[SIZE];
+            arr1 = new Q64long[SIZE];
+            arr2 = new Q64long[SIZE];
             populate(arr1, arr2, 75);
         }
     }
@@ -207,8 +207,8 @@ public class StatesQ64long {
     public static class RefState100 extends RefState {
         @Setup
         public void setup() {
-            arr1 = new Q64long.ref[SIZE];
-            arr2 = new Q64long.ref[SIZE];
+            arr1 = new Q64long[SIZE];
+            arr2 = new Q64long[SIZE];
             populate(arr1, arr2, 100);
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/acmp/field/StatesQ64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/acmp/field/StatesQ64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,9 +118,9 @@ public class StatesQ64long {
     }
 
     public static class RefWrapper {
-        public Q64long.ref f;
+        public Q64long f;
 
-        public RefWrapper(Q64long.ref f) {
+        public RefWrapper(Q64long f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q128int.ref[] src = s.arr;
+        Q128int[] src = s.arr;
         Q128int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -65,7 +65,7 @@ public class Inline128int extends StatesQ128int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         Q128int[] src = s.arr;
-        Q128int.ref[] dst = d.arr;
+        Q128int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q32int.ref[] src = s.arr;
+        Q32int[] src = s.arr;
         Q32int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -65,7 +65,7 @@ public class Inline32int extends StatesQ32int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         Q32int[] src = s.arr;
-        Q32int.ref[] dst = d.arr;
+        Q32int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q64byte.ref[] src = s.arr;
+        Q64byte[] src = s.arr;
         Q64byte[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -65,7 +65,7 @@ public class Inline64byte extends StatesQ64byte {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         Q64byte[] src = s.arr;
-        Q64byte.ref[] dst = d.arr;
+        Q64byte[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q64int.ref[] src = s.arr;
+        Q64int[] src = s.arr;
         Q64int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -65,7 +65,7 @@ public class Inline64int extends StatesQ64int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         Q64int[] src = s.arr;
-        Q64int.ref[] dst = d.arr;
+        Q64int[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/copy/InlineOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/copy/InlineOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        QOpt.ref<Int32>[] src = s.arr;
+        QOpt<Int32>[] src = s.arr;
         QOpt<Int32>[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -66,7 +66,7 @@ public class InlineOpt extends StatesQOpt {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         QOpt<Int32>[] src = s.arr;
-        QOpt.ref<Int32>[] dst = d.arr;
+        QOpt<Int32>[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Identity32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Identity32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class Identity32int extends StatesR32int {
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
         R32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = R32int.default;
+            arr[i] = new R32int();
         }
     }
 
@@ -82,7 +82,7 @@ public class Identity32int extends StatesR32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, R32int.default);
+        Arrays.fill(st.arr, new R32int()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/IdentityOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/IdentityOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class IdentityOpt extends StatesROpt {
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
         ROpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = ROpt<Int32>.default;
+            arr[i] = ROpt.of();
         }
     }
 
@@ -84,7 +84,7 @@ public class IdentityOpt extends StatesROpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, ROpt<Int32>.default);
+        Arrays.fill(st.arr, ROpt.of()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class Inline128int extends StatesQ128int {
 
     public static class RefStaticField {
-        static Q128int.ref f = new Q128int(42);
+        static Q128int f = new Q128int(42);
     }
 
     public static class ValStaticField {
@@ -43,7 +43,7 @@ public class Inline128int extends StatesQ128int {
 
     @State(Scope.Thread)
     public static class RefInstanceField {
-        Q128int.ref f = new Q128int(42);
+        Q128int f = new Q128int(42);
     }
 
     @State(Scope.Thread)
@@ -56,7 +56,7 @@ public class Inline128int extends StatesQ128int {
     public void Def_to_Val_as_Val_fill(Val_as_Val st) {
         Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q128int.default;
+            arr[i] = new Q128int();
         }
     }
 
@@ -109,16 +109,16 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q128int.default;
+            arr[i] = new Q128int();
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         Q128int v = new Q128int(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -128,7 +128,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = RefStaticField.f;
         }
@@ -137,7 +137,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = ValStaticField.f;
         }
@@ -146,7 +146,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst(Ref_as_Ref st, RefInstanceField f) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -155,7 +155,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst(Ref_as_Ref st, ValInstanceField f) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -164,7 +164,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, Q128int.default);
+        Arrays.fill(st.arr, new Q128int()  );
     }
 
     @Benchmark
@@ -200,7 +200,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, Q128int.default);
+        Arrays.fill(st.arr, new Q128int()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class Inline32int extends StatesQ32int {
 
     public static class RefStaticField {
-        static Q32int.ref f = new Q32int(42);
+        static Q32int f = new Q32int(42);
     }
 
     public static class ValStaticField {
@@ -43,7 +43,7 @@ public class Inline32int extends StatesQ32int {
 
     @State(Scope.Thread)
     public static class RefInstanceField {
-        Q32int.ref f = new Q32int(42);
+        Q32int f = new Q32int(42);
     }
 
     @State(Scope.Thread)
@@ -56,7 +56,7 @@ public class Inline32int extends StatesQ32int {
     public void Def_to_Val_as_Val_fill(Val_as_Val st) {
         Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q32int.default;
+            arr[i] = new Q32int();
         }
     }
 
@@ -109,16 +109,16 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q32int.default;
+            arr[i] = new Q32int()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         Q32int v = new Q32int(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -128,7 +128,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = RefStaticField.f;
         }
@@ -137,7 +137,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = ValStaticField.f;
         }
@@ -146,7 +146,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst(Ref_as_Ref st, RefInstanceField f) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -155,7 +155,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst(Ref_as_Ref st, ValInstanceField f) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -164,7 +164,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, Q32int.default);
+        Arrays.fill(st.arr, new Q32int()  );
     }
 
     @Benchmark
@@ -200,7 +200,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, Q32int.default);
+        Arrays.fill(st.arr, new Q32int()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class Inline64byte extends StatesQ64byte {
 
     public static class RefStaticField {
-        static Q64byte.ref f = new Q64byte(42);
+        static Q64byte f = new Q64byte(42);
     }
 
     public static class ValStaticField {
@@ -43,7 +43,7 @@ public class Inline64byte extends StatesQ64byte {
 
     @State(Scope.Thread)
     public static class RefInstanceField {
-        Q64byte.ref f = new Q64byte(42);
+        Q64byte f = new Q64byte(42);
     }
 
     @State(Scope.Thread)
@@ -56,7 +56,7 @@ public class Inline64byte extends StatesQ64byte {
     public void Def_to_Val_as_Val_fill(Val_as_Val st) {
         Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64byte.default;
+            arr[i] = new Q64byte()  ;
         }
     }
 
@@ -109,16 +109,16 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64byte.default;
+            arr[i] = new Q64byte()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         Q64byte v = new Q64byte(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -128,7 +128,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = RefStaticField.f;
         }
@@ -137,7 +137,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = ValStaticField.f;
         }
@@ -146,7 +146,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst(Ref_as_Ref st, RefInstanceField f) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -155,7 +155,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst(Ref_as_Ref st, ValInstanceField f) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -164,7 +164,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, Q64byte.default);
+        Arrays.fill(st.arr, new Q64byte()  );
     }
 
     @Benchmark
@@ -200,7 +200,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, Q64byte.default);
+        Arrays.fill(st.arr, new Q64byte()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class Inline64int extends StatesQ64int {
 
     public static class RefStaticField {
-        static Q64int.ref f = new Q64int(42);
+        static Q64int f = new Q64int(42);
     }
 
     public static class ValStaticField {
@@ -43,7 +43,7 @@ public class Inline64int extends StatesQ64int {
 
     @State(Scope.Thread)
     public static class RefInstanceField {
-        Q64int.ref f = new Q64int(42);
+        Q64int f = new Q64int(42);
     }
 
     @State(Scope.Thread)
@@ -56,7 +56,7 @@ public class Inline64int extends StatesQ64int {
     public void Def_to_Val_as_Val_fill(Val_as_Val st) {
         Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64int.default;
+            arr[i] = new Q64int()  ;
         }
     }
 
@@ -109,16 +109,16 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64int.default;
+            arr[i] = new Q64int()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         Q64int v = new Q64int(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -128,7 +128,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = RefStaticField.f;
         }
@@ -137,7 +137,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = ValStaticField.f;
         }
@@ -146,7 +146,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst(Ref_as_Ref st, RefInstanceField f) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -155,7 +155,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst(Ref_as_Ref st, ValInstanceField f) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -164,7 +164,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, Q64int.default);
+        Arrays.fill(st.arr, new Q64int()  );
     }
 
     @Benchmark
@@ -200,7 +200,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, Q64int.default);
+        Arrays.fill(st.arr, new Q64int()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/fill/InlineOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/fill/InlineOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.util.Arrays;
 public class InlineOpt extends StatesQOpt {
 
     public static class RefStaticField {
-        static QOpt.ref<Int32> f = QOpt.of(new R32int(42));
+        static QOpt<Int32> f = QOpt.of(new R32int(42));
     }
 
     public static class ValStaticField {
@@ -45,7 +45,7 @@ public class InlineOpt extends StatesQOpt {
 
     @State(Scope.Thread)
     public static class RefInstanceField {
-        QOpt.ref<Int32> f = QOpt.of(new R32int(42));
+        QOpt<Int32> f = QOpt.of(new R32int(42));
     }
 
     @State(Scope.Thread)
@@ -58,7 +58,7 @@ public class InlineOpt extends StatesQOpt {
     public void Def_to_Val_as_Val_fill(Val_as_Val st) {
         QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = QOpt<Int32>.default;
+            arr[i] = QOpt.of();
         }
     }
 
@@ -111,16 +111,16 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = QOpt<Int32>.default;
+            arr[i] = QOpt.of();
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill(Ref_as_Ref st) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         QOpt<Int32> v = QOpt.of(new R32int(42));
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -130,7 +130,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = RefStaticField.f;
         }
@@ -139,7 +139,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat(Ref_as_Ref st) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = ValStaticField.f;
         }
@@ -148,7 +148,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst(Ref_as_Ref st, RefInstanceField f) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -157,7 +157,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst(Ref_as_Ref st, ValInstanceField f) {
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -166,7 +166,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, QOpt<Int32>.default);
+        Arrays.fill(st.arr, QOpt.of() );
     }
 
     @Benchmark
@@ -202,7 +202,7 @@ public class InlineOpt extends StatesQOpt {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, QOpt<Int32>.default);
+        Arrays.fill(st.arr, QOpt.of()  );
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline128int extends StatesQ128int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q128int.ref v) {
+    public void ref_consume(Q128int v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
@@ -72,7 +72,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -81,7 +81,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Ref_read(Val_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -90,7 +90,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Int_read(Val_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline32int extends StatesQ32int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q32int.ref v) {
+    public void ref_consume(Q32int v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
@@ -72,7 +72,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -81,7 +81,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Ref_read(Val_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -90,7 +90,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Int_read(Val_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline64byte extends StatesQ64byte {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64byte.ref v) {
+    public void ref_consume(Q64byte v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
@@ -72,7 +72,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -81,7 +81,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Ref_read(Val_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -90,7 +90,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Int_read(Val_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/read/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/read/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline64int extends StatesQ64int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64int.ref v) {
+    public void ref_consume(Q64int v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
@@ -72,7 +72,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -81,7 +81,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Ref_read(Val_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -90,7 +90,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Int_read(Val_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,14 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q128int(i);
         }
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q128int.ref getRef(int i) {
+    public static Q128int getRef(int i) {
         return new Q128int(i);
     }
 
@@ -69,7 +69,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getRef(i);
         }
@@ -87,7 +87,7 @@ public class Inline128int extends StatesQ128int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getVal(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,14 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q32int(i);
         }
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q32int.ref getRef(int i) {
+    public static Q32int getRef(int i) {
         return new Q32int(i);
     }
 
@@ -69,7 +69,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getRef(i);
         }
@@ -87,7 +87,7 @@ public class Inline32int extends StatesQ32int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getVal(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,14 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q64byte(i);
         }
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64byte.ref getRef(int i) {
+    public static Q64byte getRef(int i) {
         return new Q64byte(i);
     }
 
@@ -69,7 +69,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getRef(i);
         }
@@ -87,7 +87,7 @@ public class Inline64byte extends StatesQ64byte {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getVal(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/set/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/set/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,14 +41,14 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q64int(i);
         }
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64int.ref getRef(int i) {
+    public static Q64int getRef(int i) {
         return new Q64int(i);
     }
 
@@ -69,7 +69,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getRef(i);
         }
@@ -87,7 +87,7 @@ public class Inline64int extends StatesQ64int {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_set(Ref_as_Ref st) {
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = getVal(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/sum/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/sum/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class Inline128int extends StatesQ128int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_fields(Val_as_Ref st) {
         int s = 0;
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0.v0;
             s += arr[i].v0.v1.v0;
@@ -62,7 +62,7 @@ public class Inline128int extends StatesQ128int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_fields(Ref_as_Ref st) {
         int s = 0;
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0.v0;
             s += arr[i].v0.v1.v0;
@@ -87,7 +87,7 @@ public class Inline128int extends StatesQ128int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_sum(Val_as_Ref st) {
         int s = 0;
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }
@@ -98,7 +98,7 @@ public class Inline128int extends StatesQ128int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_sum(Ref_as_Ref st) {
         int s = 0;
-        Q128int.ref[] arr = st.arr;
+        Q128int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/sum/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/sum/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class Inline32int extends StatesQ32int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_fields(Val_as_Ref st) {
         int s = 0;
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0;
         }
@@ -56,7 +56,7 @@ public class Inline32int extends StatesQ32int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_fields(Ref_as_Ref st) {
         int s = 0;
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0;
         }
@@ -78,7 +78,7 @@ public class Inline32int extends StatesQ32int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_sum(Val_as_Ref st) {
         int s = 0;
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }
@@ -89,7 +89,7 @@ public class Inline32int extends StatesQ32int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_sum(Ref_as_Ref st) {
         int s = 0;
-        Q32int.ref[] arr = st.arr;
+        Q32int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/sum/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/sum/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class Inline64byte extends StatesQ64byte {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte Val_as_Ref_fields(Val_as_Ref st) {
         byte s = 0;
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0;
             s += arr[i].v0.v1;
@@ -70,7 +70,7 @@ public class Inline64byte extends StatesQ64byte {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte Ref_as_Ref_fields(Ref_as_Ref st) {
         byte s = 0;
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0;
             s += arr[i].v0.v1;
@@ -99,7 +99,7 @@ public class Inline64byte extends StatesQ64byte {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte Val_as_Ref_sum(Val_as_Ref st) {
         byte s = 0;
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].byteSum();
         }
@@ -110,7 +110,7 @@ public class Inline64byte extends StatesQ64byte {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte Ref_as_Ref_sum(Ref_as_Ref st) {
         byte s = 0;
-        Q64byte.ref[] arr = st.arr;
+        Q64byte[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].byteSum();
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/sum/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/sum/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class Inline64int extends StatesQ64int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_fields(Val_as_Ref st) {
         int s = 0;
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0;
             s += arr[i].v1.v0;
@@ -58,7 +58,7 @@ public class Inline64int extends StatesQ64int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_fields(Ref_as_Ref st) {
         int s = 0;
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0.v0;
             s += arr[i].v1.v0;
@@ -81,7 +81,7 @@ public class Inline64int extends StatesQ64int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_sum(Val_as_Ref st) {
         int s = 0;
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }
@@ -92,7 +92,7 @@ public class Inline64int extends StatesQ64int {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_sum(Ref_as_Ref st) {
         int s = 0;
-        Q64int.ref[] arr = st.arr;
+        Q64int[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].intSum();
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/sum/InlineOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/sum/InlineOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class InlineOpt extends StatesQOpt {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_fields(Val_as_Ref st) {
         int s = 0;
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].value.intValue();
         }
@@ -57,7 +57,7 @@ public class InlineOpt extends StatesQOpt {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_fields(Ref_as_Ref st) {
         int s = 0;
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].value.intValue();
         }
@@ -79,7 +79,7 @@ public class InlineOpt extends StatesQOpt {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_sum(Val_as_Ref st) {
         int s = 0;
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].get().intValue();
         }
@@ -90,7 +90,7 @@ public class InlineOpt extends StatesQOpt {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_sum(Ref_as_Ref st) {
         int s = 0;
-        QOpt.ref<Int32>[] arr = st.arr;
+        QOpt<Int32>[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].get().intValue();
         }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class StatesQ128byte extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q128byte.ref[] arr;
+        public Q128byte[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q128byte(i);
@@ -86,7 +86,7 @@ public class StatesQ128byte extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q128byte.ref[size];
+            arr = new Q128byte[size];
             fill();
         }
     }
@@ -110,7 +110,7 @@ public class StatesQ128byte extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q128byte.ref[size];
+            arr = new Q128byte[size];
             fill();
         }
     }
@@ -126,7 +126,7 @@ public class StatesQ128byte extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q128byte.ref[size];
+            arr = new Q128byte[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class StatesQ128int extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q128int.ref[] arr;
+        public Q128int[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q128int(i);
@@ -87,7 +87,7 @@ public class StatesQ128int extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q128int.ref[size];
+            arr = new Q128int[size];
             fill();
         }
     }
@@ -111,7 +111,7 @@ public class StatesQ128int extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q128int.ref[size];
+            arr = new Q128int[size];
             fill();
         }
     }
@@ -127,7 +127,7 @@ public class StatesQ128int extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q128int.ref[size];
+            arr = new Q128int[size];
             fill();
         }
     }
@@ -168,7 +168,7 @@ public class StatesQ128int extends SizeBase {
     public static class Ref_as_By extends StatesQ32int.ByState {
         @Setup
         public void setup() {
-            arr = new Q128int.ref[size];
+            arr = new Q128int[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128long.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ128long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class StatesQ128long extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q128long.ref[] arr;
+        public Q128long[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q128long(i);
@@ -86,7 +86,7 @@ public class StatesQ128long extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q128long.ref[size];
+            arr = new Q128long[size];
             fill();
         }
     }
@@ -110,7 +110,7 @@ public class StatesQ128long extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q128long.ref[size];
+            arr = new Q128long[size];
             fill();
         }
     }
@@ -126,7 +126,7 @@ public class StatesQ128long extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q128long.ref[size];
+            arr = new Q128long[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class StatesQ32int extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q32int.ref[] arr;
+        public Q32int[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q32int(i);
@@ -87,7 +87,7 @@ public class StatesQ32int extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q32int.ref[size];
+            arr = new Q32int[size];
             fill();
         }
     }
@@ -111,7 +111,7 @@ public class StatesQ32int extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q32int.ref[size];
+            arr = new Q32int[size];
             fill();
         }
     }
@@ -127,7 +127,7 @@ public class StatesQ32int extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q32int.ref[size];
+            arr = new Q32int[size];
             fill();
         }
     }
@@ -168,7 +168,7 @@ public class StatesQ32int extends SizeBase {
     public static class Ref_as_By extends ByState {
         @Setup
         public void setup() {
-            arr = new Q32int.ref[size];
+            arr = new Q32int[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class StatesQ64byte extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q64byte.ref[] arr;
+        public Q64byte[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q64byte(i);
@@ -87,7 +87,7 @@ public class StatesQ64byte extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q64byte.ref[size];
+            arr = new Q64byte[size];
             fill();
         }
     }
@@ -111,7 +111,7 @@ public class StatesQ64byte extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q64byte.ref[size];
+            arr = new Q64byte[size];
             fill();
         }
     }
@@ -127,7 +127,7 @@ public class StatesQ64byte extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q64byte.ref[size];
+            arr = new Q64byte[size];
             fill();
         }
     }
@@ -168,7 +168,7 @@ public class StatesQ64byte extends SizeBase {
     public static class Ref_as_By extends ByState {
         @Setup
         public void setup() {
-            arr = new Q64byte.ref[size];
+            arr = new Q64byte[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQ64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class StatesQ64int extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q64int.ref[] arr;
+        public Q64int[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q64int(i);
@@ -87,7 +87,7 @@ public class StatesQ64int extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q64int.ref[size];
+            arr = new Q64int[size];
             fill();
         }
     }
@@ -111,7 +111,7 @@ public class StatesQ64int extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q64int.ref[size];
+            arr = new Q64int[size];
             fill();
         }
     }
@@ -127,7 +127,7 @@ public class StatesQ64int extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q64int.ref[size];
+            arr = new Q64int[size];
             fill();
         }
     }
@@ -168,7 +168,7 @@ public class StatesQ64int extends SizeBase {
     public static class Ref_as_By extends StatesQ32int.ByState {
         @Setup
         public void setup() {
-            arr = new Q64int.ref[size];
+            arr = new Q64int[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/array/util/StatesQOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/array/util/StatesQOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class StatesQOpt extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public QOpt.ref<Int32>[] arr;
+        public QOpt<Int32>[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] =  QOpt.of(new R32int(i));
@@ -88,7 +88,7 @@ public class StatesQOpt extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new QOpt.ref[size];
+            arr = new QOpt[size];
             fill();
         }
     }
@@ -112,7 +112,7 @@ public class StatesQOpt extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new QOpt.ref[size];
+            arr = new QOpt[size];
             fill();
         }
     }
@@ -128,7 +128,7 @@ public class StatesQOpt extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new QOpt.ref[size];
+            arr = new QOpt[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy0.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Obj_to_Ref_copy(Obj_as_Obj s, Ref_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -114,7 +114,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Obj_to_Ref_copy(Obj_as_Obj s, Val_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -204,7 +204,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Obj_to_Ref_copy(Int_as_Obj s, Ref_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -214,7 +214,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Obj_to_Ref_copy(Int_as_Obj s, Val_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -304,7 +304,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Obj_to_Ref_copy(Ref_as_Obj s, Ref_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -314,7 +314,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Obj_to_Ref_copy(Ref_as_Obj s, Val_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -404,7 +404,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Obj_to_Ref_copy(Val_as_Obj s, Ref_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -414,7 +414,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Obj_to_Ref_copy(Val_as_Obj s, Val_as_Ref d) {
         Object[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -504,7 +504,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Int_to_Ref_copy(Int_as_Int s, Ref_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -514,7 +514,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Int_to_Ref_copy(Int_as_Int s, Val_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -604,7 +604,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Int_to_Ref_copy(Ref_as_Int s, Ref_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -614,7 +614,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Int_to_Ref_copy(Ref_as_Int s, Val_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -704,7 +704,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Int_to_Ref_copy(Val_as_Int s, Ref_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -714,7 +714,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Int_to_Ref_copy(Val_as_Int s, Val_as_Ref d) {
         Int64[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = (Q64long)src[i];
         }
@@ -733,7 +733,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Obj_as_Ref_to_Obj_copy(Ref_as_Ref s, Obj_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -743,7 +743,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Ref_to_Obj_copy(Ref_as_Ref s, Int_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -753,7 +753,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Obj_copy(Ref_as_Ref s, Ref_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -763,7 +763,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Obj_copy(Ref_as_Ref s, Val_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -773,7 +773,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Ref_to_Int_copy(Ref_as_Ref s, Int_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -783,7 +783,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Int_copy(Ref_as_Ref s, Ref_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -793,7 +793,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Int_copy(Ref_as_Ref s, Val_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -803,8 +803,8 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Ref_copy(Ref_as_Ref s, Ref_as_Ref d) {
-        Q64long.ref[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] src = s.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }
@@ -813,8 +813,8 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Ref_copy(Ref_as_Ref s, Val_as_Ref d) {
-        Q64long.ref[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] src = s.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }
@@ -823,7 +823,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -833,7 +833,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Obj_as_Ref_to_Obj_copy(Val_as_Ref s, Obj_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -843,7 +843,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Int_as_Ref_to_Obj_copy(Val_as_Ref s, Int_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -853,7 +853,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Obj_copy(Val_as_Ref s, Ref_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -863,7 +863,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Obj_copy(Val_as_Ref s, Val_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Object[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -873,7 +873,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Int_as_Ref_to_Int_copy(Val_as_Ref s, Int_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -883,7 +883,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Int_copy(Val_as_Ref s, Ref_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -893,7 +893,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Int_copy(Val_as_Ref s, Val_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Int64[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -903,8 +903,8 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Ref_copy(Val_as_Ref s, Ref_as_Ref d) {
-        Q64long.ref[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] src = s.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }
@@ -913,8 +913,8 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Ref_copy(Val_as_Ref s, Val_as_Ref d) {
-        Q64long.ref[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] src = s.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }
@@ -923,7 +923,7 @@ public class InlineCopy0 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
@@ -1004,7 +1004,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         Q64long[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }
@@ -1014,7 +1014,7 @@ public class InlineCopy0 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Val_to_Ref_copy(Val_as_Val s, Val_as_Ref d) {
         Q64long[] src = s.arr;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
             dst[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy1.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -663,7 +663,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Obj_as_Ref_to_Obj_copy(Ref_as_Ref s, Obj_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -672,7 +672,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Ref_to_Obj_copy(Ref_as_Ref s, Int_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -681,7 +681,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Obj_copy(Ref_as_Ref s, Ref_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -690,7 +690,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Obj_copy(Ref_as_Ref s, Val_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -699,7 +699,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Ref_to_Int_copy(Ref_as_Ref s, Int_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -708,7 +708,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Int_copy(Ref_as_Ref s, Ref_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -717,7 +717,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Int_copy(Ref_as_Ref s, Val_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -726,7 +726,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Ref_copy(Ref_as_Ref s, Ref_as_Ref d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -735,7 +735,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Ref_copy(Ref_as_Ref s, Val_as_Ref d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -744,7 +744,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Val_copy(Ref_as_Ref s, Val_as_Val d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -753,7 +753,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Obj_as_Ref_to_Obj_copy(Val_as_Ref s, Obj_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -762,7 +762,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Int_as_Ref_to_Obj_copy(Val_as_Ref s, Int_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -771,7 +771,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Obj_copy(Val_as_Ref s, Ref_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -780,7 +780,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Obj_copy(Val_as_Ref s, Val_as_Obj d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -789,7 +789,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Int_as_Ref_to_Int_copy(Val_as_Ref s, Int_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -798,7 +798,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Int_copy(Val_as_Ref s, Ref_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -807,7 +807,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Int_copy(Val_as_Ref s, Val_as_Int d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -816,7 +816,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Ref_copy(Val_as_Ref s, Ref_as_Ref d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -825,7 +825,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Ref_copy(Val_as_Ref s, Val_as_Ref d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }
@@ -834,7 +834,7 @@ public class InlineCopy1 extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Val_copy(Val_as_Ref s, Val_as_Val d) {
-        Q64long.ref[] src = s.arr;
+        Q64long[] src = s.arr;
         for (int i = 0; i < src.length; i++) {
             d.arr[i] = src[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy2.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/copy/InlineCopy2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Obj_to_Ref_copy(Obj_as_Obj s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -115,7 +115,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Obj_to_Ref_copy(Obj_as_Obj s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -205,7 +205,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Obj_to_Ref_copy(Int_as_Obj s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -215,7 +215,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Obj_to_Ref_copy(Int_as_Obj s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -305,7 +305,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Obj_to_Ref_copy(Ref_as_Obj s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -315,7 +315,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Obj_to_Ref_copy(Ref_as_Obj s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -405,7 +405,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Obj_to_Ref_copy(Val_as_Obj s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -415,7 +415,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Obj_to_Ref_copy(Val_as_Obj s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -505,7 +505,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Int_to_Ref_copy(Int_as_Int s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -515,7 +515,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Int_to_Ref_copy(Int_as_Int s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -605,7 +605,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Int_to_Ref_copy(Ref_as_Int s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -615,7 +615,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Int_to_Ref_copy(Ref_as_Int s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -705,7 +705,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Int_to_Ref_copy(Val_as_Int s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -715,7 +715,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Int_to_Ref_copy(Val_as_Int s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = (Q64long)s.arr[i];
         }
@@ -805,7 +805,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_to_Ref_copy(Ref_as_Ref s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }
@@ -815,7 +815,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_to_Ref_copy(Ref_as_Ref s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }
@@ -905,7 +905,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_to_Ref_copy(Val_as_Ref s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }
@@ -915,7 +915,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_to_Ref_copy(Val_as_Ref s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }
@@ -1005,7 +1005,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Val_to_Ref_copy(Val_as_Val s, Ref_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }
@@ -1015,7 +1015,7 @@ public class InlineCopy2 extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Val_to_Ref_copy(Val_as_Val s, Val_as_Ref d) {
         int len = s.arr.length;
-        Q64long.ref[] dst = d.arr;
+        Q64long[] dst = d.arr;
         for (int i = 0; i < len; i++) {
             dst[i] = s.arr[i];
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillDef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Val_fill0(Val_as_Val st) {
         Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -45,16 +45,16 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Val_fill1(Val_as_Val st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -63,16 +63,16 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Ref_fill1(Val_as_Ref st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -81,7 +81,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Ref_as_Ref_fill1(Ref_as_Ref st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -90,7 +90,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Int_fill0(Val_as_Int st) {
         Int64[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -99,7 +99,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Int_fill1(Val_as_Int st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -108,7 +108,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Ref_as_Int_fill0(Ref_as_Int st) {
         Int64[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -117,7 +117,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Ref_as_Int_fill1(Ref_as_Int st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -126,7 +126,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Int_as_Int_fill0(Int_as_Int st) {
         Int64[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -135,7 +135,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Int_as_Int_fill1(Int_as_Int st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -144,7 +144,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Obj_fill0(Val_as_Obj st) {
         Object[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -153,7 +153,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Val_as_Obj_fill1(Val_as_Obj st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -162,7 +162,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Ref_as_Obj_fill0(Ref_as_Obj st) {
         Object[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -171,7 +171,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Ref_as_Obj_fill1(Ref_as_Obj st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -180,7 +180,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Int_as_Obj_fill0(Int_as_Obj st) {
         Object[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -189,7 +189,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Int_as_Obj_fill1(Int_as_Obj st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
@@ -198,7 +198,7 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Obj_as_Obj_fill0(Obj_as_Obj st) {
         Object[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i] = Q64long.default;
+            arr[i] = new Q64long()  ;
         }
     }
 
@@ -207,68 +207,68 @@ public class Inline64longFillDef extends StatesQ64long {
     public void Def_to_Obj_as_Obj_fill1(Obj_as_Obj st) {
         int len = st.arr.length;
         for (int i = 0; i < len; i++) {
-            st.arr[i] = Q64long.default;
+            st.arr[i] = new Q64long()  ;
         }
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Val_arrayfill(Val_as_Val st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Ref_arrayfill(Val_as_Ref st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Ref_arrayfill(Ref_as_Ref st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Int_arrayfill(Val_as_Int st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Int_arrayfill(Ref_as_Int st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Int_as_Int_arrayfill(Int_as_Int st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Val_as_Obj_arrayfill(Val_as_Obj st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Ref_as_Obj_arrayfill(Ref_as_Obj st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Int_as_Obj_arrayfill(Int_as_Obj st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Def_to_Obj_as_Obj_arrayfill(Obj_as_Obj st) {
-        Arrays.fill(st.arr, Q64long.default);
+        Arrays.fill(st.arr, new Q64long()  );
     }
 
 }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class Inline64longFillInstInt extends StatesQ64long {
 
     @State(Scope.Thread)
     public static class InstanceField {
-        Q64long.ref f = new Q64long(42);
+        Q64long f = new Q64long(42);
     }
 
     @Benchmark
@@ -61,7 +61,7 @@ public class Inline64longFillInstInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Ref_fillinst0( Val_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long) f.f;
         }
@@ -79,7 +79,7 @@ public class Inline64longFillInstInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Ref_fillinst0( Ref_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long) f.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstObj.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class Inline64longFillInstObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Ref_fillinst0(Val_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long) f.f;
         }
@@ -79,7 +79,7 @@ public class Inline64longFillInstObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Ref_fillinst0(Ref_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long) f.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class Inline64longFillInstRef extends StatesQ64long {
 
     @State(Scope.Thread)
     public static class InstanceField {
-        Q64long.ref f = new Q64long(42);
+        Q64long f = new Q64long(42);
     }
 
     @Benchmark
@@ -61,7 +61,7 @@ public class Inline64longFillInstRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_fillinst0(Val_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -79,7 +79,7 @@ public class Inline64longFillInstRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillinst0(Ref_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstVal.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInstVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class Inline64longFillInstVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_fillinst0(Val_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }
@@ -79,7 +79,7 @@ public class Inline64longFillInstVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillinst0(Ref_as_Ref st, InstanceField f) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = f.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Inline64longFillInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Int64 v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)v;
@@ -80,7 +80,7 @@ public class Inline64longFillInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Int64 v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)v;

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillNew.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class Inline64longFillNew extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Q64long v = new Q64long(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -75,7 +75,7 @@ public class Inline64longFillNew extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Q64long v = new Q64long(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillObj.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Inline64longFillObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Object v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)v;
@@ -80,7 +80,7 @@ public class Inline64longFillObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Object v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)v;

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.Arrays;
 public class Inline64longFillRef extends StatesQ64long {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64long.ref get(int i) {
+    public static Q64long get(int i) {
         return new Q64long(i);
     }
 
@@ -41,7 +41,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fill0(Val_as_Val st) {
         Q64long[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -51,7 +51,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Val_fill1(Val_as_Val st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -60,8 +60,8 @@ public class Inline64longFillRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long[] arr = st.arr;
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -71,7 +71,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_fill1(Val_as_Ref st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -80,8 +80,8 @@ public class Inline64longFillRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long[] arr = st.arr;
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -91,7 +91,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fill1(Ref_as_Ref st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -101,7 +101,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Int_fill0(Val_as_Int st) {
         Int64[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -111,7 +111,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Int_fill1(Val_as_Int st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -121,7 +121,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Int_fill0(Ref_as_Int st) {
         Int64[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -131,7 +131,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Int_fill1(Ref_as_Int st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -141,7 +141,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Int_fill0(Int_as_Int st) {
         Int64[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -151,7 +151,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Int_fill1(Int_as_Int st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -161,7 +161,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Obj_fill0(Val_as_Obj st) {
         Object[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -171,7 +171,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Obj_fill1(Val_as_Obj st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -181,7 +181,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Obj_fill0(Ref_as_Obj st) {
         Object[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -191,7 +191,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Obj_fill1(Ref_as_Obj st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -201,7 +201,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Obj_fill0(Int_as_Obj st) {
         Object[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -211,7 +211,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Int_as_Obj_fill1(Int_as_Obj st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }
@@ -221,7 +221,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Obj_as_Obj_fill0(Obj_as_Obj st) {
         Object[] arr = st.arr;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
         }
@@ -231,7 +231,7 @@ public class Inline64longFillRef extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Obj_as_Obj_fill1(Obj_as_Obj st) {
         int len = st.arr.length;
-        Q64long.ref v = get(42);
+        Q64long v = get(42);
         for (int i = 0; i < len; i++) {
             st.arr[i] = v;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class Inline64longFillStatInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Ref_fillstat0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)StaticField.f;
         }
@@ -75,7 +75,7 @@ public class Inline64longFillStatInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Ref_fillstat0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)StaticField.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatObj.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class Inline64longFillStatObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Ref_fillstat0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)StaticField.f;
         }
@@ -75,7 +75,7 @@ public class Inline64longFillStatObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Ref_fillstat0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)StaticField.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.util.Arrays;
 public class Inline64longFillStatRef extends StatesQ64long {
 
     public static class StaticField {
-        static Q64long.ref f = new Q64long(42);
+        static Q64long f = new Q64long(42);
     }
 
     @Benchmark
@@ -57,7 +57,7 @@ public class Inline64longFillStatRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_fillstat0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = StaticField.f;
         }
@@ -75,7 +75,7 @@ public class Inline64longFillStatRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_fillstat0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = StaticField.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatVal.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillStatVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class Inline64longFillStatVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_fillstat0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = StaticField.f;
         }
@@ -75,7 +75,7 @@ public class Inline64longFillStatVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fillstat0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = StaticField.f;
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillVal.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/fill/Inline64longFillVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Inline64longFillVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_fill0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;
@@ -80,7 +80,7 @@ public class Inline64longFillVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_fill0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         Q64long v = get(42);
         for (int i = 0; i < arr.length; i++) {
             arr[i] = v;

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/read/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/read/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline64long extends StatesQ64long {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64long.ref v) {
+    public void ref_consume(Q64long v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
@@ -85,7 +85,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Val_read(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -94,7 +94,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Ref_read(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -103,7 +103,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Int_read(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }
@@ -112,7 +112,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_as_Ref_to_Obj_read(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             obj_consume(arr[i]);
         }
@@ -148,7 +148,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_as_Ref_to_Val_read(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             val_consume(arr[i]);
         }
@@ -157,7 +157,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_as_Ref_to_Ref_read(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             ref_consume(arr[i]);
         }
@@ -166,7 +166,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_as_Ref_to_Int_read(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             int_consume(arr[i]);
         }
@@ -175,7 +175,7 @@ public class Inline64long extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_as_Ref_to_Obj_read(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             obj_consume(arr[i]);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Inline64longSetInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Val_as_Ref_set0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)get(i);
         }
@@ -74,7 +74,7 @@ public class Inline64longSetInt extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Int_to_Ref_as_Ref_set0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)get(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetNew.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class Inline64longSetNew extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Val_as_Ref_set0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q64long(i);
         }
@@ -69,7 +69,7 @@ public class Inline64longSetNew extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void New_to_Ref_as_Ref_set0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = new Q64long(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetObj.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Inline64longSetObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Val_as_Ref_set0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)get(i);
         }
@@ -74,7 +74,7 @@ public class Inline64longSetObj extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Obj_to_Ref_as_Ref_set0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = (Q64long)get(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetRef.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.CompilerControl;
 public class Inline64longSetRef extends StatesQ64long {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64long.ref get(int i) {
+    public static Q64long get(int i) {
         return new Q64long(i);
     }
 
@@ -56,7 +56,7 @@ public class Inline64longSetRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Val_as_Ref_set0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = get(i);
         }
@@ -74,7 +74,7 @@ public class Inline64longSetRef extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Ref_to_Ref_as_Ref_set0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = get(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetVal.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/set/Inline64longSetVal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Inline64longSetVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Val_as_Ref_set0(Val_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = get(i);
         }
@@ -74,7 +74,7 @@ public class Inline64longSetVal extends StatesQ64long {
     @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void Val_to_Ref_as_Ref_set0(Ref_as_Ref st) {
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
             arr[i] = get(i);
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/sum/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/sum/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Inline64long extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long Val_as_Ref_fields0(Val_as_Ref st) {
         long s = 0;
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0;
         }
@@ -78,7 +78,7 @@ public class Inline64long extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long Ref_as_Ref_fields0(Ref_as_Ref st) {
         long s = 0;
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].v0;
         }
@@ -122,7 +122,7 @@ public class Inline64long extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long Val_as_Ref_sum0(Val_as_Ref st) {
         long s = 0;
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].longSum();
         }
@@ -166,7 +166,7 @@ public class Inline64long extends StatesQ64long {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public long Ref_as_Ref_sum0(Ref_as_Ref st) {
         long s = 0;
-        Q64long.ref[] arr = st.arr;
+        Q64long[] arr = st.arr;
         for(int i=0; i < arr.length; i++) {
             s += arr[i].longSum();
         }

--- a/test/micro/org/openjdk/bench/valhalla/arraytotal/util/StatesQ64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/arraytotal/util/StatesQ64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class StatesQ64long extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q64long.ref[] arr;
+        public Q64long[] arr;
         void fill() {
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Q64long(i);
@@ -87,7 +87,7 @@ public class StatesQ64long extends SizeBase {
     public static class Ref_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }
@@ -111,7 +111,7 @@ public class StatesQ64long extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }
@@ -127,7 +127,7 @@ public class StatesQ64long extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }
@@ -168,7 +168,7 @@ public class StatesQ64long extends SizeBase {
     public static class Ref_as_By extends ByState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/copy/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class Inline64long extends StatesQ64long {
         ObjWrapper[] src = s.arr;
         RefWrapper[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
-            dst[i].f = (Q64long.ref)src[i].f;
+            dst[i].f = (Q64long)src[i].f;
         }
     }
 
@@ -96,7 +96,7 @@ public class Inline64long extends StatesQ64long {
         IntWrapper[] src = s.arr;
         RefWrapper[] dst = d.arr;
         for (int i = 0; i < src.length; i++) {
-            dst[i].f = (Q64long.ref)src[i].f;
+            dst[i].f = (Q64long)src[i].f;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Inline128int extends StatesQ128int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q128int.ref v) {
+    public void ref_consume(Q128int v) {
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Inline32int extends StatesQ32int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q32int.ref v) {
+    public void ref_consume(Q32int v) {
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Inline64byte extends StatesQ64byte {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64byte.ref v) {
+    public void ref_consume(Q64byte v) {
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public class Inline64int extends StatesQ64int {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64int.ref v) {
+    public void ref_consume(Q64int v) {
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/valhalla/field/read/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/read/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class Inline64long extends StatesQ64long {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void ref_consume(Q64long.ref v) {
+    public void ref_consume(Q64long v) {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.CompilerControl;
 public class Inline128int extends StatesQ128int {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q128int.ref getRef(int i) {
+    public static Q128int getRef(int i) {
         return new Q128int(i);
     }
 
@@ -71,7 +71,7 @@ public class Inline128int extends StatesQ128int {
     public void Def_to_Val_set(ValState st) {
         ValWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q128int.default;
+            arr[i].f = new Q128int()  ;
         }
     }
 
@@ -107,7 +107,7 @@ public class Inline128int extends StatesQ128int {
     public void Def_to_Ref_set(RefState st) {
         RefWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q128int.default;
+            arr[i].f = new Q128int()  ;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.CompilerControl;
 public class Inline32int extends StatesQ32int {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q32int.ref getRef(int i) {
+    public static Q32int getRef(int i) {
         return new Q32int(i);
     }
 
@@ -71,7 +71,7 @@ public class Inline32int extends StatesQ32int {
     public void Def_to_Val_set(ValState st) {
         ValWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q32int.default;
+            arr[i].f = new Q32int()  ;
         }
     }
 
@@ -107,7 +107,7 @@ public class Inline32int extends StatesQ32int {
     public void Def_to_Ref_set(RefState st) {
         RefWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q32int.default;
+            arr[i].f = new Q32int()  ;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.CompilerControl;
 public class Inline64byte extends StatesQ64byte {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64byte.ref getRef(int i) {
+    public static Q64byte getRef(int i) {
         return new Q64byte(i);
     }
 
@@ -71,7 +71,7 @@ public class Inline64byte extends StatesQ64byte {
     public void Def_to_Val_set(ValState st) {
         ValWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64byte.default;
+            arr[i].f = new Q64byte()  ;
         }
     }
 
@@ -107,7 +107,7 @@ public class Inline64byte extends StatesQ64byte {
     public void Def_to_Ref_set(RefState st) {
         RefWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64byte.default;
+            arr[i].f = new Q64byte()  ;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.CompilerControl;
 public class Inline64int extends StatesQ64int {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64int.ref getRef(int i) {
+    public static Q64int getRef(int i) {
         return new Q64int(i);
     }
 
@@ -71,7 +71,7 @@ public class Inline64int extends StatesQ64int {
     public void Def_to_Val_set(ValState st) {
         ValWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64int.default;
+            arr[i].f = new Q64int()  ;
         }
     }
 
@@ -107,7 +107,7 @@ public class Inline64int extends StatesQ64int {
     public void Def_to_Ref_set(RefState st) {
         RefWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64int.default;
+            arr[i].f = new Q64int()  ;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/set/Inline64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/set/Inline64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class Inline64long extends StatesQ64long {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public static Q64long.ref getRef(int i) {
+    public static Q64long getRef(int i) {
         return new Q64long(i);
     }
 
@@ -100,7 +100,7 @@ public class Inline64long extends StatesQ64long {
     public void Def_to_Val_set(ValState st) {
         ValWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64long.default;
+            arr[i].f = new Q64long()  ;
         }
     }
 
@@ -154,7 +154,7 @@ public class Inline64long extends StatesQ64long {
     public void Def_to_Ref_set(RefState st) {
         RefWrapper[] arr = st.arr;
         for (int i = 0; i < arr.length; i++) {
-            arr[i].f = Q64long.default;
+            arr[i].f = new Q64long()  ;
         }
     }
 

--- a/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,9 @@ public class StatesQ128int extends SizeBase {
 
 
     public static class RefWrapper {
-        public Q128int.ref f;
+        public Q128int f;
 
-        public RefWrapper(Q128int.ref f) {
+        public RefWrapper(Q128int f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,9 @@ public class StatesQ32int extends SizeBase {
 
 
     public static class RefWrapper {
-        public Q32int.ref f;
+        public Q32int f;
 
-        public RefWrapper(Q32int.ref f) {
+        public RefWrapper(Q32int f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,9 @@ public class StatesQ64byte extends SizeBase {
 
 
     public static class RefWrapper {
-        public Q64byte.ref f;
+        public Q64byte f;
 
-        public RefWrapper(Q64byte.ref f) {
+        public RefWrapper(Q64byte f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,9 @@ public class StatesQ64int extends SizeBase {
 
 
     public static class RefWrapper {
-        public Q64int.ref f;
+        public Q64int f;
 
-        public RefWrapper(Q64int.ref f) {
+        public RefWrapper(Q64int f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/field/util/StatesQ64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,9 @@ public class StatesQ64long extends SizeBase {
 
 
     public static class RefWrapper {
-        public Q64long.ref f;
+        public Q64long f;
 
-        public RefWrapper(Q64long.ref f) {
+        public RefWrapper(Q64long f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlattenedArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class IsFlattenedArray {
 
 }
 
-primitive class Point {
+value class Point {
     int x;
     int y;
     public Point(int x, int y) {

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray0.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class InlineArray0 {
         public int my_method();
     }
 
-    public static primitive class Val1 implements MyInterface {
+    public static value class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -62,7 +62,7 @@ public class InlineArray0 {
         }
     }
 
-    public static primitive class Val2 implements MyInterface {
+    public static value class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -73,7 +73,7 @@ public class InlineArray0 {
         }
     }
 
-    public static primitive class Val3 implements MyInterface {
+    public static value class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -91,7 +91,7 @@ public class InlineArray0 {
 
     @State(Scope.Thread)
     public static abstract class Ref1State {
-        public Val1.ref[] arr;
+        public Val1[] arr;
     }
 
     @State(Scope.Thread)
@@ -132,7 +132,7 @@ public class InlineArray0 {
     public static class Ref1_as_Ref extends Ref1State {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -142,7 +142,7 @@ public class InlineArray0 {
     public static class Ref1_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -172,7 +172,7 @@ public class InlineArray0 {
     public static class Ref2_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val2.ref[SIZE];
+            arr = new Val2[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val2(i);
             }
@@ -202,7 +202,7 @@ public class InlineArray0 {
     public static class Ref3_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val3.ref[SIZE];
+            arr = new Val3[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val3(i);
             }
@@ -230,7 +230,7 @@ public class InlineArray0 {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int reduceRef(Val1.ref[] arr) {
+    public int reduceRef(Val1[] arr) {
         int r = 0;
         for (int i = 0; i < arr.length; i++) {
             r += arr[i].my_method();

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray1.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArray1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class InlineArray1 {
         public int my_method();
     }
 
-    public static primitive class Val1 implements MyInterface {
+    public static value class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -63,7 +63,7 @@ public class InlineArray1 {
         }
     }
 
-    public static primitive class Val2 implements MyInterface {
+    public static value class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -75,7 +75,7 @@ public class InlineArray1 {
         }
     }
 
-    public static primitive class Val3 implements MyInterface {
+    public static value class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -94,7 +94,7 @@ public class InlineArray1 {
 
     @State(Scope.Thread)
     public static abstract class Ref1State {
-        public Val1.ref[] arr;
+        public Val1[] arr;
     }
 
     @State(Scope.Thread)
@@ -135,7 +135,7 @@ public class InlineArray1 {
     public static class Ref1_as_Ref extends Ref1State {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -145,7 +145,7 @@ public class InlineArray1 {
     public static class Ref1_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -175,7 +175,7 @@ public class InlineArray1 {
     public static class Ref2_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val2.ref[SIZE];
+            arr = new Val2[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val2(i);
             }
@@ -205,7 +205,7 @@ public class InlineArray1 {
     public static class Ref3_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Val3.ref[SIZE];
+            arr = new Val3[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val3(i);
             }
@@ -233,7 +233,7 @@ public class InlineArray1 {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int reduceRef(Val1.ref[] arr) {
+    public int reduceRef(Val1[] arr) {
         int r = 0;
         for (int i = 0; i < arr.length; i++) {
             r += arr[i].my_method();

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashExplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashExplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class InlineArrayHashExplicit {
 
     public static final int SIZE = 128;
 
-    public static primitive class Val1  {
+    public static value class Val1  {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -58,7 +58,7 @@ public class InlineArrayHashExplicit {
         }
     }
 
-    public static primitive class Val2  {
+    public static value class Val2  {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -69,7 +69,7 @@ public class InlineArrayHashExplicit {
         }
     }
 
-    public static primitive class Val3  {
+    public static value class Val3  {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -87,7 +87,7 @@ public class InlineArrayHashExplicit {
 
     @State(Scope.Thread)
     public static abstract class Ref1State {
-        public Val1.ref[] arr;
+        public Val1[] arr;
     }
 
     @State(Scope.Thread)
@@ -128,7 +128,7 @@ public class InlineArrayHashExplicit {
     public static class Ref1_as_Ref extends Ref1State {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -138,7 +138,7 @@ public class InlineArrayHashExplicit {
     public static class Ref1_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -168,7 +168,7 @@ public class InlineArrayHashExplicit {
     public static class Ref2_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val2.ref[SIZE];
+            arr = new Val2[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val2(i);
             }
@@ -198,7 +198,7 @@ public class InlineArrayHashExplicit {
     public static class Ref3_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val3.ref[SIZE];
+            arr = new Val3[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val3(i);
             }
@@ -226,7 +226,7 @@ public class InlineArrayHashExplicit {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int reduceRef(Val1.ref[] arr) {
+    public int reduceRef(Val1[] arr) {
         int r = 0;
         for (int i = 0; i < arr.length; i++) {
             r += arr[i].hashCode();

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashImplicit.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineArrayHashImplicit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,21 +47,21 @@ public class InlineArrayHashImplicit {
 
     public static final int SIZE = 128;
 
-    public static primitive class Val1  {
+    public static value class Val1  {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
         }
     }
 
-    public static primitive class Val2  {
+    public static value class Val2  {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
         }
     }
 
-    public static primitive class Val3  {
+    public static value class Val3  {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -75,7 +75,7 @@ public class InlineArrayHashImplicit {
 
     @State(Scope.Thread)
     public static abstract class Ref1State {
-        public Val1.ref[] arr;
+        public Val1[] arr;
     }
 
     @State(Scope.Thread)
@@ -116,7 +116,7 @@ public class InlineArrayHashImplicit {
     public static class Ref1_as_Ref extends Ref1State {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -126,7 +126,7 @@ public class InlineArrayHashImplicit {
     public static class Ref1_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val1.ref[SIZE];
+            arr = new Val1[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val1(i);
             }
@@ -156,7 +156,7 @@ public class InlineArrayHashImplicit {
     public static class Ref2_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val2.ref[SIZE];
+            arr = new Val2[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val2(i);
             }
@@ -186,7 +186,7 @@ public class InlineArrayHashImplicit {
     public static class Ref3_as_Obj extends ObjState {
         @Setup
         public void setup() {
-            arr = new Val3.ref[SIZE];
+            arr = new Val3[SIZE];
             for (int i = 0; i < arr.length; i++) {
                 arr[i] = new Val3(i);
             }
@@ -214,7 +214,7 @@ public class InlineArrayHashImplicit {
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public int reduceRef(Val1.ref[] arr) {
+    public int reduceRef(Val1[] arr) {
         int r = 0;
         for (int i = 0; i < arr.length; i++) {
             r += arr[i].hashCode();

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineField.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class InlineField {
         public int my_method();
     }
 
-    public static primitive class Val1 implements MyInterface {
+    public static value class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -62,7 +62,7 @@ public class InlineField {
         }
     }
 
-    public static primitive class Val2 implements MyInterface {
+    public static value class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -73,7 +73,7 @@ public class InlineField {
         }
     }
 
-    public static primitive class Val3 implements MyInterface {
+    public static value class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -93,9 +93,9 @@ public class InlineField {
     }
 
     public static class Ref1Wrapper {
-        public Val1.ref f;
+        public Val1 f;
 
-        public Ref1Wrapper(Val1.ref f) {
+        public Ref1Wrapper(Val1 f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineField1.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineField1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class InlineField1 {
         public int my_method();
     }
 
-    public static primitive class Val1 implements MyInterface {
+    public static value class Val1 implements MyInterface {
         public final int f0;
         public Val1(int f0) {
             this.f0 = f0;
@@ -63,7 +63,7 @@ public class InlineField1 {
         }
     }
 
-    public static primitive class Val2 implements MyInterface {
+    public static value class Val2 implements MyInterface {
         public final int f0;
         public Val2(int f0) {
             this.f0 = f0;
@@ -75,7 +75,7 @@ public class InlineField1 {
         }
     }
 
-    public static primitive class Val3 implements MyInterface {
+    public static value class Val3 implements MyInterface {
         public final int f0;
         public Val3(int f0) {
             this.f0 = f0;
@@ -96,9 +96,9 @@ public class InlineField1 {
     }
 
     public static class Ref1Wrapper {
-        public Val1.ref f;
+        public Val1 f;
 
-        public Ref1Wrapper(Val1.ref f) {
+        public Ref1Wrapper(Val1 f) {
             this.f = f;
         }
     }

--- a/test/micro/org/openjdk/bench/valhalla/invoke/InlineRec.java
+++ b/test/micro/org/openjdk/bench/valhalla/invoke/InlineRec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class InlineRec {
     @Param("100")
     public int depth;
 
-    public static primitive class V {
+    public static value class V {
         final int v;
 
         public V(int v) {

--- a/test/micro/org/openjdk/bench/valhalla/matrix/Inline.java
+++ b/test/micro/org/openjdk/bench/valhalla/matrix/Inline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ public abstract class Inline extends Base {
 
     public static final Complex IZERO = new QComplex(0,0);
     public static final QComplex VZERO = new QComplex(0,0);
-    public static final QComplex.ref RZERO = new QComplex(0,0);
+    public static final QComplex RZERO = new QComplex(0,0);
 
     private static void populate(Complex[][] m) {
         int size = m.length;
@@ -50,25 +50,25 @@ public abstract class Inline extends Base {
 //    }
 
     public static class Ref extends Inline {
-        QComplex.ref[][] A;
-        QComplex.ref[][] B;
+        QComplex[][] A;
+        QComplex[][] B;
 
         @Setup
         public void setup() {
-            A = new QComplex.ref[size][size];
+            A = new QComplex[size][size];
             populate(A);
-            B = new QComplex.ref[size][size];
+            B = new QComplex[size][size];
             populate(B);
         }
 
         @Benchmark
         @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-        public QComplex.ref[][] multiply() {
+        public QComplex[][] multiply() {
             int size = A.length;
-            QComplex.ref[][] R = new QComplex.ref[size][size];
+            QComplex[][] R = new QComplex[size][size];
             for (int i = 0; i < size; i++) {
                 for (int j = 0; j < size; j++) {
-                    QComplex.ref s = RZERO;
+                    QComplex s = RZERO;
                     for (int k = 0; k < size; k++) {
                         s = s.add(A[i][k].mul(B[k][j]));
                     }
@@ -218,8 +218,8 @@ public abstract class Inline extends Base {
     }
 
     public static class RCov extends Inline {
-        QComplex.ref[][] A;
-        QComplex.ref[][] B;
+        QComplex[][] A;
+        QComplex[][] B;
 
         @Setup
         public void setup() {
@@ -231,12 +231,12 @@ public abstract class Inline extends Base {
 
         @Benchmark
         @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-        public QComplex.ref[][] multiply() {
+        public QComplex[][] multiply() {
             int size = A.length;
-            QComplex.ref[][] R = new QComplex[size][size];
+            QComplex[][] R = new QComplex[size][size];
             for (int i = 0; i < size; i++) {
                 for (int j = 0; j < size; j++) {
-                    QComplex.ref s = RZERO;
+                    QComplex s = RZERO;
                     for (int k = 0; k < size; k++) {
                         s = s.add(A[i][k].mul(B[k][j]));
                     }

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class ArrayListInt
     private static final long serialVersionUID = 8683452581122892189L;
 
     /**
-     * Default initial capacity.
+     *new ()   initial capacity.
      */
     private static final int DEFAULT_CAPACITY = 10;
 

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListOfIntBench.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListOfIntBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class ArrayListOfIntBench {
     ArrayListInt arrayListInt;
     ArrayListPrimitiveInt arrayListPrimitiveInt;
     ArrayList<Integer> arrayListOfInteger;
-    ArrayList<PrimitiveInt.ref> arrayListOfPrimitiveInt;
+    ArrayList<PrimitiveInt> arrayListOfPrimitiveInt;
     Random random;
 
     @Setup
@@ -88,7 +88,7 @@ public class ArrayListOfIntBench {
             arrayListOfInteger.add(i, i);
         }
 
-        arrayListOfPrimitiveInt = new ArrayList<PrimitiveInt.ref>(size);
+        arrayListOfPrimitiveInt = new ArrayList<PrimitiveInt>(size);
         for (int i = 0; i < size; i++) {
             arrayListOfPrimitiveInt.add(i, new PrimitiveInt(i));
         }
@@ -125,7 +125,7 @@ public class ArrayListOfIntBench {
 
     @Benchmark
     public Object appendListOfPrimitiveInt() {
-        ArrayList<PrimitiveInt.ref> list = new ArrayList<>(size);
+        ArrayList<PrimitiveInt> list = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             list.add(new PrimitiveInt(i));
         }
@@ -222,7 +222,7 @@ public class ArrayListOfIntBench {
 
     @Benchmark
     public int thrashListOfPrimitiveInt() {
-        final ArrayList<PrimitiveInt.ref> list = arrayListOfPrimitiveInt;
+        final ArrayList<PrimitiveInt> list = arrayListOfPrimitiveInt;
         int sum = 0;
 
         for (int i = 0; i < 1000; i++) {

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListPrimitiveInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/ArrayListPrimitiveInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -507,7 +507,7 @@ public class ArrayListPrimitiveInt
         final int newSize;
         if ((newSize = size - 1) > i)
             System.arraycopy(es, i + 1, es, i, newSize - i);
-        es[size = newSize] = PrimitiveInt.default;
+        es[size = newSize] = new PrimitiveInt();
     }
 
     /**
@@ -518,7 +518,7 @@ public class ArrayListPrimitiveInt
         modCount++;
         final PrimitiveInt[] es = elementData;
         for (int to = size, i = size = 0; i < to; i++)
-            es[i] = PrimitiveInt.default;
+            es[i] = new PrimitiveInt();
     }
 
     /**
@@ -547,7 +547,7 @@ public class ArrayListPrimitiveInt
     private void shiftTailOverGap(PrimitiveInt[] es, int lo, int hi) {
         System.arraycopy(es, hi, es, lo, size - hi);
         for (int to = size, i = (size -= hi - lo); i < to; i++)
-            es[i] = PrimitiveInt.default;
+            es[i] = new PrimitiveInt();
     }
 
     /**
@@ -628,7 +628,7 @@ public class ArrayListPrimitiveInt
             }
         }
 
-        public void forEachRemaining(Consumer<? super PrimitiveInt.ref> action) {
+        public void forEachRemaining(Consumer<? super PrimitiveInt> action) {
             Objects.requireNonNull(action);
             final int size = ArrayListPrimitiveInt.this.size;
             int i = cursor;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/PrimitiveInt.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/PrimitiveInt.java
@@ -1,7 +1,34 @@
+/*
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.openjdk.bench.valhalla.sandbox.corelibs;
 
-public primitive class PrimitiveInt {
+public value class PrimitiveInt {
     int value;
+
+    PrimitiveInt() {
+        this.value = 0;
+    }
 
     PrimitiveInt(int value) {
         this.value = value;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/XArrayList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1095,7 +1095,7 @@ public class XArrayList<E> extends AbstractList<E>
     /**
      * Create an inline cursor for this XArrayList.
      */
-    private primitive class AListCursor<E> implements InlineCursor<E> {
+    private value class AListCursor<E> implements InlineCursor<E> {
         // Inner class field 'this' is initialized
         int index;
         int expectedModCount;

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/HashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +224,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
     /**
      * Basic hash bin node, used for most entries.
      */
-    static primitive class YNode<K,V> implements Map.Entry<K,V> {
+    static value class YNode<K,V> implements Map.Entry<K,V> {
         final int hash;
         final short probes; // maybe only a byte
         final K key;
@@ -278,7 +278,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
         }
     }
 
-    primitive class YNodeWrapper implements Map.Entry<K,V> {
+    value class YNodeWrapper implements Map.Entry<K,V> {
         final int index;
         final YNode<K,V> entry;
 
@@ -930,7 +930,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
             removeNode(curr);
             return entry;
         }
-        return YNode.default;
+        return new YNode();
     }
 
     @SuppressWarnings("unchecked")
@@ -978,7 +978,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
         if ((tab = table) != null && size > 0) {
             size = 0;
             for (int i = 0; i < tab.length; i++)
-                tab[i] = YNode.default;
+                tab[i] = new YNode();
         }
     }
 
@@ -1373,7 +1373,7 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
 
         int hash = hash(key);
         int index = getNode(hash, key);
-        YNode<K,V> oldValue = (index >= 0) ? table[index] : YNode.default;
+        YNode<K,V> oldValue = (index >= 0) ? table[index] : new YNode();
 
         int mc = modCount;
         V v = remappingFunction.apply(key, oldValue.value);
@@ -1887,4 +1887,3 @@ public class HashMap<K,V> extends XAbstractMap<K,V>
     }
 
 }
-

--- a/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
+++ b/test/micro/org/openjdk/bench/valhalla/sandbox/corelibs/mapprotos/XHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,17 +299,24 @@ public class XHashMap<K,V> extends XAbstractMap<K,V>
     static final int MIN_TREEIFY_CAPACITY = 64;
 
     private XNode<K,V> emptyXNode() {
-        return XNode.default;
+        return new XNode();
     }
     /**
      * Basic hash bin node, used for most entries.  (See below for
      * TreeNode subclass, and in LinkedHashMap for its Entry subclass.)
      */
-    static primitive class XNode<K,V> implements Map.Entry<K,V> {
+    static value class XNode<K,V> implements Map.Entry<K,V> {
         final int hash;
         final K key;
         V value;
         Node<K,V> next;
+
+        XNode() {
+            this.hash = 0;
+            this.key = null;
+            this.value = null;
+            this.next = null;
+        }
 
         XNode(int hash, K key, V value, Node<K,V> next) {
             this.hash = hash;
@@ -390,7 +397,7 @@ public class XHashMap<K,V> extends XAbstractMap<K,V>
         }
     }
 
-    primitive class XNodeWrapper implements Map.Entry<K,V> {
+    value class XNodeWrapper implements Map.Entry<K,V> {
         int index;
 
         XNodeWrapper(int index) {

--- a/test/micro/org/openjdk/bench/valhalla/traversal/Inline32.java
+++ b/test/micro/org/openjdk/bench/valhalla/traversal/Inline32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class Inline32 extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q32int.ref[] arr;
+        public Q32int[] arr;
         void fill() {
             int[] a = Utils.makeRandomRing(arr.length);
             for (int i = 0; i < a.length; i++) {
@@ -74,7 +74,7 @@ public class Inline32 extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q32int.ref[size];
+            arr = new Q32int[size];
             fill();
         }
     }
@@ -100,7 +100,7 @@ public class Inline32 extends SizeBase {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_walk(Ref_as_Ref s) {
         int steps = 0;
-        Q32int.ref[] values = s.arr;
+        Q32int[] values = s.arr;
         for (int i = values[0].intValue(); i != 0; i = values[i].intValue()) steps++;
         return steps;
     }

--- a/test/micro/org/openjdk/bench/valhalla/traversal/Inline64.java
+++ b/test/micro/org/openjdk/bench/valhalla/traversal/Inline64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class Inline64 extends SizeBase {
     }
 
     public static abstract class RefState extends SizeState {
-        public Q64long.ref[] arr;
+        public Q64long[] arr;
         void fill() {
             int[] a = Utils.makeRandomRing(arr.length);
             for (int i = 0; i < a.length; i++) {
@@ -74,7 +74,7 @@ public class Inline64 extends SizeBase {
     public static class Ref_as_Int extends IntState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }
@@ -90,7 +90,7 @@ public class Inline64 extends SizeBase {
     public static class Ref_as_Ref extends RefState {
         @Setup
         public void setup() {
-            arr = new Q64long.ref[size];
+            arr = new Q64long[size];
             fill();
         }
     }
@@ -142,7 +142,7 @@ public class Inline64 extends SizeBase {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Ref_as_Ref_walk(Ref_as_Ref s) {
         int steps = 0;
-        Q64long.ref[] values = s.arr;
+        Q64long[] values = s.arr;
         for (int i = values[0].intValue(); i != 0; i = values[i].intValue()) steps++;
         return steps;
     }
@@ -151,7 +151,7 @@ public class Inline64 extends SizeBase {
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public int Val_as_Ref_walk(Val_as_Ref s) {
         int steps = 0;
-        Q64long.ref[] values = s.arr;
+        Q64long[] values = s.arr;
         for (int i = values[0].intValue(); i != 0; i = values[i].intValue()) steps++;
         return steps;
     }

--- a/test/micro/org/openjdk/bench/valhalla/types/A64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/A64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/valhalla/types/Int32.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Int32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/valhalla/types/Opt.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Opt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q128byte implements Int128, ByByte {
+public value class Q128byte implements Int128, ByByte {
 
     public final Q64byte v0;
     public final Q64byte v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,14 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q128int implements Int128, ByInt {
+public value class Q128int implements Int128, ByInt {
 
     public final Q64int v0;
     public final Q64int v1;
+
+    public Q128int() {
+        this(0, 0);
+    }
 
     public Q128int(long v) {
         this(0, v);

--- a/test/micro/org/openjdk/bench/valhalla/types/Q128long.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q128long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q128long implements Int128, ByLong {
+public value class Q128long implements Int128, ByLong {
 
     public final long v0;
     public final long v1;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q32byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q32byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,16 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q32byte implements Int32, ByByte {
+public value class Q32byte implements Int32, ByByte {
 
     public final byte v0;
     public final byte v1;
     public final byte v2;
     public final byte v3;
+
+    public Q32byte() {
+        this(0);
+    }
 
     public Q32byte(int v) {
         this((byte) (v >>> 24), (byte) (v >>> 16), (byte) (v >>> 8), (byte) (v));

--- a/test/micro/org/openjdk/bench/valhalla/types/Q32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,13 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q32int implements Int32, ByInt {
+public value class Q32int implements Int32, ByInt {
 
     public final int v0;
+
+    public Q32int() {
+        v0 = 0;
+    }
 
     public Q32int(int val) {
         this.v0 = val;

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,15 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q64byte implements Int64, ByByte {
+public value class Q64byte implements Int64, ByByte {
 
     public final Q32byte v0;
     public final Q32byte v1;
+
+    public Q64byte() {
+        this.v0 = new Q32byte();
+        this.v1 = new Q32byte();
+    }
 
     public Q64byte(long v) {
         this((int) (v >>> 32), (int) v);

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,14 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q64int implements Int64, ByInt {
+public value class Q64int implements Int64, ByInt {
 
     public final Q32int v0;
     public final Q32int v1;
+
+    public Q64int() {
+        this(0);
+    }
 
     public Q64int(long v) {
         this((int) (v >>> 32), (int) v);

--- a/test/micro/org/openjdk/bench/valhalla/types/Q64long.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/Q64long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,13 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class Q64long implements Int64, ByLong {
+public value class Q64long implements Int64, ByLong {
 
     public final long v0;
+
+    public Q64long() {
+        this(0);
+    }
 
     public Q64long(long v0) {
         this.v0 = v0;

--- a/test/micro/org/openjdk/bench/valhalla/types/QComplex.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/QComplex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 package org.openjdk.bench.valhalla.types;
 
-public primitive class QComplex implements Complex {
+public value class QComplex implements Complex {
 
     public final double re;
     public final double im;

--- a/test/micro/org/openjdk/bench/valhalla/types/QOpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/QOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,16 @@ package org.openjdk.bench.valhalla.types;
 
 import java.util.NoSuchElementException;
 
-public primitive class QOpt<T> implements Opt<T> {
+public value class QOpt<T> implements Opt<T> {
 
     public final T value;
 
     private QOpt(T value) {
         this.value = value;
+    }
+
+    public static <T> QOpt<T> of() {
+        return new QOpt<>(null);
     }
 
     public static <T> QOpt<T> of(T value) {

--- a/test/micro/org/openjdk/bench/valhalla/types/R32byte.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/R32byte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,4 +83,3 @@ public class R32byte implements Int32, ByByte {
     }
 
 }
-

--- a/test/micro/org/openjdk/bench/valhalla/types/R32int.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/R32int.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,10 @@ package org.openjdk.bench.valhalla.types;
 public class R32int implements Int32, ByInt {
 
     public final int v0;
+
+    public R32int() {
+        this.v0 = 0;
+    }
 
     public R32int(int val) {
         this.v0 = val;

--- a/test/micro/org/openjdk/bench/valhalla/types/ROpt.java
+++ b/test/micro/org/openjdk/bench/valhalla/types/ROpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,16 @@ public class ROpt<T> implements Opt<T> {
 
     public T value;
 
+    private <T> ROpt() {
+        this.value = null;
+    }
+
     private ROpt(T value) {
         this.value = value;
+    }
+
+    public static <T> ROpt<T> of() {
+        return new ROpt<>(null);
     }
 
     public static <T> ROpt<T> of(T value) {


### PR DESCRIPTION
A bulk update to change "primitive class" to "value class, remove .ref and replace .default with no-arg constructor. 
Plus other changes to get the benchmarks to compile.

No assertions are made beyond compilation.  The generated benchmarks.jar is well formed and can list the benchmarks.

The makefile rule build-microbenchmark is re-enabled for the `test` target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327080](https://bugs.openjdk.org/browse/JDK-8327080): [lworld] Update Valhalla micros to JEP 401 (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1028/head:pull/1028` \
`$ git checkout pull/1028`

Update a local copy of the PR: \
`$ git checkout pull/1028` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1028`

View PR using the GUI difftool: \
`$ git pr show -t 1028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1028.diff">https://git.openjdk.org/valhalla/pull/1028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1028#issuecomment-1972104142)