### PR TITLE
8329345: [lworld] type of expression in a synchronized statement can be an abstract value class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -864,7 +864,7 @@ public class Check {
             }
             return;
         }
-        if (t.isPrimitive() || t.isValueClass())
+        if (t.isPrimitive() || (t.isValueClass() && !t.tsym.isAbstract()))
             typeTagError(pos, diags.fragment(Fragments.TypeReqIdentity), t);
     }
 

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -26,6 +26,7 @@
  *
  * @test
  * @bug 8287136 8292630 8279368 8287136 8287770 8279840 8279672 8292753 8287763 8279901 8287767 8293183 8293120
+ *      8329345
  * @summary Negative compilation tests, and positive compilation (smoke) tests for Value Objects
  * @library /lib/combo /tools/lib
  * @modules
@@ -295,7 +296,8 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     }
                 }
                 """);
-        assertFail("compiler.err.type.found.req",
+        // OK if the value class is abstract
+        assertOK(
                 """
                 interface I {}
                 abstract value class VI implements I {}


### PR DESCRIPTION
14.19 The synchronized Statement of the JLS for 401 [1] states:


SynchronizedStatement:
    synchronized ( Expression ) Block

The type of Expression must be a reference type, and must not be a final value class type, or a type variable or intersection type bounded by a final value class type, or a compile-time error occurs.

javac is not allowing value classes even if they are abstract, javac should be in sync with the latest spec

[1] https://cr.openjdk.org/~dlsmith/jep401/jep401-20240222/specs/value-objects-jls.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8329345](https://bugs.openjdk.org/browse/JDK-8329345): [lworld] type of expression in a synchronized statement can be an abstract value class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1068/head:pull/1068` \
`$ git checkout pull/1068`

Update a local copy of the PR: \
`$ git checkout pull/1068` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1068`

View PR using the GUI difftool: \
`$ git pr show -t 1068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1068.diff">https://git.openjdk.org/valhalla/pull/1068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1068#issuecomment-2027762024)