### PR TITLE
JDK 8327435: [lworld+vector] Align existing Vector API support with JEP 401

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6537,8 +6537,8 @@ bool ClassFileParser::is_jdk_internal_class(const Klass* cls) {
       return true;
     }
     cls = cls->super();
-   }
-   return false;
+  }
+  return false;
 }
 
 void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const stream,

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1954,15 +1954,6 @@ Node* GraphKit::set_results_for_java_call(CallJavaNode* call, bool separate_io_p
       if (type->is_inlinetypeptr()) {
         ret = InlineTypeNode::make_from_oop(this, ret, type->inline_klass(), type->inline_klass()->is_null_free());
       }
-      Node* receiver = !call->method()->is_static() ? call->in(TypeFunc::Parms) : nullptr;
-      if (ret->is_InlineType() &&
-          receiver && receiver->bottom_type()->isa_instptr() &&
-          receiver->bottom_type()->is_instptr()->instance_klass()->name()->get_symbol() == vmSymbols::jdk_internal_misc_Unsafe() &&
-          call->method()->name()->get_symbol() == vmSymbols::makePrivateBuffer_name()) {
-        // Re-buffer scalarized InlineTypeNodes returned from makePrivateBuffer
-        // and transition the allocation into larval state.
-        ret = ret->as_InlineType()->make_larval(this);
-      }
     }
   }
 

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -301,22 +301,9 @@ bool InlineTypeNode::field_is_null_free(uint index) const {
   return field->is_null_free();
 }
 
