### PR TITLE
8332235: [lworld] introduce internal annotation to indicate that the ACC_STRICT flag must be set

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/annotation/Strict.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/Strict.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to indicate the compiler that the ACC_STRICT flag should be set to
+ * the annotated field. Internal and experimental use only
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Strict {
+}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -251,6 +251,7 @@ public class Symtab {
     public final Type valueBasedInternalType;
     public final Type migratedValueClassType;
     public final Type migratedValueClassInternalType;
+    public final Type strictType;
 
     /** The symbol representing the length field of an array.
      */
@@ -624,6 +625,7 @@ public class Symtab {
         constantBootstrapsType = enterClass("java.lang.invoke.ConstantBootstraps");
         valueBasedType = enterClass("jdk.internal.ValueBased");
         valueBasedInternalType = enterSyntheticAnnotation("jdk.internal.ValueBased+Annotation");
+        strictType = enterSyntheticAnnotation("jdk.internal.vm.annotation.Strict");
         migratedValueClassType = enterClass("jdk.internal.MigratedValueClass");
         migratedValueClassInternalType = enterSyntheticAnnotation("jdk.internal.MigratedValueClass+Annotation");
         classDescType = enterClass("java.lang.constant.ClassDesc");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -387,6 +387,13 @@ public class Annotate {
             }
 
             if (!c.type.isErroneous()
+                    && toAnnotate.kind == VAR
+                    && toAnnotate.owner.kind == TYP
+                    && types.isSameType(c.type, syms.strictType)) {
+                toAnnotate.flags_field |= Flags.STRICT;
+            }
+
+            if (!c.type.isErroneous()
                     && types.isSameType(c.type, syms.restrictedType)) {
                 toAnnotate.flags_field |= Flags.RESTRICTED;
             }


### PR DESCRIPTION
experimental annotation to indicate the compiler that the annotated field should have the ACC_STRICT flag set

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8332235](https://bugs.openjdk.org/browse/JDK-8332235): [lworld] introduce internal annotation to indicate that the ACC_STRICT flag must be set (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1105/head:pull/1105` \
`$ git checkout pull/1105`

Update a local copy of the PR: \
`$ git checkout pull/1105` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1105`

View PR using the GUI difftool: \
`$ git pr show -t 1105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1105.diff">https://git.openjdk.org/valhalla/pull/1105.diff</a>

</details>
