### PR TITLE
8331462: [lworld] javac is setting the ACC_STRICT flag for value-based classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -835,7 +835,7 @@ public class ClassWriter extends ClassFile {
         databuf.appendChar(poolWriter.innerClasses.size());
         for (ClassSymbol inner : poolWriter.innerClasses) {
             inner.markAbstractIfNeeded(types);
-            int flags = adjustFlags(inner.flags_field);
+            int flags = adjustFlags(inner, inner.flags_field);
             if ((flags & INTERFACE) != 0) flags |= ABSTRACT; // Interfaces are always ABSTRACT
             if (dumpInnerClassModifiers) {
                 PrintWriter pw = log.getWriter(Log.WriterKind.ERROR);
@@ -976,7 +976,7 @@ public class ClassWriter extends ClassFile {
     /** Write field symbol, entering all references into constant pool.
      */
     void writeField(VarSymbol v) {
-        int flags = adjustFlags(v.flags());
+        int flags = adjustFlags(v, v.flags());
         databuf.appendChar(flags);
         if (dumpFieldModifiers) {
             PrintWriter pw = log.getWriter(Log.WriterKind.ERROR);
@@ -1005,7 +1005,7 @@ public class ClassWriter extends ClassFile {
     /** Write method symbol, entering all references into constant pool.
      */
     void writeMethod(MethodSymbol m) {
-        int flags = adjustFlags(m.flags());
+        int flags = adjustFlags(m, m.flags());
         databuf.appendChar(flags);
         if (dumpMethodModifiers) {
             PrintWriter pw = log.getWriter(Log.WriterKind.ERROR);
@@ -1602,7 +1602,7 @@ public class ClassWriter extends ClassFile {
             flags = ACC_MODULE;
         } else {
             long originalFlags = c.flags();
-            flags = adjustFlags(c.flags() & ~(DEFAULT | STRICTFP));
+            flags = adjustFlags(c, c.flags() & ~(DEFAULT | STRICTFP));
             if ((flags & PROTECTED) != 0) flags |= PUBLIC;
             flags = flags & ClassFlags;
             flags |= (originalFlags & IDENTITY_TYPE) != 0 ? ACC_IDENTITY : flags;
@@ -1766,7 +1766,7 @@ public class ClassWriter extends ClassFile {
         return i;
     }
 
-    int adjustFlags(final long flags) {
+    int adjustFlags(Symbol sym, final long flags) {
         int result = (int)flags;
 
         // Elide strictfp bit in class files
@@ -1782,8 +1782,10 @@ public class ClassWriter extends ClassFile {
         if ((flags & IDENTITY_TYPE) != 0) {
             result |= ACC_IDENTITY;
         }
-        if ((flags & STRICT) != 0) {
-            result |= ACC_STRICT;
+        if (sym.kind == VAR) {
+            if ((flags & STRICT) != 0) {
+                result |= ACC_STRICT;
+            }
         }
         return result;
     }

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
@@ -75,7 +75,7 @@ public class ValueBasedFlagsTest extends TestRunner {
                 """
                 package java.lang;
                 @jdk.internal.ValueBased
-                final class ValueBasedTest {}        
+                final class ValueBasedTest {}
                 """);
         Path classes = base.resolve("classes");
         tb.createDirectories(classes);

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueBasedFlagsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331462
+ * @summary [lworld] javac is setting the ACC_STRICT flag for value-based classes
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.code
+ *      jdk.compiler/com.sun.tools.javac.util
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main ValueBasedFlagsTest
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.util.Assert;
+import com.sun.tools.classfile.ClassFile;
+
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.Task;
+
+public class ValueBasedFlagsTest extends TestRunner {
+    ToolBox tb = new ToolBox();
+
+    public ValueBasedFlagsTest() {
+        super(System.err);
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    Path[] findJavaFiles(Path... paths) throws Exception {
+        return tb.findJavaFiles(paths);
+    }
+
+    public static void main(String... args) throws Exception {
+        new ValueBasedFlagsTest().runTests();
+    }
+
+    @Test
+    public void testValueBased(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                package java.lang;
+                @jdk.internal.ValueBased
+                final class ValueBasedTest {}        
+                """);
+        Path classes = base.resolve("classes");
+        tb.createDirectories(classes);
+
+        new toolbox.JavacTask(tb)
+                .options("--patch-module", "java.base=" + src.toString(),
+                        "--enable-preview", "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src))
+                .run()
+                .writeAll();
+        Path classFilePath = classes.resolve("java", "lang", "ValueBasedTest.class");
+        ClassFile classFile = ClassFile.read(classFilePath.toFile());
+        Assert.check((classFile.access_flags.flags & Flags.ACC_STRICT) == 0);
+    }
+}


### PR DESCRIPTION
javac is erroneously generating the ACC_STRICT flag for value based classes, so classes annotated with: `@jdk.internal.ValueBased` like `java.lang.Integer` etc has the ACC_STRICT flag set. This flag should only be applied to instance fields of value classes not to any class

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331462](https://bugs.openjdk.org/browse/JDK-8331462): [lworld] javac is setting the ACC_STRICT flag for value-based classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1091/head:pull/1091` \
`$ git checkout pull/1091`

Update a local copy of the PR: \
`$ git checkout pull/1091` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1091`

View PR using the GUI difftool: \
`$ git pr show -t 1091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1091.diff">https://git.openjdk.org/valhalla/pull/1091.diff</a>

</details>
