### PR TITLE
8328699: [lworld] C2 compilation fails with "no reachable node should have no use"

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -827,7 +827,7 @@ void CallGenerator::do_late_inline_helper() {
 
           // Update oop input to buffer
           kit.gvn().hash_delete(vt);
-          vt->set_oop(kit.gvn().transform(oop));
+          vt->set_oop(kit.gvn(), kit.gvn().transform(oop));
           vt->set_is_buffered(kit.gvn());
           vt = kit.gvn().transform(vt)->as_InlineType();
 

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -114,7 +114,7 @@ Node *ConstraintCastNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if (!_type->maybe_null()) {
       vt->as_InlineType()->set_is_init(*phase);
     }
-    vt->set_oop(phase->transform(cast));
+    vt->set_oop(*phase, phase->transform(cast));
     return vt;
   }
 

--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2075,7 +2075,7 @@ InlineTypeNode* PhiNode::push_inline_types_down(PhaseGVN* phase, bool can_reshap
       Node* cast = casts.pop()->clone();
       cast->set_req_X(1, n->as_InlineType()->get_oop(), phase);
       n = n->clone();
-      n->as_InlineType()->set_oop(phase->transform(cast));
+      n->as_InlineType()->set_oop(*phase, phase->transform(cast));
       n = phase->transform(n);
     }
     bool transform = !can_reshape && (i == (req()-1)); // Transform phis on last merge

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -589,6 +589,7 @@ void Parse::do_call() {
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
     // TODO 8325106 MemBarRelease vs. MemBarStoreStore
+    // TODO 8328704
     // insert_mem_bar(Op_MemBarRelease);
   }
 

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -589,7 +589,7 @@ void Parse::do_call() {
     // Do not let stores that initialize this buffer be reordered with a subsequent
     // store that would make this buffer accessible by other threads.
     // TODO 8325106 MemBarRelease vs. MemBarStoreStore
-    insert_mem_bar(Op_MemBarRelease);
+    // insert_mem_bar(Op_MemBarRelease);
   }
 
   // Speculative type of the receiver if any

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -45,7 +45,7 @@ InlineTypeNode* InlineTypeNode::clone_with_phis(PhaseGVN* gvn, Node* region, boo
   PhiNode* oop = PhiNode::make(region, vt->get_oop(), t);
   gvn->set_type(oop, t);
   gvn->record_for_igvn(oop);
-  vt->set_oop(oop);
+  vt->set_oop(*gvn, oop);
 
   // Create a PhiNode for merging the is_buffered values
   t = Type::get_const_basic_type(T_BOOLEAN);
@@ -116,7 +116,7 @@ InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* 
   PhiNode* phi = get_oop()->as_Phi();
   phi->set_req(pnum, other->get_oop());
   if (transform) {
-    set_oop(gvn->transform(phi));
+    set_oop(*gvn, gvn->transform(phi));
   }
 
   // Merge is_buffered inputs
@@ -609,7 +609,7 @@ InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
   // Use cloned InlineTypeNode to propagate oop from now on
   Node* res_oop = kit->gvn().transform(oop);
   InlineTypeNode* vt = clone()->as_InlineType();
-  vt->set_oop(res_oop);
+  vt->set_oop(kit->gvn(), res_oop);
   vt->set_is_buffered(kit->gvn());
   vt = kit->gvn().transform(vt)->as_InlineType();
   if (safe_for_replace) {
@@ -720,13 +720,13 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       inline_klass()->is_initialized() &&
       (!oop->is_Con() || phase->type(oop)->is_zero_type())) {
     // Use the pre-allocated oop for null-free default or empty inline types
-    set_oop(default_oop(*phase, inline_klass()));
+    set_oop(*phase, default_oop(*phase, inline_klass()));
     assert(is_allocated(phase), "should now be allocated");
     return this;
   }
   if (oop->isa_InlineType() && !phase->type(oop)->maybe_null()) {
     InlineTypeNode* vtptr = oop->as_InlineType();
-    set_oop(vtptr->get_oop());
+    set_oop(*phase, vtptr->get_oop());
     set_is_buffered(*phase);
     set_is_init(*phase);
     for (uint i = Values; i < vtptr->req(); ++i) {
@@ -740,7 +740,7 @@ Node* InlineTypeNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     // type is not buffered (in this case we should not use the oop).
     Node* base = is_loaded(phase);
     if (base != nullptr && get_oop() != base && !phase->type(base)->maybe_null()) {
-      set_oop(base);
+      set_oop(*phase, base);
       assert(is_allocated(phase), "should now be allocated");
       return this;
     }
@@ -911,7 +911,7 @@ InlineTypeNode* InlineTypeNode::make_from_oop_impl(GraphKit* kit, Node* oop, ciI
       vt = vt->clone_with_phis(&gvn, region);
       vt->merge_with(&gvn, null_vt, 2, true);
       if (!null_free) {
-        vt->set_oop(oop);
+        vt->set_oop(gvn, oop);
       }
       kit->set_control(gvn.transform(region));
     }
@@ -959,7 +959,7 @@ InlineTypeNode* InlineTypeNode::make_from_multi(GraphKit* kit, MultiNode* multi,
   if (!in) {
     // Keep track of the oop. The returned inline type might already be buffered.
     Node* oop = kit->gvn().transform(new ProjNode(multi, base_input++));
-    vt->set_oop(oop);
+    vt->set_oop(kit->gvn(), oop);
   }
   GrowableArray<ciType*> visited;
   visited.push(vk);
@@ -984,7 +984,7 @@ InlineTypeNode* InlineTypeNode::make_larval(GraphKit* kit, bool allocate) const 
     alloc->_larval = true;
 
     store(kit, alloc_oop, alloc_oop, vk);
-    res->set_oop(alloc_oop);
+    res->set_oop(kit->gvn(), alloc_oop);
   }
   // TODO 8239003
   //res->set_type(TypeInlineType::make(vk, true));

--- a/src/hotspot/share/opto/inlinetypenode.hpp
+++ b/src/hotspot/share/opto/inlinetypenode.hpp
@@ -109,11 +109,11 @@ public:
 
   // Get oop for heap allocated inline type (may be TypePtr::NULL_PTR)
   Node* get_oop() const    { return in(Oop); }
-  void  set_oop(Node* oop) { set_req(Oop, oop); }
+  void  set_oop(PhaseGVN& gvn, Node* oop) { set_req_X(Oop, oop, &gvn); }
   Node* get_is_init() const { return in(IsInit); }
-  void  set_is_init(PhaseGVN& gvn, bool init = true) { set_req(IsInit, gvn.intcon(init ? 1 : 0)); }
+  void  set_is_init(PhaseGVN& gvn, bool init = true) { set_req_X(IsInit, gvn.intcon(init ? 1 : 0), &gvn); }
   Node* get_is_buffered() const { return in(IsBuffered); }
-  void  set_is_buffered(PhaseGVN& gvn, bool buffered = true) { set_req(IsBuffered, gvn.intcon(buffered ? 1 : 0)); }
+  void  set_is_buffered(PhaseGVN& gvn, bool buffered = true) { set_req_X(IsBuffered, gvn.intcon(buffered ? 1 : 0), &gvn); }
 
   void set_is_larval(bool is_larval) { _is_larval = is_larval; }
   bool is_larval() { return _is_larval; }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1096,7 +1096,7 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc, bool inline_
         assert(use->as_InlineType()->get_oop() == res, "unexpected inline type ptr use");
         // Cut off oop input and remove known instance id from type
         _igvn.rehash_node_delayed(use);
-        use->as_InlineType()->set_oop(_igvn.zerocon(T_OBJECT));
+        use->as_InlineType()->set_oop(_igvn, _igvn.zerocon(T_OBJECT));
         const TypeOopPtr* toop = _igvn.type(use)->is_oopptr()->cast_to_instance_id(TypeOopPtr::InstanceBot);
         _igvn.set_type(use, toop);
         use->as_InlineType()->set_type(toop);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
@@ -164,6 +164,8 @@ public class TestBufferTearing {
     }
 
     public static void main(String[] args) throws Exception {
+        // TODO 8328704 re-enable
+        /*
         // Create threads that concurrently update some value class (array) fields
         // and check the fields of the value classes for consistency to detect tearing.
         TestBufferTearing test = new TestBufferTearing();
@@ -173,5 +175,6 @@ public class TestBufferTearing {
             runner.start();
         }
         runner.join();
+        */
     }
 }


### PR DESCRIPTION
`InlineTypeNode::set_*` methods should use `set_req_X` instead of `set_req` to make sure that an input node becoming dead is processed by IGVN.

Edit: I just noticed that the barrier part of JDK-8328682 causes some issues so I'm using this change to quickly back it out. Will REDO with JDK-8328704.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328699](https://bugs.openjdk.org/browse/JDK-8328699): [lworld] C2 compilation fails with "no reachable node should have no use" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1055/head:pull/1055` \
`$ git checkout pull/1055`

Update a local copy of the PR: \
`$ git checkout pull/1055` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1055`

View PR using the GUI difftool: \
`$ git pr show -t 1055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1055.diff">https://git.openjdk.org/valhalla/pull/1055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1055#issuecomment-2012295326)