### PR TITLE
8326401: [lworld] compiler/valhalla/inlinetypes/TestLWorld.java fails after merge of jdk-22+25

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -3310,9 +3310,8 @@ public class TestLWorld {
     }
 
     @Test
-    @IR(failOn = {ALLOC_G, MEMBAR})
-        // TODO 8326401
-        // counts = {PREDICATE_TRAP, "= 1"})
+    @IR(failOn = {ALLOC_G, MEMBAR},
+        counts = {PREDICATE_TRAP, "= 1"})
     public long test113_sharp() {
         long res = 0;
         for (int i = 0; i < lArr.length; i++) {


### PR DESCRIPTION
The uncommented IR rule no longer fails with latest `lworld`. I'm therefore simply proposing to re-enable the IR rule again.

Tested `TestLWorld.java` with tier1-4 flag settings.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326401](https://bugs.openjdk.org/browse/JDK-8326401): [lworld] compiler/valhalla/inlinetypes/TestLWorld.java fails after merge of jdk-22+25 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1087/head:pull/1087` \
`$ git checkout pull/1087`

Update a local copy of the PR: \
`$ git checkout pull/1087` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1087`

View PR using the GUI difftool: \
`$ git pr show -t 1087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1087.diff">https://git.openjdk.org/valhalla/pull/1087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1087#issuecomment-2082019020)