### PR TITLE
8332387: [lworld] monitorenter on value class instances must throw IdentityException instead of IllegalMonitorStateException

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -272,14 +272,14 @@ void NewObjectArrayStub::emit_code(LIR_Assembler* ce) {
 void MonitorEnterStub::emit_code(LIR_Assembler* ce) {
   assert(__ rsp_offset() == 0, "frame size should be fixed");
   __ bind(_entry);
-  if (_throw_imse_stub != nullptr) {
+  if (_throw_ie_stub != nullptr) {
     // When we come here, _obj_reg has already been checked to be non-null.
     __ ldr(rscratch1, Address(_obj_reg->as_register(), oopDesc::mark_offset_in_bytes()));
     __ mov(rscratch2, markWord::inline_type_pattern);
     __ andr(rscratch1, rscratch1, rscratch2);
 
     __ cmp(rscratch1, rscratch2);
-    __ br(Assembler::EQ, *_throw_imse_stub->entry());
+    __ br(Assembler::EQ, *_throw_ie_stub->entry());
   }
 
   ce->store_parameter(_obj_reg->as_register(),  1);

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -328,16 +328,16 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
     info_for_exception = state_for(x);
   }
 
-  CodeStub* throw_imse_stub =
+  CodeStub* throw_ie_stub =
       x->maybe_inlinetype() ?
-      new SimpleExceptionStub(Runtime1::throw_illegal_monitor_state_exception_id, LIR_OprFact::illegalOpr, state_for(x)) :
+      new SimpleExceptionStub(Runtime1::throw_identity_exception_id, LIR_OprFact::illegalOpr, state_for(x)) :
       nullptr;
 
   // this CodeEmitInfo must not have the xhandlers because here the
   // object is already locked (xhandlers expect object to be unlocked)
   CodeEmitInfo* info = state_for(x, x->state(), true);
   monitor_enter(obj.result(), lock, syncTempOpr(), scratch,
-                x->monitor_no(), info_for_exception, info, throw_imse_stub);
+                x->monitor_no(), info_for_exception, info, throw_ie_stub);
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -931,6 +931,12 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
       }
       break;
 
+    case throw_identity_exception_id:
+      { StubFrame f(sasm, "throw_identity_exception", dont_gc_arguments);
+        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), false);
+      }
+      break;
+
     case slow_subtype_check_id:
       {
         // Typical calling sequence:

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -4237,7 +4237,7 @@ void TemplateTable::monitorenter()
 
   __ bind(is_inline_type);
   __ call_VM(noreg, CAST_FROM_FN_PTR(address,
-                    InterpreterRuntime::throw_illegal_monitor_state_exception));
+                    InterpreterRuntime::throw_identity_exception));
   __ should_not_reach_here();
 }
 

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -325,14 +325,14 @@ void NewObjectArrayStub::emit_code(LIR_Assembler* ce) {
 void MonitorEnterStub::emit_code(LIR_Assembler* ce) {
   assert(__ rsp_offset() == 0, "frame size should be fixed");
   __ bind(_entry);
-  if (_throw_imse_stub != nullptr) {
+  if (_throw_ie_stub != nullptr) {
     // When we come here, _obj_reg has already been checked to be non-null.
     const int is_value_mask = markWord::inline_type_pattern;
     Register mark = _scratch_reg->as_register();
     __ movptr(mark, Address(_obj_reg->as_register(), oopDesc::mark_offset_in_bytes()));
     __ andptr(mark, is_value_mask);
     __ cmpl(mark, is_value_mask);
-    __ jcc(Assembler::equal, *_throw_imse_stub->entry());
+    __ jcc(Assembler::equal, *_throw_ie_stub->entry());
   }
   ce->store_parameter(_obj_reg->as_register(),  1);
   ce->store_parameter(_lock_reg->as_register(), 0);

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -337,8 +337,8 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
     info_for_exception = state_for(x);
   }
 
-  CodeStub* throw_imse_stub = x->maybe_inlinetype() ?
-      new SimpleExceptionStub(Runtime1::throw_illegal_monitor_state_exception_id,
+  CodeStub* throw_ie_stub = x->maybe_inlinetype() ?
+      new SimpleExceptionStub(Runtime1::throw_identity_exception_id,
                               LIR_OprFact::illegalOpr, state_for(x))
     : nullptr;
 
@@ -346,7 +346,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   // object is already locked (xhandlers expect object to be unlocked)
   CodeEmitInfo* info = state_for(x, x->state(), true);
   monitor_enter(obj.result(), lock, syncTempOpr(), scratch,
-                x->monitor_no(), info_for_exception, info, throw_imse_stub);
+                x->monitor_no(), info_for_exception, info, throw_ie_stub);
 }
 
 

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1350,6 +1350,12 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
       }
       break;
 
