### PR TITLE
8327150: [lworld] Update C1 to support new value construction scheme from JEP 401

### DIFF
--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -252,7 +252,6 @@ NewInstanceStub::NewInstanceStub(LIR_Opr klass_reg, LIR_Opr result, ciInstanceKl
   _klass_reg = klass_reg;
   _info = new CodeEmitInfo(info);
   assert(stub_id == Runtime1::new_instance_id                 ||
-         stub_id == Runtime1::new_instance_no_inline_id       ||
          stub_id == Runtime1::fast_new_instance_id            ||
          stub_id == Runtime1::fast_new_instance_init_check_id,
          "need new_instance id");

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1319,26 +1319,10 @@ void LIRGenerator::do_Convert(Convert* x) {
 void LIRGenerator::do_NewInstance(NewInstance* x) {
   print_if_not_loaded(x);
 
-  CodeEmitInfo* info = state_for(x, x->state());
+  CodeEmitInfo* info = state_for(x, x->needs_state_before() ? x->state_before() : x->state());
   LIR_Opr reg = result_register_for(x->type());
   new_instance(reg, x->klass(), x->is_unresolved(),
                /* allow_inline */ false,
-               FrameMap::rcx_oop_opr,
-               FrameMap::rdi_oop_opr,
-               FrameMap::rsi_oop_opr,
-               LIR_OprFact::illegalOpr,
-               FrameMap::rdx_metadata_opr, info);
-  LIR_Opr result = rlock_result(x);
-  __ move(reg, result);
-}
-
-void LIRGenerator::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
-  // Mapping to do_NewInstance (same code) but use state_before for reexecution.
-  CodeEmitInfo* info = state_for(x, x->state_before());
-  x->set_to_object_type();
-  LIR_Opr reg = result_register_for(x->type());
-  new_instance(reg, x->klass(), false,
-               /* allow_inline */ true,
                FrameMap::rcx_oop_opr,
                FrameMap::rdi_oop_opr,
                FrameMap::rsi_oop_opr,

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1019,7 +1019,6 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
       break;
 
     case new_instance_id:
-    case new_instance_no_inline_id:
     case fast_new_instance_id:
     case fast_new_instance_init_check_id:
       {
@@ -1028,8 +1027,6 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
         if (id == new_instance_id) {
           __ set_info("new_instance", dont_gc_arguments);
-        } else if (id == new_instance_no_inline_id) {
-          __ set_info("new_instance_no_inline", dont_gc_arguments);
         } else if (id == fast_new_instance_id) {
           __ set_info("fast new_instance", dont_gc_arguments);
         } else {
@@ -1040,11 +1037,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         __ enter();
         OopMap* map = save_live_registers(sasm, 2);
         int call_offset;
-        if (id == new_instance_no_inline_id) {
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance_no_inline), klass);
-        } else {
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
-        }
+        call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_rax(sasm);

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -640,7 +640,7 @@ void Canonicalizer::do_Convert        (Convert*         x) {
 }
 
 void Canonicalizer::do_NullCheck      (NullCheck*       x) {
-  if (x->obj()->as_NewArray() != nullptr || x->obj()->as_NewInstance() != nullptr || x->obj()->as_NewInlineTypeInstance()) {
+  if (x->obj()->as_NewArray() != nullptr || x->obj()->as_NewInstance() != nullptr) {
     set_canonical(x->obj());
   } else {
     Constant* con = x->obj()->as_Constant();
@@ -659,7 +659,6 @@ void Canonicalizer::do_NullCheck      (NullCheck*       x) {
 void Canonicalizer::do_TypeCast       (TypeCast*        x) {}
 void Canonicalizer::do_Invoke         (Invoke*          x) {}
 void Canonicalizer::do_NewInstance    (NewInstance*     x) {}
-void Canonicalizer::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {}
 void Canonicalizer::do_NewTypeArray   (NewTypeArray*    x) {}
 void Canonicalizer::do_NewObjectArray (NewObjectArray*  x) {}
 void Canonicalizer::do_NewMultiArray  (NewMultiArray*   x) {}
@@ -692,7 +691,7 @@ void Canonicalizer::do_InstanceOf     (InstanceOf*      x) {
   if (x->klass()->is_loaded()) {
     Value obj = x->obj();
     ciType* exact = obj->exact_type();
-    if (exact != nullptr && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray() || obj->as_NewInlineTypeInstance())) {
+    if (exact != nullptr && exact->is_loaded() && (obj->as_NewInstance() || obj->as_NewArray())) {
       set_constant(exact->is_subtype_of(x->klass()) ? 1 : 0);
       return;
     }
@@ -815,7 +814,7 @@ void Canonicalizer::do_If(If* x) {
       }
     }
   } else if (rt == objectNull &&
-           (l->as_NewInstance() || l->as_NewArray() || l->as_NewInlineTypeInstance() ||
+           (l->as_NewInstance() || l->as_NewArray() ||
              (l->as_Local() && l->as_Local()->is_receiver()))) {
     if (x->cond() == Instruction::eql) {
       BlockBegin* sux = x->fsux();

--- a/src/hotspot/share/c1/c1_Canonicalizer.hpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.hpp
@@ -70,7 +70,6 @@ class Canonicalizer: InstructionVisitor {
   virtual void do_TypeCast       (TypeCast*        x);
   virtual void do_Invoke         (Invoke*          x);
   virtual void do_NewInstance    (NewInstance*     x);
-  virtual void do_NewInlineTypeInstance(NewInlineTypeInstance* x);
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -255,9 +255,6 @@ void Compiler::compile_method(ciEnv* env, ciMethod* method, int entry_bci, bool 
     // of Compilation to occur before we release the any
     // competing compiler thread
     ResourceMark rm;
-    if (PrintCFGToFile) {  // borrowing flag for JDK build
-      tty->print_cr("Starting C1 compilation of %s.%s", method->holder()->name()->as_utf8(), method->name()->as_utf8());
-    }
     Compilation c(this, env, method, entry_bci, buffer_blob, install_code, directive);
   }
 }

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -255,6 +255,9 @@ void Compiler::compile_method(ciEnv* env, ciMethod* method, int entry_bci, bool 
     // of Compilation to occur before we release the any
     // competing compiler thread
     ResourceMark rm;
+    if (PrintCFGToFile) {  // borrowing flag for JDK build
+      tty->print_cr("Starting C1 compilation of %s.%s", method->holder()->name()->as_utf8(), method->name()->as_utf8());
+    }
     Compilation c(this, env, method, entry_bci, buffer_blob, install_code, directive);
   }
 }

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -306,14 +306,6 @@ ciType* NewInstance::declared_type() const {
   return exact_type();
 }
 
-ciType* NewInlineTypeInstance::exact_type() const {
-  return klass();
-}
-
-ciType* NewInlineTypeInstance::declared_type() const {
-  return exact_type();
-}
-
 ciType* CheckCast::declared_type() const {
   return klass();
 }

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -2062,11 +2062,6 @@ LEAF(If, BlockEnd)
     s->append(tsux);
     s->append(fsux);
     set_sux(s);
-    if (!_substitutability_check) {
-      // FIXME: Removal of NewInlineTypeInstance instruction makes those assert hard to write
-      // assert(x->as_NewInlineTypeInstance() == nullptr || y->type() == objectNull, "Sanity check");
-      // assert(y->as_NewInlineTypeInstance() == nullptr || x->type() == objectNull, "Sanity check");
-    }
   }
 
   // accessors

--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -70,7 +70,6 @@ class   ExceptionObject;
 class   StateSplit;
 class     Invoke;
 class     NewInstance;
-class     NewInlineTypeInstance;
 class     NewArray;
 class       NewTypeArray;
 class       NewObjectArray;
@@ -172,7 +171,6 @@ class InstructionVisitor: public StackObj {
   virtual void do_TypeCast       (TypeCast*        x) = 0;
   virtual void do_Invoke         (Invoke*          x) = 0;
   virtual void do_NewInstance    (NewInstance*     x) = 0;
-  virtual void do_NewInlineTypeInstance(NewInlineTypeInstance* x) = 0;
   virtual void do_NewTypeArray   (NewTypeArray*    x) = 0;
   virtual void do_NewObjectArray (NewObjectArray*  x) = 0;
   virtual void do_NewMultiArray  (NewMultiArray*   x) = 0;
@@ -569,7 +567,6 @@ class Instruction: public CompilationResourceObj {
   virtual StateSplit*       as_StateSplit()      { return nullptr; }
   virtual Invoke*           as_Invoke()          { return nullptr; }
   virtual NewInstance*      as_NewInstance()     { return nullptr; }
-  virtual NewInlineTypeInstance* as_NewInlineTypeInstance() { return nullptr; }
   virtual NewArray*         as_NewArray()        { return nullptr; }
   virtual NewTypeArray*     as_NewTypeArray()    { return nullptr; }
   virtual NewObjectArray*   as_NewObjectArray()  { return nullptr; }
@@ -982,7 +979,7 @@ class DelayedLoadIndexed;
 LEAF(LoadIndexed, AccessIndexed)
  private:
   NullCheck*  _explicit_null_check;              // For explicit null check elimination
-  NewInlineTypeInstance* _vt;
+  NewInstance* _vt;
   DelayedLoadIndexed* _delayed;
 
  public:
@@ -1001,8 +998,8 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* exact_type() const;
   ciType* declared_type() const;
 
-  NewInlineTypeInstance* vt() const { return _vt; }
-  void set_vt(NewInlineTypeInstance* vt) { _vt = vt; }
+  NewInstance* vt() const { return _vt; }
+  void set_vt(NewInstance* vt) { _vt = vt; }
 
   DelayedLoadIndexed* delayed() const { return _delayed; }
   void set_delayed(DelayedLoadIndexed* delayed) { _delayed = delayed; }
@@ -1342,17 +1339,19 @@ LEAF(NewInstance, StateSplit)
  private:
   ciInstanceKlass* _klass;
   bool _is_unresolved;
+  bool _needs_state_before;
 
  public:
   // creation
-  NewInstance(ciInstanceKlass* klass, ValueStack* state_before, bool is_unresolved)
+  NewInstance(ciInstanceKlass* klass, ValueStack* state_before, bool is_unresolved, bool needs_state_before)
   : StateSplit(instanceType, state_before)
-  , _klass(klass), _is_unresolved(is_unresolved)
+  , _klass(klass), _is_unresolved(is_unresolved), _needs_state_before(needs_state_before)
   {}
 
   // accessors
   ciInstanceKlass* klass() const                 { return _klass; }
   bool is_unresolved() const                     { return _is_unresolved; }
+  bool needs_state_before() const                { return _needs_state_before; }
 
   virtual bool needs_exception_state() const     { return false; }
 
@@ -1360,32 +1359,6 @@ LEAF(NewInstance, StateSplit)
   virtual bool can_trap() const                  { return true; }
   ciType* exact_type() const;
   ciType* declared_type() const;
-};
-
-LEAF(NewInlineTypeInstance, StateSplit)
-  ciInlineKlass* _klass;
-
-public:
-
-  // Default creation, always allocated for now
-  NewInlineTypeInstance(ciInlineKlass* klass, ValueStack* state_before)
-  : StateSplit(instanceType, state_before)
-   , _klass(klass)
-  {
-    set_null_free(true);
-  }
-
-  // accessors
-  ciInlineKlass* klass() const { return _klass; }
-  virtual bool needs_exception_state() const     { return false; }
-
-  // generic
-  virtual bool can_trap() const                  { return true; }
-  ciType* exact_type() const;
-  ciType* declared_type() const;
-
-  // Only done in LIR Generator -> map everything to object
-  void set_to_object_type() { set_type(instanceType); }
 };
 
 BASE(NewArray, StateSplit)
@@ -2090,8 +2063,9 @@ LEAF(If, BlockEnd)
     s->append(fsux);
     set_sux(s);
     if (!_substitutability_check) {
-      assert(x->as_NewInlineTypeInstance() == nullptr || y->type() == objectNull, "Sanity check");
-      assert(y->as_NewInlineTypeInstance() == nullptr || x->type() == objectNull, "Sanity check");
+      // FIXME: Removal of NewInlineTypeInstance instruction makes those assert hard to write
+      // assert(x->as_NewInlineTypeInstance() == nullptr || y->type() == objectNull, "Sanity check");
+      // assert(y->as_NewInlineTypeInstance() == nullptr || x->type() == objectNull, "Sanity check");
     }
   }
 

--- a/src/hotspot/share/c1/c1_InstructionPrinter.cpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.cpp
@@ -501,11 +501,6 @@ void InstructionPrinter::do_NewTypeArray(NewTypeArray* x) {
   output()->put(']');
 }
 
-void InstructionPrinter::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
-  output()->print("new inline type instance ");
-  print_klass(x->klass());
-}
-
 void InstructionPrinter::do_NewObjectArray(NewObjectArray* x) {
   output()->print("new object array [");
   print_value(x->length());

--- a/src/hotspot/share/c1/c1_InstructionPrinter.hpp
+++ b/src/hotspot/share/c1/c1_InstructionPrinter.hpp
@@ -102,7 +102,6 @@ class InstructionPrinter: public InstructionVisitor {
   virtual void do_TypeCast       (TypeCast*        x);
   virtual void do_Invoke         (Invoke*          x);
   virtual void do_NewInstance    (NewInstance*     x);
-  virtual void do_NewInlineTypeInstance(NewInlineTypeInstance* x);
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -659,13 +659,14 @@ void LIRGenerator::new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unr
     CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, stub_id);
 
     assert(klass->is_loaded(), "must be loaded");
+    assert(!klass->is_inlinetype() || !klass->as_inline_klass()->is_empty(), "Sanity check");
     // allocate space for instance
     assert(klass->size_helper() > 0, "illegal instance size");
     const int instance_size = align_object_size(klass->size_helper());
     __ allocate_object(dst, scratch1, scratch2, scratch3, scratch4,
                        oopDesc::header_size(), instance_size, klass_reg, !klass->is_initialized(), slow_path);
   } else {
-    CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, allow_inline ? Runtime1::new_instance_id : Runtime1::new_instance_no_inline_id);
+    CodeStub* slow_path = new NewInstanceStub(klass_reg, dst, klass, info, Runtime1::new_instance_id);
     __ jump(slow_path);
     __ branch_destination(slow_path->continuation());
   }

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -579,7 +579,6 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   virtual void do_TypeCast       (TypeCast*        x);
   virtual void do_Invoke         (Invoke*          x);
   virtual void do_NewInstance    (NewInstance*     x);
-  virtual void do_NewInlineTypeInstance(NewInlineTypeInstance* x);
   virtual void do_NewTypeArray   (NewTypeArray*    x);
   virtual void do_NewObjectArray (NewObjectArray*  x);
   virtual void do_NewMultiArray  (NewMultiArray*   x);

--- a/src/hotspot/share/c1/c1_Optimizer.cpp
+++ b/src/hotspot/share/c1/c1_Optimizer.cpp
@@ -565,7 +565,6 @@ public:
   void do_TypeCast       (TypeCast*        x);
   void do_Invoke         (Invoke*          x);
   void do_NewInstance    (NewInstance*     x);
-  void do_NewInlineTypeInstance(NewInlineTypeInstance* x);
   void do_NewTypeArray   (NewTypeArray*    x);
   void do_NewObjectArray (NewObjectArray*  x);
   void do_NewMultiArray  (NewMultiArray*   x);
@@ -713,7 +712,6 @@ class NullCheckEliminator: public ValueVisitor {
   void handle_NullCheck       (NullCheck* x);
   void handle_Invoke          (Invoke* x);
   void handle_NewInstance     (NewInstance* x);
-  void handle_NewInlineTypeInstance(NewInlineTypeInstance* x);
   void handle_NewArray        (NewArray* x);
   void handle_AccessMonitor   (AccessMonitor* x);
   void handle_Intrinsic       (Intrinsic* x);
@@ -753,7 +751,6 @@ void NullCheckVisitor::do_NullCheck      (NullCheck*       x) { nce()->handle_Nu
 void NullCheckVisitor::do_TypeCast       (TypeCast*        x) {}
 void NullCheckVisitor::do_Invoke         (Invoke*          x) { nce()->handle_Invoke(x); }
 void NullCheckVisitor::do_NewInstance    (NewInstance*     x) { nce()->handle_NewInstance(x); }
-void NullCheckVisitor::do_NewInlineTypeInstance(NewInlineTypeInstance* x) { nce()->handle_NewInlineTypeInstance(x); }
 void NullCheckVisitor::do_NewTypeArray   (NewTypeArray*    x) { nce()->handle_NewArray(x); }
 void NullCheckVisitor::do_NewObjectArray (NewObjectArray*  x) { nce()->handle_NewArray(x); }
 void NullCheckVisitor::do_NewMultiArray  (NewMultiArray*   x) { nce()->handle_NewArray(x); }
@@ -1102,13 +1099,6 @@ void NullCheckEliminator::handle_NewInstance(NewInstance* x) {
   set_put(x);
   if (PrintNullCheckElimination) {
     tty->print_cr("NewInstance %d is non-null", x->id());
-  }
-}
-
-void NullCheckEliminator::handle_NewInlineTypeInstance(NewInlineTypeInstance* x) {
-  set_put(x);
-  if (PrintNullCheckElimination) {
-    tty->print_cr("NewInlineTypeInstance %d is non-null", x->id());
   }
 }
 

--- a/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
+++ b/src/hotspot/share/c1/c1_RangeCheckElimination.hpp
@@ -139,7 +139,6 @@ public:
     void do_NullCheck      (NullCheck*       x) { /* nothing to do */ };
     void do_TypeCast       (TypeCast*        x) { /* nothing to do */ };
     void do_NewInstance    (NewInstance*     x) { /* nothing to do */ };
-    void do_NewInlineTypeInstance(NewInlineTypeInstance* x) { /* nothing to do */ };
     void do_NewTypeArray   (NewTypeArray*    x) { /* nothing to do */ };
     void do_NewObjectArray (NewObjectArray*  x) { /* nothing to do */ };
     void do_NewMultiArray  (NewMultiArray*   x) { /* nothing to do */ };

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -370,10 +370,9 @@ static void allocate_instance(JavaThread* current, Klass* klass, TRAPS) {
   // make sure klass is initialized
   h->initialize(CHECK);
   oop obj = nullptr;
-  if(h->is_empty_inline_type()) {
-    assert(h->is_inline_klass(), "Sanity check");
-    assert(InlineKlass::cast(h)->default_value() != nullptr, "");
+  if (h->is_empty_inline_type()) {
     obj = InlineKlass::cast(h)->default_value();
+    assert(obj != nullptr, "default value must exist");
   } else {
     // allocate instance and return via TLS
     obj = h->allocate_instance(CHECK);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -369,22 +369,20 @@ static void allocate_instance(JavaThread* current, Klass* klass, TRAPS) {
   h->check_valid_for_instantiation(true, CHECK);
   // make sure klass is initialized
   h->initialize(CHECK);
-  // allocate instance and return via TLS
-  oop obj = h->allocate_instance(CHECK);
+  oop obj = nullptr;
+  if(h->is_empty_inline_type()) {
+    assert(h->is_inline_klass(), "Sanity check");
+    assert(InlineKlass::cast(h)->default_value() != nullptr, "");
+    obj = InlineKlass::cast(h)->default_value();
+  } else {
+    // allocate instance and return via TLS
+    obj = h->allocate_instance(CHECK);
+  }
   current->set_vm_result(obj);
 JRT_END
 
 JRT_ENTRY(void, Runtime1::new_instance(JavaThread* current, Klass* klass))
   allocate_instance(current, klass, CHECK);
-JRT_END
-
-// Same as new_instance but throws error for inline klasses
-JRT_ENTRY(void, Runtime1::new_instance_no_inline(JavaThread* current, Klass* klass))
-  if (klass->is_inline_klass()) {
-    SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_InstantiationError());
-  } else {
-    allocate_instance(current, klass, CHECK);
-  }
 JRT_END
 
 JRT_ENTRY(void, Runtime1::new_type_array(JavaThread* current, Klass* klass, jint length))

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -47,7 +47,6 @@ class StubAssembler;
   stub(throw_null_pointer_exception) \
   stub(register_finalizer)           \
   stub(new_instance)                 \
-  stub(new_instance_no_inline)       \
   stub(fast_new_instance)            \
   stub(fast_new_instance_init_check) \
   stub(new_type_array)               \

--- a/src/hotspot/share/c1/c1_ValueMap.hpp
+++ b/src/hotspot/share/c1/c1_ValueMap.hpp
@@ -191,7 +191,6 @@ class ValueNumberingVisitor: public InstructionVisitor {
   void do_NullCheck      (NullCheck*       x) { /* nothing to do */ }
   void do_TypeCast       (TypeCast*        x) { /* nothing to do */ }
   void do_NewInstance    (NewInstance*     x) { /* nothing to do */ }
-  void do_NewInlineTypeInstance(NewInlineTypeInstance* x) { /* nothing to do */ }
   void do_NewTypeArray   (NewTypeArray*    x) { /* nothing to do */ }
   void do_NewObjectArray (NewObjectArray*  x) { /* nothing to do */ }
   void do_NewMultiArray  (NewMultiArray*   x) { /* nothing to do */ }

--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -694,7 +694,7 @@ bool ciInstanceKlass::can_be_inline_klass(bool is_exact) {
   if (!is_exact) {
     // Not exact, check if this is a valid super for an inline klass
     VM_ENTRY_MARK;
-    return !get_instanceKlass()->access_flags().is_identity_class();
+    return !get_instanceKlass()->access_flags().is_identity_class() || is_java_lang_Object() ;
   }
   return false;
 }


### PR DESCRIPTION
Fix value creation in C1, remove the old special node for value creation and out everything under the NewInstance node.
There's also a fix in can_be_inline_klass() method that was causing a wrong behavior for acmp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327150](https://bugs.openjdk.org/browse/JDK-8327150): [lworld] Update C1 to support new value construction scheme from JEP 401 (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1029/head:pull/1029` \
`$ git checkout pull/1029`

Update a local copy of the PR: \
`$ git checkout pull/1029` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1029`

View PR using the GUI difftool: \
`$ git pr show -t 1029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1029.diff">https://git.openjdk.org/valhalla/pull/1029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1029#issuecomment-1973912471)