### PR TITLE
8328839: [lworld] javac allows super constructor invocations before all fields have been initialized

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
@@ -126,6 +126,8 @@ public class AttrContext {
      */
     JCTree preferredTreeForDiagnostics;
 
+    boolean instanceInitializerBlock = false;
+
     /** Duplicate this context, replacing scope field and copying all others.
      */
     AttrContext dup(WriteableScope scope) {
@@ -149,6 +151,7 @@ public class AttrContext {
         info.preferredTreeForDiagnostics = preferredTreeForDiagnostics;
         info.visitingServiceImplementation = visitingServiceImplementation;
         info.allowProtectedAccess = allowProtectedAccess;
+        info.instanceInitializerBlock = instanceInitializerBlock;
         return info;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -774,7 +774,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
 
         // Explicit 'this' reference?
         Type.ClassType currentClassType = (Type.ClassType)methodClass.sym.type;
-        if (isExplicitThisReference(types, currentClassType, tree)) {
+        if (TreeInfo.isExplicitThisReference(types, currentClassType, tree)) {
             refs.mapInto(refs, ThisRef.class, direct -> new ExprRef(depth, direct));
             return;
         }
@@ -1156,43 +1156,6 @@ class ThisEscapeAnalyzer extends TreeScanner {
         return sym != null &&
             sym.kind == VAR &&
             (sym.owner.kind == MTH || sym.owner.kind == VAR);
-    }
-
-    /** Check if the given tree is an explicit reference to the 'this' instance of the
-     *  class currently being compiled. This is true if tree is:
-     *  - An unqualified 'this' identifier
-     *  - A 'super' identifier qualified by a class name whose type is 'currentClass' or a supertype
-     *  - A 'this' identifier qualified by a class name whose type is 'currentClass' or a supertype
-     *    but also NOT an enclosing outer class of 'currentClass'.
-     */
-    private boolean isExplicitThisReference(Types types, Type.ClassType currentClass, JCTree tree) {
-        switch (tree.getTag()) {
-            case PARENS:
-                return isExplicitThisReference(types, currentClass, TreeInfo.skipParens(tree));
-            case IDENT:
-            {
-                JCIdent ident = (JCIdent)tree;
-                Names names = ident.name.table.names;
-                return ident.name == names._this;
-            }
-            case SELECT:
-            {
-                JCFieldAccess select = (JCFieldAccess)tree;
-                Type selectedType = types.erasure(select.selected.type);
-                if (!selectedType.hasTag(CLASS))
-                    return false;
-                ClassSymbol currentClassSym = (ClassSymbol)((Type.ClassType)types.erasure(currentClass)).tsym;
-                ClassSymbol selectedClassSym = (ClassSymbol)((Type.ClassType)selectedType).tsym;
-                Names names = select.name.table.names;
-                return currentClassSym.isSubClass(selectedClassSym, types) &&
-                        (select.name == names._super ||
-                        (select.name == names._this &&
-                            (currentClassSym == selectedClassSym ||
-                            !currentClassSym.isEnclosedBy(selectedClassSym))));
-            }
-            default:
-                return false;
-        }
     }
 
     // When scanning nodes we can be in one of two modes:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4065,6 +4065,10 @@ compiler.err.concrete.supertype.for.value.class=\
 compiler.err.super.class.method.cannot.be.synchronized=\
     The method {0} in the super class {2} of the value class {1} is synchronized. This is disallowed
 
+# 0: symbol or name
+compiler.err.cant.ref.after.ctor.called=\
+    cannot reference {0} after supertype constructor has been called
+
 # 0: symbol
 compiler.err.deconstruction.pattern.only.records=\
     deconstruction patterns can only be applied to records, {0} is not a record

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -182,6 +182,41 @@ public class TreeInfo {
         }
     }
 
+    /** Check if the given tree is an explicit reference to the 'this' instance of the
+     *  class currently being compiled. This is true if tree is:
+     *  - An unqualified 'this' identifier
+     *  - A 'super' identifier qualified by a class name whose type is 'currentClass' or a supertype
+     *  - A 'this' identifier qualified by a class name whose type is 'currentClass' or a supertype
+     *    but also NOT an enclosing outer class of 'currentClass'.
+     */
+    public static boolean isExplicitThisReference(Types types, Type.ClassType currentClass, JCTree tree) {
+        switch (tree.getTag()) {
+            case PARENS:
+                return isExplicitThisReference(types, currentClass, skipParens(tree));
+            case IDENT: {
+                JCIdent ident = (JCIdent)tree;
+                Names names = ident.name.table.names;
+                return ident.name == names._this || ident.name == names._super;
+            }
+            case SELECT: {
+                JCFieldAccess select = (JCFieldAccess)tree;
+                Type selectedType = types.erasure(select.selected.type);
+                if (!selectedType.hasTag(TypeTag.CLASS))
+                    return false;
+                Symbol.ClassSymbol currentClassSym = (Symbol.ClassSymbol)((Type.ClassType)types.erasure(currentClass)).tsym;
+                Symbol.ClassSymbol selectedClassSym = (Symbol.ClassSymbol)((Type.ClassType)selectedType).tsym;
+                Names names = select.name.table.names;
+                return currentClassSym.isSubClass(selectedClassSym, types) &&
+                        (select.name == names._super ||
+                                (select.name == names._this &&
+                                        (currentClassSym == selectedClassSym ||
+                                                !currentClassSym.isEnclosedBy(selectedClassSym))));
+            }
+            default:
+                return false;
+        }
+    }
+
     /** Is this a call to super?
      */
     public static boolean isSuperCall(JCTree tree) {

--- a/test/langtools/tools/javac/diags/examples/FieldAssigmentAfterSuper.java
+++ b/test/langtools/tools/javac/diags/examples/FieldAssigmentAfterSuper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.cant.ref.after.ctor.called
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version}
+
+value class V {
+    int i;
+    V(int i) {
+        super();
+        this.i = i;
+    }
+}


### PR DESCRIPTION
this code is being accepted by javac:

value class V {
    int i;

    V() {
        super();
        i = 1;
    }
}

it should be rejected. Also, with value records, the implicit super call always ends up before the field stores. Reported by Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328839](https://bugs.openjdk.org/browse/JDK-8328839): [lworld] javac allows super constructor invocations before all fields have been initialized (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1061/head:pull/1061` \
`$ git checkout pull/1061`

Update a local copy of the PR: \
`$ git checkout pull/1061` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1061`

View PR using the GUI difftool: \
`$ git pr show -t 1061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1061.diff">https://git.openjdk.org/valhalla/pull/1061.diff</a>

</details>