+    case throw_identity_exception_id:
+      { StubFrame f(sasm, "throw_identity_exception", dont_gc_arguments);
+        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), false);
+      }
+      break;
+
     case slow_subtype_check_id:
       {
         // Typical calling sequence:

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4707,7 +4707,7 @@ void TemplateTable::monitorenter() {
 
   __ bind(is_inline_type);
   __ call_VM(noreg, CAST_FROM_FN_PTR(address,
-                    InterpreterRuntime::throw_illegal_monitor_state_exception));
+                    InterpreterRuntime::throw_identity_exception));
   __ should_not_reach_here();
 }
 

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -424,17 +424,17 @@ class MonitorAccessStub: public CodeStub {
 class MonitorEnterStub: public MonitorAccessStub {
  private:
   CodeEmitInfo* _info;
-  CodeStub* _throw_imse_stub;
+  CodeStub* _throw_ie_stub;
   LIR_Opr _scratch_reg;
 
  public:
   MonitorEnterStub(LIR_Opr obj_reg, LIR_Opr lock_reg, CodeEmitInfo* info,
-                   CodeStub* throw_imse_stub = nullptr, LIR_Opr scratch_reg = LIR_OprFact::illegalOpr)
+                   CodeStub* throw_ie_stub = nullptr, LIR_Opr scratch_reg = LIR_OprFact::illegalOpr)
     : MonitorAccessStub(obj_reg, lock_reg) {
     _info = new CodeEmitInfo(info);
     _scratch_reg = scratch_reg;
-    _throw_imse_stub = throw_imse_stub;
-    if (_throw_imse_stub != nullptr) {
+    _throw_ie_stub = throw_ie_stub;
+    if (_throw_ie_stub != nullptr) {
       assert(_scratch_reg != LIR_OprFact::illegalOpr, "must be");
     }
     FrameMap* f = Compilation::current()->frame_map();

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -838,7 +838,7 @@ void LIR_OpVisitState::visit(LIR_Op* op) {
       assert(opLock->_result->is_illegal(), "unused");
 
       do_stub(opLock->_stub);
-      do_stub(opLock->_throw_imse_stub);
+      do_stub(opLock->_throw_ie_stub);
 
       break;
     }
@@ -1206,8 +1206,8 @@ void LIR_OpLock::emit_code(LIR_Assembler* masm) {
   if (stub()) {
     masm->append_code_stub(stub());
   }
-  if (throw_imse_stub()) {
-    masm->append_code_stub(throw_imse_stub());
+  if (throw_ie_stub()) {
+    masm->append_code_stub(throw_ie_stub());
   }
 }
 
@@ -1561,7 +1561,7 @@ void LIR_List::fcmp2int(LIR_Opr left, LIR_Opr right, LIR_Opr dst, bool is_unorde
                      dst));
 }
 
-void LIR_List::lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_imse_stub) {
+void LIR_List::lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_ie_stub) {
   append(new LIR_OpLock(
                     lir_lock,
                     hdr,
@@ -1570,7 +1570,7 @@ void LIR_List::lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scrat
                     scratch,
                     stub,
                     info,
-                    throw_imse_stub));
+                    throw_ie_stub));
 }
 
 void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub) {

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1982,23 +1982,23 @@ class LIR_OpLock: public LIR_Op {
   LIR_Opr _lock;
   LIR_Opr _scratch;
   CodeStub* _stub;
-  CodeStub* _throw_imse_stub;
+  CodeStub* _throw_ie_stub;
  public:
-  LIR_OpLock(LIR_Code code, LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_imse_stub=nullptr)
+  LIR_OpLock(LIR_Code code, LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_ie_stub=nullptr)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
     , _hdr(hdr)
     , _obj(obj)
     , _lock(lock)
     , _scratch(scratch)
     , _stub(stub)
-    , _throw_imse_stub(throw_imse_stub)                    {}
+    , _throw_ie_stub(throw_ie_stub)                    {}
 
   LIR_Opr hdr_opr() const                        { return _hdr; }
   LIR_Opr obj_opr() const                        { return _obj; }
   LIR_Opr lock_opr() const                       { return _lock; }
   LIR_Opr scratch_opr() const                    { return _scratch; }
   CodeStub* stub() const                         { return _stub; }
-  CodeStub* throw_imse_stub() const              { return _throw_imse_stub; }
+  CodeStub* throw_ie_stub() const                { return _throw_ie_stub; }
 
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_OpLock* as_OpLock() { return this; }
@@ -2488,7 +2488,7 @@ class LIR_List: public CompilationResourceObj {
 
   void load_stack_address_monitor(int monitor_ix, LIR_Opr dst)  { append(new LIR_Op1(lir_monaddr, LIR_OprFact::intConst(monitor_ix), dst)); }
   void unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub);
-  void lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_imse_stub=nullptr);
+  void lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, CodeStub* throw_ie_stub=nullptr);
 
   void breakpoint()                                                  { append(new LIR_Op0(lir_breakpoint)); }
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -625,13 +625,13 @@ void LIRGenerator::logic_op (Bytecodes::Code code, LIR_Opr result_op, LIR_Opr le
 
 
 void LIRGenerator::monitor_enter(LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no,
-                                 CodeEmitInfo* info_for_exception, CodeEmitInfo* info, CodeStub* throw_imse_stub) {
+                                 CodeEmitInfo* info_for_exception, CodeEmitInfo* info, CodeStub* throw_ie_stub) {
   if (!GenerateSynchronizationCode) return;
   // for slow path, use debug info for state after successful locking
-  CodeStub* slow_path = new MonitorEnterStub(object, lock, info, throw_imse_stub, scratch);
+  CodeStub* slow_path = new MonitorEnterStub(object, lock, info, throw_ie_stub, scratch);
   __ load_stack_address_monitor(monitor_no, lock);
   // for handling NullPointerException, use debug info representing just the lock stack before this monitorenter
-  __ lock_object(hdr, object, lock, scratch, slow_path, info_for_exception, throw_imse_stub);
+  __ lock_object(hdr, object, lock, scratch, slow_path, info_for_exception, throw_ie_stub);
 }
 
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -378,7 +378,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
 
   void logic_op   (Bytecodes::Code code, LIR_Opr dst_reg, LIR_Opr left, LIR_Opr right);
 
-  void monitor_enter (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info, CodeStub* throw_imse_stub);
+  void monitor_enter (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info, CodeStub* throw_ie_stub);
   void monitor_exit  (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no);
 
   void new_instance(LIR_Opr dst, ciInstanceKlass* klass, bool is_unresolved, bool allow_inline, LIR_Opr scratch1, LIR_Opr scratch2, LIR_Opr scratch3, LIR_Opr scratch4, LIR_Opr klass_reg, CodeEmitInfo* info);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -142,6 +142,7 @@ uint Runtime1::_throw_null_pointer_exception_count = 0;
 uint Runtime1::_throw_class_cast_exception_count = 0;
 uint Runtime1::_throw_incompatible_class_change_error_count = 0;
 uint Runtime1::_throw_illegal_monitor_state_exception_count = 0;
+uint Runtime1::_throw_identity_exception_count = 0;
 uint Runtime1::_throw_count = 0;
 
 static uint _byte_arraycopy_stub_cnt = 0;
@@ -883,6 +884,12 @@ JRT_ENTRY(void, Runtime1::throw_illegal_monitor_state_exception(JavaThread* curr
   NOT_PRODUCT(_throw_illegal_monitor_state_exception_count++;)
   ResourceMark rm(current);
   SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_IllegalMonitorStateException());
+JRT_END
+
+JRT_ENTRY(void, Runtime1::throw_identity_exception(JavaThread* current))
+  NOT_PRODUCT(_throw_identity_exception_count++;)
+  ResourceMark rm(current);
+  SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_IdentityException());
 JRT_END
 
 JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, BasicObjectLock* lock))
