### PR TITLE
8327637: [lworld] runtime/valhalla/inlinetypes/PreloadCircularityTest.java fails with --enable-preview

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
@@ -26,6 +26,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.value
  * @library /test/lib
+ * @enablePreview
  * @compile PreloadCircularityTest.java
  * @run main/othervm -XX:+EnableValhalla PreloadCircularityTest
  */
@@ -313,7 +314,7 @@ public class PreloadCircularityTest {
     void test_50() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class50a");
         out.shouldHaveExitValue(0);
-        out.shouldNotContain("[info][class,preload]");
+        out.shouldNotContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class50a");
     }
 
     @ImplicitlyConstructible
@@ -457,7 +458,7 @@ public class PreloadCircularityTest {
 
     static ProcessBuilder exec(String... args) throws Exception {
         List<String> argsList = new ArrayList<>();
-        Collections.addAll(argsList, "-XX:+EnableValhalla");
+        Collections.addAll(argsList, "--enable-preview");
         Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
         Collections.addAll(argsList, "-Xlog:class+preload=info");
         Collections.addAll(argsList, args);
@@ -470,6 +471,7 @@ public class PreloadCircularityTest {
         Class c = tests.getClass();
         System.out.println("Iterating over test methods");
         boolean hasFailedTest = false;
+        StringBuilder sb = new StringBuilder("Following tests have failed: ");
         for (Method m : c.getDeclaredMethods()) {
             if (m.getName().startsWith("test_")) {
                 boolean failed = false;
@@ -482,10 +484,11 @@ public class PreloadCircularityTest {
                 }
                 System.out.println("Test " + m.getName() + " : " + (failed ? "FAILED" : "PASSED"));
                 hasFailedTest = failed ? true : hasFailedTest;
+                if (failed) sb.append(m.getName()).append(", ");
             }
         }
         if (hasFailedTest) {
-            throw new RuntimeException("Not all tests passed");
+            throw new RuntimeException(sb.toString());
         }
     }
 }


### PR DESCRIPTION
Fix test_50 by making output analysis more precise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8327637](https://bugs.openjdk.org/browse/JDK-8327637): [lworld] runtime/valhalla/inlinetypes/PreloadCircularityTest.java fails with --enable-preview (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1050.diff">https://git.openjdk.org/valhalla/pull/1050.diff</a>

</details>
