### PR TITLE
8321734: [lworld] C2: flat_in_array type is not handled correctly leading to crashes

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3446,8 +3446,9 @@ Node* GraphKit::gen_instanceof(Node* obj, Node* superklass, bool safe_for_replac
 // uncommon trap or exception is thrown.
 Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_control, bool null_free) {
   kill_dead_locals();           // Benefit all the uncommon traps
-  const TypeKlassPtr *tk = _gvn.type(superklass)->is_klassptr()->try_improve();
-  const TypeOopPtr *toop = tk->cast_to_exactness(false)->as_instance_type();
+  const TypeKlassPtr* klass_ptr_type = _gvn.type(superklass)->is_klassptr();
+  const TypeKlassPtr* improved_klass_ptr_type = klass_ptr_type->try_improve();
+  const TypeOopPtr* toop = improved_klass_ptr_type->cast_to_exactness(false)->as_instance_type();
   bool safe_for_replace = (failure_control == nullptr);
   assert(!null_free || toop->is_inlinetypeptr(), "must be an inline type pointer");
 
@@ -3457,7 +3458,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
   // because if the test is going to turn into zero code, we don't
   // want a residual null check left around.  (Causes a slowdown,
   // for example, in some objArray manipulations, such as a[i]=a[j].)
-  if (tk->singleton()) {
+  if (improved_klass_ptr_type->singleton()) {
     const TypeKlassPtr* kptr = nullptr;
     const Type* t = _gvn.type(obj);
     if (t->isa_oop_ptr()) {
@@ -3467,7 +3468,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
       kptr = TypeInstKlassPtr::make(TypePtr::NotNull, vk, Type::Offset(0));
     }
     if (kptr != nullptr) {
-      switch (C->static_subtype_check(tk, kptr)) {
+      switch (C->static_subtype_check(improved_klass_ptr_type, kptr)) {
       case Compile::SSC_always_true:
         // If we know the type check always succeed then we don't use
         // the profiling data at this bytecode. Don't lose it, feed it
@@ -3561,7 +3562,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
   }
 
   Node* cast_obj = nullptr;
-  if (tk->klass_is_exact()) {
+  if (improved_klass_ptr_type->klass_is_exact()) {
     // The following optimization tries to statically cast the speculative type of the object
     // (for example obtained during profiling) to the type of the superklass and then do a
     // dynamic check that the type of the object is what we expect. To work correctly
@@ -3571,7 +3572,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
     // a speculative type use it to perform an exact cast.
     ciKlass* spec_obj_type = obj_type->speculative_type();
     if (spec_obj_type != nullptr || data != nullptr) {
-      cast_obj = maybe_cast_profiled_receiver(not_null_obj, tk, spec_obj_type, safe_for_replace);
+      cast_obj = maybe_cast_profiled_receiver(not_null_obj, improved_klass_ptr_type, spec_obj_type, safe_for_replace);
       if (cast_obj != nullptr) {
         if (failure_control != nullptr) // failure is now impossible
           (*failure_control) = top();
@@ -3583,8 +3584,14 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
 
   if (cast_obj == nullptr) {
     // Generate the subtype check
-    Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, superklass);
-
+    Node* improved_superklass = superklass;
+    if (improved_klass_ptr_type != klass_ptr_type && improved_klass_ptr_type->singleton()) {
+      // Only improve the super class for constants which allows subsequent sub type checks to possibly be commoned up.
+      // The other non-constant cases cannot be improved with a cast node here since they could be folded to top.
+      // Additionally, the benefit would only be minor in non-constant cases.
+      improved_superklass = makecon(improved_klass_ptr_type);
+    }
+    Node* not_subtype_ctrl = gen_subtype_check(not_null_obj, improved_superklass);
     // Plug in success path into the merge
     cast_obj = _gvn.transform(new CheckCastPPNode(control(), not_null_obj, toop));
     // Failure path ends in uncommon trap (or may be dead - failure impossible)

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -992,6 +992,9 @@ public:
 void Type::check_symmetrical(const Type* t, const Type* mt, const VerifyMeet& verify) const {
   Compile* C = Compile::current();
   const Type* mt2 = verify.meet(t, this);
+
+  // Verify that:
+  //      this meet t == t meet this
   if (mt != mt2) {
     tty->print_cr("=== Meet Not Commutative ===");
     tty->print("t           = ");   t->dump(); tty->cr();
@@ -1008,6 +1011,12 @@ void Type::check_symmetrical(const Type* t, const Type* mt, const VerifyMeet& ve
   // Interface:AnyNull meet Oop:AnyNull == Interface:AnyNull
   // Interface:NotNull meet Oop:NotNull == java/lang/Object:NotNull
 
+  // Verify that:
+  //      !(t meet this)  meet !t ==
+  //      (!t join !this) meet !t == !t
+  // and
+  //      !(t meet this)  meet !this ==
+  //      (!t join !this) meet !this == !this
   if (t2t != t->_dual || t2this != this->_dual) {
     tty->print_cr("=== Meet Not Symmetric ===");
     tty->print("t   =                   ");              t->dump(); tty->cr();
@@ -4521,10 +4530,11 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
                                                             ciKlass*& res_klass, bool& res_xk, bool& res_flat_in_array) {
   ciKlass* this_klass = this_type->klass();
   ciKlass* other_klass = other_type->klass();
-  bool this_flat_in_array = this_type->flat_in_array();
-  bool other_flat_in_array = other_type->flat_in_array();
-  bool this_flat_in_array_orig = this_flat_in_array;
-  bool other_flat_in_array_orig = other_flat_in_array;
+  const bool this_flat_in_array = this_type->flat_in_array();
+  const bool other_flat_in_array = other_type->flat_in_array();
+  const bool this_not_flat_in_array = this_type->not_flat_in_array();
+  const bool other_not_flat_in_array = other_type->not_flat_in_array();
+
   bool this_xk = this_type->klass_is_exact();
   bool other_xk = other_type->klass_is_exact();
   PTR this_ptr = this_type->ptr();
@@ -4572,39 +4582,47 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
   // centerline and or-ed above it.  (N.B. Constants are always exact.)
 
   // Check for subtyping:
+  // Flat in array matrix, yes = y, no = n, maybe = m, top/empty = T:
+  //        yes maybe no   -> Super Klass
+  //   yes   y    y    y
+  // maybe   y    m    m
+  //    no   T    n    n
+  //    |
+  //    v
+  // Sub Klass
+
   const T* subtype = nullptr;
   bool subtype_exact = false;
-  bool flat_array = false;
+  bool flat_in_array = false;
   if (this_type->is_same_java_type_as(other_type)) {
     subtype = this_type;
     subtype_exact = below_centerline(ptr) ? (this_xk && other_xk) : (this_xk || other_xk);
-    flat_array = below_centerline(ptr) ? (this_flat_in_array && other_flat_in_array) : (this_flat_in_array || other_flat_in_array);
-  } else if (!other_xk && this_type->is_meet_subtype_of(other_type) && (!other_flat_in_array || this_flat_in_array)) {
+    flat_in_array = below_centerline(ptr) ? (this_flat_in_array && other_flat_in_array) : (this_flat_in_array || other_flat_in_array);
+  } else if (!other_xk && is_meet_subtype_of(this_type, other_type)) {
     subtype = this_type;     // Pick subtyping class
     subtype_exact = this_xk;
-    flat_array = this_flat_in_array;
-  } else if (!this_xk && other_type->is_meet_subtype_of(this_type) && (!this_flat_in_array || other_flat_in_array)) {
+    bool other_flat_this_maybe_flat = other_flat_in_array && (!this_flat_in_array && !this_not_flat_in_array);
+    flat_in_array = this_flat_in_array || other_flat_this_maybe_flat;
+  } else if (!this_xk && is_meet_subtype_of(other_type, this_type)) {
     subtype = other_type;    // Pick subtyping class
     subtype_exact = other_xk;
-    flat_array = other_flat_in_array;
+    bool this_flat_other_maybe_flat = this_flat_in_array && (!other_flat_in_array && !other_not_flat_in_array);
+    flat_in_array = other_flat_in_array || this_flat_other_maybe_flat;
   }
 
   if (subtype) {
     if (above_centerline(ptr)) { // both are up?
       this_type = other_type = subtype;
       this_xk = other_xk = subtype_exact;
-      this_flat_in_array = other_flat_in_array = flat_array;
     } else if (above_centerline(this_ptr) && !above_centerline(other_ptr)) {
       this_type = other_type; // tinst is down; keep down man
       this_xk = other_xk;
-      this_flat_in_array = other_flat_in_array;
+      flat_in_array = other_flat_in_array;
     } else if (above_centerline(other_ptr) && !above_centerline(this_ptr)) {
       other_type = this_type; // this is down; keep down man
-      other_xk = this_xk;
-      other_flat_in_array = this_flat_in_array;
+      flat_in_array = this_flat_in_array;
     } else {
       this_xk = subtype_exact;  // either they are equal, or we'll do an LCA
-      this_flat_in_array = flat_array;
     }
   }
 
@@ -4615,7 +4633,7 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
     // handled elsewhere).
     res_klass = this_type->klass();
     res_xk = this_xk;
-    res_flat_in_array = this_flat_in_array;
+    res_flat_in_array = subtype ? flat_in_array : this_flat_in_array;
     return SUBTYPE;
   } // Else classes are not equal
 
@@ -4632,9 +4650,13 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
 
   res_klass = k;
   res_xk = false;
-  res_flat_in_array = this_flat_in_array_orig && other_flat_in_array_orig;
+  res_flat_in_array = this_flat_in_array && other_flat_in_array;
 
   return LCA;
+}
+
+template<class T> bool TypePtr::is_meet_subtype_of(const T* sub_type, const T* super_type) {
+  return sub_type->is_meet_subtype_of(super_type) && !(super_type->flat_in_array() && sub_type->not_flat_in_array());
 }
 
 //------------------------java_mirror_type--------------------------------------

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4611,17 +4611,21 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
   }
 
   if (subtype) {
-    if (above_centerline(ptr)) { // both are up?
+    if (above_centerline(ptr)) {
+      // Both types are empty.
       this_type = other_type = subtype;
       this_xk = other_xk = subtype_exact;
     } else if (above_centerline(this_ptr) && !above_centerline(other_ptr)) {
-      this_type = other_type; // tinst is down; keep down man
+      // this_type is empty while other_type is not. Take other_type.
+      this_type = other_type;
       this_xk = other_xk;
       flat_in_array = other_flat_in_array;
     } else if (above_centerline(other_ptr) && !above_centerline(this_ptr)) {
+      // other_type is empty while this_type is not. Take this_type.
       other_type = this_type; // this is down; keep down man
       flat_in_array = this_flat_in_array;
     } else {
+      // this_type and other_type are both non-empty.
       this_xk = subtype_exact;  // either they are equal, or we'll do an LCA
     }
   }

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1023,6 +1023,9 @@ protected:
   };
   template<class T> static TypePtr::MeetResult meet_instptr(PTR& ptr, const TypeInterfaces*& interfaces, const T* this_type,
                                                             const T* other_type, ciKlass*& res_klass, bool& res_xk, bool& res_flat_array);
+ private:
+  template<class T> static bool is_meet_subtype_of(const T* sub_type, const T* super_type);
+ protected:
 
   template<class T> static MeetResult meet_aryptr(PTR& ptr, const Type*& elem, const T* this_ary, const T* other_ary,
                                                   ciKlass*& res_klass, bool& res_xk, bool &res_flat, bool &res_not_flat, bool &res_not_null_free);
@@ -1093,7 +1096,7 @@ public:
 
   virtual bool can_be_inline_type() const { return false; }
   virtual bool flat_in_array()      const { return false; }
-  virtual bool not_flat_in_array()  const { return false; }
+  virtual bool not_flat_in_array()  const { return true; }
   virtual bool is_flat()            const { return false; }
   virtual bool is_not_flat()        const { return false; }
   virtual bool is_null_free()       const { return false; }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,8 +76,6 @@ compiler/codecache/CheckLargePages.java 8317831 linux-x64
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
-applications/ctw/modules/jdk_jshell.java 8321734 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -27,7 +27,7 @@
  * @requires vm.gc.Serial
  * @summary Test that CmpPNode::sub and SubTypeCheckNode::sub correctly identify unrelated classes based on the flat
  *          in array property of the types. Additionally check that the type system properly handles the case of a
- *         super class being flat in array while the sub klass could be flat in array.
+ *          super class being flat in array while the sub klass could be flat in array.
  * @library /test/lib /
  * @enablePreview
  * @modules java.base/jdk.internal.value
@@ -40,7 +40,7 @@
  * @bug 8321734
  * @summary Test that CmpPNode::sub and SubTypeCheckNode::sub correctly identify unrelated classes based on the flat
  *          in array property of the types. Additionally check that the type system properly handles the case of a
- *         super class being flat in array while the sub klass could be flat in array.
+ *          super class being flat in array while the sub klass could be flat in array.
  * @library /test/lib /
  * @enablePreview
  * @modules java.base/jdk.internal.value

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -236,6 +236,4 @@ public class TestFlatInArraysFolding {
         public void foo() {}
         public void bar() {}
     }
-
 }
-

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321734
+ * @requires vm.gc.Serial
+ * @summary Test that CmpPNode::sub and SubTypeCheckNode::sub correctly identify unrelated classes based on the
+ *          flat in array property of the types.
+ * @library /test/lib /
+ * @run driver compiler.valhalla.inlinetypes.TestFlatInArraysFolding
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import compiler.lib.ir_framework.*;
+
+public class TestFlatInArraysFolding {
+    static Object[] oArrArr = new Object[100][100];
+    static Object[] oArr = new Object[100];
+
+    static int iFld;
+
+    public static void main(String[] args) {
+        // Disable Loop Unrolling for IR matching in testCmpP().
+        // Use IgnoreUnrecognizedVMOptions since LoopMaxUnroll is a C2 flag.
+        // testSubTypeCheck() only triggers with SerialGC.
+        new TestFramework()
+                .setDefaultWarmup(0)
+                .addFlags("-XX:+UseSerialGC", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:LoopMaxUnroll=0")
+                .start();
+    }
+
+    // SubTypeCheck is not folded while CheckCastPPNode is replaced by top which results in a bad graph (data dies while
+    // control does not).
+    @Test
+    static void testSubTypeCheck() {
+        for (int i = 0; i < 100; i++) {
+            Object arrayElement = oArrArr[i];
+            oArr = (Object[])arrayElement;
+        }
+    }
+
+    // Only improve the super class for constants which allows subsequent sub type checks to possibly be commoned up.
+    // The other non-constant cases cannot be improved with a cast node here since they could be folded to top.
+    // Additionally, the benefit would only be minor in non-constant cases.
+
+    @Test
+    @IR(counts = {IRNode.COUNTED_LOOP, "2", // Loop Unswitching done?
+                  IRNode.STORE_I, "1"}) // CmpP folded in unswitched loop version with flat in array?
+    static void testCmpP() {
+        for (int i = 0; i < 100; i++) {
+            Object arrayElement = oArrArr[i];
+            if (arrayElement == oArr) {
+                iFld = 34;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
There are multiple issues around types being `flat_in_array`:

#### 1. `SubTypeCheckNode` is not folded while `CheckCastPP` is correctly replaced by top due to an impossible type:
Test: `testSubTypeCheckNotFoldedParsingAbstractClass():` 

We have the following:
- `PUnique` is the unique concrete value sub class of the abstract value `AUnique` class
- `Object[] arr` -> elements could be an inline type that is flat

We apply loop unswitching such that we have a loop where the access `arr[i]` is with a flat inline type (i.e. marked as flat-in-array) and one version without. In the flat-in-array loop, we have the following sub type check for the `checkcast` for `(AUnique)arr[i]`:
```
AUnique [maybe-flat-in-array] <: Object [flat-in-array]
```
Since we do not know if `AUnique` is flat-in-array, we cannot fold this check. However, the corresponding `CheckCastPP` for this sub type check uses the unique concrete sub class `PUnique` which is known to be *not*-flat-in-array with `FlatArrayElementMaxSize=4`. Since a not-flat-in-array type cannot be a sub type of a flat-in-array type (determined during class loading), the `CheckCastPP` is replaced by top. But the `SubTypeCheck` is not folded. 

This was found in Valhalla and fixed in mainline with JDK-8328480. I've added the Valhalla specific test and merged the fix from mainline into this patch.

#### 2. Wrong `not_flat_in_array` default value
Test: `testSubTypeCheck()` and `testCmpP()`:
Arrays are always normal objects (i.e. not inline types). They are therefore never flat-in-array and always not-flat-in-array. While they are correctly never marked as flat-in-array, they are currently not marked as *not*-flat-in-array and thus have the implicit state *maybe*-flat-in-array:
https://github.com/openjdk/valhalla/blob/e01ec832189453cc302c7ca8915e69bb63a3d4b1/src/hotspot/share/opto/type.hpp#L1096

This becomes a problem for `SubTypeCheck` and `CmpP` nodes which cannot determine that a flat-in-array klass and an array klass are unrelated. But the type system itself correctly treat arrays as *not*-flat-in-array when doing a meet operation. As a result, data is folded while control is not.

This is fixed by changing the flat-in-array tri-state: As a default, a type is always not-flat-in-array. Inline types then override this property accordingly.

#### 3. Type system wrongly treats "maybe-be-flat-in-array <: flat-in-array" as top
Test: `testUnswitchingAbstractClass()`
 "maybe-be-flat-in-array <: flat-in-array" should not be treated as top. We could have cases where we know more about the super type while the sub type does not. In this case, the sub type should take over the flat-in-array property. We therefore have the following decision matrix for sub und super types:
https://github.com/openjdk/valhalla/blob/beb128981325b71c6891048d98282df08dddf329/src/hotspot/share/opto/type.cpp#L4585-L4592

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8321734](https://bugs.openjdk.org/browse/JDK-8321734): [lworld] C2: flat_in_array type is not handled correctly leading to crashes (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [8501d19f](https://git.openjdk.org/valhalla/pull/1079/files/8501d19fe3dc244ac41ada228b417f171c50ac32)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1079/head:pull/1079` \
`$ git checkout pull/1079`

Update a local copy of the PR: \
`$ git checkout pull/1079` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1079`

View PR using the GUI difftool: \
`$ git pr show -t 1079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1079.diff">https://git.openjdk.org/valhalla/pull/1079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1079#issuecomment-2066386286)