### PR TITLE
8331496: [lworld] Class::isValue, Class::isIdentity and new java.lang.reflect APIs should be reflective preview API

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -689,7 +689,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public native boolean isIdentity();
 
     /**
@@ -701,7 +701,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public boolean isValue() {
         if (!PreviewFeatures.isEnabled()) {
             return false;

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -206,8 +206,10 @@ public enum AccessFlag {
      * source modifier {@link Modifier#IDENTITY identity}, with a mask
      * value of <code>{@value "0x%04x" Modifier#IDENTITY}</code>.
      * @jvms 4.1 -B. Class access and property modifiers
+     *
+     * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     IDENTITY(Modifier.IDENTITY, false,
             PreviewFeatures.isEnabled() ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET,
             new Function<ClassFileFormatVersion, Set<Location>>() {

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -140,7 +140,10 @@ public class Modifier {
      * @param   mod a set of modifiers
      * @return {@code true} if {@code mod} includes the
      * {@code identity} modifier; {@code false} otherwise.
+     *
+     * @since Valhalla
      */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public static boolean isIdentity(int mod) {
         return (mod & IDENTITY) != 0;
     }
@@ -319,8 +322,10 @@ public class Modifier {
     /**
      * The {@code int} value representing the {@code ACC_IDENTITY}
      * modifier.
+     *
+     * @since Valhalla
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
     public static final int IDENTITY         = 0x00000020;
 
     /**

--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -26,7 +26,6 @@
 package sun.misc;
 
 import jdk.internal.vm.annotation.ForceInline;
-import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
@@ -617,18 +616,6 @@ public final class Unsafe {
      */
     public static final int INVALID_FIELD_OFFSET = jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET;
 
-
-    // Temp internal hack (@see java.lang.Class.isValue())
-    private static boolean isValueClass(Class<?> clazz) {
-        if (!PreviewFeatures.isEnabled()) {
-            return false;
-        }
-        if (clazz.isPrimitive() || clazz.isArray() || clazz.isInterface()) {
-             return false;
-        }
-        return ((clazz.getModifiers() & /*Modifier.IDENTITY*/0x00000020) == 0);
-    }
-
     /**
      * Reports the location of a given field in the storage allocation of its
      * class.  Do not expect to perform any sort of arithmetic on this offset;
@@ -655,6 +642,7 @@ public final class Unsafe {
      */
     @Deprecated(since="18")
     @ForceInline
+    @SuppressWarnings("preview")
     public long objectFieldOffset(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -666,7 +654,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
-        if (isValueClass(declaringClass)) {
+        if (declaringClass.isValue()) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.objectFieldOffset(f);
@@ -697,6 +685,7 @@ public final class Unsafe {
      */
     @Deprecated(since="18")
     @ForceInline
+    @SuppressWarnings("preview")
     public long staticFieldOffset(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -708,7 +697,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get field offset on a record class: " + f);
         }
-        if (isValueClass(declaringClass)) {
+        if (declaringClass.isValue()) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.staticFieldOffset(f);
@@ -731,6 +720,7 @@ public final class Unsafe {
      */
     @Deprecated(since="18")
     @ForceInline
+    @SuppressWarnings("preview")
     public Object staticFieldBase(Field f) {
         if (f == null) {
             throw new NullPointerException();
@@ -742,7 +732,7 @@ public final class Unsafe {
         if (declaringClass.isRecord()) {
             throw new UnsupportedOperationException("can't get base address on a record class: " + f);
         }
-        if (isValueClass(declaringClass)) {
+        if (declaringClass.isValue()) {
             throw new UnsupportedOperationException("can't get field offset on a value class: " + f);
         }
         return theInternalUnsafe.staticFieldBase(f);


### PR DESCRIPTION
Mark the reflection APIs added for JEP 401 as reflective preview API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331496](https://bugs.openjdk.org/browse/JDK-8331496): [lworld] Class::isValue, Class::isIdentity and new java.lang.reflect APIs should be reflective preview API (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1090/head:pull/1090` \
`$ git checkout pull/1090`

Update a local copy of the PR: \
`$ git checkout pull/1090` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1090`

View PR using the GUI difftool: \
`$ git pr show -t 1090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1090.diff">https://git.openjdk.org/valhalla/pull/1090.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1090#issuecomment-2088724017)