### PR TITLE
8327636: [lworld] Make primitive wrappers be value class if preview feature is enabled

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -27,6 +27,16 @@
 # Generate the value class replacements for selected java.base source files
 
 java.base-VALUE_CLASS-REPLACEMENTS := \
+    java/lang/Byte.java \
+    java/lang/Short.java \
+    java/lang/Integer.java \
+    java/lang/Long.java \
+    java/lang/Float.java \
+    java/lang/Double.java \
+    java/lang/Boolean.java \
+    java/lang/Character.java \
+    java/lang/Number.java \
+    java/lang/Record.java \
     java/util/Optional.java \
     java/util/OptionalInt.java \
     java/util/OptionalLong.java \

--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -53,7 +53,6 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/YearMonth.java \
     java/time/Year.java \
     java/time/Period.java \
-    java/lang/Record.java \
     #
 
 java.base-VALUE-CLASS-FILES := \

--- a/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ValueObjectMethods.java
@@ -1109,7 +1109,7 @@ final class ValueObjectMethods {
      */
     private static <T> boolean isSubstitutable(T a, Object b) {
         if (VERBOSE) {
-            System.out.println("substitutable " + a + " vs " + b);
+            System.out.println("substitutable " + a.getClass() + ": " + a + " vs " + b);
         }
 
         // Called directly from the VM.

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -208,6 +208,13 @@ public class VerifyAccess {
                 return true;
             }
 
+            // exports are not setup during early VM initialization
+            if (!jdk.internal.misc.VM.isModuleSystemInited()) {
+                //  access java.base classes only
+                assert lookupModule == refModule && refModule == Object.class.getModule();
+                return true;
+            }
+
             // allow access to public types in all unconditionally exported packages
             if ((allowedModes & UNCONDITIONAL_ALLOWED) != 0) {
                 return refModule.isExported(refc.getPackageName());
@@ -228,12 +235,8 @@ public class VerifyAccess {
             Module prevLookupModule = prevLookupClass != null ? prevLookupClass.getModule()
                                                               : null;
             assert refModule != lookupModule || refModule != prevLookupModule;
-            if (isModuleAccessible(refc, lookupModule, prevLookupModule))
-                return true;
 
-            // not exported but allow access during VM initialization
-            // because java.base does not have its exports setup
-            if (!jdk.internal.misc.VM.isModuleSystemInited())
+            if (isModuleAccessible(refc, lookupModule, prevLookupModule))
                 return true;
 
             // public class not accessible to lookupClass

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -202,16 +202,10 @@ public class VerifyAccess {
             Module lookupModule = lookupClass.getModule();
             Module refModule = refc.getModule();
 
-            // early VM startup case, java.base not defined
-            if (lookupModule == null) {
-                assert refModule == null;
-                return true;
-            }
-
-            // exports are not setup during early VM initialization
-            if (!jdk.internal.misc.VM.isModuleSystemInited()) {
-                //  access java.base classes only
-                assert lookupModule == refModule && refModule == Object.class.getModule();
+            // early VM startup case, java.base not defined or
+            // module system is not fully initialized and exports are not set up
+            if (lookupModule == null || !jdk.internal.misc.VM.isModuleSystemInited()) {
+                assert lookupModule == refModule;
                 return true;
             }
 


### PR DESCRIPTION
As specified in JEP 401, when preview features are enabled, the following standard library classes are considered to be value classes:
```
    java.lang.Byte
    java.lang.Short
    java.lang.Integer
    java.lang.Long
    java.lang.Float
    java.lang.Double
    java.lang.Boolean
    java.lang.Character
    java.util.Optional
    java.lang.Number
    java.lang.Record
```

These value classes are loaded only if --enable-preview is set.    All valhalla tests should have preview enabled to ensure testing with the proper set of library classes.

Testing: Run `jdk_valhalla` and `hotspot_valhalla_runtime` with  `-Xint` with and without `--enable-preview`.  The result is pretty good.  [JDK-8327637](https://bugs.openjdk.org/browse/JDK-8327637) and [JDK-8327639](https://bugs.openjdk.org/browse/JDK-8327639) need further investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327636](https://bugs.openjdk.org/browse/JDK-8327636): [lworld] Make primitive wrappers be value class if preview feature is enabled (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer) ⚠️ Review applies to [ff15f65e](https://git.openjdk.org/valhalla/pull/1040/files/ff15f65eb5c39b40e5c4c92b607b373fd2dbf037)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1040/head:pull/1040` \
`$ git checkout pull/1040`

Update a local copy of the PR: \
`$ git checkout pull/1040` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1040`

View PR using the GUI difftool: \
`$ git pr show -t 1040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1040.diff">https://git.openjdk.org/valhalla/pull/1040.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1040#issuecomment-1984704910)