### PR TITLE
8327836: [lworld] update java/lang/invoke/VarHandles tests with preview feature enabled

### DIFF
--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestAccessValue.java
@@ -25,6 +25,7 @@
 
 /*
  * @test
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm -Diters=10   -Xint                                                   VarHandleTestAccessValue
  *

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessValue.java
@@ -25,6 +25,7 @@
 
 /*
  * @test
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations
  *          to hit compilation thresholds

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
@@ -26,6 +26,7 @@
 /*
  * @test
  * @bug 8156486
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
  * @run testng/othervm VarHandleTestMethodTypeValue
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true VarHandleTestMethodTypeValue

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestAccess.java.template
@@ -26,6 +26,7 @@
 /*
  * @test
 #if[Value]
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
 #end[Value]
  * @run testng/othervm -Diters=10   -Xint                                                   VarHandleTestAccess$Type$

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodHandleAccess.java.template
@@ -26,6 +26,7 @@
 /*
  * @test
 #if[Value]
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
 #end[Value]
  * @comment Set CompileThresholdScaling to 0.1 so that the warmup loop sets to 2000 iterations

--- a/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
+++ b/test/jdk/java/lang/invoke/VarHandles/X-VarHandleTestMethodType.java.template
@@ -27,6 +27,7 @@
  * @test
  * @bug 8156486
 #if[Value]
+ * @enablePreview
  * @modules java.base/jdk.internal.vm.annotation
 #end[Value]
  * @run testng/othervm VarHandleTestMethodType$Type$


### PR DESCRIPTION
Update test/jdk/java/lang/invoke/VarHandles valhalla tests with `@enablePreview`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327836](https://bugs.openjdk.org/browse/JDK-8327836): [lworld] update java/lang/invoke/VarHandles tests with preview feature enabled (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1043/head:pull/1043` \
`$ git checkout pull/1043`

Update a local copy of the PR: \
`$ git checkout pull/1043` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1043`

View PR using the GUI difftool: \
`$ git pr show -t 1043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1043.diff">https://git.openjdk.org/valhalla/pull/1043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1043#issuecomment-1989036204)