### PR TITLE
8330583: [lworld] javac doesn't set ACC_STRICT to final synthetic fields in value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -1638,7 +1638,7 @@ public class Lower extends TreeTranslator {
      *  @param owner      The class in which the definition goes.
      */
     JCVariableDecl outerThisDef(int pos, ClassSymbol owner) {
-        VarSymbol outerThis = makeOuterThisVarSymbol(owner, FINAL | SYNTHETIC);
+        VarSymbol outerThis = makeOuterThisVarSymbol(owner, FINAL | SYNTHETIC | (owner.isValueClass() ? STRICT : 0));
         return makeOuterThisVarDecl(pos, outerThis);
     }
 


### PR DESCRIPTION
javac is not setting the ACC_STRICT flag to final synthetic fields in value classes. The code below reproduces the issue:

```
class NestedTest {
    value class MyValue {
        int i = 0;

        public String toString() {
            return "MyValue("+i+","+outerInt+")";
        }
    }

    int outerInt = 42;
    MyValue v = new MyValue();

    public static void main(String[] args) {
        NestedTest nt = new NestedTest();
    }
}
```
in this case class MyValue has an outer this field of type NestedTest which is final and synthetic but in the case of value classes should also be strict.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8330583](https://bugs.openjdk.org/browse/JDK-8330583): [lworld] javac doesn't set ACC_STRICT to final synthetic fields in value classes (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1080/head:pull/1080` \
`$ git checkout pull/1080`

Update a local copy of the PR: \
`$ git checkout pull/1080` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1080`

View PR using the GUI difftool: \
`$ git pr show -t 1080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1080.diff">https://git.openjdk.org/valhalla/pull/1080.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1080#issuecomment-2070939228)