### PR TITLE
8332323: [lworld] runtime/valhalla/inlinetypes/ValuePreloadTest.java fails with compilation error

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -26,7 +26,7 @@
  * @library /test/lib
  * @enablePreview
  * @compile ValuePreloadClient0.java PreloadValue0.java ValuePreloadClient1.jcod
- * @run driver ValuePreloadTest
+ * @run main ValuePreloadTest
  */
 
 import java.util.ArrayList;


### PR DESCRIPTION
Simple fix in the way the test is launched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8332323](https://bugs.openjdk.org/browse/JDK-8332323): [lworld] runtime/valhalla/inlinetypes/ValuePreloadTest.java fails with compilation error (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1106/head:pull/1106` \
`$ git checkout pull/1106`

Update a local copy of the PR: \
`$ git checkout pull/1106` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1106`

View PR using the GUI difftool: \
`$ git pr show -t 1106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1106.diff">https://git.openjdk.org/valhalla/pull/1106.diff</a>

</details>
