### PR TITLE
8329205: [lworld] Add jdk.internal.value.CheckedType API

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -158,6 +158,7 @@ JVM_IsHiddenClass
 JVM_IsIdentityClass
 JVM_IsImplicitlyConstructibleClass
 JVM_IsInterface
+JVM_IsNullRestrictedArray
 JVM_IsPreviewEnabled
 JVM_IsValhallaEnabled
 JVM_IsContinuationsSupported

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -623,8 +623,8 @@ class methodHandle;
   do_intrinsic(_copyMemory,               jdk_internal_misc_Unsafe,     copyMemory_name, copyMemory_signature,         F_RN)     \
    do_name(     copyMemory_name,                                        "copyMemory0")                                           \
    do_signature(copyMemory_signature,                                   "(Ljava/lang/Object;JLjava/lang/Object;JJ)V")            \
-  do_intrinsic(_isFlattenedArray,         jdk_internal_misc_Unsafe,     isFlattenedArray_name, class_boolean_signature, F_RN)    \
-   do_name(     isFlattenedArray_name,                                  "isFlattenedArray")                                      \
+  do_intrinsic(_isFlatArray,              jdk_internal_misc_Unsafe,     isFlatArray_name, class_boolean_signature, F_RN)         \
+   do_name(     isFlatArray_name,                                       "isFlatArray")                                           \
   do_intrinsic(_loadFence,                jdk_internal_misc_Unsafe,     loadFence_name, loadFence_signature,           F_R)      \
    do_name(     loadFence_name,                                         "loadFence")                                             \
    do_alias(    loadFence_signature,                                    void_method_signature)                                   \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1140,6 +1140,9 @@ JVM_GetTemporaryDirectory(JNIEnv *env);
 JNIEXPORT jarray JNICALL
 JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint len);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsNullRestrictedArray(JNIEnv *env, jobject obj);
