### PR TITLE
8327498: [lworld] Remove Q-descriptor change from ASM and other clean up

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -297,7 +297,7 @@ public sealed interface ClassDesc
      * @return whether this {@linkplain ClassDesc} describes a class or interface type
      */
     default boolean isClassOrInterface() {
-        return descriptorString().startsWith("L") || descriptorString().startsWith("Q");
+        return descriptorString().startsWith("L");
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDescImpl.java
@@ -36,7 +36,6 @@ import static java.util.Objects.requireNonNull;
  */
 final class ClassDescImpl implements ClassDesc {
     private final String descriptor;
-    private final boolean isValue;
 
     /**
      * Creates a {@linkplain ClassDesc} from a descriptor string for a class or
@@ -54,7 +53,6 @@ final class ClassDescImpl implements ClassDesc {
             || len != descriptor.length())
             throw new IllegalArgumentException(String.format("not a valid reference type descriptor: %s", descriptor));
         this.descriptor = descriptor;
-        this.isValue = ConstantUtils.basicType(descriptor, 0, descriptor.length(), false) == 'Q';
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -548,9 +548,9 @@ sealed class DirectMethodHandle extends MethodHandle {
 
     /** This subclass handles static field references. */
     static final class StaticAccessor extends DirectMethodHandle {
-        final Class<?> fieldType;
-        final Object staticBase;
-        final long staticOffset;
+        private final Class<?> fieldType;
+        private final Object   staticBase;
+        private final long     staticOffset;
 
         private StaticAccessor(MethodType mtype, LambdaForm form, MemberName member,
                                boolean crackable, Object staticBase, long staticOffset) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleInfo.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleInfo.java
@@ -163,7 +163,6 @@ public interface MethodHandleInfo {
      * This is {@value java.lang.constant.ConstantDescs#INIT_NAME}
      * if the underlying member was a constructor,
      * else it is a simple method name or field name.
-     * was a constructor, else it is a simple method name or field name.
      * @return the simple name of the underlying member
      */
     public String getName();

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -602,12 +602,12 @@ class MethodHandleNatives {
         sb.append(prefix);
         for (int i = 1; i < guardType.parameterCount() - 1; i++) {
             Class<?> pt = guardType.parameterType(i);
-            sb.append(getCharErasedType(pt));
+            sb.append(getCharType(pt));
         }
-        sb.append('_').append(getCharErasedType(guardType.returnType()));
+        sb.append('_').append(getCharType(guardType.returnType()));
         return sb.toString();
     }
-    static char getCharErasedType(Class<?> pt) {
+    static char getCharType(Class<?> pt) {
         return Wrapper.forBasicType(pt).basicTypeChar();
     }
     static NoSuchMethodError newNoSuchMethodErrorOnVarHandle(String name, MethodType mtype) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -3797,7 +3797,6 @@ return mh1;
             if (name.startsWith("<") && refKind != REF_newInvokeSpecial) {
                 return null;
             }
-
             return IMPL_NAMES.resolveOrNull(refKind, new MemberName(refc, name, type, refKind), lookupClassOrNull(), allowedModes);
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Classfile.java
@@ -1074,7 +1074,6 @@ public sealed interface Classfile
 
     /** 0x0040 */
     int ACC_VOLATILE = 0x0040;
-    int ACC_VALUE    = 0x0040;
 
     /** 0x0080 */
     int ACC_TRANSIENT = 0x0080;

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/ClassReader.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/ClassReader.java
@@ -1854,8 +1854,6 @@ public class ClassReader {
                 case Opcodes.PUTSTATIC:
                 case Opcodes.GETFIELD:
                 case Opcodes.PUTFIELD:
-                case Opcodes.DEFAULT:
-                case Opcodes.WITHFIELD:
                 case Opcodes.INVOKEVIRTUAL:
                 case Opcodes.INVOKESPECIAL:
                 case Opcodes.INVOKESTATIC:
@@ -2468,19 +2466,18 @@ public class ClassReader {
                 case Opcodes.INVOKESPECIAL:
                 case Opcodes.INVOKESTATIC:
                 case Opcodes.INVOKEINTERFACE:
-                case Opcodes.WITHFIELD:
                     {
                         int cpInfoOffset = cpInfoOffsets[readUnsignedShort(currentOffset + 1)];
                         int nameAndTypeCpInfoOffset = cpInfoOffsets[readUnsignedShort(cpInfoOffset + 2)];
                         String owner = readClass(cpInfoOffset, charBuffer);
                         String name = readUTF8(nameAndTypeCpInfoOffset, charBuffer);
                         String descriptor = readUTF8(nameAndTypeCpInfoOffset + 2, charBuffer);
-                        if (opcode >= Opcodes.INVOKEVIRTUAL && opcode <= Opcodes.INVOKEINTERFACE) {
+                        if (opcode < Opcodes.INVOKEVIRTUAL) {
+                            methodVisitor.visitFieldInsn(opcode, owner, name, descriptor);
+                        } else {
                             boolean isInterface =
                                     classBuffer[cpInfoOffset - 1] == Symbol.CONSTANT_INTERFACE_METHODREF_TAG;
                             methodVisitor.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
-                        } else {
-                            methodVisitor.visitFieldInsn(opcode, owner, name, descriptor);
                         }
                         if (opcode == Opcodes.INVOKEINTERFACE) {
                             currentOffset += 5;
@@ -2515,7 +2512,6 @@ public class ClassReader {
                 case Opcodes.ANEWARRAY:
                 case Opcodes.CHECKCAST:
                 case Opcodes.INSTANCEOF:
-                case Opcodes.DEFAULT:
                     methodVisitor.visitTypeInsn(opcode, readClass(currentOffset + 1, charBuffer));
                     currentOffset += 3;
                     break;
@@ -3267,8 +3263,7 @@ public class ClassReader {
                     while (methodDescriptor.charAt(currentMethodDescritorOffset) == '[') {
                         ++currentMethodDescritorOffset;
                     }
-                    char descType = methodDescriptor.charAt(currentMethodDescritorOffset);
-                    if (descType == 'L' || descType == 'Q') {
+                    if (methodDescriptor.charAt(currentMethodDescritorOffset) == 'L') {
                         ++currentMethodDescritorOffset;
                         while (methodDescriptor.charAt(currentMethodDescritorOffset) != ';') {
                             ++currentMethodDescritorOffset;

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Constants.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Constants.java
@@ -185,8 +185,10 @@ final class Constants {
 
     // The delta between the ASM_IFEQ, ..., ASM_IF_ACMPNE, ASM_GOTO and ASM_JSR opcodes
     // and IFEQ, ..., IF_ACMPNE, GOTO and JSR.
-    // Offset to next available opcode after WITHFIELD from IFEQ
-    static final int ASM_OPCODE_DELTA = (Opcodes.WITHFIELD + 1) - Opcodes.IFEQ;
+    static final int ASM_OPCODE_DELTA = 49;
+
+    // The delta between the ASM_IFNULL and ASM_IFNONNULL opcodes and IFNULL and IFNONNULL.
+    static final int ASM_IFNULL_OPCODE_DELTA = 20;
 
     // ASM specific opcodes, used for long forward jump instructions.
 
@@ -206,14 +208,9 @@ final class Constants {
     static final int ASM_IF_ACMPNE = Opcodes.IF_ACMPNE + ASM_OPCODE_DELTA;
     static final int ASM_GOTO = Opcodes.GOTO + ASM_OPCODE_DELTA;
     static final int ASM_JSR = Opcodes.JSR + ASM_OPCODE_DELTA;
-
-    // The delta between the ASM_IFNULL and ASM_IFNONNULL opcodes and IFNULL and IFNONNULL.
-    // Offset to next available opcode after ASM_JSR from IFNULL.
-    static final int ASM_IFNULL_OPCODE_DELTA = (ASM_JSR + 1) - Opcodes.IFNULL;
-
     static final int ASM_IFNULL = Opcodes.IFNULL + ASM_IFNULL_OPCODE_DELTA;
     static final int ASM_IFNONNULL = Opcodes.IFNONNULL + ASM_IFNULL_OPCODE_DELTA;
-    static final int ASM_GOTO_W = GOTO_W + ASM_IFNULL_OPCODE_DELTA;
+    static final int ASM_GOTO_W = 220;
 
     private Constants() {}
 
@@ -254,4 +251,3 @@ final class Constants {
         }
     }
 }
-

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Frame.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Frame.java
@@ -361,7 +361,6 @@ class Frame {
             case 'D':
                 return DOUBLE;
             case 'L':
-            case 'Q':
                 internalName = buffer.substring(offset + 1, buffer.length() - 1);
                 return REFERENCE_KIND | symbolTable.addType(internalName);
             case '[':
@@ -396,7 +395,6 @@ class Frame {
                         typeValue = DOUBLE;
                         break;
                     case 'L':
-                    case 'Q':
                         internalName = buffer.substring(elementDescriptorOffset + 1, buffer.length() - 1);
                         typeValue = REFERENCE_KIND | symbolTable.addType(internalName);
                         break;

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/MethodWriter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/MethodWriter.java
@@ -312,10 +312,7 @@ final class MethodWriter extends MethodVisitor {
         -1, // ifnull = 198 (0xc6)
         -1, // ifnonnull = 199 (0xc7)
         NA, // goto_w = 200 (0xc8)
-        NA, // jsr_w = 201 (0xc9)
-        NA, // breakpoint = 202 (0xca)
-        NA, // default = 203 (0xcb)
-        NA, // withfield = 204 (0xcc)
+        NA // jsr_w = 201 (0xc9)
     };
 
     /** Where the constants used in this MethodWriter must be stored. */
@@ -1011,7 +1008,7 @@ final class MethodWriter extends MethodVisitor {
         if (currentBasicBlock != null) {
             if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
                 currentBasicBlock.frame.execute(opcode, lastBytecodeOffset, typeSymbol, symbolTable);
-            } else if (opcode == Opcodes.NEW || opcode == Opcodes.DEFAULT) {
+            } else if (opcode == Opcodes.NEW) {
                 // The stack size delta is 1 for NEW, and 0 for ANEWARRAY, CHECKCAST, or INSTANCEOF.
                 int size = relativeStackSize + 1;
                 if (size > maxRelativeStackSize) {
@@ -1037,9 +1034,6 @@ final class MethodWriter extends MethodVisitor {
                 int size;
                 char firstDescChar = descriptor.charAt(0);
                 switch (opcode) {
-                    case Opcodes.WITHFIELD:
-                        size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? -2 : -1);
-                        break;
                     case Opcodes.GETSTATIC:
                         size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? 2 : 1);
                         break;

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Opcodes.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Opcodes.java
@@ -338,16 +338,13 @@ public interface Opcodes {
     int ACC_OPEN = 0x0020; // module
     int ACC_TRANSITIVE = 0x0020; // module requires
     int ACC_VOLATILE = 0x0040; // field
-    int ACC_VALUE = 0x0040; // class
     int ACC_BRIDGE = 0x0040; // method
     int ACC_STATIC_PHASE = 0x0040; // module requires
     int ACC_VARARGS = 0x0080; // method
     int ACC_TRANSIENT = 0x0080; // field
     int ACC_NATIVE = 0x0100; // method
-    int ACC_INLINE = 0x0100; // inline class
     int ACC_INTERFACE = 0x0200; // class
     int ACC_ABSTRACT = 0x0400; // class, method
-    int ACC_PRIMITIVE = 0x0800; // class
     int ACC_STRICT = 0x0800; // method
     int ACC_SYNTHETIC = 0x1000; // class, field, method, parameter, module *
     int ACC_ANNOTATION = 0x2000; // class
@@ -590,7 +587,5 @@ public interface Opcodes {
     int MULTIANEWARRAY = 197; // visitMultiANewArrayInsn
     int IFNULL = 198; // visitJumpInsn
     int IFNONNULL = 199; // -
-    int DEFAULT = 203; // visitTypeInsn
-    int WITHFIELD = 204; // visitFieldInsn
 }
 

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Type.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/Type.java
@@ -60,9 +60,7 @@
 package jdk.internal.org.objectweb.asm;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 /**
  * A Java field or method type. This class can be used to make it easier to manipulate type and
@@ -337,8 +335,7 @@ public final class Type {
             while (methodDescriptor.charAt(currentOffset) == '[') {
                 currentOffset++;
             }
-            char c = methodDescriptor.charAt(currentOffset++);
-            if (c == 'L' || c == 'Q') {
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
                 // Skip the argument descriptor content.
                 int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
                 currentOffset = Math.max(currentOffset, semiColumnOffset + 1);
@@ -357,8 +354,7 @@ public final class Type {
             while (methodDescriptor.charAt(currentOffset) == '[') {
                 currentOffset++;
             }
-            char c = methodDescriptor.charAt(currentOffset++);
-            if (c == 'L' || c == 'Q') {
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
                 // Skip the argument descriptor content.
                 int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
                 currentOffset = Math.max(currentOffset, semiColumnOffset + 1);
@@ -429,8 +425,7 @@ public final class Type {
             while (methodDescriptor.charAt(currentOffset) == '[') {
                 currentOffset++;
             }
-            char c = methodDescriptor.charAt(currentOffset++);
-            if (c == 'L' || c == 'Q') {
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
                 // Skip the argument descriptor content.
                 int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
                 currentOffset = Math.max(currentOffset, semiColumnOffset + 1);
@@ -473,7 +468,6 @@ public final class Type {
             case '[':
                 return new Type(ARRAY, descriptorBuffer, descriptorBegin, descriptorEnd);
             case 'L':
-            case 'Q':
                 return new Type(OBJECT, descriptorBuffer, descriptorBegin + 1, descriptorEnd - 1);
             case '(':
                 return new Type(METHOD, descriptorBuffer, descriptorBegin, descriptorEnd);
@@ -679,12 +673,8 @@ public final class Type {
             }
             stringBuilder.append(descriptor);
         } else {
-            stringBuilder.append(isPrimitiveClass(currentClass) ? 'Q' : 'L').append(getInternalName(currentClass)).append(';');
+            stringBuilder.append('L').append(getInternalName(currentClass)).append(';');
         }
-    }
-
-    static boolean isPrimitiveClass(Class<?> clazz) {
-        return (clazz.getModifiers() & Opcodes.ACC_PRIMITIVE) != 0;
     }
 
     // -----------------------------------------------------------------------------------------------
@@ -780,8 +770,7 @@ public final class Type {
                 while (methodDescriptor.charAt(currentOffset) == '[') {
                     currentOffset++;
                 }
-                char c = methodDescriptor.charAt(currentOffset++);
-                if (c == 'L' || c == 'Q') {
+                if (methodDescriptor.charAt(currentOffset++) == 'L') {
                     // Skip the argument descriptor content.
                     int semiColumnOffset = methodDescriptor.indexOf(';', currentOffset);
                     currentOffset = Math.max(currentOffset, semiColumnOffset + 1);

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/AnalyzerAdapter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/AnalyzerAdapter.java
@@ -533,7 +533,6 @@ public class AnalyzerAdapter extends MethodVisitor {
                 push(descriptor);
                 break;
             case 'L':
-            case 'Q':
                 push(descriptor.substring(1, descriptor.length() - 1));
                 break;
             default:

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/Method.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/Method.java
@@ -223,7 +223,6 @@ public class Method {
         if (descriptor != null) {
             stringBuilder.append(descriptor);
         } else {
-            // FIXME: support Q-type
             stringBuilder.append('L');
             if (elementType.indexOf('.') < 0) {
                 if (!defaultPackage) {

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/Remapper.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/commons/Remapper.java
@@ -84,7 +84,6 @@ public abstract class Remapper {
       */
     public String mapDesc(final String descriptor) {
         return mapType(Type.getType(descriptor)).getDescriptor();
-            // FIXME: support Q-type
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/signature/SignatureReader.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/signature/SignatureReader.java
@@ -115,7 +115,7 @@ public class SignatureReader {
                 // ReferenceTypeSignature, it means the class bound is empty (which is a valid case).
                 offset = classBoundStartOffset + 1;
                 currentChar = signature.charAt(offset);
-                if (currentChar == 'L' || currentChar == 'Q' || currentChar == '[' || currentChar == 'T') {
+                if (currentChar == 'L' || currentChar == '[' || currentChar == 'T') {
                     offset = parseType(signature, offset, signatureVistor.visitClassBound());
                 }
 

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckClassAdapter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckClassAdapter.java
@@ -639,7 +639,7 @@ public class CheckClassAdapter extends ClassVisitor {
             pos = checkTypeParameters(signature, pos);
         }
         pos = checkClassTypeSignature(signature, pos);
-        while (getChar(signature, pos) == 'L' || getChar(signature, pos) == 'Q') {
+        while (getChar(signature, pos) == 'L') {
             pos = checkClassTypeSignature(signature, pos);
         }
         if (pos != signature.length()) {
@@ -667,7 +667,7 @@ public class CheckClassAdapter extends ClassVisitor {
             pos = checkTypeParameters(signature, pos);
         }
         pos = checkChar('(', signature, pos);
-        while ("ZCBSIFJDLQ[T".indexOf(getChar(signature, pos)) != -1) {
+        while ("ZCBSIFJDL[T".indexOf(getChar(signature, pos)) != -1) {
             pos = checkJavaTypeSignature(signature, pos);
         }
         pos = checkChar(')', signature, pos);
@@ -678,7 +678,7 @@ public class CheckClassAdapter extends ClassVisitor {
         }
         while (getChar(signature, pos) == '^') {
             ++pos;
-            if (getChar(signature, pos) == 'L' || getChar(signature, pos) == 'Q') {
+            if (getChar(signature, pos) == 'L') {
                 pos = checkClassTypeSignature(signature, pos);
             } else {
                 pos = checkTypeVariableSignature(signature, pos);
@@ -794,12 +794,7 @@ public class CheckClassAdapter extends ClassVisitor {
         // ClassTypeSignatureSuffix:
         //   . SimpleClassTypeSignature
         int pos = startPos;
-        if (getChar(signature, pos) == 'L' || getChar(signature, pos) == 'Q') {
-            pos = pos + 1;
-        } else {
-            throw new IllegalArgumentException(signature + ": 'L' or 'Q' expected at index " + pos);
-        }
-
+        pos = checkChar('L', signature, pos);
         pos = checkSignatureIdentifier(signature, pos);
         while (getChar(signature, pos) == '/') {
             pos = checkSignatureIdentifier(signature, pos + 1);

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckMethodAdapter.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/CheckMethodAdapter.java
@@ -1418,7 +1418,6 @@ public class CheckMethodAdapter extends MethodVisitor {
                     throw new IllegalArgumentException(INVALID_DESCRIPTOR + descriptor);
                 }
             case 'L':
-            case 'Q':
                 int endPos = descriptor.indexOf(';', startPos);
                 if (startPos == -1 || endPos - startPos < 2) {
                     throw new IllegalArgumentException(INVALID_DESCRIPTOR + descriptor);

--- a/src/java.base/share/classes/jdk/internal/reflect/AccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/AccessorGenerator.java
@@ -419,7 +419,7 @@ class AccessorGenerator implements ClassFileConstants {
             return "[" + getClassName(c.getComponentType(), true);
         } else {
             if (addPrefixAndSuffixForNonPrimitiveTypes) {
-                return c.descriptorString();
+                return internalize("L" + c.getName() + ";");
             } else {
                 return internalize(c.getName());
             }

--- a/src/java.base/share/classes/jdk/internal/reflect/SerializationConstructorAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/SerializationConstructorAccessorGenerator.java
@@ -299,7 +299,7 @@ class SerializationConstructorAccessorGenerator extends AccessorGenerator {
         for (int i = 0; i < parameterTypes.length; i++) {
             Class<?> c = parameterTypes[i];
             if (!isPrimitive(c)) {
-                asm.emitConstantPoolUTF8(getClassName(c, true));
+                asm.emitConstantPoolUTF8(getClassName(c, false));
                 asm.emitConstantPoolClass(asm.cpi());
             }
         }

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.invoke.util;
 
 import java.lang.reflect.Modifier;
 import static java.lang.reflect.Modifier.*;
-
 import jdk.internal.reflect.Reflection;
 
 /**

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -112,7 +112,6 @@ jdk_lang = \
     jdk/internal/ref \
     jdk/internal/jimage \
     jdk/internal/math \
-    jdk/modules \
     jdk/internal/vm \
     jdk/modules \
     jni/nullCaller \

--- a/test/jdk/java/lang/Class/ArrayMethods.java
+++ b/test/jdk/java/lang/Class/ArrayMethods.java
@@ -102,7 +102,7 @@ public class ArrayMethods {
         if (thisFailed) {
             failed++;
             System.out.println(Arrays.asList(is));
-            System.out.println("Should contain exactly Cloneable and Serializable in that order.");
+            System.out.println("Should contain exactly Cloneable, Serializable in that order.");
         }
     }
 }

--- a/test/jdk/java/lang/Class/GenericStringTest.java
+++ b/test/jdk/java/lang/Class/GenericStringTest.java
@@ -27,7 +27,7 @@
  * @summary Check Class.toGenericString()
  * @author Joseph D. Darcy
  * @compile GenericStringTest.java
- * @run main/othervm -XX:+EnableValhalla -XX:+EnablePrimitiveClasses GenericStringTest
+ * @run main/othervm -XX:+EnableValhalla GenericStringTest
  */
 
 import java.lang.reflect.*;
@@ -73,8 +73,7 @@ public class GenericStringTest {
                                      LocalMap.class,
                                      AnEnum.class,
                                      AnotherEnum.class,
-                                     AValueClass.class,
-                                     APrimitiveClass.class)) {
+                                     AValueClass.class)) {
             failures += checkToGenericString(clazz, clazz.getAnnotation(ExpectedGenericString.class).value());
         }
 
@@ -118,6 +117,3 @@ enum AnotherEnum {
 
 @ExpectedGenericString("final value class AValueClass<E>")
 value class AValueClass<E> {}
-
-@ExpectedGenericString("final primitive class APrimitiveClass<E>")
-primitive class APrimitiveClass<E> {}

--- a/test/jdk/java/lang/invoke/TEST.properties
+++ b/test/jdk/java/lang/invoke/TEST.properties
@@ -1,5 +1,0 @@
-# disabled till JDK-8219408 is fixed
-allowSmartActionArgs=false
-
-# Reflection methods for primitive classes are in PrimitiveClass instead of java.lang.class
-modules = java.base/jdk.internal.value

--- a/test/langtools/tools/javac/classfiles/InnerClasses/SyntheticClasses.java
+++ b/test/langtools/tools/javac/classfiles/InnerClasses/SyntheticClasses.java
@@ -50,7 +50,7 @@ public class SyntheticClasses {
         File testClasses = new File(System.getProperty("test.classes"));
         for (File classFile : Objects.requireNonNull(testClasses.listFiles(f -> f.getName().endsWith(".class")))) {
             ClassModel cf = Classfile.of().parse(classFile.toPath());
-            if ((cf.flags().flagsMask() & (Classfile.ACC_SYNTHETIC | Classfile.ACC_VALUE | Classfile.ACC_ABSTRACT)) == Classfile.ACC_SYNTHETIC) {
+            if ((cf.flags().flagsMask() & (Classfile.ACC_SYNTHETIC | Classfile.ACC_ABSTRACT)) == Classfile.ACC_SYNTHETIC) {
                 if ((cf.flags().flagsMask() & Classfile.ACC_IDENTITY) == 0) {
                     throw new IllegalStateException("Missing ACC_IDENTITY on synthetic concrete identity class: " + cf.thisClass().asInternalName());
                 }


### PR DESCRIPTION
Remove the changes to support Q-descriptor and other clean up to match the master version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327498](https://bugs.openjdk.org/browse/JDK-8327498): [lworld] Remove Q-descriptor change from ASM and other clean up (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1036/head:pull/1036` \
`$ git checkout pull/1036`

Update a local copy of the PR: \
`$ git checkout pull/1036` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1036`

View PR using the GUI difftool: \
`$ git pr show -t 1036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1036.diff">https://git.openjdk.org/valhalla/pull/1036.diff</a>

</details>