-static bool is_vector_payload(ciKlass* klass) {
-  return klass->is_subclass_of(ciEnv::current()->vector_VectorPayload_klass());
-}
-
-static bool is_vector_payload_mf(ciKlass* klass) {
-  return klass->is_subclass_of(ciEnv::current()->vector_VectorPayloadMF_klass());
-}
-
 void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_List& worklist, SafePointNode* sfpt) {
   ciInlineKlass* vk = inline_klass();
   uint nfields = vk->nof_nonstatic_fields();
-  if (is_vector_payload_mf(vk)) {
-     assert(field_count() == nfields, "");
-  } else if (is_vector_payload(vk)) {
-     assert(field_value(0)->as_InlineType()->field_count() == nfields, "");
-  }
   JVMState* jvms = sfpt->jvms();
   // Replace safepoint edge by SafePointScalarObjectNode and add field values
   assert(jvms != nullptr, "missing JVMS");
@@ -327,7 +314,7 @@ void InlineTypeNode::make_scalar_in_safepoint(PhaseIterGVN* igvn, Unique_Node_Li
   sobj->init_req(0, igvn->C->root());
   // Nullable inline types have an IsInit field that needs
   // to be checked before using the field values.
-  if (!igvn->type(get_is_init())->is_int()->is_con(1)) {
+  if (!vk->is_null_free()) {
     sfpt->add_req(get_is_init());
   } else {
     sfpt->add_req(igvn->C->top());

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -56,7 +56,7 @@ protected:
   const TypePtr* field_adr_type(Node* base, int offset, ciInstanceKlass* holder, DecoratorSet decorators, PhaseGVN& gvn) const;
 
   // Checks if the inline type fields are all set to default values
-  bool is_default(PhaseGVN* gvn) const;
+  virtual bool is_default(PhaseGVN* gvn) const;
 
   // Checks if the inline type oop is an allocated buffer with larval state
   bool is_larval(PhaseGVN* gvn) const;

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2655,9 +2655,11 @@ bool LibraryCallKit::inline_unsafe_finish_private_buffer() {
 
   // Allocation node must exist to generate IR for transitioning allocation out
   // of larval state. Disable the intrinsic and take unsafe slow path if allocation
-  // is not reachable,  oop returned by Unsafe_finishPrivateBuffer native method
-  // will automatically rematerialize InlineTypeNode.
+  // is not reachable, this can happen if makePrivateBuffer was not intrinsified and
+  // was falling over to unsafe implementation which return a larval transitioned oop.
   if (AllocateNode::Ideal_allocation(buffer) == nullptr) {
+    // Oop returned by Unsafe_finishPrivateBuffer native method
+    // will automatically re-materialize InlineTypeNode.
     return false;
   }
   receiver = null_check(receiver);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -853,6 +853,12 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
   sobj->init_req(0, C->root());
   transform_later(sobj);
 
+  if (iklass && iklass->is_inlinetype()) {
+    // Value object has two additional inputs before the non-static fields
+    sfpt->add_req(_igvn.intcon(1));
+    sfpt->add_req(_igvn.intcon(alloc->_larval ? 1 : 0));
+  }
+
   // Scan object's fields adding an input to the safepoint for each field.
   for (int j = 0; j < nfields; j++) {
     intptr_t offset;

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -320,7 +320,7 @@ Node* PhaseVector::expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
   // in case the input "vect" is not the original vector value when creating the
   // VectorBox (e.g. original vector value is a PhiNode).
   ciInlineKlass* payload = vk->declared_nonstatic_field_at(0)->type()->as_inline_klass();
-  Node* payload_value = InlineTypeNode::make_uninitialized(gvn, payload, true);
+  Node* payload_value = InlineTypeNode::make_uninitialized(gvn, payload, false);
   payload_value->as_InlineType()->set_field_value(0, vect);
   payload_value = gvn.transform(payload_value);
 
@@ -331,7 +331,7 @@ Node* PhaseVector::expand_vbox_alloc_node(VectorBoxAllocateNode* vbox_alloc,
   vector = gvn.transform(vector)->as_InlineType();
 
   Node* klass_node = kit.makecon(TypeKlassPtr::make(vk));
-  Node* alloc_oop  = kit.new_instance(klass_node, NULL, NULL, /* deoptimize_on_exception */ true);
+  Node* alloc_oop  = kit.new_instance(klass_node, nullptr, nullptr, /* deoptimize_on_exception */ true);
   vector->store(&kit, alloc_oop, alloc_oop, vk);
 
   C->set_max_vector_size(MAX2(C->max_vector_size(), vect_type->length_in_bytes()));
@@ -351,7 +351,7 @@ void PhaseVector::expand_vunbox_node(VectorUnboxNode* vec_unbox) {
       node = node->as_InlineType()->field_value(0);
     }
 
-    assert(node->bottom_type()->isa_vect() != NULL, "not a vector");
+    assert(node->bottom_type()->isa_vect() != nullptr, "not a vector");
     assert(Type::cmp(vec_unbox->bottom_type(), node->bottom_type()) == 0, "type is not matched");
 
     C->set_max_vector_size(MAX2(C->max_vector_size(), vec_unbox->bottom_type()->is_vect()->length_in_bytes()));

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -1709,17 +1709,18 @@ class VectorBoxNode : public InlineTypeNode {
     VectorBoxNode* box_node = new VectorBoxNode(C, vk, box, box_type, vt, false);
 
     ciInlineKlass* payload = vk->declared_nonstatic_field_at(0)->type()->as_inline_klass();
-    Node* payload_value = InlineTypeNode::make_uninitialized(gvn, payload, true);
+    Node* payload_value = InlineTypeNode::make_uninitialized(gvn, payload, false);
     payload_value->as_InlineType()->set_field_value(0, val);
     payload_value = gvn.transform(payload_value);
 
     box_node->set_field_value(0, payload_value);
     box_node->set_is_buffered(gvn, false);
-    box_node->set_is_init(gvn);
+    box_node->set_is_init(gvn, true);
 
     return box_node;
   }
 
+  virtual bool is_default(PhaseGVN* gvn) const { return false; }
   const  TypeInstPtr* box_type() const { assert(_box_type != nullptr, ""); return _box_type; };
   const  TypeVect*    vec_type() const { assert(_vec_type != nullptr, ""); return _vec_type; };
 

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.MultiField;
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.LooselyConsistentValue;
 import jdk.internal.misc.Unsafe;
 
 import java.util.function.*;
@@ -162,7 +164,8 @@ public class VectorSupport {
 
     public static abstract class VectorShuffle<E> extends VectorPayload { }
 
-    public abstract static class VectorPayloadMF {
+    @LooselyConsistentValue
+    public abstract value static class VectorPayloadMF {
         public abstract long multiFieldOffset();
 
         @ForceInline
@@ -382,7 +385,9 @@ public class VectorSupport {
         }
     }
 
-    public primitive static class VectorPayloadMFMaxB extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxB extends VectorPayloadMF {
         @MultiField(value = -1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxB.class);
@@ -391,7 +396,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxS extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxS extends VectorPayloadMF {
         @MultiField(value = -1)
         short mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxS.class);
@@ -400,7 +407,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxI extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxI extends VectorPayloadMF {
         @MultiField(value = -1)
         int mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxI.class);
@@ -409,7 +418,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxL extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxL extends VectorPayloadMF {
         @MultiField(value = -1)
         long mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxL.class);
@@ -418,7 +429,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxF extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxF extends VectorPayloadMF {
         @MultiField(value = -1)
         float mfield = 0.0f;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxF.class);
@@ -427,7 +440,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxD extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxD extends VectorPayloadMF {
         @MultiField(value = -1)
         double mfield = 0.0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxD.class);
@@ -436,7 +451,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF8Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF8Z extends VectorPayloadMF {
         @MultiField(value = 1)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF8Z.class);
@@ -445,7 +462,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF16Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF16Z extends VectorPayloadMF {
         @MultiField(value = 2)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF16Z.class);
@@ -454,7 +473,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF32Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF32Z extends VectorPayloadMF {
         @MultiField(value = 4)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF32Z.class);
@@ -463,7 +484,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64Z extends VectorPayloadMF {
         @MultiField(value = 8)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64Z.class);
@@ -472,7 +495,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128Z extends VectorPayloadMF {
         @MultiField(value = 16)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128Z.class);
@@ -481,7 +506,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256Z extends VectorPayloadMF {
         @MultiField(value = 32)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256Z.class);
@@ -490,7 +517,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512Z extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512Z extends VectorPayloadMF {
         @MultiField(value = 64)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512Z.class);
@@ -499,7 +528,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxBZ extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxBZ extends VectorPayloadMF {
         @MultiField(value = -1)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxBZ.class);
@@ -508,7 +539,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxSZ extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxSZ extends VectorPayloadMF {
         @MultiField(value = -1)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxSZ.class);
@@ -517,7 +550,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxIZ extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxIZ extends VectorPayloadMF {
         @MultiField(value = -1)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxIZ.class);
@@ -526,7 +561,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxLZ extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxLZ extends VectorPayloadMF {
         @MultiField(value = -1)
         boolean mfield = false;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxLZ.class);
@@ -535,7 +572,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF8B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF8B extends VectorPayloadMF {
         @MultiField(value = 1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF8B.class);
@@ -544,7 +583,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF16B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF16B extends VectorPayloadMF {
         @MultiField(value = 2)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF16B.class);
@@ -553,7 +594,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF32B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF32B extends VectorPayloadMF {
         @MultiField(value = 4)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF32B.class);
@@ -562,7 +605,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64B extends VectorPayloadMF {
         @MultiField(value = 8)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64B.class);
@@ -571,7 +616,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128B extends VectorPayloadMF {
         @MultiField(value = 16)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128B.class);
@@ -580,7 +627,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256B extends VectorPayloadMF {
         @MultiField(value = 32)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256B.class);
@@ -589,7 +638,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512B extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512B extends VectorPayloadMF {
         @MultiField(value = 64)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512B.class);
@@ -598,7 +649,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxBB extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxBB extends VectorPayloadMF {
         @MultiField(value = -1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxBB.class);
@@ -607,7 +660,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxSB extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxSB extends VectorPayloadMF {
         @MultiField(value = -1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxSB.class);
@@ -616,7 +671,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxIB extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxIB extends VectorPayloadMF {
         @MultiField(value = -1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxIB.class);
@@ -625,7 +682,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMFMaxLB extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMFMaxLB extends VectorPayloadMF {
         @MultiField(value = -1)
         byte mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMFMaxLB.class);
@@ -634,7 +693,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64S extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64S extends VectorPayloadMF {
         @MultiField(value = 4)
         short mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64S.class);
@@ -643,7 +704,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128S extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128S extends VectorPayloadMF {
         @MultiField(value = 8)
         short mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128S.class);
@@ -652,7 +715,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256S extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256S extends VectorPayloadMF {
         @MultiField(value = 16)
         short mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256S.class);
@@ -661,7 +726,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512S extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512S extends VectorPayloadMF {
         @MultiField(value = 32)
         short mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512S.class);
@@ -670,7 +737,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64I extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64I extends VectorPayloadMF {
         @MultiField(value = 2)
         int mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64I.class);
@@ -679,7 +748,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128I extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128I extends VectorPayloadMF {
         @MultiField(value = 4)
         int mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128I.class);
@@ -688,7 +759,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256I extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256I extends VectorPayloadMF {
         @MultiField(value = 8)
         int mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256I.class);
@@ -697,7 +770,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512I extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512I extends VectorPayloadMF {
         @MultiField(value = 16)
         int mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512I.class);
@@ -706,7 +781,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64L extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64L extends VectorPayloadMF {
         @MultiField(value = 1)
         final long mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64L.class);
@@ -715,7 +792,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128L extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128L extends VectorPayloadMF {
         @MultiField(value = 2)
         final long mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128L.class);
@@ -724,7 +803,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256L extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256L extends VectorPayloadMF {
         @MultiField(value = 4)
         final long mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256L.class);
@@ -733,7 +814,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512L extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512L extends VectorPayloadMF {
         @MultiField(value = 8)
         final long mfield = 0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512L.class);
@@ -742,7 +825,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64F extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64F extends VectorPayloadMF {
         @MultiField(value = 2)
         float mfield = 0.0f;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64F.class);
@@ -751,7 +836,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128F extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128F extends VectorPayloadMF {
         @MultiField(value = 4)
         float mfield = 0.0f;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128F.class);
@@ -760,7 +847,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256F extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256F extends VectorPayloadMF {
         @MultiField(value = 8)
         float mfield = 0.0f;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256F.class);
@@ -769,7 +858,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512F extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512F extends VectorPayloadMF {
         @MultiField(value = 16)
         float mfield = 0.0f;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512F.class);
@@ -778,7 +869,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF64D extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF64D extends VectorPayloadMF {
         @MultiField(value = 1)
         double mfield = 0.0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF64D.class);
@@ -787,7 +880,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF128D extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF128D extends VectorPayloadMF {
         @MultiField(value = 2)
         double mfield = 0.0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF128D.class);
@@ -796,7 +891,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF256D extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF256D extends VectorPayloadMF {
         @MultiField(value = 4)
         double mfield = 0.0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF256D.class);
@@ -805,7 +902,9 @@ public class VectorSupport {
         public long multiFieldOffset() { return MFOFFSET; }
     }
 
-    public primitive static class VectorPayloadMF512D extends VectorPayloadMF {
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    public value static class VectorPayloadMF512D extends VectorPayloadMF {
         @MultiField(value = 8)
         double mfield = 0.0;
         static final long MFOFFSET = multiFieldOffset(VectorPayloadMF512D.class);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Byte128Vector extends ByteVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128B.class);
 
+    @NullRestricted
     private final VectorPayloadMF128B payload;
 
     Byte128Vector(Object value) {
@@ -590,6 +592,7 @@ value class Byte128Vector extends ByteVector {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF128Z payload;
 
         Byte128Mask(VectorPayloadMF payload, int offset) {
@@ -760,6 +763,7 @@ value class Byte128Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF128B payload;
 
         Byte128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Byte256Vector extends ByteVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256B.class);
 
+    @NullRestricted
     private final VectorPayloadMF256B payload;
 
     Byte256Vector(Object value) {
@@ -622,6 +624,7 @@ value class Byte256Vector extends ByteVector {
             this.payload = (VectorPayloadMF256Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF256Z payload;
 
         Byte256Mask(VectorPayloadMF payload, int offset) {
@@ -792,6 +795,7 @@ value class Byte256Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF256B payload;
 
         Byte256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Byte512Vector extends ByteVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512B.class);
 
+    @NullRestricted
     private final VectorPayloadMF512B payload;
 
     Byte512Vector(Object value) {
@@ -686,6 +688,7 @@ value class Byte512Vector extends ByteVector {
             this.payload = (VectorPayloadMF512Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF512Z payload;
 
         Byte512Mask(VectorPayloadMF payload, int offset) {
@@ -856,6 +859,7 @@ value class Byte512Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF512B payload;
 
         Byte512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Byte64Vector extends ByteVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64B.class);
 
+    @NullRestricted
     private final VectorPayloadMF64B payload;
 
     Byte64Vector(Object value) {
@@ -574,6 +576,7 @@ value class Byte64Vector extends ByteVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Byte64Mask(VectorPayloadMF payload, int offset) {
@@ -744,6 +747,7 @@ value class Byte64Vector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Byte64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class ByteMaxVector extends ByteVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxB.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxB payload;
 
     ByteMaxVector(Object value) {
@@ -560,6 +562,7 @@ value class ByteMaxVector extends ByteVector {
             this.payload = (VectorPayloadMFMaxBZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxBZ payload;
 
         ByteMaxMask(VectorPayloadMF payload, int offset) {
@@ -730,6 +733,7 @@ value class ByteMaxVector extends ByteVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Byte> ETYPE = byte.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxBB payload;
 
         ByteMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Double128Vector extends DoubleVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128D.class);
 
+    @NullRestricted
     private final VectorPayloadMF128D payload;
 
     Double128Vector(Object value) {
@@ -551,6 +553,7 @@ value class Double128Vector extends DoubleVector {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF16Z payload;
 
         Double128Mask(VectorPayloadMF payload, int offset) {
@@ -721,6 +724,7 @@ value class Double128Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF16B payload;
 
         Double128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Double256Vector extends DoubleVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256D.class);
 
+    @NullRestricted
     private final VectorPayloadMF256D payload;
 
     Double256Vector(Object value) {
@@ -555,6 +557,7 @@ value class Double256Vector extends DoubleVector {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF32Z payload;
 
         Double256Mask(VectorPayloadMF payload, int offset) {
@@ -725,6 +728,7 @@ value class Double256Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF32B payload;
 
         Double256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Double512Vector extends DoubleVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512D.class);
 
+    @NullRestricted
     private final VectorPayloadMF512D payload;
 
     Double512Vector(Object value) {
@@ -563,6 +565,7 @@ value class Double512Vector extends DoubleVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Double512Mask(VectorPayloadMF payload, int offset) {
@@ -733,6 +736,7 @@ value class Double512Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Double512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Double64Vector extends DoubleVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64D.class);
 
+    @NullRestricted
     private final VectorPayloadMF64D payload;
 
     Double64Vector(Object value) {
@@ -549,6 +551,7 @@ value class Double64Vector extends DoubleVector {
             this.payload = (VectorPayloadMF8Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF8Z payload;
 
         Double64Mask(VectorPayloadMF payload, int offset) {
@@ -719,6 +722,7 @@ value class Double64Vector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF8B payload;
 
         Double64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class DoubleMaxVector extends DoubleVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxD.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxD payload;
 
     DoubleMaxVector(Object value) {
@@ -548,6 +550,7 @@ value class DoubleMaxVector extends DoubleVector {
             this.payload = (VectorPayloadMFMaxLZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxLZ payload;
 
         DoubleMaxMask(VectorPayloadMF payload, int offset) {
@@ -718,6 +721,7 @@ value class DoubleMaxVector extends DoubleVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Double> ETYPE = double.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxLB payload;
 
         DoubleMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Float128Vector extends FloatVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128F.class);
 
+    @NullRestricted
     private final VectorPayloadMF128F payload;
 
     Float128Vector(Object value) {
@@ -555,6 +557,7 @@ value class Float128Vector extends FloatVector {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF32Z payload;
 
         Float128Mask(VectorPayloadMF payload, int offset) {
@@ -725,6 +728,7 @@ value class Float128Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF32B payload;
 
         Float128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Float256Vector extends FloatVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256F.class);
 
+    @NullRestricted
     private final VectorPayloadMF256F payload;
 
     Float256Vector(Object value) {
@@ -563,6 +565,7 @@ value class Float256Vector extends FloatVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Float256Mask(VectorPayloadMF payload, int offset) {
@@ -733,6 +736,7 @@ value class Float256Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Float256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Float512Vector extends FloatVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512F.class);
 
+    @NullRestricted
     private final VectorPayloadMF512F payload;
 
     Float512Vector(Object value) {
@@ -579,6 +581,7 @@ value class Float512Vector extends FloatVector {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF128Z payload;
 
         Float512Mask(VectorPayloadMF payload, int offset) {
@@ -749,6 +752,7 @@ value class Float512Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF128B payload;
 
         Float512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Float64Vector extends FloatVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64F.class);
 
+    @NullRestricted
     private final VectorPayloadMF64F payload;
 
     Float64Vector(Object value) {
@@ -551,6 +553,7 @@ value class Float64Vector extends FloatVector {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF16Z payload;
 
         Float64Mask(VectorPayloadMF payload, int offset) {
@@ -721,6 +724,7 @@ value class Float64Vector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF16B payload;
 
         Float64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class FloatMaxVector extends FloatVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxF.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxF payload;
 
     FloatMaxVector(Object value) {
@@ -548,6 +550,7 @@ value class FloatMaxVector extends FloatVector {
             this.payload = (VectorPayloadMFMaxIZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxIZ payload;
 
         FloatMaxMask(VectorPayloadMF payload, int offset) {
@@ -718,6 +721,7 @@ value class FloatMaxVector extends FloatVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Float> ETYPE = float.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxIB payload;
 
         FloatMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Int128Vector extends IntVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128I.class);
 
+    @NullRestricted
     private final VectorPayloadMF128I payload;
 
     Int128Vector(Object value) {
@@ -566,6 +568,7 @@ value class Int128Vector extends IntVector {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF32Z payload;
 
         Int128Mask(VectorPayloadMF payload, int offset) {
@@ -736,6 +739,7 @@ value class Int128Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF32B payload;
 
         Int128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Int256Vector extends IntVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256I.class);
 
+    @NullRestricted
     private final VectorPayloadMF256I payload;
 
     Int256Vector(Object value) {
@@ -574,6 +576,7 @@ value class Int256Vector extends IntVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Int256Mask(VectorPayloadMF payload, int offset) {
@@ -744,6 +747,7 @@ value class Int256Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Int256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Int512Vector extends IntVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512I.class);
 
+    @NullRestricted
     private final VectorPayloadMF512I payload;
 
     Int512Vector(Object value) {
@@ -590,6 +592,7 @@ value class Int512Vector extends IntVector {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF128Z payload;
 
         Int512Mask(VectorPayloadMF payload, int offset) {
@@ -760,6 +763,7 @@ value class Int512Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF128B payload;
 
         Int512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Int64Vector extends IntVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64I.class);
 
+    @NullRestricted
     private final VectorPayloadMF64I payload;
 
     Int64Vector(Object value) {
@@ -562,6 +564,7 @@ value class Int64Vector extends IntVector {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF16Z payload;
 
         Int64Mask(VectorPayloadMF payload, int offset) {
@@ -732,6 +735,7 @@ value class Int64Vector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF16B payload;
 
         Int64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class IntMaxVector extends IntVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxI.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxI payload;
 
     IntMaxVector(Object value) {
@@ -560,6 +562,7 @@ value class IntMaxVector extends IntVector {
             this.payload = (VectorPayloadMFMaxIZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxIZ payload;
 
         IntMaxMask(VectorPayloadMF payload, int offset) {
@@ -744,6 +747,7 @@ value class IntMaxVector extends IntVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Integer> ETYPE = int.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxIB payload;
 
         IntMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Long128Vector extends LongVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128L.class);
 
+    @NullRestricted
     private final VectorPayloadMF128L payload;
 
     Long128Vector(Object value) {
@@ -552,6 +554,7 @@ value class Long128Vector extends LongVector {
             this.payload = (VectorPayloadMF16Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF16Z payload;
 
         Long128Mask(VectorPayloadMF payload, int offset) {
@@ -722,6 +725,7 @@ value class Long128Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF16B payload;
 
         Long128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Long256Vector extends LongVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256L.class);
 
+    @NullRestricted
     private final VectorPayloadMF256L payload;
 
     Long256Vector(Object value) {
@@ -556,6 +558,7 @@ value class Long256Vector extends LongVector {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF32Z payload;
 
         Long256Mask(VectorPayloadMF payload, int offset) {
@@ -726,6 +729,7 @@ value class Long256Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF32B payload;
 
         Long256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Long512Vector extends LongVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512L.class);
 
+    @NullRestricted
     private final VectorPayloadMF512L payload;
 
     Long512Vector(Object value) {
@@ -564,6 +566,7 @@ value class Long512Vector extends LongVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Long512Mask(VectorPayloadMF payload, int offset) {
@@ -734,6 +737,7 @@ value class Long512Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Long512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Long64Vector extends LongVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64L.class);
 
+    @NullRestricted
     private final VectorPayloadMF64L payload;
 
     Long64Vector(Object value) {
@@ -550,6 +552,7 @@ value class Long64Vector extends LongVector {
             this.payload = (VectorPayloadMF8Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF8Z payload;
 
         Long64Mask(VectorPayloadMF payload, int offset) {
@@ -720,6 +723,7 @@ value class Long64Vector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF8B payload;
 
         Long64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class LongMaxVector extends LongVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxL.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxL payload;
 
     LongMaxVector(Object value) {
@@ -550,6 +552,7 @@ value class LongMaxVector extends LongVector {
             this.payload = (VectorPayloadMFMaxLZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxLZ payload;
 
         LongMaxMask(VectorPayloadMF payload, int offset) {
@@ -720,6 +723,7 @@ value class LongMaxVector extends LongVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Long> ETYPE = long.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxLB payload;
 
         LongMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Short128Vector extends ShortVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF128S.class);
 
+    @NullRestricted
     private final VectorPayloadMF128S payload;
 
     Short128Vector(Object value) {
@@ -574,6 +576,7 @@ value class Short128Vector extends ShortVector {
             this.payload = (VectorPayloadMF64Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF64Z payload;
 
         Short128Mask(VectorPayloadMF payload, int offset) {
@@ -744,6 +747,7 @@ value class Short128Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF64B payload;
 
         Short128Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Short256Vector extends ShortVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF256S.class);
 
+    @NullRestricted
     private final VectorPayloadMF256S payload;
 
     Short256Vector(Object value) {
@@ -590,6 +592,7 @@ value class Short256Vector extends ShortVector {
             this.payload = (VectorPayloadMF128Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF128Z payload;
 
         Short256Mask(VectorPayloadMF payload, int offset) {
@@ -760,6 +763,7 @@ value class Short256Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF128B payload;
 
         Short256Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Short512Vector extends ShortVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF512S.class);
 
+    @NullRestricted
     private final VectorPayloadMF512S payload;
 
     Short512Vector(Object value) {
@@ -622,6 +624,7 @@ value class Short512Vector extends ShortVector {
             this.payload = (VectorPayloadMF256Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF256Z payload;
 
         Short512Mask(VectorPayloadMF payload, int offset) {
@@ -792,6 +795,7 @@ value class Short512Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF256B payload;
 
         Short512Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class Short64Vector extends ShortVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF64S.class);
 
+    @NullRestricted
     private final VectorPayloadMF64S payload;
 
     Short64Vector(Object value) {
@@ -566,6 +568,7 @@ value class Short64Vector extends ShortVector {
             this.payload = (VectorPayloadMF32Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF32Z payload;
 
         Short64Mask(VectorPayloadMF payload, int offset) {
@@ -736,6 +739,7 @@ value class Short64Vector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMF32B payload;
 
         Short64Shuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class ShortMaxVector extends ShortVector {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMFMaxS.class);
 
+    @NullRestricted
     private final VectorPayloadMFMaxS payload;
 
     ShortMaxVector(Object value) {
@@ -560,6 +562,7 @@ value class ShortMaxVector extends ShortVector {
             this.payload = (VectorPayloadMFMaxSZ) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMFMaxSZ payload;
 
         ShortMaxMask(VectorPayloadMF payload, int offset) {
@@ -730,6 +733,7 @@ value class ShortMaxVector extends ShortVector {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
         static final Class<Short> ETYPE = short.class; // used by the JVM
 
+        @NullRestricted
         private final VectorPayloadMFMaxSB payload;
 
         ShortMaxShuffle(VectorPayloadMF payload) {

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -31,6 +31,7 @@ import jdk.internal.misc.Unsafe;
 import java.util.function.IntUnaryOperator;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.annotation.NullRestricted;
 import jdk.internal.vm.vector.VectorSupport;
 
 import static jdk.internal.vm.vector.VectorSupport.*;
@@ -57,6 +58,7 @@ value class $vectortype$ extends $abstractvectortype$ {
 
     static final long MFOFFSET = VectorPayloadMF.multiFieldOffset(VectorPayloadMF$bits$$Boxinitials$.class);
 
+    @NullRestricted
     private final VectorPayloadMF$bits$$Boxinitials$ payload;
 
     $vectortype$(Object value) {
@@ -843,6 +845,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             this.payload = (VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$Z payload;
 
         $masktype$(VectorPayloadMF payload, int offset) {
@@ -857,6 +860,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             this.payload = (VectorPayloadMF$vectorsizeinbytes$Z) payload;
         }
 
+        @NullRestricted
         private final VectorPayloadMF$vectorsizeinbytes$Z payload;
 
         $masktype$(VectorPayloadMF payload, int offset) {
@@ -1051,6 +1055,7 @@ value class $vectortype$ extends $abstractvectortype$ {
         static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
 
 #if[Max]
+        @NullRestricted
         private final VectorPayloadMF$vectorsizeinbytes$$Boxbitsinitials$B payload;
 
         $shuffletype$(VectorPayloadMF payload) {
@@ -1067,6 +1072,7 @@ value class $vectortype$ extends $abstractvectortype$ {
             this(prepare(fn, VSPECIES));
         }
 #else[Max]
+        @NullRestricted
         private final VectorPayloadMF$vectorsizeinbytes$B payload;
 
         $shuffletype$(VectorPayloadMF payload) {


### PR DESCRIPTION
-  Align existing vector API java side implementation with JEP 401[1] and future JEP Null-Restricted Value Class Types[2]
-  Existing primitive value class based vector payloads becomes value classes decorated with LosselyConsistent and ImplicitlyConstructible annotations, this
   relaxes atomicity constraints on instance updates and guarantees initialization by a default value.
-  Payload field in concrete values classes is NullRestricted to promote its flattening.
-  In future we can consider making publicly exposed abstract vector classes as sealed classes to restrict its sub-classing by known concrete vector classes.

All existing Vector API JTREG tests are passing at various AVX level with/wo -XX:+DeoptimizeALot.

Best Regards,
Jatin
[1] https://openjdk.org/jeps/401
[2] https://openjdk.org/jeps/8316779

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1034/head:pull/1034` \
`$ git checkout pull/1034`

Update a local copy of the PR: \
`$ git checkout pull/1034` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1034`

View PR using the GUI difftool: \
`$ git pr show -t 1034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1034.diff">https://git.openjdk.org/valhalla/pull/1034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1034#issuecomment-1980211053)