### PR TITLE
8293541: [lworld] IR verification fails for TestLWorld::test109_sharp and test110_sharp

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2040,8 +2040,9 @@ bool PhiNode::wait_for_region_igvn(PhaseGVN* phase) {
 }
 
 // Push inline type input nodes (and null) down through the phi recursively (can handle data loops).
-InlineTypeNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk) {
-  InlineTypeNode* vt = InlineTypeNode::make_null(*phase, vk)->clone_with_phis(phase, in(0), !_type->maybe_null());
+InlineTypeNode* PhiNode::push_inline_types_down(PhaseGVN* phase, bool can_reshape, ciInlineKlass* inline_klass) {
+  assert(inline_klass != nullptr, "must be");
+  InlineTypeNode* vt = InlineTypeNode::make_null(*phase, inline_klass)->clone_with_phis(phase, in(0), !_type->maybe_null());
   if (can_reshape) {
     // Replace phi right away to be able to use the inline
     // type node when reaching the phi again through data loops.
@@ -2064,10 +2065,10 @@ InlineTypeNode* PhiNode::push_inline_types_through(PhaseGVN* phase, bool can_res
       n = n->in(1);
     }
     if (phase->type(n)->is_zero_type()) {
-      n = InlineTypeNode::make_null(*phase, vk);
+      n = InlineTypeNode::make_null(*phase, inline_klass);
     } else if (n->is_Phi()) {
       assert(can_reshape, "can only handle phis during IGVN");
-      n = phase->transform(n->as_Phi()->push_inline_types_through(phase, can_reshape, vk));
+      n = phase->transform(n->as_Phi()->push_inline_types_down(phase, can_reshape, inline_klass));
     }
     while (casts.size() != 0) {
       // Push the cast(s) through the InlineTypeNode
@@ -2633,70 +2634,9 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 #endif
 
-  // Check recursively if inputs are either an inline type, constant null
-  // or another Phi (including self references through data loops). If so,
-  // push the inline types down through the phis to enable folding of loads.
-  if (EnableValhalla && _type->isa_ptr() && req() > 2) {
-    ResourceMark rm;
-    Unique_Node_List worklist;
-    worklist.push(this);
-    bool can_optimize = true;
-    ciInlineKlass* vk = nullptr;
-    Node_List casts;
-
-    // TODO 8302217 We need to prevent endless pushing through
-    bool only_phi = (outcnt() != 0);
-    for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
-      Node* n = fast_out(i);
-      if (n->is_InlineType() && n->in(1) == this) {
-        can_optimize = false;
-        break;
-      }
-      if (!n->is_Phi()) {
-        only_phi = false;
-      }
-    }
-    if (only_phi) {
-      can_optimize = false;
-    }
-    for (uint next = 0; next < worklist.size() && can_optimize; next++) {
-      Node* phi = worklist.at(next);
-      for (uint i = 1; i < phi->req() && can_optimize; i++) {
-        Node* n = phi->in(i);
-        if (n == nullptr) {
-          can_optimize = false;
-          break;
-        }
-        while (n->is_ConstraintCast()) {
-          if (n->in(0) != nullptr && n->in(0)->is_top()) {
-            // Will die, don't optimize
-            can_optimize = false;
-            break;
-          }
-          casts.push(n);
-          n = n->in(1);
-        }
-        const Type* t = phase->type(n);
-        if (n->is_InlineType() && (vk == nullptr || vk == t->inline_klass())) {
-          vk = (vk == nullptr) ? t->inline_klass() : vk;
-        } else if (n->is_Phi() && can_reshape && n->bottom_type()->isa_ptr()) {
-          worklist.push(n);
-        } else if (!t->is_zero_type()) {
-          can_optimize = false;
-        }
-      }
-    }
-    // Check if cast nodes can be pushed through
-    const Type* t = Type::get_const_type(vk);
-    while (casts.size() != 0 && can_optimize && t != nullptr) {
-      Node* cast = casts.pop();
-      if (t->filter(cast->bottom_type()) == Type::TOP) {
-        can_optimize = false;
-      }
-    }
-    if (can_optimize && vk != nullptr) {
-      return push_inline_types_through(phase, can_reshape, vk);
-    }
+  Node* inline_type = try_push_inline_types_down(phase, can_reshape);
+  if (inline_type != this) {
+    return inline_type;
   }
 
   // Try to convert a Phi with two duplicated convert nodes into a phi of the pre-conversion type and the convert node
@@ -2740,6 +2680,90 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   return progress;              // Return any progress
+}
+
+// Check recursively if inputs are either an inline type, constant null
+// or another Phi (including self references through data loops). If so,
+// push the inline types down through the phis to enable folding of loads.
+Node* PhiNode::try_push_inline_types_down(PhaseGVN* phase, const bool can_reshape) {
+  if (!can_be_inline_type()) {
+    return this;
+  }
+
+  ciInlineKlass* inline_klass;
+  if (can_push_inline_types_down(phase, can_reshape, inline_klass)) {
+    assert(inline_klass != nullptr, "must be");
+    return push_inline_types_down(phase, can_reshape, inline_klass);
+  }
+  return this;
+}
+
+bool PhiNode::can_push_inline_types_down(PhaseGVN* phase, const bool can_reshape, ciInlineKlass*& inline_klass) {
+  if (req() <= 2) {
+    // Dead phi.
+    return false;
+  }
+  inline_klass = nullptr;
+
+  // TODO 8302217 We need to prevent endless pushing through
+  bool only_phi = (outcnt() != 0);
+  for (DUIterator_Fast imax, i = fast_outs(imax); i < imax; i++) {
+    Node* n = fast_out(i);
+    if (n->is_InlineType() && n->in(1) == this) {
+      return false;
+    }
+    if (!n->is_Phi()) {
+      only_phi = false;
+    }
+  }
+  if (only_phi) {
+    return false;
+  }
+
+  ResourceMark rm;
+  Unique_Node_List worklist;
+  worklist.push(this);
+  Node_List casts;
+
+  for (uint next = 0; next < worklist.size(); next++) {
+    Node* phi = worklist.at(next);
+    for (uint i = 1; i < phi->req(); i++) {
+      Node* n = phi->in(i);
+      if (n == nullptr) {
+        return false;
+      }
+      while (n->is_ConstraintCast()) {
+        if (n->in(0) != nullptr && n->in(0)->is_top()) {
+          // Will die, don't optimize
+          return false;
+        }
+        casts.push(n);
+        n = n->in(1);
+      }
+      const Type* type = phase->type(n);
+      if (n->is_InlineType() && (inline_klass == nullptr || inline_klass == type->inline_klass())) {
+        inline_klass = type->inline_klass();
+      } else if (n->is_Phi() && can_reshape && n->bottom_type()->isa_ptr()) {
+        worklist.push(n);
+      } else if (!type->is_zero_type()) {
+        return false;
+      }
+    }
+  }
+  if (inline_klass == nullptr) {
+    return false;
+  }
+
+  // Check if cast nodes can be pushed through
+  const Type* t = Type::get_const_type(inline_klass);
+  while (casts.size() != 0 && t != nullptr) {
+    Node* cast = casts.pop();
+    if (t->filter(cast->bottom_type()) == Type::TOP) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 static int compare_types(const Type* const& e1, const Type* const& e2) {

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -181,6 +181,9 @@ class PhiNode : public TypeNode {
 
   bool must_wait_for_region_in_irreducible_loop(PhaseGVN* phase) const;
 
+  bool can_push_inline_types_down(PhaseGVN* phase, bool can_reshape, ciInlineKlass*& inline_klass);
+  InlineTypeNode* push_inline_types_down(PhaseGVN* phase, bool can_reshape, ciInlineKlass* inline_klass);
+
 public:
   // Node layout (parallels RegionNode):
   enum { Region,                // Control input is the Phi's region.
@@ -254,7 +257,11 @@ public:
            type()->higher_equal(tp);
   }
 
-  InlineTypeNode* push_inline_types_through(PhaseGVN* phase, bool can_reshape, ciInlineKlass* vk);
+  bool can_be_inline_type() const {
+    return EnableValhalla && _type->isa_instptr() && _type->is_instptr()->can_be_inline_type();
+  }
+
+  Node* try_push_inline_types_down(PhaseGVN* phase, bool can_reshape);
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -687,6 +687,10 @@ bool PhaseMacroExpand::can_eliminate_allocation(PhaseIterGVN* igvn, AllocateNode
           NOT_PRODUCT(fail_eliminate = "null or TOP memory";)
           can_eliminate = false;
         } else if (!reduce_merge_precheck) {
+          if (res->is_Phi() && res->as_Phi()->can_be_inline_type()) {
+            // Can only eliminate allocation if the phi had been replaced by an InlineTypeNode before which did not happen.
+            can_eliminate = false;
+          }
           safepoints->append_if_missing(sfpt);
         }
       } else if (use->is_InlineType() && use->as_InlineType()->get_oop() == res) {
@@ -896,9 +900,9 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
     Node* field_val = nullptr;
     const TypeOopPtr* field_addr_type = res_type->add_offset(offset)->isa_oopptr();
     if (res_type->is_flat()) {
-      ciInlineKlass* vk = res_type->is_aryptr()->elem()->inline_klass();
-      assert(vk->flat_in_array(), "must be flat in array");
-      field_val = inline_type_from_mem(sfpt->memory(), sfpt->control(), vk, field_addr_type->isa_aryptr(), 0, alloc);
+      ciInlineKlass* inline_klass = res_type->is_aryptr()->elem()->inline_klass();
+      assert(inline_klass->flat_in_array(), "must be flat in array");
+      field_val = inline_type_from_mem(sfpt->memory(), sfpt->control(), inline_klass, field_addr_type->isa_aryptr(), 0, alloc);
     } else {
       field_val = value_from_mem(sfpt->memory(), sfpt->control(), basic_elem_type, field_type, field_addr_type, alloc);
     }
@@ -942,9 +946,18 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
         field_val = transform_later(new DecodeNNode(field_val, field_val->get_ptr_type()));
       }
     }
+
+    // Keep track of inline types to scalarize them later
     if (field_val->is_InlineType()) {
-      // Keep track of inline types to scalarize them later
       value_worklist->push(field_val);
+    } else if (field_val->is_Phi()) {
+      PhiNode* phi = field_val->as_Phi();
+      // Eagerly replace inline type phis now since we could be removing an inline type allocation where we must
+      // scalarize all its fields in safepoints.
+      field_val = phi->try_push_inline_types_down(&_igvn, true);
+      if (field_val->is_InlineType()) {
+        value_worklist->push(field_val);
+      }
     }
     sfpt->add_req(field_val);
   }
@@ -1203,7 +1216,7 @@ bool PhaseMacroExpand::eliminate_allocate_node(AllocateNode *alloc) {
   bool boxing_alloc = (res == nullptr) && C->eliminate_boxing() &&
                       tklass->isa_instklassptr() &&
                       tklass->is_instklassptr()->instance_klass()->is_box_klass();
-  if (!alloc->_is_scalar_replaceable && (!boxing_alloc || (res != nullptr))) {
+  if (!alloc->_is_scalar_replaceable && !boxing_alloc && !inline_alloc) {
     return false;
   }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3180,9 +3180,8 @@ public class TestLWorld {
     }
 
     @Test
-// TODO 8293541
-//    @IR(failOn = {ALLOC_G, MEMBAR},
-//        counts = {PREDICATE_TRAP, "= 1"})
+    @IR(failOn = {ALLOC_G, MEMBAR},
+        counts = {PREDICATE_TRAP, "= 1"})
     @IR(failOn = {ALLOC_G, MEMBAR})
     public long test109_sharp() {
         long res = 0;
@@ -3219,9 +3218,8 @@ public class TestLWorld {
     }
 
     @Test
-// TODO 8293541
-//    @IR(failOn = {ALLOC_G, MEMBAR},
-//        counts = {PREDICATE_TRAP, "= 1"})
+    @IR(failOn = {ALLOC_G, MEMBAR},
+        counts = {PREDICATE_TRAP, "= 1"})
     @IR(failOn = {ALLOC_G, MEMBAR})
     public long test110_sharp() {
         long res = 0;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestOnStackReplacement.java
@@ -120,8 +120,9 @@ public class TestOnStackReplacement {
         test2();
     }
 
+    // TODO: Should be fixed with JDK-8327465.
     // Test loop peeling and unrolling
-    @Test(compLevel = CompLevel.WAIT_FOR_COMPILATION)
+    //@Test(compLevel = CompLevel.WAIT_FOR_COMPILATION)
     public void test3() {
         MyValue1 v1 = MyValue1.createWithFieldsInline(0, 0);
         MyValue1 v2 = MyValue1.createWithFieldsInline(1, 1);
@@ -136,8 +137,8 @@ public class TestOnStackReplacement {
         }
     }
 
-    @Run(test = "test3")
-    @Warmup(0)
+    //@Run(test = "test3")
+    //@Warmup(0)
     public void test3_verifier() {
         test3();
     }


### PR DESCRIPTION
`test109_sharp()` and `test110_sharp()` originally failed because we have no longer beeen able to apply Loop Predication due to the following merge mistake (left previous, middle merged, right new code from mainline):

![image](https://github.com/openjdk/valhalla/assets/17833009/31c5065a-7e8a-4fcd-bc23-241176cfe9a6)

This changed the application of EA for these tests in such a way that we need to apply EA twice (iteratively) to remove the wrapping box object and the inline type allocation. This had the side effect that we missed to re-add a memory phi to the IGVN worklist to apply an optimization to get rid of a diamond-if control flow which blocks Loop Predication. IR matching failed because we could not find the corresponding predicate trap for an expected Hoisted Check Predicate.

This was also a problem in mainline but we had no IR test to catch this. [JDK-8314997](https://bugs.openjdk.org/browse/JDK-8314997) fixed this for mainline and once it was merged with Valhalla, `test109_sharp()` and `test110_sharp()` would now work again.

But I think we should still fix the merge mistake to eagerly try to remove inline type allocations, regardless of their escape/replaceable status as it was originally intended before the merge. This allows us to get rid of some extra EA iterations.

However, fixing this merge mistake caused an assertion failure later in EA which checked that safepoints do not have inline type allocation uses (they should be replaced by `SafePointScalarObjectNodes`). To fix that, we need to make sure that any inline type pointer phi node created for an inline type field here (`create_scalarized_object_description()` -> `value_from_mem()` -> `value_from_mem_phi()`):

https://github.com/openjdk/valhalla/blob/814a5e93cb392a77a43550bf8dab5ab9d52bdcfd/src/hotspot/share/opto/macro.cpp#L378-L379

when trying to create a `SafePointScalarObjectNode` for a safepoint use is eagerly replaced by an `InlineTypeNode`. To achieve that, I've added a call to `push_inline_types_through()` (renamed to `push_inline_types_down()`) which was only used in `PhiNode::Ideal()` before. I've applied some refactoring and renaming to share that code with EA

I've tried out some additional assertions in EA that an inline type pointer phi should already be replaced by an `InlineTypeNode` if possible. But that failed. I think we are missing some optimization opportunities here. As this might be out of scope of this bug, I suggest to file a separate RFE to investigate further.

#### Disabled Test Due to Existing Bug
I disabled TestOnStackReplacement::test3() by uncommenting it. It triggered the following assertion:
```
assert(outer->outcnt() >= phis + 2 - be_loads && outer->outcnt() <= phis + 2 + stores + 1) failed: only phis
```
I've had a closer look and it seems like this patch here just revealed an existing rare issue that was only seen with this one test and some stress options. I've filed [JDK-8327465](https://bugs.openjdk.org/browse/JDK-8327465) to not block this fix and follow up on it later.

#### Testing
I performed testing on an older repo state before transitioning to the JEP 401 model to verify the correctness of this patch.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8293541](https://bugs.openjdk.org/browse/JDK-8293541): [lworld] IR verification fails for TestLWorld::test109_sharp and test110_sharp (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1038/head:pull/1038` \
`$ git checkout pull/1038`

Update a local copy of the PR: \
`$ git checkout pull/1038` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1038`

View PR using the GUI difftool: \
`$ git pr show -t 1038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1038.diff">https://git.openjdk.org/valhalla/pull/1038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1038#issuecomment-1982771011)