### PR TITLE
8331583: [lworld] runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java fails with compilation error

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
@@ -115,8 +115,9 @@
                             "    @NullRestricted" +
                             "    " + vName + " v1;" +
                             "}";
+        String java_version = System.getProperty("java.specification.version");
         byte[] byteCode = InMemoryJavaCompiler.compile(className, sourceCode,
-                                                      "-source", "22", "--enable-preview",
+                                                      "-source", java_version, "--enable-preview",
                                                       "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED");
         jdk.test.lib.helpers.ClassFileInstaller.writeClassToDisk(className, byteCode);
         testNames.add(className);
@@ -134,8 +135,9 @@
     }
     sb.append("    }");
     sb.append("}");
+    String java_version = System.getProperty("java.specification.version");
     byte[] byteCode = InMemoryJavaCompiler.compile(className, sb.toString(),
-                                                   "-source", "22", "--enable-preview",
+                                                   "-source", java_version, "--enable-preview",
                                                    "-cp", ".");
     jdk.test.lib.helpers.ClassFileInstaller.writeClassToDisk(className, byteCode);
   }


### PR DESCRIPTION
Small fix removing a hard coded Java version number causing test failures after merge with mainline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331583](https://bugs.openjdk.org/browse/JDK-8331583): [lworld] runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java fails with compilation error (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1094/head:pull/1094` \
`$ git checkout pull/1094`

Update a local copy of the PR: \
`$ git checkout pull/1094` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1094`

View PR using the GUI difftool: \
`$ git pr show -t 1094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1094.diff">https://git.openjdk.org/valhalla/pull/1094.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1094#issuecomment-2090902726)