### PR TITLE
8328543: [lworld] Library and test updates to use --enable-preview instead of ValhallaFeatures

### DIFF
--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -180,8 +180,7 @@ import static java.lang.constant.ConstantDescs.DEFAULT_NAME;
  * @since   1.0
  */
 @jdk.internal.ValueBased
-public final
-class Character implements java.io.Serializable, Comparable<Character>, Constable {
+public final class Character implements java.io.Serializable, Comparable<Character>, Constable {
     /**
      * The minimum radix available for conversion to and from strings.
      * The constant value of this field is the smallest value permitted

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -663,6 +663,9 @@ public final class Class<T> implements java.io.Serializable,
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public boolean isValue() {
+        if (!PreviewFeatures.isEnabled()) {
+            return false;
+        }
          if (isPrimitive() || isArray() || isInterface())
              return false;
         return ((getModifiers() & Modifier.IDENTITY) == 0);
@@ -1496,8 +1499,11 @@ public final class Class<T> implements java.io.Serializable,
                 getClassAccessFlagsRaw() : getModifiers();
         var cffv = ClassFileFormatVersion.fromMajor(getClassFileVersion() & 0xffff);
         if (cffv.compareTo(ClassFileFormatVersion.latest()) >= 0) {
-            // Ignore unspecified (0x800) access flag for current version
+            // Ignore unspecified (0x0800) access flag for current version
             accessFlags &= ~0x0800;
+        }
+        if (!PreviewFeatures.isEnabled() && location == AccessFlag.Location.INNER_CLASS) {
+            accessFlags &= ~Modifier.IDENTITY; // drop ACC_IDENTITY bit in inner class if not in preview
         }
         return AccessFlag.maskToAccessFlags(accessFlags, location, cffv);
     }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -52,7 +52,6 @@ import jdk.internal.classfile.ClassHierarchyResolver;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.CodeBuilder;
 import jdk.internal.classfile.TypeKind;
-import jdk.internal.misc.ValhallaFeatures;
 import jdk.internal.module.Modules;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
@@ -371,7 +370,7 @@ public class MethodHandleProxies {
         return Classfile.of(ClassHierarchyResolverOption.of(ClassHierarchyResolver.ofClassLoading(loader)))
                         .build(proxyDesc, clb -> {
             clb.withSuperclass(CD_Object);
-            clb.withFlags((ValhallaFeatures.isEnabled() ? ACC_IDENTITY : 0) | ACC_FINAL | ACC_SYNTHETIC);
+            clb.withFlags(ACC_IDENTITY | ACC_FINAL | ACC_SYNTHETIC);
             clb.withInterfaceSymbols(ifaceDesc);
 
             // static and instance fields

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import jdk.internal.classfile.ClassHierarchyResolver;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.CodeBuilder;
 import jdk.internal.classfile.TypeKind;
+import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.module.Modules;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
@@ -370,7 +371,7 @@ public class MethodHandleProxies {
         return Classfile.of(ClassHierarchyResolverOption.of(ClassHierarchyResolver.ofClassLoading(loader)))
                         .build(proxyDesc, clb -> {
             clb.withSuperclass(CD_Object);
-            clb.withFlags(ACC_IDENTITY | ACC_FINAL | ACC_SYNTHETIC);
+            clb.withFlags((PreviewFeatures.isEnabled() ? ACC_IDENTITY  : 0) | ACC_FINAL | ACC_SYNTHETIC);
             clb.withInterfaceSymbols(ifaceDesc);
 
             // static and instance fields

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -26,6 +26,7 @@
 package java.lang.reflect;
 
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.misc.PreviewFeatures;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -191,12 +192,14 @@ public enum AccessFlag {
      * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
-    SUPER(0x0000_0020, false, Location.EMPTY_SET,
+    SUPER(0x0000_0020, false,
+            PreviewFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS,
             new Function<ClassFileFormatVersion, Set<Location>>() {
             @Override
             public Set<Location> apply(ClassFileFormatVersion cffv) {
-                return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0)
-                        ? Location.EMPTY_SET : Location.SET_CLASS;}
+                return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0) &&
+                        PreviewFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS;
+            }
         }),
 
     /**
@@ -207,12 +210,14 @@ public enum AccessFlag {
      */
     @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     IDENTITY(Modifier.IDENTITY, false,
-            Location.SET_CLASS_INNER_CLASS,
+            PreviewFeatures.isEnabled() ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET,
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
-                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0)
-                            ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;}
+                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0
+                            && PreviewFeatures.isEnabled())
+                            ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;
+                }
             }),
 
     /**
@@ -689,7 +694,7 @@ public enum AccessFlag {
     private static class LocationToFlags {
         private static Map<Location, Set<AccessFlag>> locationToFlags =
             Map.ofEntries(entry(Location.CLASS,
-                                Set.of(PUBLIC, FINAL, IDENTITY,
+                                Set.of(PUBLIC, FINAL, (PreviewFeatures.isEnabled() ? IDENTITY : SUPER),
                                        INTERFACE, ABSTRACT,
                                        SYNTHETIC, ANNOTATION,
                                        ENUM, AccessFlag.MODULE)),

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -25,6 +25,8 @@
 
 package java.lang.reflect;
 
+import jdk.internal.javac.PreviewFeature;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Map;
@@ -185,7 +187,7 @@ public enum AccessFlag {
      * @apiNote
      * In Java SE 8 and above, the JVM treats the {@code ACC_SUPER}
      * flag as set in every class file (JVMS {@jvms 4.1}).
-     * For class file versions up to but not including Valhalla,
+     * For class file versions up to but not including PreviewFeature VALUE_OBJECTS,
      * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
@@ -203,6 +205,7 @@ public enum AccessFlag {
      * value of <code>{@value "0x%04x" Modifier#IDENTITY}</code>.
      * @jvms 4.1 -B. Class access and property modifiers
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     IDENTITY(Modifier.IDENTITY, false,
             Location.SET_CLASS_INNER_CLASS,
             new Function<ClassFileFormatVersion, Set<Location>>() {

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -188,7 +188,7 @@ public enum AccessFlag {
      * @apiNote
      * In Java SE 8 and above, the JVM treats the {@code ACC_SUPER}
      * flag as set in every class file (JVMS {@jvms 4.1}).
-     * If preview feature is enabled, 
+     * If preview feature is enabled,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
     SUPER(0x0000_0020, false,

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -188,7 +188,8 @@ public enum AccessFlag {
      * @apiNote
      * In Java SE 8 and above, the JVM treats the {@code ACC_SUPER}
      * flag as set in every class file (JVMS {@jvms 4.1}).
-     * For class file versions up to but not including PreviewFeature VALUE_OBJECTS,
+     * If preview feature is enabled, 
+     * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -190,8 +190,6 @@ public enum AccessFlag {
      * flag as set in every class file (JVMS {@jvms 4.1}).
      * If preview feature is enabled, 
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
-     * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
-     * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
     SUPER(0x0000_0020, false,
             PreviewFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS,

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -25,8 +25,6 @@
 
 package java.lang.reflect;
 
-import jdk.internal.misc.ValhallaFeatures;
-
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Map;
@@ -187,17 +185,16 @@ public enum AccessFlag {
      * @apiNote
      * In Java SE 8 and above, the JVM treats the {@code ACC_SUPER}
      * flag as set in every class file (JVMS {@jvms 4.1}).
-     * For class file versions up to Valhalla or if Valhalla is not enabled,
+     * For class file versions up to but not including Valhalla,
      * {@code 0x0020} access flag bit is {@linkplain #SUPER SUPER access flag}; otherwise,
      * the {@code 0x0020} access flag bit is {@linkplain #IDENTITY IDENTITY access flag}.
      */
