### PR TITLE
8331602: [lworld] Test using -XX:+EnableNullableFieldFlattening should not be run in product mode

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullableFlatFieldTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/NullableFlatFieldTest.java
@@ -23,6 +23,7 @@
 
  /*
  * @test NullableFlatFieldTest
+ * @requires vm.debug == true
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -27,6 +27,7 @@ package runtime.valhalla.inlinetypes;
 
 /*
  * @test UnsafeTest
+ * @requires vm.debug == true
  * @summary unsafe get/put/with inline type
  * @modules java.base/jdk.internal.misc
  * @library /test/lib


### PR DESCRIPTION
NullableFlatFieldTest and UnsafeTest needs EnableNullableFieldFlattening, which is a develop flag, not available on product build. EnableNullableFieldFlattening is a temporary flag that will be removed once all the VM supports nullable flat fields. For now, those two tests will only be run with debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331602](https://bugs.openjdk.org/browse/JDK-8331602): [lworld] Test using -XX:+EnableNullableFieldFlattening should not be run in product mode (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1095/head:pull/1095` \
`$ git checkout pull/1095`

Update a local copy of the PR: \
`$ git checkout pull/1095` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1095`

View PR using the GUI difftool: \
`$ git pr show -t 1095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1095.diff">https://git.openjdk.org/valhalla/pull/1095.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1095#issuecomment-2091450840)