### PR TITLE
8331154: [lworld] javac is not adding the STRICT flag to final instance fields of value records

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -413,7 +413,7 @@ public class Flags {
     /**
      * Flag to indicate that a field is strict
      */
-    public static final long STRICT = 1L<<51; // VarSymbols
+    public static final long STRICT = 1L<<53; // VarSymbols
 
     /**
      * Describe modifier flags as they might appear in source code, i.e.,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -1550,14 +1550,11 @@ public class Lower extends TreeTranslator {
     }
 
     /** Proxy definitions for all free variables in given list, in reverse order.
-     *  @param pos        The source code position of the definition.
-     *  @param freevars   The free variables.
-     *  @param owner      The class in which the definitions go.
+     *  @param pos               The source code position of the definition.
+     *  @param freevars          The free variables.
+     *  @param owner             The class in which the definitions go.
+     *  @param additionalFlags   Any additional flags
      */
-    List<JCVariableDecl> freevarDefs(int pos, List<VarSymbol> freevars, Symbol owner) {
-        return freevarDefs(pos, freevars, owner, 0);
-    }
-
     List<JCVariableDecl> freevarDefs(int pos, List<VarSymbol> freevars, Symbol owner,
             long additionalFlags) {
         long flags = FINAL | SYNTHETIC | additionalFlags;
@@ -2311,7 +2308,7 @@ public class Lower extends TreeTranslator {
 
         // If this is a local class, define proxies for all its free variables.
         List<JCVariableDecl> fvdefs = freevarDefs(
-            tree.pos, freevars(currentClass), currentClass);
+            tree.pos, freevars(currentClass), currentClass, currentClass.isValueClass() ? STRICT : 0);
 
         // Recursively translate superclass, interfaces.
         tree.extending = translate(tree.extending);


### PR DESCRIPTION
The compiler has an internal STRICT flag that was clashing with another flag used in record fields. Due to this clash the internal STRICT flag was being interpreted as another flag. The fix here is to select another bit position for the STRICT flag avoiding the clash. There was also another issue with locals captured by anonymous classes for which the STRICT flag was not being generated. This issue has been fixed as part of this PR too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331154](https://bugs.openjdk.org/browse/JDK-8331154): [lworld] javac is not adding the STRICT flag to final instance fields of value records (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1083/head:pull/1083` \
`$ git checkout pull/1083`

Update a local copy of the PR: \
`$ git checkout pull/1083` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1083`

View PR using the GUI difftool: \
`$ git pr show -t 1083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1083.diff">https://git.openjdk.org/valhalla/pull/1083.diff</a>

</details>
