### PR TITLE
8327280: [lworld] aarch64 compilation fails without support for JDK-8327150

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -196,7 +196,6 @@ NewInstanceStub::NewInstanceStub(LIR_Opr klass_reg, LIR_Opr result, ciInstanceKl
   _klass_reg = klass_reg;
   _info = new CodeEmitInfo(info);
   assert(stub_id == Runtime1::new_instance_id                 ||
-         stub_id == Runtime1::new_instance_no_inline_id       ||
          stub_id == Runtime1::fast_new_instance_id            ||
          stub_id == Runtime1::fast_new_instance_init_check_id,
          "need new_instance id");

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -1136,7 +1136,7 @@ void LIRGenerator::do_NewInstance(NewInstance* x) {
     tty->print_cr("   ###class not loaded at new bci %d", x->printable_bci());
   }
 #endif
-  CodeEmitInfo* info = state_for(x, x->state());
+  CodeEmitInfo* info = state_for(x, x->needs_state_before() ? x->state_before() : x->state());
   LIR_Opr reg = result_register_for(x->type());
   new_instance(reg, x->klass(), x->is_unresolved(),
                /* allow_inline */ false,
@@ -1147,23 +1147,6 @@ void LIRGenerator::do_NewInstance(NewInstance* x) {
                FrameMap::r3_metadata_opr, info);
   LIR_Opr result = rlock_result(x);
   __ move(reg, result);
-}
-
-void LIRGenerator::do_NewInlineTypeInstance(NewInlineTypeInstance* x) {
-  // Mapping to do_NewInstance (same code) but use state_before for reexecution.
-  CodeEmitInfo* info = state_for(x, x->state_before());
-  x->set_to_object_type();
-  LIR_Opr reg = result_register_for(x->type());
-  new_instance(reg, x->klass(), false,
-               /* allow_inline */ true,
-               FrameMap::r10_oop_opr,
-               FrameMap::r11_oop_opr,
-               FrameMap::r4_oop_opr,
-               LIR_OprFact::illegalOpr,
-               FrameMap::r3_metadata_opr, info);
-  LIR_Opr result = rlock_result(x);
-  __ move(reg, result);
-
 }
 
 void LIRGenerator::do_NewTypeArray(NewTypeArray* x) {

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -650,7 +650,6 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
       break;
 
     case new_instance_id:
-    case new_instance_no_inline_id:
     case fast_new_instance_id:
     case fast_new_instance_init_check_id:
       {
@@ -659,8 +658,6 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
         if (id == new_instance_id) {
           __ set_info("new_instance", dont_gc_arguments);
-        } else if (id == new_instance_no_inline_id) {
-          __ set_info("new_instance_no_inline", dont_gc_arguments);
         } else if (id == fast_new_instance_id) {
           __ set_info("fast new_instance", dont_gc_arguments);
         } else {
@@ -671,11 +668,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         __ enter();
         OopMap* map = save_live_registers(sasm);
         int call_offset;
-        if (id == new_instance_no_inline_id) {
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance_no_inline), klass);
-        } else {
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
-        }
+        call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_instance), klass);
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers_except_r0(sasm);


### PR DESCRIPTION
Remove the old "new inline instance" code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327280](https://bugs.openjdk.org/browse/JDK-8327280): [lworld] aarch64 compilation fails without support for JDK-8327150 (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1031/head:pull/1031` \
`$ git checkout pull/1031`

Update a local copy of the PR: \
`$ git checkout pull/1031` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1031`

View PR using the GUI difftool: \
`$ git pr show -t 1031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1031.diff">https://git.openjdk.org/valhalla/pull/1031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1031#issuecomment-1978071751)