-    SUPER(0x0000_0020, false,
-            ValhallaFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS,
+    SUPER(0x0000_0020, false, Location.EMPTY_SET,
             new Function<ClassFileFormatVersion, Set<Location>>() {
             @Override
             public Set<Location> apply(ClassFileFormatVersion cffv) {
-                return (cffv.compareTo(ClassFileFormatVersion.RELEASE_21) >= 0 &&
-                        ValhallaFeatures.isEnabled()) ? Location.EMPTY_SET : Location.SET_CLASS;}
+                return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0)
+                        ? Location.EMPTY_SET : Location.SET_CLASS;}
         }),
 
     /**
@@ -207,12 +204,12 @@ public enum AccessFlag {
      * @jvms 4.1 -B. Class access and property modifiers
      */
     IDENTITY(Modifier.IDENTITY, false,
-            ValhallaFeatures.isEnabled() ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET,
+            Location.SET_CLASS_INNER_CLASS,
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
-                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_21) >= 0 &&
-                            ValhallaFeatures.isEnabled()) ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;}
+                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0)
+                            ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;}
             }),
 
     /**
@@ -352,19 +349,14 @@ public enum AccessFlag {
      * major versions 46 through 60, inclusive (JVMS {@jvms 4.6}),
      * corresponding to Java SE 1.2 through 16.
      */