+
 /* Generics reflection support.
  *
  * Returns information about the given class's EnclosingMethod

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -735,7 +735,7 @@ bool C2Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_nanoTime:
   case vmIntrinsics::_allocateInstance:
   case vmIntrinsics::_allocateUninitializedArray:
-  case vmIntrinsics::_isFlattenedArray:
+  case vmIntrinsics::_isFlatArray:
   case vmIntrinsics::_newArray:
   case vmIntrinsics::_newNullRestrictedArray:
   case vmIntrinsics::_getLength:

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -512,7 +512,7 @@ bool LibraryCallKit::try_to_inline(int predicate) {
   case vmIntrinsics::_writebackPostSync0:       return inline_unsafe_writebackSync0(false);
   case vmIntrinsics::_allocateInstance:         return inline_unsafe_allocate();
   case vmIntrinsics::_copyMemory:               return inline_unsafe_copyMemory();
-  case vmIntrinsics::_isFlattenedArray:         return inline_unsafe_isFlattenedArray();
+  case vmIntrinsics::_isFlatArray:              return inline_unsafe_isFlatArray();
   case vmIntrinsics::_getLength:                return inline_native_getLength();
   case vmIntrinsics::_copyOf:                   return inline_array_copyOf(false);
   case vmIntrinsics::_copyOfRange:              return inline_array_copyOf(true);
@@ -5221,11 +5221,11 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
 #undef XTOP
 
 // TODO 8325106 Remove this and corresponding tests. Flatness is not a property of the Class anymore with JEP 401.
-//----------------------inline_unsafe_isFlattenedArray-------------------
-// public native boolean Unsafe.isFlattenedArray(Class<?> arrayClass);
+//----------------------inline_unsafe_isFlatArray------------------------
+// public native boolean Unsafe.isFlatArray(Class<?> arrayClass);
 // This intrinsic exploits assumptions made by the native implementation
 // (arrayClass is neither null nor primitive) to avoid unnecessary null checks.
-bool LibraryCallKit::inline_unsafe_isFlattenedArray() {
+bool LibraryCallKit::inline_unsafe_isFlatArray() {
   Node* cls = argument(1);
   Node* p = basic_plus_adr(cls, java_lang_Class::klass_offset());
   Node* kls = _gvn.transform(LoadKlassNode::make(_gvn, nullptr, immutable_memory(), p,

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -252,7 +252,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_unsafe_writeback0();
   bool inline_unsafe_writebackSync0(bool is_pre);
   bool inline_unsafe_copyMemory();
-  bool inline_unsafe_isFlattenedArray();
+  bool inline_unsafe_isFlatArray();
   bool inline_unsafe_make_private_buffer();
   bool inline_unsafe_finish_private_buffer();
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -443,6 +443,12 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint 
   return (jarray) JNIHandles::make_local(THREAD, array);
 JVM_END
 
+
+JVM_ENTRY(jboolean, JVM_IsNullRestrictedArray(JNIEnv *env, jobject obj))
+  arrayOop oop = arrayOop(JNIHandles::resolve_non_null(obj));
+  return oop->is_null_free_array();
+JVM_END
+
 // java.lang.Runtime /////////////////////////////////////////////////////////////////////////
 
 extern volatile jint vm_created;

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -332,14 +332,14 @@ UNSAFE_ENTRY(jlong, Unsafe_ValueHeaderSize(JNIEnv *env, jobject unsafe, jclass c
   return vk->first_field_offset();
 } UNSAFE_END
 
-UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedField(JNIEnv *env, jobject unsafe, jobject o)) {
+UNSAFE_ENTRY(jboolean, Unsafe_IsFlatField(JNIEnv *env, jobject unsafe, jobject o)) {
   oop f = JNIHandles::resolve_non_null(o);
   Klass* k = java_lang_Class::as_Klass(java_lang_reflect_Field::clazz(f));
   int slot = java_lang_reflect_Field::slot(f);
   return InstanceKlass::cast(k)->field_is_flat(slot);
 } UNSAFE_END
 
-UNSAFE_ENTRY(jboolean, Unsafe_IsFlattenedArray(JNIEnv *env, jobject unsafe, jclass c)) {
+UNSAFE_ENTRY(jboolean, Unsafe_IsFlatArray(JNIEnv *env, jobject unsafe, jclass c)) {
   Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(c));
   return k->is_flatArray_klass();
 } UNSAFE_END
@@ -1000,14 +1000,14 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "getReferenceVolatile", CC "(" OBJ "J)" OBJ,      FN_PTR(Unsafe_GetReferenceVolatile)},
     {CC "putReferenceVolatile", CC "(" OBJ "J" OBJ ")V",  FN_PTR(Unsafe_PutReferenceVolatile)},
 
-    {CC "isFlattenedArray", CC "(" CLS ")Z",                     FN_PTR(Unsafe_IsFlattenedArray)},
-    {CC "isFlattenedField0", CC "(" OBJ ")Z",                    FN_PTR(Unsafe_IsFlattenedField)},
-    {CC "getValue",         CC "(" OBJ "J" CLS ")" OBJ,          FN_PTR(Unsafe_GetValue)},
-    {CC "putValue",         CC "(" OBJ "J" CLS OBJ ")V",         FN_PTR(Unsafe_PutValue)},
-    {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,         FN_PTR(Unsafe_UninitializedDefaultValue)},
-    {CC "makePrivateBuffer",     CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_MakePrivateBuffer)},
-    {CC "finishPrivateBuffer",   CC "(" OBJ ")" OBJ,             FN_PTR(Unsafe_FinishPrivateBuffer)},
-    {CC "valueHeaderSize",       CC "(" CLS ")J",                FN_PTR(Unsafe_ValueHeaderSize)},
+    {CC "isFlatArray", CC "(" CLS ")Z",                   FN_PTR(Unsafe_IsFlatArray)},
+    {CC "isFlatField0", CC "(" OBJ ")Z",                  FN_PTR(Unsafe_IsFlatField)},
+    {CC "getValue",         CC "(" OBJ "J" CLS ")" OBJ,   FN_PTR(Unsafe_GetValue)},
+    {CC "putValue",         CC "(" OBJ "J" CLS OBJ ")V",  FN_PTR(Unsafe_PutValue)},
+    {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,  FN_PTR(Unsafe_UninitializedDefaultValue)},
+    {CC "makePrivateBuffer",     CC "(" OBJ ")" OBJ,      FN_PTR(Unsafe_MakePrivateBuffer)},
+    {CC "finishPrivateBuffer",   CC "(" OBJ ")" OBJ,      FN_PTR(Unsafe_FinishPrivateBuffer)},
+    {CC "valueHeaderSize",       CC "(" CLS ")J",         FN_PTR(Unsafe_ValueHeaderSize)},
 
     {CC "getUncompressedObject", CC "(" ADR ")" OBJ,  FN_PTR(Unsafe_GetUncompressedObject)},
 

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -63,7 +63,6 @@ import jdk.internal.reflect.ReflectionFactory;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaSecurityAccess;
 import jdk.internal.util.ByteArray;
-import jdk.internal.value.ValueClass;
 import sun.reflect.misc.ReflectUtil;
 
 /**
@@ -2106,7 +2105,7 @@ public final class ObjectStreamClass implements Serializable {
                 Field f = fields[i].getField();
                 vals[offsets[i]] = switch (typeCodes[i]) {
                     case 'L', '[' ->
-                            UNSAFE.isFlattened(f)
+                            UNSAFE.isFlatField(f)
                                     ? UNSAFE.getValue(obj, readKeys[i], f.getType())
                                     : UNSAFE.getReference(obj, readKeys[i]);
                     default       -> throw new InternalError();
@@ -2159,7 +2158,7 @@ public final class ObjectStreamClass implements Serializable {
                                 obj.getClass().getName());
                         }
                         if (!dryRun) {
-                            if (UNSAFE.isFlattened(f)) {
+                            if (UNSAFE.isFlatField(f)) {
                                 UNSAFE.putValue(obj, key, f.getType(), val);
                             } else {
                                 UNSAFE.putReference(obj, key, val);

--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -651,7 +651,6 @@ sealed class DirectMethodHandle extends MethodHandle {
             // retyping can be done without a cast
             return FT_UNCHECKED_REF;
         } else {
-            // null check for value type in addition to check cast
             return ftype.isValue() ? FT_CHECKED_VALUE : FT_CHECKED_REF;
         }
     }
@@ -778,13 +777,15 @@ sealed class DirectMethodHandle extends MethodHandle {
         Kind kind = getFieldKind(isGetter, isVolatile, isFlat, fw);
 
         MethodType linkerType;
-        boolean hasValueTypeArg = isGetter ? ftypeKind == FT_CHECKED_VALUE : isFlat;
+        boolean hasValueTypeArg = isFlat;
         if (isGetter) {
-            linkerType = hasValueTypeArg ? MethodType.methodType(ft, Object.class, long.class, Class.class)
-                                         : MethodType.methodType(ft, Object.class, long.class);
+            linkerType = hasValueTypeArg
+                            ? MethodType.methodType(ft, Object.class, long.class, Class.class)
+                            : MethodType.methodType(ft, Object.class, long.class);
         } else {
-            linkerType = isFlat ? MethodType.methodType(void.class, Object.class, long.class, Class.class, ft)
-                                : MethodType.methodType(void.class, Object.class, long.class, ft);
+            linkerType = hasValueTypeArg
+                            ? MethodType.methodType(void.class, Object.class, long.class, Class.class, ft)
+                            : MethodType.methodType(void.class, Object.class, long.class, ft);
         }
         MemberName linker = new MemberName(Unsafe.class, kind.methodName, linkerType, REF_invokeVirtual);
         try {

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -25,6 +25,9 @@
 
 package java.lang.invoke;
 
+import jdk.internal.value.CheckedType;
+import jdk.internal.value.NormalCheckedType;
+import jdk.internal.value.NullRestrictedCheckedType;
 import sun.invoke.util.VerifyAccess;
 
 import java.lang.reflect.Constructor;
@@ -222,6 +225,14 @@ final class MemberName implements Member, Cloneable {
             assert type instanceof Class<?> : "bad field type " + type;
         }
         return (Class<?>) type;
+    }
+
+    /**
+     * Return {@code CheckedType} representing the type of this member.
+     */
+    public CheckedType getCheckedFieldType() {
+        return isNullRestricted() ? NullRestrictedCheckedType.of(getFieldType())
+                                  : NormalCheckedType.of(getFieldType());
     }
 
     /** Utility method to produce either the method type or field type of this member. */

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5190,7 +5190,6 @@ assert((int)twice.invokeExact(21) == 42);
      */
     public static MethodHandle zero(Class<?> type) {
         Objects.requireNonNull(type);
-        // TODO: implicitly constructible value class
         if (type.isPrimitive()) {
             return zero(Wrapper.forPrimitiveType(type), type);
         } else {

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -61,12 +61,12 @@ final class VarHandles {
             if (!type.isPrimitive()) {
                 if (f.isFlat()) {
                     return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleValues.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
-                        : new VarHandleValues.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
+                        ? new VarHandleValues.FieldInstanceReadOnly(refc, foffset, type, f.getCheckedFieldType())
+                        : new VarHandleValues.FieldInstanceReadWrite(refc, foffset, type, f.getCheckedFieldType()));
                 } else {
                     return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                       ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type, f.isNullRestricted())
-                       : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type, f.isNullRestricted()));
+                       ? new VarHandleReferences.FieldInstanceReadOnly(refc, foffset, type, f.getCheckedFieldType())
+                       : new VarHandleReferences.FieldInstanceReadWrite(refc, foffset, type, f.getCheckedFieldType()));
                 }
             }
             else if (type == boolean.class) {
@@ -129,12 +129,12 @@ final class VarHandles {
         if (!type.isPrimitive()) {
             if (f.isFlat()) {
                 return maybeAdapt(f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleValues.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
-                        : new VarHandleValues.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted()));
+                        ? new VarHandleValues.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType())
+                        : new VarHandleValues.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType()));
             } else {
                 return f.isFinal() && !isWriteAllowedOnFinalFields
-                        ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.isNullRestricted())
-                        : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.isNullRestricted());
+                        ? new VarHandleReferences.FieldStaticReadOnly(decl, base, foffset, type, f.getCheckedFieldType())
+                        : new VarHandleReferences.FieldStaticReadWrite(decl, base, foffset, type, f.getCheckedFieldType());
             }
         }
         else if (type == boolean.class) {
@@ -223,7 +223,7 @@ final class VarHandles {
         int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
 
         if (!componentType.isPrimitive()) {
-            return maybeAdapt(UNSAFE.isFlattenedArray(arrayClass)
+            return maybeAdapt(UNSAFE.isFlatArray(arrayClass)
                 ? new VarHandleValues.Array(aoffset, ashift, arrayClass)
                 : new VarHandleReferences.Array(aoffset, ashift, arrayClass));
         }

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -24,9 +24,11 @@
  */
 package java.lang.invoke;
 
-#if[Reference]
+#if[Object]
+import jdk.internal.value.CheckedType;
+import jdk.internal.value.NullRestrictedCheckedType;
 import jdk.internal.value.ValueClass;
-#end[Reference]
+#end[Object]
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -45,40 +47,36 @@ final class VarHandle$Type$s {
         final Class<?> receiverType;
 #if[Object]
         final Class<?> fieldType;
+        final CheckedType checkedFieldType;
 #end[Object]
-#if[Reference]
-        final boolean nullRestricted;
-#end[Reference]
 
-        FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
-            this(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldInstanceReadOnly.FORM, false);
+        FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, FieldInstanceReadOnly.FORM, false);
         }
 
-        protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
+        protected FieldInstanceReadOnly(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType},
                                         VarForm form, boolean exact) {
             super(form, exact);
             this.fieldOffset = fieldOffset;
             this.receiverType = receiverType;
 #if[Object]
             this.fieldType = fieldType;
+            this.checkedFieldType = checkedFieldType;
 #end[Object]
-#if[Reference]
-            this.nullRestricted = nullRestricted;
-#end[Reference]
         }
 
         @Override
         public FieldInstanceReadOnly withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, vform, true);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, vform, true);
         }
 
         @Override
         public FieldInstanceReadOnly withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, vform, false);
