### PR TITLE
8329400: [lworld] add a test to check that IllegalMonitorStateException is thrown for value objects

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/IllegalMonitorStateExceptionTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/IllegalMonitorStateExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8329400
+ * @summary test to check that IllegalMonitorStateException is thrown for value objects
+ * @enablePreview
+ * @run main IllegalMonitorStateExceptionTest
+ */
+
+public value class IllegalMonitorStateExceptionTest {
+    void m(Object o) {
+        synchronized (o) {}
+    }
+
+    public static void main(String[] args) throws Exception {
+        IllegalMonitorStateExceptionTest v = new IllegalMonitorStateExceptionTest();
+        try {
+            v.m(v);
+            throw new AssertionError("should have failed with IllegalMonitorStateExceptionTest");
+        } catch (IllegalMonitorStateException e) {
+            // as expected
+        }
+    }
+}


### PR DESCRIPTION
just adding a missing regression test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8329400](https://bugs.openjdk.org/browse/JDK-8329400): [lworld] add a test to check that IllegalMonitorStateException is thrown for value objects (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1069/head:pull/1069` \
`$ git checkout pull/1069`

Update a local copy of the PR: \
`$ git checkout pull/1069` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1069`

View PR using the GUI difftool: \
`$ git pr show -t 1069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1069.diff">https://git.openjdk.org/valhalla/pull/1069.diff</a>

</details>
