### PR TITLE
8328704: [REDO] [lworld] Missing barrier after value object construction

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -586,11 +586,6 @@ void Parse::do_call() {
     InlineTypeNode* clone = receiver->clone()->as_InlineType();
     clone->set_is_larval(false);
     replace_in_map(receiver, _gvn.transform(clone));
-    // Do not let stores that initialize this buffer be reordered with a subsequent
-    // store that would make this buffer accessible by other threads.
-    // TODO 8325106 MemBarRelease vs. MemBarStoreStore
-    // TODO 8328704
-    // insert_mem_bar(Op_MemBarRelease);
   }
 
   // Speculative type of the receiver if any

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1085,8 +1085,6 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
     } else {
       return nullptr;
     }
-
-    // TODO value might be phi because we loaded from a nullable oop...
   }
   return base;
 }

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -587,7 +587,7 @@ InlineTypeNode* InlineTypeNode::buffer(GraphKit* kit, bool safe_for_replace) {
       // store that would make this buffer accessible by other threads.
       AllocateNode* alloc = AllocateNode::Ideal_allocation(alloc_oop);
       assert(alloc != nullptr, "must have an allocation node");
-      // TODO 8325106 MemBarRelease vs. MemBarStoreStore
+      // TODO 8325106 MemBarRelease vs. MemBarStoreStore, see set_alloc_with_final
       kit->insert_mem_bar(Op_MemBarStoreStore, alloc->proj_out_or_null(AllocateNode::RawAddress));
     }
 
@@ -1085,6 +1085,8 @@ Node* InlineTypeNode::is_loaded(PhaseGVN* phase, ciInlineKlass* vk, Node* base, 
     } else {
       return nullptr;
     }
+
+    // TODO value might be phi because we loaded from a nullable oop...
   }
   return base;
 }

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -716,6 +716,8 @@ bool PhaseMacroExpand::can_eliminate_allocation(PhaseIterGVN* igvn, AllocateNode
       } else if (use->Opcode() == Op_StoreX && use->in(MemNode::Address) == res) {
         // Store to mark word of inline type larval buffer
         assert(res_type->is_inlinetypeptr(), "Unexpected store to mark word");
+      } else if (res_type->is_inlinetypeptr() && use->Opcode() == Op_MemBarRelease) {
+        // Inline type buffer allocations are followed by a membar
       } else if (reduce_merge_precheck && (use->is_Phi() || use->is_EncodeP() || use->Opcode() == Op_MemBarRelease)) {
         // Nothing to do
       } else if (use->Opcode() != Op_CastP2X) { // CastP2X is used by card mark
@@ -1111,6 +1113,10 @@ void PhaseMacroExpand::process_users_of_allocation(CallNode *alloc, bool inline_
         // Store to mark word of inline type larval buffer
         assert(inline_alloc, "Unexpected store to mark word");
         _igvn.replace_node(use, use->in(MemNode::Memory));
+      } else if (use->Opcode() == Op_MemBarRelease) {
+        // Inline type buffer allocations are followed by a membar
+        assert(inline_alloc, "Unexpected MemBarRelease");
+        use->as_MemBar()->remove(&_igvn);
       } else {
         eliminate_gc_barrier(use);
       }

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -983,7 +983,7 @@ static bool skip_through_membars(Compile::AliasType* atp, const TypeInstPtr* tp,
                          (tp != nullptr) && (tp->isa_aryptr() != nullptr) &&
                          tp->isa_aryptr()->is_stable();
 
-    return (eliminate_boxing && non_volatile) || is_stable_ary;
+    return (eliminate_boxing && non_volatile) || is_stable_ary || tp->is_inlinetypeptr();
   }
 
   return false;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -931,7 +931,7 @@ void Compile::return_values(JVMState* jvms) {
       InlineTypeNode* vt = res->as_InlineType();
       ret->add_req_batch(nullptr, tf()->range_cc()->cnt() - TypeFunc::Parms);
       if (vt->is_allocated(&kit.gvn()) && !StressCallingConvention) {
-        ret->init_req(TypeFunc::Parms, vt->get_oop());
+        ret->init_req(TypeFunc::Parms, vt);
       } else {
         // Return the tagged klass pointer to signal scalarization to the caller
         Node* tagged_klass = vt->tagged_klass(kit.gvn());

--- a/src/hotspot/share/opto/parse3.cpp
+++ b/src/hotspot/share/opto/parse3.cpp
@@ -52,7 +52,6 @@ void Parse::do_field_access(bool is_get, bool is_field) {
 
   if (is_get && is_field && field_holder->is_inlinetype() && peek()->is_InlineType()) {
     InlineTypeNode* vt = peek()->as_InlineType();
-    // TODO shouldn't we cast the oop input to non-null here and reload the inline type to get rid of the phi diamond? Should we emit the loads lazily?
     null_check(vt);
     Node* value = vt->field_value_by_offset(field->offset_in_bytes());
     if (value->is_InlineType()) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -717,7 +717,6 @@ public class TestBasicFunctionality {
 
     // Verify that C2 recognizes value class loads and re-uses the oop to avoid allocations
     @Test
-    // TODO fix
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
         failOn = {ALLOC, ALLOCA, STORE})
     public MyValue3 test31() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -718,8 +718,8 @@ public class TestBasicFunctionality {
     // Verify that C2 recognizes value class loads and re-uses the oop to avoid allocations
     @Test
     // TODO fix
-    //@IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
-    //    failOn = {ALLOC, ALLOCA, STORE})
+    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
+        failOn = {ALLOC, ALLOCA, STORE})
     public MyValue3 test31() {
         // C2 can re-use the oop returned by createDontInline()
         // because the corresponding value object is equal to 'copy'.

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBufferTearing.java
@@ -152,8 +152,6 @@ public class TestBufferTearing {
     }
 
     public static void main(String[] args) throws Exception {
-        // TODO 8328704 re-enable
-        /*
         // Create threads that concurrently update some value class (array) fields
         // and check the fields of the value classes for consistency to detect tearing.
         TestBufferTearing test = new TestBufferTearing();
@@ -163,6 +161,5 @@ public class TestBufferTearing {
             runner.start();
         }
         runner.join();
-        */
     }
 }


### PR DESCRIPTION
Added a missing barrier after value object construction.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328704](https://bugs.openjdk.org/browse/JDK-8328704): [REDO] [lworld] Missing barrier after value object construction (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1062/head:pull/1062` \
`$ git checkout pull/1062`

Update a local copy of the PR: \
`$ git checkout pull/1062` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1062`

View PR using the GUI difftool: \
`$ git pr show -t 1062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1062.diff">https://git.openjdk.org/valhalla/pull/1062.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1062#issuecomment-2018016784)