### PR TITLE
8330582: [lworld] The JVM must enforce new field modifiers rules

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1479,8 +1479,8 @@ void ClassFileParser::parse_fields(const ClassFileStream* const cfs,
     cfs->guarantee_more(8, CHECK);
 
     jint recognized_modifiers = JVM_RECOGNIZED_FIELD_MODIFIERS;
-    if (supports_inline_types()) {
-      recognized_modifiers |= JVM_ACC_STRICT;
+    if (!supports_inline_types()) {
+      recognized_modifiers &= ~JVM_ACC_STRICT;
     }
 
     const jint flags = cfs->get_u2_fast() & recognized_modifiers;

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4798,6 +4798,7 @@ void ClassFileParser:: verify_legal_field_modifiers(jint flags,
         is_illegal = true;
       } else if (supports_inline_types()) {
         if (!is_identity_class && !is_static && !is_strict) {
+          /* non-static value class fields must be be strict */
           is_illegal = true;
         } else if (is_abstract && !is_identity_class && !is_static) {
           is_illegal = true;

--- a/src/hotspot/share/include/jvm_constants.h
+++ b/src/hotspot/share/include/jvm_constants.h
@@ -45,8 +45,8 @@
                                         JVM_ACC_VOLATILE | \
                                         JVM_ACC_TRANSIENT | \
                                         JVM_ACC_ENUM | \
-                                        JVM_ACC_SYNTHETIC | \
-                                        JVM_ACC_STRICT)
+                                        JVM_ACC_STRICT | \
+                                        JVM_ACC_SYNTHETIC)
 
 #define JVM_RECOGNIZED_METHOD_MODIFIERS (JVM_ACC_PUBLIC | \
                                          JVM_ACC_PRIVATE | \

--- a/src/hotspot/share/include/jvm_constants.h
+++ b/src/hotspot/share/include/jvm_constants.h
@@ -45,7 +45,8 @@
                                         JVM_ACC_VOLATILE | \
                                         JVM_ACC_TRANSIENT | \
                                         JVM_ACC_ENUM | \
-                                        JVM_ACC_SYNTHETIC)
+                                        JVM_ACC_SYNTHETIC | \
+                                        JVM_ACC_STRICT)
 
 #define JVM_RECOGNIZED_METHOD_MODIFIERS (JVM_ACC_PUBLIC | \
                                          JVM_ACC_PRIVATE | \

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2712,7 +2712,7 @@ JVM_END
 JVM_ENTRY(jint, JVM_GetFieldIxModifiers(JNIEnv *env, jclass cls, int field_index))
   Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(cls));
   k = JvmtiThreadState::class_to_verify_considering_redefinition(k, thread);
-  return InstanceKlass::cast(k)->field_access_flags(field_index) & JVM_RECOGNIZED_FIELD_MODIFIERS;
+  return InstanceKlass::cast(k)->field_access_flags(field_index);
 JVM_END
 
 
