### PR TITLE
8331217: [lworld] sun.misc.Unsafe should fail to get the offset of a field of value type

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -653,6 +653,9 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
+        if (declaringClass.isValue()) {
+            throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
+        }
         return theInternalUnsafe.objectFieldOffset(f);
     }
 
@@ -692,6 +695,9 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
+        if (declaringClass.isValue()) {
+            throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
+        }
         return theInternalUnsafe.staticFieldOffset(f);
     }
 
@@ -722,6 +728,9 @@ public final class Unsafe {
         }
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get base address on a record class: " + f);
+        }
+        if (declaringClass.isValue()) {
+            throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.staticFieldBase(f);
     }


### PR DESCRIPTION
Memory-access methods in `sun.misc.Unsafe` are proposed to be deprecated for removal [1]. `staticFieldOffset`, `staticFieldBase` and `staticFieldOffset` should throw UOE if the given field is of value type.

[1] https://openjdk.org/jeps/8323072

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331217](https://bugs.openjdk.org/browse/JDK-8331217): [lworld] sun.misc.Unsafe should fail to get the offset of a field of value type (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1086/head:pull/1086` \
`$ git checkout pull/1086`

Update a local copy of the PR: \
`$ git checkout pull/1086` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1086`

View PR using the GUI difftool: \
`$ git pr show -t 1086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1086.diff">https://git.openjdk.org/valhalla/pull/1086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1086#issuecomment-2080236920)