+                : new FieldInstanceReadOnly(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, vform, false);
         }
 
         @Override
@@ -104,11 +102,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -117,11 +115,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -130,11 +128,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -143,11 +141,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -155,37 +153,33 @@ final class VarHandle$Type$s {
     }
 
     static final class FieldInstanceReadWrite extends FieldInstanceReadOnly {
-        FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
-            this(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
+        FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}) {
+            this(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, false);
         }
 
-        private FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
+        private FieldInstanceReadWrite(Class<?> receiverType, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType},
                                        boolean exact) {
-            super(receiverType, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldInstanceReadWrite.FORM, exact);
+            super(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, FieldInstanceReadWrite.FORM, exact);
         }
 
         @Override
         public FieldInstanceReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, true);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, true);
         }
 
         @Override
         public FieldInstanceReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Reference]?, fieldType, nullRestricted}{#if[Value]?, fieldType, true}, false);
+                : new FieldInstanceReadWrite(receiverType, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, false);
         }
 
 #if[Object]
         @ForceInline
         static Object checkCast(FieldInstanceReadWrite handle, $type$ value) {
-#if[Reference]
-            if (value == null && handle.nullRestricted)
-                throw new NullPointerException("null-restricted field");
-#end[Reference]
-            return handle.fieldType.cast(value);
+            return handle.checkedFieldType.cast(value);
         }
 #end[Object]
 
@@ -430,14 +424,14 @@ final class VarHandle$Type$s {
         final long fieldOffset;
 #if[Object]
         final Class<?> fieldType;
-        final boolean nullRestricted;
+        final CheckedType checkedFieldType;
 #end[Object]
 
-        FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
-            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldStaticReadOnly.FORM, false);
+        FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}) {
+            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, FieldStaticReadOnly.FORM, false);
         }
 
-        protected FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
+        protected FieldStaticReadOnly(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType},
                                       VarForm form, boolean exact) {
             super(form, exact);
             this.declaringClass = declaringClass;
@@ -445,7 +439,7 @@ final class VarHandle$Type$s {
             this.fieldOffset = fieldOffset;
 #if[Object]
             this.fieldType = fieldType;
-            this.nullRestricted = nullRestricted;
+            this.checkedFieldType = checkedFieldType;
 #end[Object]
         }
 
@@ -453,14 +447,14 @@ final class VarHandle$Type$s {
         public FieldStaticReadOnly withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, true);
+                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, vform, true);
         }
 
         @Override
         public FieldStaticReadOnly withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, vform, false);
+                : new FieldStaticReadOnly(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, vform, false);
         }
 
         @Override
@@ -488,11 +482,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -501,11 +495,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -514,11 +508,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -527,11 +521,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[Value]?, handle.fieldType});
-#if[Reference]
-            if (handle.nullRestricted && value == null) {
+#if[Object]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
                 return ValueClass.zeroInstance(handle.fieldType);
             }
