### PR TITLE
8328641: [lworld] runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java fails with java.lang.IncompatibleClassChangeError: value class AME5_B cannot inherit from class AME5_A

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -51,8 +51,9 @@ public class ClassAccessFlagsRawTest {
         m = cl.getDeclaredMethod("getClassAccessFlagsRaw", new Class[0]);
         m.setAccessible(true);
 
-        testIt("SUPERset", 0x21);  // ACC_SUPER 0x20 + ACC_PUBLIC 0x1
-        testIt("SUPERnotset", Modifier.PUBLIC);
+        testIt("SUPERset", Modifier.PUBLIC | Modifier.IDENTITY);
+        // Because of the repurposing of ACC_SUPER into ACC_IDENTITY by JEP 401, the VM now fixes missing ACC_IDENTITY flags in old class files
+        testIt("SUPERnotset", Modifier.PUBLIC | Modifier.IDENTITY);
 
         // test primitive array.  should return ACC_ABSTRACT | ACC_FINAL | ACC_PUBLIC.
         int flags = (int)m.invoke((new int[3]).getClass());
@@ -63,14 +64,16 @@ public class ClassAccessFlagsRawTest {
 
         // test object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[2]).getClass());
-        if (flags != Modifier.PUBLIC) {
+        // Because of the repurposing of ACC_SUPER into ACC_IDENTITY by JEP 401, the VM now fixes missing ACC_IDENTITY flags in old class files
+        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
             throw new RuntimeException(
                 "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
         }
 
         // test multi-dimensional object array.  should return flags of component.
         flags = (int)m.invoke((new SUPERnotset[4][2]).getClass());
-        if (flags != Modifier.PUBLIC) {
+        // Because of the repurposing of ACC_SUPER into ACC_IDENTITY by JEP 401, the VM now fixes missing ACC_IDENTITY flags in old class files
+        if (flags != (Modifier.PUBLIC | Modifier.IDENTITY)) {
             throw new RuntimeException(
                 "expected 0x1, got 0x" + Integer.toHexString(flags) + " for object array");
         }


### PR DESCRIPTION
Make the VM fix the missing ACC_IDENTITY flags even when preview or Valhalla modes are not enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328641](https://bugs.openjdk.org/browse/JDK-8328641): [lworld] runtime/exceptionMsgs/AbstractMethodError/AbstractMethodErrorTest.java fails with java.lang.IncompatibleClassChangeError: value class AME5_B cannot inherit from class AME5_A (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1056/head:pull/1056` \
`$ git checkout pull/1056`

Update a local copy of the PR: \
`$ git checkout pull/1056` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1056`

View PR using the GUI difftool: \
`$ git pr show -t 1056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1056.diff">https://git.openjdk.org/valhalla/pull/1056.diff</a>

</details>
