### PR TITLE
8328329: [lworld] Optimize field type checking sequence for x86 target.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6249,6 +6249,13 @@ void Assembler::subss(XMMRegister dst, Address src) {
   emit_operand(dst, src, 0);
 }
 
+void Assembler::btl(Register dst, int imm8) {
+  int encode = prefix_and_encode(dst->encoding());
+  emit_int16(0x0F, (unsigned char)0xBA);
+  emit_int8(modrm_encoding(0x3, rsp->encoding() /* /4 */ , encode));
+  emit_int8(imm8);
+}
+
 void Assembler::testb(Register dst, int imm8, bool use_ral) {
   NOT_LP64(assert(dst->has_byte_register(), "must have byte register"));
   if (dst == rax) {

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6249,13 +6249,6 @@ void Assembler::subss(XMMRegister dst, Address src) {
   emit_operand(dst, src, 0);
 }
 
-void Assembler::btl(Register dst, int imm8) {
-  int encode = prefix_and_encode(dst->encoding());
-  emit_int16(0x0F, (unsigned char)0xBA);
-  emit_int8(modrm_encoding(0x3, rsp->encoding() /* /4 */ , encode));
-  emit_int8(imm8);
-}
-
 void Assembler::testb(Register dst, int imm8, bool use_ral) {
   NOT_LP64(assert(dst->has_byte_register(), "must have byte register"));
   if (dst == rax) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1730,6 +1730,7 @@ private:
   void btsq(Address dst, int imm8);
   void btrq(Address dst, int imm8);
 #endif
+  void btl(Register dst, int imm8);
 
   void orw(Register dst, Register src);
 

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1730,8 +1730,6 @@ private:
   void btsq(Address dst, int imm8);
   void btrq(Address dst, int imm8);
 #endif
-  void btl(Register dst, int imm8);
-
   void orw(Register dst, Register src);
 
   void orl(Address dst, int32_t imm32);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3002,26 +3002,20 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
 
 void MacroAssembler::test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free_inline_type) {
   movl(temp_reg, flags);
-  shrl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
-  andl(temp_reg, 0x1);
-  testl(temp_reg, temp_reg);
-  jcc(Assembler::notZero, is_null_free_inline_type);
+  btl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
+  jcc(Assembler::carrySet, is_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free_inline_type) {
   movl(temp_reg, flags);
-  shrl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
-  andl(temp_reg, 0x1);
-  testl(temp_reg, temp_reg);
-  jcc(Assembler::zero, not_null_free_inline_type);
+  btl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
+  jcc(Assembler::carryClear, not_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label& is_flat) {
   movl(temp_reg, flags);
-  shrl(temp_reg, ResolvedFieldEntry::is_flat_shift);
-  andl(temp_reg, 0x1);
-  testl(temp_reg, temp_reg);
-  jcc(Assembler::notZero, is_flat);
+  btl(temp_reg, ResolvedFieldEntry::is_flat_shift);
+  jcc(Assembler::carrySet, is_flat);
 }
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3002,20 +3002,20 @@ void MacroAssembler::test_klass_is_empty_inline_type(Register klass, Register te
 
 void MacroAssembler::test_field_is_null_free_inline_type(Register flags, Register temp_reg, Label& is_null_free_inline_type) {
   movl(temp_reg, flags);
-  btl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
-  jcc(Assembler::carrySet, is_null_free_inline_type);
+  testl(temp_reg, 1 << ResolvedFieldEntry::is_null_free_inline_type_shift);
+  jcc(Assembler::notEqual, is_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_not_null_free_inline_type(Register flags, Register temp_reg, Label& not_null_free_inline_type) {
   movl(temp_reg, flags);
-  btl(temp_reg, ResolvedFieldEntry::is_null_free_inline_type_shift);
-  jcc(Assembler::carryClear, not_null_free_inline_type);
+  testl(temp_reg, 1 << ResolvedFieldEntry::is_null_free_inline_type_shift);
+  jcc(Assembler::equal, not_null_free_inline_type);
 }
 
 void MacroAssembler::test_field_is_flat(Register flags, Register temp_reg, Label& is_flat) {
   movl(temp_reg, flags);
-  btl(temp_reg, ResolvedFieldEntry::is_flat_shift);
-  jcc(Assembler::carrySet, is_flat);
+  testl(temp_reg, 1 << ResolvedFieldEntry::is_flat_shift);
+  jcc(Assembler::notEqual, is_flat);
 }
 
 void MacroAssembler::test_oop_prototype_bit(Register oop, Register temp_reg, int32_t test_bit, bool jmp_set, Label& jmp_label) {


### PR DESCRIPTION
- For field access bytecodes (getfield / putfield) interpreter perform special handling for flat / null restricted fields.
- Patch replaces existing flag checking sequence with efficient sequence based on 'bt' instruction.

Kindly review and approve.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328329](https://bugs.openjdk.org/browse/JDK-8328329): [lworld] Optimize field type checking sequence for x86 target. (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1051/head:pull/1051` \
`$ git checkout pull/1051`

Update a local copy of the PR: \
`$ git checkout pull/1051` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1051`

View PR using the GUI difftool: \
`$ git pr show -t 1051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1051.diff">https://git.openjdk.org/valhalla/pull/1051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1051#issuecomment-2003135932)