### PR TITLE
8327481: [lworld] Update primitive wrappers to value classes when --enable-preview

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -27,6 +27,16 @@
 # Generate the value class replacements for selected java.base source files
 
 java.base-VALUE_CLASS-REPLACEMENTS := \
+    java/lang/Number.java \
+    java/lang/Byte.java \
+    java/lang/Short.java \
+    java/lang/Integer.java \
+    java/lang/Long.java \
+    java/lang/Float.java \
+    java/lang/Double.java \
+    java/lang/Boolean.java \
+    java/lang/Character.java \
+    java/lang/Record.java \
     java/util/Optional.java \
     java/util/OptionalInt.java \
     java/util/OptionalLong.java \
@@ -43,7 +53,6 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/YearMonth.java \
     java/time/Year.java \
     java/time/Period.java \
-    java/lang/Record.java \
     #
 
 java.base-VALUE-CLASS-FILES := \


### PR DESCRIPTION
Apply list of JEP 401 value classes with --enable-preview

    java.lang.Byte
    java.lang.Short
    java.lang.Integer
    java.lang.Long
    java.lang.Float
    java.lang.Double
    java.lang.Boolean
    java.lang.Character
    java.util.Optional
    java.lang.Number
    java.lang.Record

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327481](https://bugs.openjdk.org/browse/JDK-8327481): [lworld] Update primitive wrappers to value classes when --enable-preview (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1035/head:pull/1035` \
`$ git checkout pull/1035`

Update a local copy of the PR: \
`$ git checkout pull/1035` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1035/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1035`

View PR using the GUI difftool: \
`$ git pr show -t 1035`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1035.diff">https://git.openjdk.org/valhalla/pull/1035.diff</a>

</details>