-    STRICT(0x0000_0800, true, !ValhallaFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_FIELD,
+    STRICT(Modifier.STRICT, true, Location.EMPTY_SET,
              new Function<ClassFileFormatVersion, Set<Location>>() {
                @Override
                public Set<Location> apply(ClassFileFormatVersion cffv) {
-                   if (ValhallaFeatures.isEnabled() && cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0) {
-                       return Location.SET_FIELD;
-                   } else if (cffv.compareTo(ClassFileFormatVersion.RELEASE_2) >= 0 &&
-                              cffv.compareTo(ClassFileFormatVersion.RELEASE_16) <= 0) {
-                       return Location.SET_METHOD;
-                   } else {
-                       return Location.EMPTY_SET;
-                   }
-               }
+                   return (cffv.compareTo(ClassFileFormatVersion.RELEASE_2)  >= 0 &&
+                           cffv.compareTo(ClassFileFormatVersion.RELEASE_16) <= 0) ?
+                       Location.SET_METHOD:
+                       Location.EMPTY_SET;}
            }),
 
     /**

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -25,6 +25,8 @@
 
 package java.lang.reflect;
 
+import jdk.internal.javac.PreviewFeature;
+
 import java.util.StringJoiner;
 
 /**
@@ -318,6 +320,7 @@ public class Modifier {
      * The {@code int} value representing the {@code ACC_IDENTITY}
      * modifier.
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
     public static final int IDENTITY         = 0x00000020;
 
     /**

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -150,6 +150,7 @@ module java.base {
         java.desktop, // for ScopedValue
         jdk.compiler,
         jdk.incubator.vector,
+        jdk.jfr,
         jdk.jshell;
     exports jdk.internal.access to
         java.desktop,

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotModifiers.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotModifiers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 package jdk.vm.ci.hotspot;
+
+import jdk.internal.misc.PreviewFeatures;
 
 import static java.lang.reflect.Modifier.ABSTRACT;
 import static java.lang.reflect.Modifier.FINAL;
@@ -53,7 +55,8 @@ public class HotSpotModifiers {
     // @formatter:on
 
     public static int jvmClassModifiers() {
-        return PUBLIC | FINAL | INTERFACE | ABSTRACT | ANNOTATION | ENUM | SYNTHETIC | 0x0020; // ACC_IDENTITY temp constant to avoid preview dependency
+        return PUBLIC | FINAL | INTERFACE | ABSTRACT | ANNOTATION | ENUM | SYNTHETIC |
+                (PreviewFeatures.isEnabled() ? 0x0020 : 0); // ACC_IDENTITY temp constant to avoid preview dependency
     }
 
     public static int jvmMethodModifiers() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotModifiers.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotModifiers.java
@@ -32,7 +32,6 @@ import static java.lang.reflect.Modifier.PUBLIC;
 import static java.lang.reflect.Modifier.STATIC;
 import static java.lang.reflect.Modifier.STRICT;
 import static java.lang.reflect.Modifier.SYNCHRONIZED;
-import static java.lang.reflect.Modifier.IDENTITY;
 import static java.lang.reflect.Modifier.TRANSIENT;
 import static java.lang.reflect.Modifier.VOLATILE;
 import static jdk.vm.ci.hotspot.HotSpotVMConfig.config;
@@ -54,7 +53,7 @@ public class HotSpotModifiers {
     // @formatter:on
 
     public static int jvmClassModifiers() {
-        return PUBLIC | FINAL | INTERFACE | ABSTRACT | ANNOTATION | ENUM | SYNTHETIC | IDENTITY;
+        return PUBLIC | FINAL | INTERFACE | ABSTRACT | ANNOTATION | ENUM | SYNTHETIC | 0x0020; // ACC_IDENTITY temp constant to avoid preview dependency
     }
 
     public static int jvmMethodModifiers() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import jdk.internal.classfile.ClassBuilder;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.Label;
 import jdk.internal.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
+import jdk.internal.misc.PreviewFeatures;
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.Event;
 import jdk.jfr.ValueDescriptor;
@@ -110,7 +111,7 @@ public final class EventClassBuilder {
 
     private void buildClassInfo(ClassBuilder builder) {
         builder.withSuperclass(Bytecode.classDesc(Event.class));
-        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, AccessFlag.IDENTITY);
+        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, (PreviewFeatures.isEnabled() ? AccessFlag.IDENTITY : AccessFlag.SUPER));
         List<jdk.internal.classfile.Annotation> annotations = new ArrayList<>();
         for (jdk.jfr.AnnotationElement a : annotationElements) {
             List<jdk.internal.classfile.AnnotationElement> list = new ArrayList<>();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
@@ -39,7 +39,6 @@ import jdk.internal.classfile.ClassBuilder;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.Label;
 import jdk.internal.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
-import jdk.internal.misc.ValhallaFeatures;
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.Event;
 import jdk.jfr.ValueDescriptor;
@@ -111,7 +110,7 @@ public final class EventClassBuilder {
 
     private void buildClassInfo(ClassBuilder builder) {
         builder.withSuperclass(Bytecode.classDesc(Event.class));
-        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, ValhallaFeatures.isEnabled() ? AccessFlag.IDENTITY : AccessFlag.SUPER);
+        builder.withFlags(AccessFlag.FINAL, AccessFlag.PUBLIC, AccessFlag.IDENTITY);
         List<jdk.internal.classfile.Annotation> annotations = new ArrayList<>();
         for (jdk.jfr.AnnotationElement a : annotationElements) {
             List<jdk.internal.classfile.AnnotationElement> list = new ArrayList<>();

--- a/test/jdk/java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandleProxies/WrapperHiddenClassTest.java
@@ -40,7 +40,7 @@ import static java.lang.constant.ConstantDescs.*;
 import static java.lang.invoke.MethodHandleProxies.*;
 import static java.lang.invoke.MethodType.methodType;
 import static jdk.internal.classfile.Classfile.*;
-import jdk.internal.misc.ValhallaFeatures;
+import jdk.internal.misc.PreviewFeatures;
 import static org.junit.jupiter.api.Assertions.*;
 
 /*
@@ -90,7 +90,7 @@ public class WrapperHiddenClassTest {
         var cf = Classfile.of();
         var bytes = cf.build(CD_HostileWrapper, clb -> {
             clb.withSuperclass(CD_Object);
-            clb.withFlags((ValhallaFeatures.isEnabled() ? ACC_IDENTITY : 0) | ACC_FINAL | ACC_SYNTHETIC);
+            clb.withFlags((PreviewFeatures.isEnabled() ? ACC_IDENTITY : 0) | ACC_FINAL | ACC_SYNTHETIC);
             clb.withInterfaceSymbols(CD_Comparator);
 
             // static and instance fields

--- a/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
@@ -26,7 +26,6 @@
  * @bug 8266670 8281463 8293626
  * @summary Basic tests of AccessFlag
  * @modules java.base/jdk.internal.misc
- * @enablePreview
  * @run main/othervm --enable-preview BasicAccessFlagTest
  * @run main BasicAccessFlagTest
  */
