### PR TITLE
8326860 [lworld] Illegal class modifiers in declaration of inner class

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4350,7 +4350,7 @@ void ClassFileParser::set_precomputed_flags(InstanceKlass* ik) {
 bool ClassFileParser::supports_inline_types() const {
   // Inline types are only supported by class file version 61.65535 and later
   return _major_version > JAVA_22_VERSION ||
-         (_major_version == JAVA_22_VERSION /*&& _minor_version == JAVA_PREVIEW_MINOR_VERSION*/); // JAVA_PREVIEW_MINOR_VERSION not yet implemented by javac, check JVMS draft
+         (_major_version == JAVA_22_VERSION && _minor_version == JAVA_PREVIEW_MINOR_VERSION);
 }
 
 // utility methods for appending an array with check for duplicates
@@ -4659,7 +4659,7 @@ void ClassFileParser::verify_legal_class_modifiers(jint flags, const char* name,
     return;
   }
 
-  // if (!_need_verify) { return; }
+  if (!_need_verify) { return; }
 
   const bool is_interface  = (flags & JVM_ACC_INTERFACE)  != 0;
   const bool is_abstract   = (flags & JVM_ACC_ABSTRACT)   != 0;
@@ -4672,8 +4672,7 @@ void ClassFileParser::verify_legal_class_modifiers(jint flags, const char* name,
   if ((is_abstract && is_final) ||
       (is_interface && !is_abstract) ||
       (is_interface && major_gte_1_5 && (is_identity || is_enum)) ||   //  ACC_SUPER (now ACC_IDENTITY) was illegal for interfaces
-      (!is_interface && major_gte_1_5 && is_annotation) ||
-      (!is_identity_class && is_enum)) {
+      (!is_interface && major_gte_1_5 && is_annotation)) {
     ResourceMark rm(THREAD);
     const char* class_note = "";
     if (!is_identity_class)  class_note = " (a value class)";
@@ -6038,8 +6037,14 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
   }
 
   // Fixing ACC_SUPER/ACC_IDENTITY for old class files
-  if ((!(flags & JVM_ACC_INTERFACE)) && _major_version <= JAVA_22_VERSION && _minor_version != JAVA_PREVIEW_MINOR_VERSION) {
-    flags |= JVM_ACC_IDENTITY;
+  if (EnableValhalla) {
+    if (!supports_inline_types()) {
+      const bool is_module = (flags & JVM_ACC_MODULE) != 0;
+      const bool is_interface = (flags & JVM_ACC_INTERFACE) != 0;
+      if (!is_module && !is_interface) {
+        flags |= JVM_ACC_IDENTITY;
+      }
+    }
   }
 
   // This class and superclass
@@ -6056,16 +6061,6 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
   bool is_java_lang_Object = class_name_in_cp == vmSymbols::java_lang_Object();
 
   verify_legal_class_modifiers(flags, nullptr, is_java_lang_Object, CHECK);
-
-  if (EnableValhalla) {
-    if(!supports_inline_types()) {
-      const bool is_module = (flags & JVM_ACC_MODULE) != 0;
-      const bool is_interface = (flags & JVM_ACC_INTERFACE) != 0;
-      if (!is_module && !is_interface && !is_java_lang_Object) {
-        flags |= JVM_ACC_IDENTITY;
-      }
-    }
-  }
 
   _access_flags.set_flags(flags);
 


### PR DESCRIPTION
Fix setting of ACC_IDENTITY in old inner classes.
Clean up code fixing ACC_IDENTITY in regular classes.
Remove rejection of value enums.
This should fix all the tests failing with "java.lang.ClassFormatError: Illegal class modifiers in declaration of inner class Status (a value class) of class ..."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326860](https://bugs.openjdk.org/browse/JDK-8326860): [lworld] Illegal class modifiers in declaration of inner class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1047/head:pull/1047` \
`$ git checkout pull/1047`

Update a local copy of the PR: \
`$ git checkout pull/1047` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1047`

View PR using the GUI difftool: \
`$ git pr show -t 1047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1047.diff">https://git.openjdk.org/valhalla/pull/1047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1047#issuecomment-1999636016)