@@ -2902,7 +2902,7 @@ JVM_ENTRY(jint, JVM_GetCPFieldModifiers(JNIEnv *env, jclass cls, int cp_index, j
       InstanceKlass* ik = InstanceKlass::cast(k_called);
       for (JavaFieldStream fs(ik); !fs.done(); fs.next()) {
         if (fs.name() == name && fs.signature() == signature) {
-          return fs.access_flags().as_short() & JVM_RECOGNIZED_FIELD_MODIFIERS;
+          return fs.access_flags().as_short();
         }
       }
       return -1;

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -86,7 +86,7 @@ void JvmtiClassFileReconstituter::write_field_infos() {
     // JVMSpec|         attribute_info attributes[attributes_count];
     // JVMSpec|   }
 
-    write_u2(access_flags.get_flags() & JVM_RECOGNIZED_FIELD_MODIFIERS);
+    write_u2(access_flags.get_flags());
     write_u2(name_index);
     write_u2(signature_index);
     u2 attr_count = 0;

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -354,7 +354,7 @@ oop MethodHandles::init_method_MemberName(Handle mname, CallInfo& info) {
 
 oop MethodHandles::init_field_MemberName(Handle mname, fieldDescriptor& fd, bool is_setter) {
   InstanceKlass* ik = fd.field_holder();
-  int flags = (jushort)( fd.access_flags().as_short() & JVM_RECOGNIZED_FIELD_MODIFIERS );
+  int flags = (jushort)( fd.access_flags().as_short());
   flags |= IS_FIELD | ((fd.is_static() ? JVM_REF_getStatic : JVM_REF_getField) << REFERENCE_KIND_SHIFT);
   if (fd.is_trusted_final()) flags |= TRUSTED_FINAL;
   if (fd.is_flat()) flags |= FLAT_FIELD;

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -888,7 +888,7 @@ oop Reflection::new_field(fieldDescriptor* fd, TRAPS) {
   java_lang_reflect_Field::set_flags(rh(), flags);
 
   // Note the ACC_ANNOTATION bit, which is a per-class access flag, is never set here.
-  int modifiers = fd->access_flags().as_int() & JVM_RECOGNIZED_FIELD_MODIFIERS;
+  int modifiers = fd->access_flags().as_int();
   java_lang_reflect_Field::set_modifiers(rh(), modifiers);
   java_lang_reflect_Field::set_override(rh(), false);
   if (fd->has_generic_signature()) {

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -66,6 +66,7 @@ class AccessFlags {
   bool is_protected   () const         { return (_flags & JVM_ACC_PROTECTED   ) != 0; }
   bool is_static      () const         { return (_flags & JVM_ACC_STATIC      ) != 0; }
   bool is_final       () const         { return (_flags & JVM_ACC_FINAL       ) != 0; }
+  bool is_strict      () const         { return (_flags & JVM_ACC_STRICT      ) != 0; }
   bool is_synchronized() const         { return (_flags & JVM_ACC_SYNCHRONIZED) != 0; }
   bool is_volatile    () const         { return (_flags & JVM_ACC_VOLATILE    ) != 0; }
   bool is_transient   () const         { return (_flags & JVM_ACC_TRANSIENT   ) != 0; }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/IllegalFieldModifiers.java
@@ -1,0 +1,63 @@
+
+
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ * @test
+ * @summary test that illegal field modifiers are detected correctly
+ * @enablePreview
+ * @compile fieldModifiersTest.jcod
+ * @run main/othervm -Xverify:remote IllegalFieldModifiers
+ */
+
+
+public class IllegalFieldModifiers {
+
+  public static void runTest(String test_name, String message) throws Exception {
+      System.out.println("Testing: " + test_name);
+      try {
+          Class newClass = Class.forName(test_name);
+      } catch (java.lang.ClassFormatError e) {
+          if (!e.getMessage().contains(message)) {
+              throw new RuntimeException( "Wrong ClassFormatError: " + e.getMessage());
+          }
+      }
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    // Test that ACC_FINAL with ACC_VOLATILE is illegal.
+    runTest("FinalAndVolatile", "Illegal field modifiers in class FinalAndVolatile");
+
+    // Test that ACC_STATIC with ACC_STRICT is illegal.
+    runTest("StrictAndStatic", "Illegal field modifiers in class StrictAndStatic");
+
+    // Test that ACC_STRICT without ACC_FINAL is illegal.
+    runTest("StrictNotFinal", "Illegal field modifiers in class StrictNotFinal");
+
+    // Test that a value class cannot have field without ACC_STATIC or ACC_STRICT
+    runTest("NotStaticNotStrict", "Illegal field modifiers in class NotStaticNotStrict");
+  }
+
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/fieldModifiersTest.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/fieldModifiersTest.jcod
@@ -155,7 +155,7 @@ class FinalAndVolatile {
 } // end class FinalAndVolatile
 
 
-// A field has both ACC_STRCIT and ACC_STATIC set
+// A field has both ACC_STRICT and ACC_STATIC set
 //
 class StrictAndStatic {
   0xCAFEBABE;

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/fieldModifiersTest.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/fieldModifiersTest.jcod
@@ -1,0 +1,517 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+ // This file contains multiple illegal inline type classes that should cause
+// ClassFormatError exceptions when attempted to be loaded.
+//
+// Many of these test were originally generated from this Java file and then
+// field modifiers are changed to cause a ClassFormatError exceptions.
+//
+// public value class Value {
+//    static int si = 0;
+//    int i = 0;
+//}
+
+
+// A field has both ACC_FINAL and ACC_VOLATILE set
+//
+class FinalAndVolatile {
+  0xCAFEBABE;
+  65535; // minor version
+  66; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Field #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "FinalAndVolatile"; // #4
+    Utf8 "i"; // #5
+    Utf8 "I"; // #6
+    Method #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "java/lang/Object"; // #10
+    Utf8 "<init>"; // #11
+    Utf8 "()V"; // #12
+    Field #2 #14; // #13
+    NameAndType #15 #6; // #14
+    Utf8 "si"; // #15
+    Utf8 "ConstantValue"; // #16
+    int 0x00000000; // #17
+    Utf8 "Code"; // #18
+    Utf8 "LineNumberTable"; // #19
+    Utf8 "<clinit>"; // #20
+    Utf8 "SourceFile"; // #21
+    Utf8 "FinalAndVolatile.java"; // #22
+  } // Constant Pool
+
+  0x0011; // access
+  #2;// this_cpx
+  #8;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0008; // access
+      #15; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field
+      0x0850; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#16) { // ConstantValue
+          #17;
+        } // end ConstantValue
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #11; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2A03B500012AB700;
+            0x07B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  3;
+                5  1;
+                9  3;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0008; // access
+      #20; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          1; // max_stack
+          0; // max_locals
+          Bytes[]{
+            0x03B3000DB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  2;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#21) { // SourceFile
+      #22;
+    } // end SourceFile
+  } // Attributes
+} // end class FinalAndVolatile
+
+
+// A field has both ACC_STRCIT and ACC_STATIC set
+//
+class StrictAndStatic {
+  0xCAFEBABE;
+  65535; // minor version
+  66; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Field #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "StrictAndStatic"; // #4
+    Utf8 "i"; // #5
+    Utf8 "I"; // #6
+    Method #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "java/lang/Object"; // #10
+    Utf8 "<init>"; // #11
+    Utf8 "()V"; // #12
+    Field #2 #14; // #13
+    NameAndType #15 #6; // #14
+    Utf8 "si"; // #15
+    Utf8 "ConstantValue"; // #16
+    int 0x00000000; // #17
+    Utf8 "Code"; // #18
+    Utf8 "LineNumberTable"; // #19
+    Utf8 "<clinit>"; // #20
+    Utf8 "SourceFile"; // #21
+    Utf8 "StrictAndStatic.java"; // #22
+  } // Constant Pool
+
+  0x0011; // access
+  #2;// this_cpx
+  #8;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0808; // access
+      #15; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field
+      0x0810; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#16) { // ConstantValue
+          #17;
+        } // end ConstantValue
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #11; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2A03B500012AB700;
+            0x07B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  3;
+                5  1;
+                9  3;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0008; // access
+      #20; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          1; // max_stack
+          0; // max_locals
+          Bytes[]{
+            0x03B3000DB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  2;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#21) { // SourceFile
+      #22;
+    } // end SourceFile
+  } // Attributes
+} // end class StrictAndStatic
+
+
+// A field has ACC_STRICT set without ACC_FINAL being set
+//
+class StrictNotFinal {
+  0xCAFEBABE;
+  65535; // minor version
+  66; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Field #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "StrictNotFinal"; // #4
+    Utf8 "i"; // #5
+    Utf8 "I"; // #6
+    Method #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "java/lang/Object"; // #10
+    Utf8 "<init>"; // #11
+    Utf8 "()V"; // #12
+    Field #2 #14; // #13
+    NameAndType #15 #6; // #14
+    Utf8 "si"; // #15
+    Utf8 "ConstantValue"; // #16
+    int 0x00000000; // #17
+    Utf8 "Code"; // #18
+    Utf8 "LineNumberTable"; // #19
+    Utf8 "<clinit>"; // #20
+    Utf8 "SourceFile"; // #21
+    Utf8 "StrictNotFinal.java"; // #22
+  } // Constant Pool
+
+  0x0011; // access
+  #2;// this_cpx
+  #8;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0008; // access
+      #15; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field
+      0x0810; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#16) { // ConstantValue
+          #17;
+        } // end ConstantValue
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #11; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2A03B500012AB700;
+            0x07B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  3;
+                5  1;
+                9  3;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0008; // access
+      #20; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          1; // max_stack
+          0; // max_locals
+          Bytes[]{
+            0x03B3000DB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  2;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#21) { // SourceFile
+      #22;
+    } // end SourceFile
+  } // Attributes
+} // end class StrictNotFinal
+
+// A value class declaring a field without ACC_STATIC nor ACC_STRICT
+//
+class NotStaticNotStrict {
+  0xCAFEBABE;
+  65535; // minor version
+  66; // version
+  [] { // Constant Pool
+    ; // first element is empty
+    Field #2 #3; // #1
+    class #4; // #2
+    NameAndType #5 #6; // #3
+    Utf8 "NotStaticNotStrict"; // #4
+    Utf8 "i"; // #5
+    Utf8 "I"; // #6
+    Method #8 #9; // #7
+    class #10; // #8
+    NameAndType #11 #12; // #9
+    Utf8 "java/lang/Object"; // #10
+    Utf8 "<init>"; // #11
+    Utf8 "()V"; // #12
+    Field #2 #14; // #13
+    NameAndType #15 #6; // #14
+    Utf8 "si"; // #15
+    Utf8 "ConstantValue"; // #16
+    int 0x00000000; // #17
+    Utf8 "Code"; // #18
+    Utf8 "LineNumberTable"; // #19
+    Utf8 "<clinit>"; // #20
+    Utf8 "SourceFile"; // #21
+    Utf8 "NotStaticNotStrict.java"; // #22
+  } // Constant Pool
+
+  0x0011; // access
+  #2;// this_cpx
+  #8;// super_cpx
+
+  [] { // Interfaces
+  } // Interfaces
+
+  [] { // Fields
+    {  // field
+      0x0008; // access
+      #15; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+      } // Attributes
+    }
+    ;
+    {  // field
+      0x0010; // access
+      #5; // name_index
+      #6; // descriptor_index
+      [] { // Attributes
+        Attr(#16) { // ConstantValue
+          #17;
+        } // end ConstantValue
+      } // Attributes
+    }
+  } // Fields
+
+  [] { // Methods
+    {  // method
+      0x0001; // access
+      #11; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          2; // max_stack
+          1; // max_locals
+          Bytes[]{
+            0x2A03B500012AB700;
+            0x07B1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  3;
+                5  1;
+                9  3;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method
+      0x0008; // access
+      #20; // name_index
+      #12; // descriptor_index
+      [] { // Attributes
+        Attr(#18) { // Code
+          1; // max_stack
+          0; // max_locals
+          Bytes[]{
+            0x03B3000DB1;
+          }
+          [] { // Traps
+          } // end Traps
+          [] { // Attributes
+            Attr(#19) { // LineNumberTable
+              [] { // line_number_table
+                0  2;
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [] { // Attributes
+    Attr(#21) { // SourceFile
+      #22;
+    } // end SourceFile
+  } // Attributes
+} // end class NotStaticNotStrict


### PR DESCRIPTION
Small changes to implement new field modifiers rules (JVMS 4.5 Fields) related to ACC_STRICT.
Those changes trigger some test failures because of a bug in javac related to final synthetic field. This bug is tracked by JDK-8330583.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8330582](https://bugs.openjdk.org/browse/JDK-8330582): [lworld] The JVM must enforce new field modifiers rules (**Bug** - P2)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1076/head:pull/1076` \
`$ git checkout pull/1076`

Update a local copy of the PR: \
`$ git checkout pull/1076` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1076`

View PR using the GUI difftool: \
`$ git pr show -t 1076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1076.diff">https://git.openjdk.org/valhalla/pull/1076.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1076#issuecomment-2063898421)