### PR TITLE
[lworld] Re-adjust problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -79,11 +79,6 @@ compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 compiler/intrinsics/float16/TestConstFloat16ToFloat.java 8325264 macosx-aarch64
 compiler/intrinsics/float16/Binary16Conversion.java 8325264 macosx-aarch64
 
-# Valhalla
-compiler/gcbarriers/TestZGCUnrolling.java 8331551 generic-all
-compiler/valhalla/inlinetypes/TestBasicFunctionality.java 8287061 generic-all
-compiler/valhalla/inlinetypes/TestValueClasses.java 8331909 macosx-aarch64
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -287,6 +287,8 @@ public class TestBasicFunctionality {
     }
 
     // Test loop with uncommon trap referencing a value object
+    // TODO 8315003 Re-enable
+    /*
     @Test
     @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
         counts = {SCOBJ, ">= 1", LOAD, "<= 12"}) // TODO 8227588 (loads should be removed)
@@ -317,6 +319,7 @@ public class TestBasicFunctionality {
         long result = test12(info.isWarmUp());
         Asserts.assertEQ(result, info.isWarmUp() ? rL + (1000 * rI) : ((Math.abs(rI) % 10) + 1) * hash());
     }
+    */
 
     // Test loop with uncommon trap referencing a value object
     @Test


### PR DESCRIPTION
Undoing the problem listing because:
- `TestZGCUnrolling.java` was already disabled with the changes for [JDK-8331538](https://bugs.openjdk.org/browse/JDK-8331538)
- `TestBasicFunctionality.java` is a large and important test. Only the failing unit test should be disabled. Also, the linked bug is wrong, it should be [JDK-8315003](https://bugs.openjdk.org/browse/JDK-8315003).
- The `TestValueClasses.java` failure seems to be highly intermittent and we should not disable the test completely. I'll investigate with [JDK-8331909](https://bugs.openjdk.org/browse/JDK-8331909) and potentially problem list the unit test.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1102/head:pull/1102` \
`$ git checkout pull/1102`

Update a local copy of the PR: \
`$ git checkout pull/1102` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1102`

View PR using the GUI difftool: \
`$ git pr show -t 1102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1102.diff">https://git.openjdk.org/valhalla/pull/1102.diff</a>

</details>
