### PR TITLE
8328715: [lworld] runtime/classFileParserBug/NameAndTypeSig.java fails with Wrong ClassFormatError exception: Method "<init>" in class nonVoidInitSigCFE (an inline class) has illegal signature "()D"

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1944,16 +1944,11 @@ void ClassFileParser::throwIllegalSignature(const char* type,
   assert(name != nullptr, "invariant");
   assert(sig != nullptr, "invariant");
 
-  const char* class_note = "";
-  if (is_inline_type() && name == vmSymbols::object_initializer_name()) {
-    class_note = " (an inline class)";
-  }
-
   ResourceMark rm(THREAD);
   Exceptions::fthrow(THREAD_AND_LOCATION,
       vmSymbols::java_lang_ClassFormatError(),
-      "%s \"%s\" in class %s%s has illegal signature \"%s\"", type,
-      name->as_C_string(), _class_name->as_C_string(), class_note, sig->as_C_string());
+      "%s \"%s\" in class %s has illegal signature \"%s\"", type,
+      name->as_C_string(), _class_name->as_C_string(), sig->as_C_string());
 }
 
 AnnotationCollector::ID


### PR DESCRIPTION
Restore the previous behavior of the VM related to ClassFormatError by removing some buggy code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328715](https://bugs.openjdk.org/browse/JDK-8328715): [lworld] runtime/classFileParserBug/NameAndTypeSig.java fails with Wrong ClassFormatError exception: Method "&lt;init&gt;" in class nonVoidInitSigCFE (an inline class) has illegal signature "()D" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1057/head:pull/1057` \
`$ git checkout pull/1057`

Update a local copy of the PR: \
`$ git checkout pull/1057` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1057`

View PR using the GUI difftool: \
`$ git pr show -t 1057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1057.diff">https://git.openjdk.org/valhalla/pull/1057.diff</a>

</details>