@@ -1709,6 +1716,7 @@ void Runtime1::print_statistics() {
   tty->print_cr(" _throw_class_cast_exception_count:             %u:", _throw_class_cast_exception_count);
   tty->print_cr(" _throw_incompatible_class_change_error_count:  %u:", _throw_incompatible_class_change_error_count);
   tty->print_cr(" _throw_illegal_monitor_state_exception_count:  %u:", _throw_illegal_monitor_state_exception_count);
+  tty->print_cr(" _throw_identity_exception_count:               %u:", _throw_identity_exception_count);
   tty->print_cr(" _throw_count:                                  %u:", _throw_count);
 
   SharedRuntime::print_ic_miss_histogram();

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -65,6 +65,7 @@ class StubAssembler;
   stub(throw_class_cast_exception)   \
   stub(throw_incompatible_class_change_error)   \
   stub(throw_illegal_monitor_state_exception)   \
+  stub(throw_identity_exception)     \
   stub(slow_subtype_check)           \
   stub(monitorenter)                 \
   stub(monitorenter_nofpu)             /* optimized version that does not preserve fpu registers */ \
@@ -125,6 +126,7 @@ class Runtime1: public AllStatic {
   static uint _throw_class_cast_exception_count;
   static uint _throw_incompatible_class_change_error_count;
   static uint _throw_illegal_monitor_state_exception_count;
+  static uint _throw_identity_exception_count;
   static uint _throw_count;
 #endif
 
@@ -173,6 +175,7 @@ class Runtime1: public AllStatic {
   static void throw_class_cast_exception(JavaThread* current, oopDesc* object);
   static void throw_incompatible_class_change_error(JavaThread* current);
   static void throw_illegal_monitor_state_exception(JavaThread* current);
+  static void throw_identity_exception(JavaThread* current);
   static void throw_array_store_exception(JavaThread* current, oopDesc* object);
 
   static void monitorenter(JavaThread* current, oopDesc* obj, BasicObjectLock* lock);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -220,6 +220,7 @@ class SerializeClosure;
   template(java_lang_IllegalArgumentException,        "java/lang/IllegalArgumentException")       \
   template(java_lang_IllegalStateException,           "java/lang/IllegalStateException")          \
   template(java_lang_IllegalMonitorStateException,    "java/lang/IllegalMonitorStateException")   \
+  template(java_lang_IdentityException,               "java/lang/IdentityException")              \
   template(java_lang_IllegalThreadStateException,     "java/lang/IllegalThreadStateException")    \
   template(java_lang_IndexOutOfBoundsException,       "java/lang/IndexOutOfBoundsException")      \
   template(java_lang_InstantiationException,          "java/lang/InstantiationException")         \

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -957,11 +957,9 @@ JRT_LEAF(void, InterpreterRuntime::monitorexit(BasicObjectLock* elem))
   elem->set_obj(nullptr);
 JRT_END
 
-
 JRT_ENTRY(void, InterpreterRuntime::throw_illegal_monitor_state_exception(JavaThread* current))
   THROW(vmSymbols::java_lang_IllegalMonitorStateException());
 JRT_END
-
 
 JRT_ENTRY(void, InterpreterRuntime::new_illegal_monitor_state_exception(JavaThread* current))
   // Returns an illegal exception to install into the current thread. The
@@ -977,6 +975,9 @@ JRT_ENTRY(void, InterpreterRuntime::new_illegal_monitor_state_exception(JavaThre
   current->set_vm_result(exception());
 JRT_END
 
+JRT_ENTRY(void, InterpreterRuntime::throw_identity_exception(JavaThread* current))
+  THROW(vmSymbols::java_lang_IdentityException());
+JRT_END
 
 //------------------------------------------------------------------------------------------------------------------------
 // Invokes

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -119,6 +119,7 @@ class InterpreterRuntime: AllStatic {
 
   static void    throw_illegal_monitor_state_exception(JavaThread* current);
   static void    new_illegal_monitor_state_exception(JavaThread* current);
+  static void    throw_identity_exception(JavaThread* current);
 
   // Breakpoints
   static void _breakpoint(JavaThread* current, Method* method, address bcp);

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -397,6 +397,7 @@ void Threads::initialize_java_lang_classes(JavaThread* main_thread, TRAPS) {
   initialize_class(vmSymbols::java_lang_ArithmeticException(), CHECK);
   initialize_class(vmSymbols::java_lang_StackOverflowError(), CHECK);
   initialize_class(vmSymbols::java_lang_IllegalMonitorStateException(), CHECK);
+  initialize_class(vmSymbols::java_lang_IdentityException(), CHECK);
   initialize_class(vmSymbols::java_lang_IllegalArgumentException(), CHECK);
 }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1161,7 +1161,7 @@ public class TestIntrinsics {
         try {
             test59(MyValue1.class);
             throw new RuntimeException("test59 failed: synchronization on value object should not succeed");
-        } catch (IllegalMonitorStateException e) {
+        } catch (IdentityException e) {
 
         }
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -1737,7 +1737,7 @@ public class TestLWorld {
         try {
             test56(testValue1);
             throw new RuntimeException("test56 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -1760,7 +1760,7 @@ public class TestLWorld {
         try {
             test57(testValue1);
             throw new RuntimeException("test57 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -1784,7 +1784,7 @@ public class TestLWorld {
         try {
             test58();
             throw new RuntimeException("test58 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -1806,7 +1806,7 @@ public class TestLWorld {
         try {
             test59(new Object(), true);
             throw new RuntimeException("test59 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -1825,18 +1825,18 @@ public class TestLWorld {
         try {
             test60(false);
             throw new RuntimeException("test60 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
         try {
             test60(true);
             throw new RuntimeException("test60 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
 
-    // Test catching the IllegalMonitorStateException in compiled code
+    // Test catching the IdentityException in compiled code
     @Test
     public void test61(Object vt) {
         boolean thrown = false;
@@ -1844,7 +1844,7 @@ public class TestLWorld {
             synchronized (vt) {
                 throw new RuntimeException("test61 failed: no exception thrown");
             }
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             thrown = true;
         }
         if (!thrown) {
@@ -1861,7 +1861,7 @@ public class TestLWorld {
     public void test62(Object o) {
         try {
             synchronized (o) { }
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
             return;
         }
@@ -1883,7 +1883,7 @@ public class TestLWorld {
     public void test63_verifier() {
         try {
             test63(testValue1);
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
             return;
         }
@@ -3776,7 +3776,7 @@ public class TestLWorld {
         try {
             test130();
             throw new RuntimeException("test130 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -3801,7 +3801,7 @@ public class TestLWorld {
         try {
             test131();
             throw new RuntimeException("test131 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -3829,7 +3829,7 @@ public class TestLWorld {
         try {
             test132();
             throw new RuntimeException("test132 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -3851,7 +3851,7 @@ public class TestLWorld {
         try {
             test133(false);
             throw new RuntimeException("test133 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }
@@ -3874,7 +3874,7 @@ public class TestLWorld {
         try {
             test134(true);
             throw new RuntimeException("test134 failed: no exception thrown");
-        } catch (IllegalMonitorStateException ex) {
+        } catch (IdentityException ex) {
             // Expected
         }
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
@@ -112,15 +112,15 @@ public class ObjectMethods {
     }
 
     static void checkSynchronized(Object val) {
-        boolean sawImse = false;
+        boolean sawIe = false;
         try {
             synchronized (val) {
-                throw new IllegalStateException("Unreachable code, reached");
+                throw new IdentityException("Unreachable code, reached");
             }
-        } catch (IllegalMonitorStateException imse) {
-            sawImse = true;
+        } catch (IdentityException ie) {
+            sawIe = true;
         }
-        if (!sawImse) {
+        if (!sawIe) {
             throw new RuntimeException("monitorenter did not fail");
         }
         // synchronized method modifiers tested by "BadInlineTypes" CFP tests
@@ -129,7 +129,7 @@ public class ObjectMethods {
 
     // Check we haven't broken the mismatched monitor block check...
     static void checkMonitorExit(Object val) {
-        boolean sawImse = false;
+        boolean sawIe = false;
         try {
             InstructionHelper.buildMethodHandle(MethodHandles.lookup(),
                                                 "mismatchedMonitorExit",
@@ -143,12 +143,12 @@ public class ObjectMethods {
             throw new IllegalStateException("Unreachable code, reached");
         } catch (Throwable t) {
             if (t instanceof IllegalMonitorStateException) {
-                sawImse = true;
+                sawIe = true;
             } else {
                 throw new RuntimeException(t);
             }
         }
-        if (!sawImse) {
+        if (!sawIe) {
             throw new RuntimeException("monitorexit did not fail");
         }
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTMonitor.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTMonitor.java
@@ -45,7 +45,7 @@ public value final class VTMonitor {
             synchronized(a) {
                 throw new RuntimeException("Synchronization on inline type should fail");
             }
-        } catch (java.lang.IllegalMonitorStateException e) {
+        } catch (java.lang.IdentityException e) {
             // Expected
         }
     }

--- a/test/langtools/tools/javac/valhalla/value-objects/IllegalMonitorStateExceptionTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/IllegalMonitorStateExceptionTest.java
@@ -39,7 +39,7 @@ public value class IllegalMonitorStateExceptionTest {
         try {
             v.m(v);
             throw new AssertionError("should have failed with IllegalMonitorStateExceptionTest");
-        } catch (IllegalMonitorStateException e) {
+        } catch (IdentityException e) {
             // as expected
         }
     }


### PR DESCRIPTION
Change the exception thrown by monitorenter when attempted on an instance of a value class.
Monitorexit is not changed according to some discussions about the JVMS changes (it still throws IllegalMonitorStateException).

Tested with Mach5, tier1-3.

Fred

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8332387](https://bugs.openjdk.org/browse/JDK-8332387): [lworld] monitorenter on value class instances must throw IdentityException instead of IllegalMonitorStateException (**Bug** - P3)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1108/head:pull/1108` \
`$ git checkout pull/1108`

Update a local copy of the PR: \
`$ git checkout pull/1108` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1108`

View PR using the GUI difftool: \
`$ git pr show -t 1108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1108.diff">https://git.openjdk.org/valhalla/pull/1108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1108#issuecomment-2125652368)