### PR TITLE
8331587: [lworld] runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java fails with java.lang.RuntimeException: assertEquals: expected 4 to equal 8

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1122,10 +1122,17 @@ void FieldLayoutBuilder::epilogue() {
   }
 #endif // ASSERT
 
+  static bool first_layout_print = true;
+
 
   if (PrintFieldLayout || (PrintInlineLayout && _has_flattening_information)) {
     ResourceMark rm;
     ttyLocker ttl;
+    if (first_layout_print) {
+      tty->print_cr("Field layout log format: @offset size/alignment [name] [signature] [comment]");
+      tty->print_cr("Heap oop size = %d", heapOopSize);
+      first_layout_print = false;
+    }
     if (_super_klass != nullptr) {
       tty->print_cr("Layout of class %s@%p extends %s@%p", _classname->as_C_string(),
                     _loader_data, _super_klass->name()->as_C_string(), _super_klass->class_loader_data());

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
@@ -157,18 +157,14 @@
   }
 
   public static void main(String[] args) throws Exception {
-    boolean useCompressedOops;
     String compressedOopsArg;
 
     switch(args[0]) {
-      case "0": useCompressedOops = false;
-                compressedOopsArg = null;
+      case "0": compressedOopsArg = null;
                 break;
-      case "1": useCompressedOops = true;
-                compressedOopsArg = "-XX:+UseCompressedOops";
+      case "1": compressedOopsArg = "-XX:+UseCompressedOops";
                 break;
-      case "2": useCompressedOops = false;
-                compressedOopsArg = "-XX:-UseCompressedOops";
+      case "2": compressedOopsArg = "-XX:-UseCompressedOops";
                 break;
       default: throw new RuntimeException("Unrecognized configuration");
     }
@@ -186,7 +182,7 @@
     System.out.print(out.getOutput());
     FieldLayoutAnalyzer.LogOutput lo = new FieldLayoutAnalyzer.LogOutput(out.asLines());
 
-    FieldLayoutAnalyzer fla =  FieldLayoutAnalyzer.createFieldLayoutAnalyzer(lo, useCompressedOops);
+    FieldLayoutAnalyzer fla =  FieldLayoutAnalyzer.createFieldLayoutAnalyzer(lo);
     fla.check();
   }
  }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
@@ -292,18 +292,14 @@ public class NullMarkersTest {
   }
 
   public static void main(String[] args) throws Exception {
-    boolean useCompressedOops;
     String compressedOopsArg;
 
     switch(args[0]) {
-      case "0": useCompressedOops = false;
-                compressedOopsArg = null;
+      case "0": compressedOopsArg = null;
                 break;
-      case "1": useCompressedOops = true;
-                compressedOopsArg = "-XX:+UseCompressedOops";
+      case "1": compressedOopsArg = "-XX:+UseCompressedOops";
                 break;
-      case "2": useCompressedOops = false;
-                compressedOopsArg = "-XX:-UseCompressedOops";
+      case "2": compressedOopsArg = "-XX:-UseCompressedOops";
                 break;
       default: throw new RuntimeException("Unrecognized configuration");
     }
@@ -320,7 +316,7 @@ public class NullMarkersTest {
     // Get and parse the test output
     System.out.print(out.getOutput());
     FieldLayoutAnalyzer.LogOutput lo = new FieldLayoutAnalyzer.LogOutput(out.asLines());
-    FieldLayoutAnalyzer fla =  FieldLayoutAnalyzer.createFieldLayoutAnalyzer(lo, useCompressedOops);
+    FieldLayoutAnalyzer fla =  FieldLayoutAnalyzer.createFieldLayoutAnalyzer(lo);
 
     // Running tests verification method (check that tests produced the right configuration)
     Class testClass = NullMarkersTest.class;


### PR DESCRIPTION
Changes in the format of field layout dump to include the size of oops. Adjustments in the FieldLayoutAnalyzer to rely on these new entry rather than an argument passed by the caller.

Test with Mach5 tiers 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331587](https://bugs.openjdk.org/browse/JDK-8331587): [lworld] runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java fails with java.lang.RuntimeException: assertEquals: expected 4 to equal 8 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1097/head:pull/1097` \
`$ git checkout pull/1097`

Update a local copy of the PR: \
`$ git checkout pull/1097` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1097`

View PR using the GUI difftool: \
`$ git pr show -t 1097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1097.diff">https://git.openjdk.org/valhalla/pull/1097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1097#issuecomment-2096794770)