### PR TITLE
8327695: [lworld] javac can generate incorrect code in inner class' constructors

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -190,6 +190,10 @@ public class Lower extends TreeTranslator {
      */
     Map<Symbol, Symbol> lambdaTranslationMap = null;
 
+    /** A hash table mapping local classes to a set of outer this fields
+     */
+    public Map<ClassSymbol, Set<JCExpression>> initializerOuterThis = new WeakHashMap<>();
+
     /** A navigator class for assembling a mapping from local class symbols
      *  to class definition trees.
      *  There is only one case; all other cases simply traverse down the tree.
@@ -2958,6 +2962,18 @@ public class Lower extends TreeTranslator {
             } else {
                 // nested class
                 thisArg = makeOwnerThis(tree.pos(), c, false);
+                if (currentMethodSym != null &&
+                        ((currentMethodSym.flags_field & (STATIC | BLOCK)) == BLOCK) &&
+                        currentMethodSym.owner.isValueClass()) {
+                    // instance initializer in a value class
+                    Set<JCExpression> outerThisSet = initializerOuterThis.get(currentClass);
+                    if (outerThisSet == null) {
+                        outerThisSet = Set.of(thisArg);
+                    } else {
+                        outerThisSet.add(thisArg);
+                    }
+                    initializerOuterThis.put(currentClass, outerThisSet);
+                }
             }
             tree.args = tree.args.prepend(thisArg);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2968,10 +2968,9 @@ public class Lower extends TreeTranslator {
                     // instance initializer in a value class
                     Set<JCExpression> outerThisSet = initializerOuterThis.get(currentClass);
                     if (outerThisSet == null) {
-                        outerThisSet = Set.of(thisArg);
-                    } else {
-                        outerThisSet.add(thisArg);
+                        outerThisSet = new HashSet<>();
                     }
+                    outerThisSet.add(thisArg);
                     initializerOuterThis.put(currentClass, outerThisSet);
                 }
             }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -34,7 +34,7 @@ public class InlineTypes {
 
     public static final Scenario[] DEFAULT_SCENARIOS = {
             new Scenario(0,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -49,7 +49,7 @@ public class InlineTypes {
                          "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(1,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -64,7 +64,7 @@ public class InlineTypes {
                          "-XX:-InlineTypeReturnedAsFields"
             ),
             new Scenario(2,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -80,7 +80,7 @@ public class InlineTypes {
                          "-XX:+StressInlineTypeReturnedAsFields"
             ),
             new Scenario(3,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -94,7 +94,7 @@ public class InlineTypes {
                          "-XX:+InlineTypeReturnedAsFields"
             ),
             new Scenario(4,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -108,7 +108,7 @@ public class InlineTypes {
                          "-XX:-ReduceInitialCardMarks"
             ),
             new Scenario(5,
-                         "-XX:+EnableValhalla",
+                         "--enable-preview",
                          "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED",
                          "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -39,10 +39,12 @@ import static compiler.valhalla.inlinetypes.InlineTypes.*;
 /*
  * @test
  * @key randomness
+ * @bug 8327695
  * @summary Test the basic value class implementation in C2.
  * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
  * @modules java.base/jdk.internal.value
  * @library /test/lib /
+ * @enablePreview
  * @compile --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED
  *          --add-exports java.base/jdk.internal.value=ALL-UNNAMED TestBasicFunctionality.java
  * @run main/othervm/timeout=300 -XX:+EnableValhalla compiler.valhalla.inlinetypes.TestBasicFunctionality


### PR DESCRIPTION
When dealing with value classes javac, as mandated by the spec, is placing field initializers before any invocation to `super()`. This works just fine most of the time but for cases like:
```
class JavacBug {
    value class V1 {}

    value class V2 {
        V1 v = new V1();
    }

    void test() {
        V2 v2 = new V2();
    }

    public static void main(String... args) {
        JavacBug jb = new JavacBug();
        jb.test();
    }
}
```
javac is generating incorrect code for class V2 due to a getfield being generated to read the synthetic field storing the outer this before invoking the constructor for V1. The proposed change is changing the generated bytecode to read the outer this from the mandated parameter javac adds to inner class constructors,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327695](https://bugs.openjdk.org/browse/JDK-8327695): [lworld] javac can generate incorrect code in inner class' constructors (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1048/head:pull/1048` \
`$ git checkout pull/1048`

Update a local copy of the PR: \
`$ git checkout pull/1048` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1048`

View PR using the GUI difftool: \
`$ git pr show -t 1048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1048.diff">https://git.openjdk.org/valhalla/pull/1048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1048#issuecomment-1999948095)