@@ -147,7 +146,6 @@ public class BasicAccessFlagTest {
     private static void testMaskToAccessFlagsPositive() {
         for (var accessFlag : AccessFlag.values()) {
             Set<AccessFlag> expectedSet = EnumSet.of(accessFlag);
-            expectedSet.remove(PreviewFeatures.isEnabled() ? AccessFlag.SUPER : AccessFlag.IDENTITY);
             for (var location : accessFlag.locations()) {
                 Set<AccessFlag> computedSet =
                     AccessFlag.maskToAccessFlags(accessFlag.mask(), location);

--- a/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/BasicAccessFlagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,23 @@
  * @test
  * @bug 8266670 8281463 8293626
  * @summary Basic tests of AccessFlag
+ * @modules java.base/jdk.internal.misc
+ * @enablePreview
+ * @run main/othervm --enable-preview BasicAccessFlagTest
+ * @run main BasicAccessFlagTest
  */
 
 import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Set;
+
+import jdk.internal.misc.PreviewFeatures;
+
 
 public class BasicAccessFlagTest {
     public static void main(String... args) throws Exception {
@@ -141,6 +147,7 @@ public class BasicAccessFlagTest {
     private static void testMaskToAccessFlagsPositive() {
         for (var accessFlag : AccessFlag.values()) {
             Set<AccessFlag> expectedSet = EnumSet.of(accessFlag);
+            expectedSet.remove(PreviewFeatures.isEnabled() ? AccessFlag.SUPER : AccessFlag.IDENTITY);
             for (var location : accessFlag.locations()) {
                 Set<AccessFlag> computedSet =
                     AccessFlag.maskToAccessFlags(accessFlag.mask(), location);

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * under the terms of the GNU General Public License version 2 only, as * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -26,19 +25,15 @@
  * @bug 8266670 8291734 8296743
  * @summary Test expected AccessFlag's on classes.
  * @modules java.base/jdk.internal.misc
- * @library /test/lib ..
  * @enablePreview
+ * @run main ClassAccessFlagPreviewTest
  */
-
-
-import jdk.internal.misc.PreviewFeatures;
 
 import java.lang.annotation.*;
 import java.lang.reflect.*;
 import java.util.*;
 
-import jtreg.SkippedException;
-
+import jdk.internal.misc.PreviewFeatures;
 
 /*
  * Class access flags that can directly or indirectly declared in
@@ -56,23 +51,28 @@ import jtreg.SkippedException;
  * file. Therefore, this test does not attempt to probe the setting of
  * that access flag.
  */
-@ExpectedClassFlags("[PUBLIC, FINAL, SUPER]")
-public final class ClassAccessFlagTest {
+@ExpectedClassFlags(value = "[PUBLIC, FINAL, SUPER]",
+        preview = "[PUBLIC, FINAL, IDENTITY]")
+public final class ClassAccessFlagPreviewTest {
     public static void main(String... args) {
-        if (PreviewFeatures.isEnabled()) {
-            throw new SkippedException("Preview mode not supported");
-        }
         // Top-level and auxiliary classes; i.e. non-inner classes
         Class<?>[] testClasses = {
-            ClassAccessFlagTest.class,
+            ClassAccessFlagPreviewTest.class,
             TestInterface.class,
+            TestFinalClass.class,
+            TestAbstractClass.class,
+            TestAbstractValueClass.class,
+            TestPrivateAbstractClass.class,
+            TestPrivateAbstractValueClass.class,
+            StaticTestInterface.class,
+            TestMarkerAnnotation.class,
             ExpectedClassFlags.class,
             TestOuterEnum.class
         };
         checkClasses(testClasses);
 
-        // Nested classes of ClassAccessFlagTest
-        checkClasses(ClassAccessFlagTest.class.getDeclaredClasses());
+        // Nested classes of ClassAccessFlagPreviewTest
+        checkClasses(ClassAccessFlagPreviewTest.class.getDeclaredClasses());
 
         checkPrimitives();
         checkArrays();
@@ -89,9 +89,11 @@ public final class ClassAccessFlagTest {
             clazz.getAnnotation(ExpectedClassFlags.class);
         if (expected != null) {
             String actual = clazz.accessFlags().toString();
-            if (!expected.value().equals(actual)) {
+            String expectedFlags = (PreviewFeatures.isEnabled() && !expected.preview().isEmpty())
+                    ? expected.preview() : expected.value();
+            if (!expectedFlags.equals(actual)) {
                 throw new RuntimeException("On " + clazz +
-                                           " expected " + expected.value() +
+                                           " expected " + expected +
                                            " got " + actual);
             }
         }
@@ -164,6 +166,18 @@ public final class ClassAccessFlagTest {
                                                arrayClass);
                 }
             }
+            // Verify IDENTITY, ABSTRACT, FINAL, and access mode
+            Set<AccessFlag> expected = new HashSet<>(4);
+            expected.add(AccessFlag.ABSTRACT);
+            expected.add(AccessFlag.FINAL);
+//            expected.add(AccessFlag.IDENTITY);  // NYI Pending: JDK-8294866
+            if (accessLevel != null)
+                expected.add(accessLevel);
+            if (!expected.equals(arrayClass.accessFlags())) {
+                throw new RuntimeException("Unexpected access flags for array: " + accessClass +
+                        ": actual: " + arrayClass.accessFlags() +
+                        ", expected: " + expected);
+            }
         }
 
     }
@@ -172,6 +186,7 @@ public final class ClassAccessFlagTest {
     // locations:
     // PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, INTERFACE, ABSTRACT,
     // SYNTHETIC, ANNOTATION, ENUM.
+    // Include cases for classes with identity, value modifier, or no modifier.
 
     @ExpectedClassFlags("[PUBLIC, STATIC, INTERFACE, ABSTRACT]")
     public      interface PublicInterface {}
@@ -182,23 +197,31 @@ public final class ClassAccessFlagTest {
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT]")
     /*package*/ interface PackageInterface {}
 
-    @ExpectedClassFlags("[FINAL]")
+    @ExpectedClassFlags(value = "[FINAL]",
+            preview = "[FINAL, IDENTITY]")
     /*package*/ final class TestFinalClass {}
 
-    @ExpectedClassFlags("[ABSTRACT]")
+    @ExpectedClassFlags(value = "[ABSTRACT]",
+            preview = "[IDENTITY, ABSTRACT]")
     /*package*/ abstract class TestAbstractClass {}
+
+    @ExpectedClassFlags(value = "[ABSTRACT]",
+            preview = "[ABSTRACT]")
+    /*package*/ abstract value class TestAbstractValueClass {}
 
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT, ANNOTATION]")
     /*package*/ @interface TestMarkerAnnotation {}
 
-    @ExpectedClassFlags("[PUBLIC, STATIC, FINAL, ENUM]")
+    @ExpectedClassFlags(value = "[PUBLIC, STATIC, FINAL, ENUM]",
+            preview = "[PUBLIC, STATIC, FINAL, IDENTITY, ENUM]")
     public enum MetaSynVar {
         QUUX;
     }
 
     // Is there is at least one special enum constant, the enum class
     // itself is implicitly abstract rather than final.
-    @ExpectedClassFlags("[PROTECTED, STATIC, ABSTRACT, ENUM]")
+    @ExpectedClassFlags(value = "[PROTECTED, STATIC, ABSTRACT, ENUM]",
+            preview = "[PROTECTED, STATIC, IDENTITY, ABSTRACT, ENUM]")
     protected enum MetaSynVar2 {
         WOMBAT{
             @Override
@@ -207,8 +230,13 @@ public final class ClassAccessFlagTest {
         public abstract int foo();
     }
 
-    @ExpectedClassFlags("[PRIVATE, ABSTRACT]")
-    private abstract class Foo {}
+    @ExpectedClassFlags(value = "[PRIVATE, ABSTRACT]",
+            preview = "[PRIVATE, IDENTITY, ABSTRACT]")
+    private abstract class TestPrivateAbstractClass {}
+
+    @ExpectedClassFlags(value = "[PRIVATE, ABSTRACT]",
+            preview = "[PRIVATE, ABSTRACT]")
+    private abstract value class TestPrivateAbstractValueClass {}
 
     @ExpectedClassFlags("[STATIC, INTERFACE, ABSTRACT]")
     interface StaticTestInterface {}
@@ -218,13 +246,15 @@ public final class ClassAccessFlagTest {
 @ExpectedClassFlags("[INTERFACE, ABSTRACT, ANNOTATION]")
 @interface ExpectedClassFlags {
     String value();
+    String preview() default "";
 }
 
 @ExpectedClassFlags("[INTERFACE, ABSTRACT]")
 interface TestInterface {}
 
 
-@ExpectedClassFlags("[FINAL, SUPER, ENUM]")
+@ExpectedClassFlags(value="[FINAL, SUPER, ENUM]",
+        preview="[FINAL, IDENTITY, ENUM]")
 enum TestOuterEnum {
     INSTANCE;
 }

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
@@ -3,7 +3,8 @@
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as * published by the Free Software Foundation.
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/lang/reflect/AccessFlag/VersionedLocationsTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/VersionedLocationsTest.java
@@ -117,7 +117,7 @@ public class VersionedLocationsTest {
 
             new StepFunctionTC(SUPER,
                                Set.of(AccessFlag.Location.CLASS),
-                               ClassFileFormatVersion.RELEASE_21),
+                               ClassFileFormatVersion.RELEASE_22),
 
             new StepFunctionTC(OPEN,
                                Set.of(),
@@ -270,8 +270,7 @@ public class VersionedLocationsTest {
                 (cffv.compareTo(ClassFileFormatVersion.RELEASE_2)  >= 0 &&
                  cffv.compareTo(ClassFileFormatVersion.RELEASE_16) <= 0) ?
                 Set.of(Location.METHOD) :
-                        (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0)
-                                ? Set.of(Location.FIELD) : Set.of();
+                Set.of();
             compareLocations(expected, STRICT, cffv);
         }
     }

--- a/test/jdk/valhalla/valuetypes/UseValueClassTest.java
+++ b/test/jdk/valhalla/valuetypes/UseValueClassTest.java
@@ -28,10 +28,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import jdk.internal.misc.PreviewFeatures;
-import jdk.internal.misc.ValhallaFeatures;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 
 import java.time.Duration;
@@ -64,6 +62,16 @@ public class UseValueClassTest {
     // Classes to be checked
     private static Stream<Class<?>> classProvider() {
         Class<?>[] classes = {
+                Byte.class,
+                Short.class,
+                Integer.class,
+                Long.class,
+                Float.class,
+                Double.class,
+                Boolean.class,
+                Character.class,
+                Number.class,
+                Record.class,
                 Duration.class,
                 Instant.class,
                 LocalDate.class,
@@ -80,21 +88,18 @@ public class UseValueClassTest {
                 Year.class,
                 YearMonth.class,
                 ZonedDateTime.class,
-                Record.class,
         };
         return Arrays.stream(classes, 0, classes.length);
     }
 
     /**
-     * Verify that the class is a value class if --enable-preview true
+     * Verify that the class is a value class if --enable-preview is true
      * @param clazz a class
      */
     @ParameterizedTest
     @MethodSource("classProvider")
     public void testValue(Class<?> clazz) {
-        System.out.printf("isPreview: %s, Valhalla.isEnabled: %s%n",
-                PreviewFeatures.isEnabled(), ValhallaFeatures.isEnabled());
-        assertEquals(PreviewFeatures.isEnabled() && ValhallaFeatures.isEnabled(),
-                clazz.isValue(), clazz.getName());
+        System.out.printf("isPreview: %s%n", PreviewFeatures.isEnabled());
+        assertEquals(PreviewFeatures.isEnabled(), clazz.isValue(), clazz.getName());
     }
 }

--- a/test/langtools/tools/javap/4870651/T4870651.java
+++ b/test/langtools/tools/javap/4870651/T4870651.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,13 @@
  * @summary javap should recognize generics, varargs, enum;
  *          javap prints "extends java.lang.Object"
  * @modules jdk.jdeps/com.sun.tools.javap
+ * @modules java.base/jdk.internal.misc
  * @build T4870651 Test
  * @run main T4870651
  */
 
 import java.io.*;
+import jdk.internal.misc.PreviewFeatures;
 
 public class T4870651 {
     public static void main(String[] args) throws Exception {
@@ -46,7 +48,9 @@ public class T4870651 {
                "v1(java.lang.String...)");
 
         verify("Test$Enum",
-               "flags: (0x4030) ACC_FINAL, ACC_IDENTITY, ACC_ENUM",
+               PreviewFeatures.isEnabled()
+                       ? "flags: (0x4030) ACC_FINAL, ACC_IDENTITY, ACC_ENUM"
+                       : "flags: (0x4030) ACC_FINAL, ACC_SUPER, ACC_ENUM",
                "flags: (0x4019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_ENUM");
 
         if (errors > 0)

--- a/test/langtools/tools/javap/T4975569.java
+++ b/test/langtools/tools/javap/T4975569.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,17 @@
  * @bug 4975569 6622215 8034861
  * @summary javap doesn't print new flag bits
  * @modules jdk.jdeps/com.sun.tools.javap
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm --enable-preview T4975569
+ * @run main T4975569
  */
 
 import java.io.*;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import jdk.internal.misc.PreviewFeatures;
 
 public class T4975569 {
     private static final String NEW_LINE = System.getProperty("line.separator");
@@ -43,7 +48,12 @@ public class T4975569 {
 
     void run() {
         verify(Anno.class.getName(), "flags: \\(0x2600\\) ACC_INTERFACE, ACC_ABSTRACT, ACC_ANNOTATION");
-        verify(E.class.getName(),    "flags: \\(0x4030\\) ACC_FINAL, ACC_IDENTITY, ACC_ENUM");
+        verify(E.class.getName(), PreviewFeatures.isEnabled()
+                ? "flags: \\(0x4030\\) ACC_FINAL, ACC_IDENTITY, ACC_ENUM"
+                : "flags: \\(0x4030\\) ACC_FINAL, ACC_SUPER, ACC_ENUM");
+        verify(E.class.getName(),    PreviewFeatures.isEnabled()
+                ? "flags: \\(0x4030\\) ACC_FINAL, ACC_IDENTITY, ACC_ENUM"
+                : "flags: \\(0x4030\\) ACC_FINAL, ACC_SUPER, ACC_ENUM");
         verify(S.class.getName(),    "flags: \\(0x1040\\) ACC_BRIDGE, ACC_SYNTHETIC",
                                      "InnerClasses:\n  static [# =\\w]+; +// ");
         verify(V.class.getName(),    "void m\\(java.lang.String...\\)",
@@ -105,4 +115,3 @@ public class T4975569 {
     protected class Prot { }
     private class Priv { int i; }
 }
-


### PR DESCRIPTION
Update AccessFlag and tests to JEP 401 and use of --enable-preview instead of ValhallaFeatures.
Minor formatting change to java.lang.Character to allow it to be a value class with --enable-preview.
(The class file format version numbers will need to be updated when re-synching with the mainline).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328543](https://bugs.openjdk.org/browse/JDK-8328543): [lworld] Library and test updates to use --enable-preview instead of ValhallaFeatures (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - Committer) ⚠️ Review applies to [c3fb4d85](https://git.openjdk.org/valhalla/pull/1060/files/c3fb4d859e24787639c911dc2077c9d548f7b0f0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1060/head:pull/1060` \
`$ git checkout pull/1060`

Update a local copy of the PR: \
`$ git checkout pull/1060` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1060`

View PR using the GUI difftool: \
`$ git pr show -t 1060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1060.diff">https://git.openjdk.org/valhalla/pull/1060.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1060#issuecomment-2015840199)