### PR TITLE
8331362: [lworld] JDK-8331217 breaks the build

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -26,6 +26,7 @@
 package sun.misc;
 
 import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
@@ -616,6 +617,18 @@ public final class Unsafe {
      */
     public static final int INVALID_FIELD_OFFSET = jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET;
 
+
+    // Temp internal hack (@see java.lang.Class.isValue())
+    private static boolean isValueClass(Class<?> clazz) {
+        if (!PreviewFeatures.isEnabled()) {
+            return false;
+        }
+        if (clazz.isPrimitive() || clazz.isArray() || clazz.isInterface()) {
+             return false;
+        }
+        return ((clazz.getModifiers() & /*Modifier.IDENTITY*/0x00000020) == 0);
+    }
+
     /**
      * Reports the location of a given field in the storage allocation of its
      * class.  Do not expect to perform any sort of arithmetic on this offset;
@@ -653,7 +666,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
-        if (declaringClass.isValue()) {
+        if (isValueClass(declaringClass)) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.objectFieldOffset(f);
@@ -695,7 +708,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
-        if (declaringClass.isValue()) {
+        if (isValueClass(declaringClass)) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.staticFieldOffset(f);
@@ -729,7 +742,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get base address on a record class: " + f);
         }
-        if (declaringClass.isValue()) {
+        if (isValueClass(declaringClass)) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.staticFieldBase(f);


### PR DESCRIPTION
Avoid preview feature code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331362](https://bugs.openjdk.org/browse/JDK-8331362): [lworld] JDK-8331217 breaks the build (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1088/head:pull/1088` \
`$ git checkout pull/1088`

Update a local copy of the PR: \
`$ git checkout pull/1088` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1088`

View PR using the GUI difftool: \
`$ git pr show -t 1088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1088.diff">https://git.openjdk.org/valhalla/pull/1088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1088#issuecomment-2084664710)