-#end[Reference]
+#end[Object]
             return value;
         }
 
@@ -540,32 +534,33 @@ final class VarHandle$Type$s {
 
     static final class FieldStaticReadWrite extends FieldStaticReadOnly {
 
-        FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted}) {
-            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, false);
+        FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType}) {
+            this(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, false);
         }
 
-        private FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, boolean nullRestricted},
+        private FieldStaticReadWrite(Class<?> declaringClass, Object base, long fieldOffset{#if[Object]?, Class<?> fieldType, CheckedType checkedFieldType},
                                      boolean exact) {
-            super(declaringClass, base, fieldOffset{#if[Object]?, fieldType, nullRestricted}, FieldStaticReadWrite.FORM, exact);
+            super(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, FieldStaticReadWrite.FORM, exact);
         }
 
         @Override
         public FieldStaticReadWrite withInvokeExactBehavior() {
             return hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}{#if[Reference]?, nullRestricted}, true);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, true);
         }
 
         @Override
         public FieldStaticReadWrite withInvokeBehavior() {
             return !hasInvokeExactBehavior()
                 ? this
-                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType}{#if[Reference]?, nullRestricted}, false);
+                : new FieldStaticReadWrite(declaringClass, base, fieldOffset{#if[Object]?, fieldType, checkedFieldType}, false);
         }
 
 #if[Object]
+        @ForceInline
         static Object checkCast(FieldStaticReadWrite handle, $type$ value) {
-            return handle.fieldType.cast(value);
+            return handle.checkedFieldType.cast(value);
         }
 #end[Object]
 
@@ -803,15 +798,6 @@ final class VarHandle$Type$s {
         static final VarForm FORM = new VarForm(FieldStaticReadWrite.class, null, $type$.class);
     }
 
-#if[Reference]
-    static VarHandle makeVarHandleValuesArray(Class<?> arrayClass) {
-        Class<?> componentType = arrayClass.getComponentType();
-        assert UNSAFE.isFlattenedArray(arrayClass);
-        // should cache these VarHandle for performance
-        return VarHandles.makeArrayElementHandle(arrayClass);
-    }
-#end[Reference]
-
     static final class Array extends VarHandle {
         final int abase;
         final int ashift;
@@ -859,7 +845,7 @@ final class VarHandle$Type$s {
 
         @Override
         final MethodType accessModeTypeUncached(AccessType at) {
-            return at.accessModeType({#if[Object]?arrayType:$type$[].class}, {#if[Object]?arrayType.getComponentType():$type$.class}, int.class);
+            return at.accessModeType({#if[Object]?arrayType:$type$[].class}, {#if[Object]?componentType:$type$.class}, int.class);
         }
 
 #if[Object]
@@ -867,9 +853,9 @@ final class VarHandle$Type$s {
         static Object runtimeTypeCheck(Array handle, Object[] oarray, Object value) {
             if (handle.arrayType == oarray.getClass()) {
                 // Fast path: static array type same as argument array type
-                return handle.componentType.cast(value);
+                return {#if[Value]?ValueClass.componentCheckedType(oarray):handle.componentType}.cast(value);
             } else {
-                // Slow path: check value against argument array component type
+                // Slow path: check value against argument array component checked type
                 return reflectiveTypeCheck(oarray, value);
             }
         }
@@ -877,7 +863,7 @@ final class VarHandle$Type$s {
         @ForceInline
         static Object reflectiveTypeCheck(Object[] oarray, Object value) {
             try {
-                return oarray.getClass().getComponentType().cast(value);
+                return ValueClass.componentCheckedType(oarray).cast(value);
             } catch (ClassCastException e) {
                 throw new ArrayStoreException();
             }
@@ -904,10 +890,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                vh.set(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                vh.set(oarray, index, value);
                 return;
             }
 #end[Reference]
@@ -923,9 +910,10 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
                 return vh.getVolatile(oarray, index);
             }
 #end[Reference]
@@ -942,10 +930,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                vh.setVolatile(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                vh.setVolatile(oarray, index, value);
                 return;
             }
 #end[Reference]
@@ -963,9 +952,10 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
                 return vh.getOpaque(oarray, index);
             }
 #end[Reference]
@@ -982,10 +972,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                vh.setOpaque(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                vh.setOpaque(oarray, index, value);
                 return;
             }
 #end[Reference]
@@ -1003,9 +994,10 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
                 return vh.getAcquire(oarray, index);
             }
 #end[Reference]
@@ -1022,10 +1014,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                vh.setRelease(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                vh.setRelease(oarray, index, value);
                 return;
             }
 #end[Reference]
@@ -1044,10 +1037,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.compareAndSet(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.compareAndSet(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.compareAndSet$Type$(array,
@@ -1065,10 +1059,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.compareAndExchange(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.compareAndExchange(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$(array,
@@ -1086,10 +1081,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.compareAndExchangeAcquire(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.compareAndExchangeAcquire(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$Acquire(array,
@@ -1107,10 +1103,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.compareAndExchangeRelease(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.compareAndExchangeRelease(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.compareAndExchange$Type$Release(array,
@@ -1128,10 +1125,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.weakCompareAndSetPlain(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.weakCompareAndSetPlain(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Plain(array,
@@ -1149,10 +1147,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.weakCompareAndSet(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.weakCompareAndSet(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$(array,
@@ -1170,10 +1169,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.weakCompareAndSetAcquire(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.weakCompareAndSetAcquire(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Acquire(array,
@@ -1191,10 +1191,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.weakCompareAndSetRelease(oarray, index, expected, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.weakCompareAndSetRelease(oarray, index, expected, value);
             }
 #end[Reference]
             return UNSAFE.weakCompareAndSet$Type$Release(array,
@@ -1212,10 +1213,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.getAndSet(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.getAndSet(oarray, index, value);
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$(array,
@@ -1232,10 +1234,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.getAndSetAcquire(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.getAndSetAcquire(oarray, index, value);
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$Acquire(array,
@@ -1252,10 +1255,11 @@ final class VarHandle$Type$s {
             $type$[] array = ($type$[]) oarray;
 #end[Object]
 #if[Reference]
-            if (UNSAFE.isFlattenedArray(oarray.getClass())) {
-                // for flattened array, delegate to VarHandle of the inline type array
-                VarHandle vh = makeVarHandleValuesArray(oarray.getClass());
-                return vh.getAndSetRelease(oarray, index, reflectiveTypeCheck(array, value));
+            Class<?> arrayType = oarray.getClass();
+            if (handle.arrayType != arrayType && UNSAFE.isFlatArray(arrayType)) {
+                // delegate to VarHandle of flat array
+                VarHandle vh = VarHandleValues.flatArrayVarHandle(arrayType);
+                return vh.getAndSetRelease(oarray, index, value);
             }
 #end[Reference]
             return UNSAFE.getAndSet$Type$Release(array,
@@ -1375,7 +1379,20 @@ final class VarHandle$Type$s {
                                        value);
         }
 #end[Bitwise]
-
         static final VarForm FORM = new VarForm(Array.class, {#if[Object]?Object[].class:$type$[].class}, {#if[Object]?Object.class:$type$.class}, int.class);
     }
+#if[Value]
+    static final ClassValue<Array> flatArrayVarHandles = new ClassValue<>() {
+        @Override protected Array computeValue(Class<?> arrayClass) {
+            assert UNSAFE.isFlatArray(arrayClass);
+            int aoffset = UNSAFE.arrayBaseOffset(arrayClass);
+            int ascale = UNSAFE.arrayIndexScale(arrayClass);
+            int ashift = 31 - Integer.numberOfLeadingZeros(ascale);
+            return new Array(aoffset, ashift, arrayClass);
+        }
+    };
+    static VarHandle flatArrayVarHandle(Class<?> arrayClass) {
+        return flatArrayVarHandles.get(arrayClass);
+    }
+#end[Value]
 }

--- a/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -25,7 +25,6 @@
 
 package java.lang.reflect;
 
-import java.util.Objects;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 /**

--- a/src/java.base/share/classes/java/lang/reflect/ReflectAccess.java
+++ b/src/java.base/share/classes/java/lang/reflect/ReflectAccess.java
@@ -126,6 +126,10 @@ class ReflectAccess implements jdk.internal.access.JavaLangReflectAccess {
         return f.isTrustedFinal();
     }
 
+    public boolean isNullRestrictedField(Field f) {
+        return f.isNullRestricted();
+    }
+
     public <T> T newInstance(Constructor<T> ctor, Object[] args, Class<?> caller)
         throws IllegalAccessException, InstantiationException, InvocationTargetException
     {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangReflectAccess.java
@@ -102,6 +102,10 @@ public interface JavaLangReflectAccess {
     /** Tests if this is a trusted final field */
     public boolean isTrustedFinalField(Field f);
 
+
+    /** Tests if this is a null-restricted field */
+    public boolean isNullRestrictedField(Field f);
+
     /** Returns a new instance created by the given constructor with access check */
     public <T> T newInstance(Constructor<T> ctor, Object[] args, Class<?> caller)
         throws IllegalAccessException, InstantiationException, InvocationTargetException;

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -26,7 +26,6 @@
 package jdk.internal.misc;
 
 import jdk.internal.ref.Cleaner;
-import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.nio.ch.DirectBuffer;
@@ -182,20 +181,20 @@ public final class Unsafe {
     /**
      * Returns true if the given field is flattened.
      */
-    public boolean isFlattened(Field f) {
+    public boolean isFlatField(Field f) {
         if (f == null) {
             throw new NullPointerException();
         }
-        return isFlattenedField0(f);
+        return isFlatField0(f);
     }
 
-    private native boolean isFlattenedField0(Object o);
+    private native boolean isFlatField0(Object o);
 
     /**
      * Returns true if the given class is a flattened array.
      */
     @IntrinsicCandidate
-    public native boolean isFlattenedArray(Class<?> arrayClass);
+    public native boolean isFlatArray(Class<?> arrayClass);
 
     /**
      * Fetches a reference value from a given Java variable.
@@ -261,20 +260,6 @@ public final class Unsafe {
      */
     @IntrinsicCandidate
     public native <V> void putValue(Object o, long offset, Class<?> valueType, V v);
-
-    /**
-     * Fetches a reference value of the given type from a given Java variable.
-     * This method can return a reference to a value if it is non-null.
-     *
-     * @param type type
-     */
-    public Object getReference(Object o, long offset, Class<?> type) {
-        return getReference(o, offset);
-    }
-
-    public Object getReferenceVolatile(Object o, long offset, Class<?> type) {
-        return getReferenceVolatile(o, offset);
-    }
 
     /**
      * Returns an uninitialized default instance of the given value class.

--- a/src/java.base/share/classes/jdk/internal/value/CheckedType.java
+++ b/src/java.base/share/classes/jdk/internal/value/CheckedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,10 @@
  * questions.
  */
 
-#include "jni.h"
-#include "jvm.h"
+package jdk.internal.value;
 
-#include "jdk_internal_value_ValueClass.h"
-
-JNIEXPORT jboolean JNICALL
-Java_jdk_internal_value_ValueClass_isImplicitlyConstructible(JNIEnv *env, jclass dummy, jclass cls) {
-    return JVM_IsImplicitlyConstructibleClass(env, cls);
+public sealed interface CheckedType permits NormalCheckedType, NullRestrictedCheckedType {
+    Object cast(Object obj);
+    boolean canCast(Object obj);
+    Class<?> boundingClass();
 }
-
-JNIEXPORT jarray JNICALL
-Java_jdk_internal_value_ValueClass_newNullRestrictedArray(JNIEnv *env, jclass cls, jclass elmClass, jint len)
-{
-    return JVM_NewNullRestrictedArray(env, elmClass, len);
-}
-
-JNIEXPORT jboolean JNICALL
-Java_jdk_internal_value_ValueClass_isNullRestrictedArray(JNIEnv *env, jclass cls, jobject obj)
-{
-    return JVM_IsNullRestrictedArray(env, obj);
-}
-

--- a/src/java.base/share/classes/jdk/internal/value/NormalCheckedType.java
+++ b/src/java.base/share/classes/jdk/internal/value/NormalCheckedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,25 +23,30 @@
  * questions.
  */
 
-#include "jni.h"
-#include "jvm.h"
+package jdk.internal.value;
 
-#include "jdk_internal_value_ValueClass.h"
+public final class NormalCheckedType implements CheckedType {
+    private final Class<?> type;
+    NormalCheckedType(Class<?> cls) {
+        this.type = cls;
+    }
 
-JNIEXPORT jboolean JNICALL
-Java_jdk_internal_value_ValueClass_isImplicitlyConstructible(JNIEnv *env, jclass dummy, jclass cls) {
-    return JVM_IsImplicitlyConstructibleClass(env, cls);
+    @Override
+    public Object cast(Object obj) {
+        return type.cast(obj);
+    }
+
+    @Override
+    public boolean canCast(Object obj) {
+        return type.isAssignableFrom(obj.getClass());
+    }
+
+    @Override
+    public Class<?> boundingClass() {
+        return type;
+    }
+
+    public static NormalCheckedType of(Class<?> cls) {
+        return new NormalCheckedType(cls);
+    }
 }
-
-JNIEXPORT jarray JNICALL
-Java_jdk_internal_value_ValueClass_newNullRestrictedArray(JNIEnv *env, jclass cls, jclass elmClass, jint len)
-{
-    return JVM_NewNullRestrictedArray(env, elmClass, len);
-}
-
-JNIEXPORT jboolean JNICALL
-Java_jdk_internal_value_ValueClass_isNullRestrictedArray(JNIEnv *env, jclass cls, jobject obj)
-{
-    return JVM_IsNullRestrictedArray(env, obj);
-}
-

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,20 @@
 
 package jdk.internal.value;
 
-import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.JavaLangReflectAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 
 /**
  * Utilities to access
  */
 public class ValueClass {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final JavaLangReflectAccess JLRA = SharedSecrets.getJavaLangReflectAccess();
 
     /**
      * Returns true if the given {@code Class} object is implicitly constructible
@@ -60,6 +64,45 @@ public class ValueClass {
     }
 
     /**
+     * Returns {@code CheckedType} representing the type of the given field.
+     */
+    public static CheckedType checkedType(Field f) {
+        return JLRA.isNullRestrictedField(f) ? NullRestrictedCheckedType.of(f.getType())
+                                             : NormalCheckedType.of(f.getType());
+    }
+
+    /**
+     * Returns {@code CheckedType} representing the component type of the given array.
+     */
+    public static CheckedType componentCheckedType(Object array) {
+        Class<?> componentType = array.getClass().getComponentType();
+        return isNullRestrictedArray(array) ? NullRestrictedCheckedType.of(componentType)
+                                            : NormalCheckedType.of(componentType);
+    }
+
+    /**
+     * Allocate an array of a value class type with components that behave in
+     * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
+     * field.
+     * <p>
+     * Because these behaviors are not specified by Java SE, arrays created with
+     * this method should only be used by internal JDK code for experimental
+     * purposes and should not affect user-observable outcomes.
+     *
+     * @throws IllegalArgumentException if {@code componentType} is not a
+     *         value class type or is not annotated with
+     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
+     */
+    @SuppressWarnings("unchecked")
+    public static Object[] newArrayInstance(CheckedType componentType, int length) {
+        if (componentType instanceof NullRestrictedCheckedType) {
+            return newNullRestrictedArray(componentType.boundingClass(), length);
+        } else {
+            return (Object[]) Array.newInstance(componentType.boundingClass(), length);
+        }
+    }
+
+    /**
      * Allocate an array of a value class type with components that behave in
      * the same way as a {@link jdk.internal.vm.annotation.NullRestricted}
      * field.
@@ -75,4 +118,6 @@ public class ValueClass {
     @IntrinsicCandidate
     public static native Object[] newNullRestrictedArray(Class<?> componentType,
                                                          int length);
+
+    public static native boolean isNullRestrictedArray(Object array);
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -377,7 +377,7 @@ public class TestIntrinsics {
             Y_OFFSET = U.objectFieldOffset(yField);
             Field v1Field = MyValue1.class.getDeclaredField("v1");
             V1_OFFSET = U.objectFieldOffset(v1Field);
-            V1_FLATTENED = U.isFlattened(v1Field);
+            V1_FLATTENED = U.isFlatField(v1Field);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -588,7 +588,7 @@ public class TestIntrinsics {
         try {
             Field test31_vt_Field = TestIntrinsics.class.getDeclaredField("test31_vt");
             TEST31_VT_OFFSET = U.objectFieldOffset(test31_vt_Field);
-            TEST31_VT_FLATTENED = U.isFlattened(test31_vt_Field);
+            TEST31_VT_FLATTENED = U.isFlatField(test31_vt_Field);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -639,7 +639,7 @@ public class TestIntrinsics {
             TEST33_ARRAY = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 2);
             TEST33_BASE_OFFSET = U.arrayBaseOffset(TEST33_ARRAY.getClass());
             TEST33_INDEX_SCALE = U.arrayIndexScale(TEST33_ARRAY.getClass());
-            TEST33_FLATTENED_ARRAY = U.isFlattenedArray(TEST33_ARRAY.getClass());
+            TEST33_FLATTENED_ARRAY = U.isFlatArray(TEST33_ARRAY.getClass());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -1612,13 +1612,13 @@ public class TestIntrinsics {
     public void test80_verifier() throws Exception {
         Test80Value1 v = new Test80Value1();
         Field field = Test80Value1.class.getDeclaredField("v");
-        Asserts.assertEQ(test80(v, U.isFlattened(field), U.objectFieldOffset(field)), v.v);
+        Asserts.assertEQ(test80(v, U.isFlatField(field), U.objectFieldOffset(field)), v.v);
     }
 
-    // Test correctness of the Unsafe::isFlattenedArray intrinsic
+    // Test correctness of the Unsafe::isFlatArray intrinsic
     @Test
     public boolean test81(Class<?> cls) {
-        return U.isFlattenedArray(cls);
+        return U.isFlatArray(cls);
     }
 
     @Run(test = "test81")
@@ -1629,18 +1629,18 @@ public class TestIntrinsics {
         Asserts.assertFalse(test81(int[].class), "test81_4 failed");
     }
 
-    // Verify that Unsafe::isFlattenedArray checks with statically known classes
+    // Verify that Unsafe::isFlatArray checks with statically known classes
     // are folded
     @Test
     @IR(failOn = {LOADK})
     public boolean test82() {
-        boolean check1 = U.isFlattenedArray(TEST33_ARRAY.getClass());
+        boolean check1 = U.isFlatArray(TEST33_ARRAY.getClass());
         if (!TEST33_FLATTENED_ARRAY) {
             check1 = !check1;
         }
-        boolean check2 = !U.isFlattenedArray(String[].class);
-        boolean check3 = !U.isFlattenedArray(String.class);
-        boolean check4 = !U.isFlattenedArray(int[].class);
+        boolean check2 = !U.isFlatArray(String[].class);
+        boolean check3 = !U.isFlatArray(String.class);
+        boolean check4 = !U.isFlatArray(int[].class);
         return check1 && check2 && check3 && check4;
     }
 

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
@@ -178,9 +178,9 @@ import jdk.internal.vm.annotation.LooselyConsistentValue;
         try {
             GoodClass5 vc = new GoodClass5();
             Field f0 = vc.getClass().getDeclaredField("f0");
-            Asserts.assertFalse(UNSAFE.isFlattened(f0), "Unexpected flat field");
+            Asserts.assertFalse(UNSAFE.isFlatField(f0), "Unexpected flat field");
             Field f1 = vc.getClass().getDeclaredField("f1");
-            Asserts.assertTrue(UNSAFE.isFlattened(f1), "Flat field expected, but field is not flat");
+            Asserts.assertTrue(UNSAFE.isFlatField(f1), "Flat field expected, but field is not flat");
         } catch (IncompatibleClassChangeError e) {
             exception = e;
             System.out.println("Received " + e);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullRestrictedArrayTest.java
@@ -124,7 +124,7 @@ public class NullRestrictedArrayTest {
       Throwable exception = null;
       try {
         Object array = ValueClass.newNullRestrictedArray(ValueClass3.class, 8);
-        Asserts.assertTrue(UNSAFE.isFlattenedArray(array.getClass()), "Expecting flat array but array is not flat");
+        Asserts.assertTrue(UNSAFE.isFlatArray(array.getClass()), "Expecting flat array but array is not flat");
       } catch (Throwable e) {
         System.out.println("Received: " + e);
         exception = e;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -156,9 +156,9 @@ public class UnsafeTest {
         System.out.format("%s%s header size %d%n", indent, vc, U.valueHeaderSize(vc));
         for (Field f : vc.getDeclaredFields()) {
             System.out.format("%s%s: %s%s offset %d%n", indent, f.getName(),
-                              U.isFlattened(f) ? "flattened " : "", f.getType(),
+                              U.isFlatField(f) ? "flattened " : "", f.getType(),
                               U.objectFieldOffset(vc, f.getName()));
-            if (U.isFlattened(f)) {
+            if (U.isFlatField(f)) {
                 printValueClass(f.getType(), level+1);
             }
         }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValueTearing.java
@@ -85,9 +85,9 @@ public class ValueTearing {
             Field TPB_array = TPointBox.class.getDeclaredField("array");
             Field NTPB_field = NTPointBox.class.getDeclaredField("field");
             Field NTPB_array = NTPointBox.class.getDeclaredField("array");
-            TFIELD_FLAT = UNSAFE.isFlattened(TPB_field);
+            TFIELD_FLAT = UNSAFE.isFlatField(TPB_field);
             TARRAY_FLAT = UNSAFE.isFlattenedArray(TPB_array.getType());
-            NTFIELD_FLAT = UNSAFE.isFlattened(NTPB_field);
+            NTFIELD_FLAT = UNSAFE.isFlatField(NTPB_field);
             NTARRAY_FLAT = UNSAFE.isFlattenedArray(NTPB_array.getType());
         } catch (ReflectiveOperationException ex) {
             throw new AssertionError(ex);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/VolatileTest.java
@@ -70,7 +70,7 @@ public class VolatileTest {
             e.printStackTrace();
             return;
         }
-        Asserts.assertTrue(U.isFlattened(f0), "mv0 should be flattened");
-        Asserts.assertFalse(U.isFlattened(f1), "mv1 should not be flattened");
+        Asserts.assertTrue(U.isFlatField(f0), "mv0 should be flattened");
+        Asserts.assertFalse(U.isFlatField(f1), "mv1 should not be flattened");
     }
 }

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -200,6 +200,7 @@ public class MethodHandleTest {
         }
         // set an array element to null
         if (nullRestricted) {
+            assertTrue(vh.get(array, 1) != null);
             assertThrows(NullPointerException.class, () -> setter.invoke(array, 1, null));
             assertThrows(NullPointerException.class, () -> vh.set(array, 1, null));
         } else {

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @enablePreview
+ * @run junit/othervm NullRestrictedArraysTest
+ * @run junit/othervm -XX:FlatArrayElementMaxSize=0 NullRestrictedArraysTest
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import jdk.internal.value.CheckedType;
+import jdk.internal.value.NullRestrictedCheckedType;
+import jdk.internal.value.ValueClass;
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.NullRestricted;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NullRestrictedArraysTest {
+    interface I {
+        int getValue();
+    }
+    @ImplicitlyConstructible
+    static value class Value implements I {
+        int v;
+        Value() {
+            this(0);
+        }
+        Value(int v) {
+            this.v = v;
+        }
+        public int getValue() {
+            return v;
+        }
+    }
+
+    static class T {
+        String s;
+        Value obj;  // can be null
+        @NullRestricted
+        Value value;
+    }
+
+    static Stream<Arguments> checkedTypes() throws ReflectiveOperationException {
+        return Stream.of(
+                Arguments.of(T.class.getDeclaredField("s"), String.class, false),
+                Arguments.of(T.class.getDeclaredField("obj"), Value.class, false),
+                Arguments.of(T.class.getDeclaredField("value"), Value.class, true)
+        );
+    }
+
+    /*
+     * Test creating null-restricted arrays with CheckedType
+     */
+    @ParameterizedTest
+    @MethodSource("checkedTypes")
+    public void testCheckedTypeArrays(Field field, Class<?> type, boolean nullRestricted) throws ReflectiveOperationException {
+        CheckedType checkedType = ValueClass.checkedType(field);
+        assertTrue(field.getType() == type);
+        assertTrue(checkedType.boundingClass() == type);
+        Object[] array = ValueClass.newArrayInstance(checkedType, 4);
+        assertTrue(ValueClass.isNullRestrictedArray(array) == nullRestricted);
+        assertTrue(checkedType instanceof NullRestrictedCheckedType == nullRestricted);
+        for (int i=0; i < array.length; i++) {
+            array[i] = type.newInstance();
+        }
+        if (nullRestricted) {
+            // NPE thrown if elements in a null-restricted array set to null
+            assertThrows(NullPointerException.class, () -> array[0] = null);
+        } else {
+            array[0] = null;
+        }
+    }
+
+    @Test
+    public void testVarHandle() {
+        int len = 4;
+        Object[] array = (Object[]) Array.newInstance(Value.class, len);
+        Object[] nullRestrictedArray = ValueClass.newNullRestrictedArray(Value.class, len);
+
+        // Test var handles
+        testVarHandleArray(array, Value[].class);
+        testVarHandleArray(array, I[].class);
+        testVarHandleNullRestrictedArray(nullRestrictedArray, Value[].class);
+        testVarHandleNullRestrictedArray(nullRestrictedArray, I[].class);
+    }
+
+    private void testVarHandleArray(Object[] array, Class<?> arrayClass) {
+        for (int i=0; i < array.length; i++) {
+            array[i] = new Value(i);
+        }
+
+        VarHandle vh = MethodHandles.arrayElementVarHandle(arrayClass);
+        Value value = new Value(0);
+        Value value1 =  new Value(1);
+
+        assertTrue(vh.get(array, 0) == value);
+        assertTrue(vh.getVolatile(array, 0) == value);
+        assertTrue(vh.getOpaque(array, 0) == value);
+        assertTrue(vh.getAcquire(array, 0) == value);
+        vh.set(array, 0, null);
+        vh.setVolatile(array, 0, null);
+        vh.setOpaque(array, 0, null);
+        vh.setRelease(array, 0, null);
+
+        vh.compareAndSet(array, 1, value1, null);             vh.set(array, 1, value1);
+        vh.compareAndExchange(array, 1, value1, null);        vh.set(array, 1, value1);
+        vh.compareAndExchangeAcquire(array, 1, value1, null); vh.set(array, 1, value1);
+        vh.compareAndExchangeRelease(array, 1, value1, null); vh.set(array, 1, value1);
+        vh.weakCompareAndSet(array, 1, value1, null);         vh.set(array, 1, value1);
+        vh.weakCompareAndSetAcquire(array, 1, value1, null);  vh.set(array, 1, value1);
+        vh.weakCompareAndSetPlain(array, 1, value1, null);    vh.set(array, 1, value1);
+        vh.weakCompareAndSetRelease(array, 1, value1, null);  vh.set(array, 1, value1);
+    }
+
+    private void testVarHandleNullRestrictedArray(Object[] array, Class<?> arrayClass) {
+        for (int i=0; i < array.length; i++) {
+            array[i] = new Value(i);
+        }
+
+        VarHandle vh = MethodHandles.arrayElementVarHandle(arrayClass);
+        Value value = new Value(0);
+        Value value1 =  new Value(1);
+        assertTrue(vh.get(array, 0) == value);
+        assertTrue(vh.getVolatile(array, 0) == value);
+        assertTrue(vh.getOpaque(array, 0) == value);
+        assertTrue(vh.getAcquire(array, 0) == value);
+        assertThrows(NullPointerException.class, () -> vh.set(array, 0, null));
+        assertThrows(NullPointerException.class, () -> vh.setVolatile(array, 0, null));
+        assertThrows(NullPointerException.class, () -> vh.setOpaque(array, 0, null));
+        assertThrows(NullPointerException.class, () -> vh.setRelease(array, 0, null));
+
+        assertThrows(NullPointerException.class, () -> vh.compareAndSet(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.compareAndExchange(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.compareAndExchangeAcquire(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.compareAndExchangeRelease(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSet(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetAcquire(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetPlain(array, 1, value1, null));
+        assertThrows(NullPointerException.class, () -> vh.weakCompareAndSetRelease(array, 1, value1, null));
+    }
+
+}

--- a/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlatArray.java
+++ b/test/micro/org/openjdk/bench/valhalla/intrinsics/IsFlatArray.java
@@ -37,7 +37,7 @@ import jdk.internal.misc.Unsafe;
                        "--enable-preview"})
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-public class IsFlattenedArray {
+public class IsFlatArray {
 
     private static final Unsafe U = Unsafe.getUnsafe();
     private static final VarHandle objectArrayVarHandle =
@@ -45,8 +45,8 @@ public class IsFlattenedArray {
 
     @State(Scope.Benchmark)
     public static class ClassState {
-        public Class flattenedArrayClass = Point[].class;
-        public Class nonFlattenedArrayClass = String[].class;
+        public Class flatArrayClass = Point[].class;
+        public Class nonFlatArrayClass = String[].class;
 
         public Object[] objectArray = new Object[10];
         public Object objectElement = new Object();
@@ -54,23 +54,23 @@ public class IsFlattenedArray {
     }
 
     @Benchmark
-    public boolean testKnownFlattenedClass() {
-        return U.isFlattenedArray(Point[].class);
+    public boolean testKnownFlatClass() {
+        return U.isFlatArray(Point[].class);
     }
 
     @Benchmark
-    public boolean testKnownNonFlattenedClass() {
-        return U.isFlattenedArray(String[].class);
+    public boolean testKnownNonFlatClass() {
+        return U.isFlatArray(String[].class);
     }
 
     @Benchmark
-    public boolean testUnknownFlattenedClass(ClassState state) {
-        return U.isFlattenedArray(state.flattenedArrayClass);
+    public boolean testUnknownFlatClass(ClassState state) {
+        return U.isFlatArray(state.flatArrayClass);
     }
 
     @Benchmark
-    public boolean testUnknownNonFlattenedClass(ClassState state) {
-        return U.isFlattenedArray(state.nonFlattenedArrayClass);
+    public boolean testUnknownNonFlatClass(ClassState state) {
+        return U.isFlatArray(state.nonFlatArrayClass);
     }
 
     @Benchmark


### PR DESCRIPTION
This PR adds `jdk.internal.value.CheckedType` and other internal APIs for null-restricted value type and array support.   Also rename `Unsafe::isFlattenedArray` to `Unsafe::isFlatArray`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8329205](https://bugs.openjdk.org/browse/JDK-8329205): [lworld] Add jdk.internal.value.CheckedType API (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1065/head:pull/1065` \
`$ git checkout pull/1065`

Update a local copy of the PR: \
`$ git checkout pull/1065` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1065`

View PR using the GUI difftool: \
`$ git pr show -t 1065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1065.diff">https://git.openjdk.org/valhalla/pull/1065.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1065#issuecomment-2023342290)