### PR TITLE
[lworld] Fixing compiler tests failing after JDK-8328543

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/CanonicalizeGetModifiers.java
+++ b/test/hotspot/jtreg/compiler/c1/CanonicalizeGetModifiers.java
@@ -27,6 +27,7 @@
  * @author Yi Yang
  * @summary Canonicalizes Foo.class.getModifiers() with interpreter mode
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -Xint
  *                   -XX:CompileCommand=compileonly,*CanonicalizeGetModifiers.test
  *                   compiler.c1.CanonicalizeGetModifiers
@@ -38,6 +39,7 @@
  * @summary Canonicalizes Foo.class.getModifiers() with C1 mode
  * @requires vm.compiler1.enabled
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+TieredCompilation
  *                   -XX:CompileCommand=compileonly,*CanonicalizeGetModifiers.test
  *                   compiler.c1.CanonicalizeGetModifiers
@@ -49,6 +51,7 @@
  * @summary Canonicalizes Foo.class.getModifiers() with C2 mode
  * @requires vm.compiler2.enabled
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,*CanonicalizeGetModifiers.test
  *                   compiler.c1.CanonicalizeGetModifiers

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/TestGetModifiers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/TestGetModifiers.java
@@ -25,6 +25,7 @@
 /*
  * @test
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -Xint
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers
@@ -34,6 +35,7 @@
  * @test
  * @requires vm.compiler1.enabled
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+TieredCompilation
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers
@@ -43,6 +45,7 @@
  * @test
  * @requires vm.compiler2.enabled
  * @library /test/lib
+ * @enablePreview
  * @run main/othervm -XX:-TieredCompilation
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers


### PR DESCRIPTION
Tests fail after [JDK-8328543](https://bugs.openjdk.org/browse/JDK-8328543) got integrated.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1072/head:pull/1072` \
`$ git checkout pull/1072`

Update a local copy of the PR: \
`$ git checkout pull/1072` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1072`

View PR using the GUI difftool: \
`$ git pr show -t 1072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1072.diff">https://git.openjdk.org/valhalla/pull/1072.diff</a>

</details>
