### PR TITLE
8333037: [lworld] Part 2: Prepare compiler implementation and tests for JEP 401

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_CodeStubs_aarch64.cpp
@@ -258,7 +258,7 @@ void NewObjectArrayStub::emit_code(LIR_Assembler* ce) {
   assert(_klass_reg->as_register() == r3, "klass_reg must in r3");
 
   if (_is_null_free) {
-    __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_flat_array_id)));
+    __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_null_free_array_id)));
   } else {
     __ far_call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_object_array_id)));
   }

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -701,7 +701,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
     case new_type_array_id:
     case new_object_array_id:
-    case new_flat_array_id:
+    case new_null_free_array_id:
       {
         Register length   = r19; // Incoming
         Register klass    = r3; // Incoming
@@ -712,7 +712,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         } else if (id == new_object_array_id) {
           __ set_info("new_object_array", dont_gc_arguments);
         } else {
-          __ set_info("new_flat_array", dont_gc_arguments);
+          __ set_info("new_null_free_array", dont_gc_arguments);
         }
 
 #ifdef ASSERT
@@ -735,9 +735,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
             __ br(Assembler::EQ, ok);
             __ stop("assert(is an object or inline type array klass)");
             break;
-          case new_flat_array_id:
-            // TODO 8325106 Fix comment
-            // new "[QVT;"
+          case new_null_free_array_id:
             __ cmpw(t0, Klass::_lh_array_tag_vt_value);  // the array can be a flat array.
             __ br(Assembler::EQ, ok);
             __ cmpw(t0, Klass::_lh_array_tag_obj_value); // the array cannot be a flat array (due to InlineArrayElementMaxFlatSize, etc)
@@ -759,8 +757,8 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         } else if (id == new_object_array_id) {
           call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_object_array), klass, length);
         } else {
-          assert(id == new_flat_array_id, "must be");
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_flat_array), klass, length);
+          assert(id == new_null_free_array_id, "must be");
+          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_null_free_array), klass, length);
         }
 
         oop_maps = new OopMapSet();

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -312,7 +312,7 @@ void NewObjectArrayStub::emit_code(LIR_Assembler* ce) {
   assert(_length->as_register() == rbx, "length must in rbx,");
   assert(_klass_reg->as_register() == rdx, "klass_reg must in rdx");
   if (_is_null_free) {
-    __ call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_flat_array_id)));
+    __ call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_null_free_array_id)));
   } else {
     __ call(RuntimeAddress(Runtime1::entry_for(Runtime1::new_object_array_id)));
   }

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1070,7 +1070,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
     case new_type_array_id:
     case new_object_array_id:
-    case new_flat_array_id:
+    case new_null_free_array_id:
       {
         Register length   = rbx; // Incoming
         Register klass    = rdx; // Incoming
@@ -1081,7 +1081,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         } else if (id == new_object_array_id) {
           __ set_info("new_object_array", dont_gc_arguments);
         } else {
-          __ set_info("new_flat_array", dont_gc_arguments);
+          __ set_info("new_null_free_array", dont_gc_arguments);
         }
 
 #ifdef ASSERT
@@ -1104,9 +1104,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
             __ jcc(Assembler::equal, ok);
             __ stop("assert(is an object or inline type array klass)");
             break;
-          case new_flat_array_id:
-            // TODO 8325106 Fix comment
-            // new "[QVT;"
+          case new_null_free_array_id:
             __ cmpl(t0, Klass::_lh_array_tag_vt_value);  // the array can be a flat array.
             __ jcc(Assembler::equal, ok);
             __ cmpl(t0, Klass::_lh_array_tag_obj_value); // the array cannot be a flat array (due to InlineArrayElementMaxFlatSize, etc)
@@ -1128,8 +1126,8 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         } else if (id == new_object_array_id) {
           call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_object_array), klass, length);
         } else {
-          assert(id == new_flat_array_id, "must be");
-          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_flat_array), klass, length);
+          assert(id == new_null_free_array_id, "must be");
+          call_offset = __ call_RT(obj, noreg, CAST_FROM_FN_PTR(address, new_null_free_array), klass, length);
         }
 
         oop_maps = new OopMapSet();

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2020,7 +2020,7 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               pending_field_access()->inc_offset(offset - field->holder()->as_inline_klass()->first_field_offset());
             } else {
               null_check(obj);
-              DelayedFieldAccess* dfa = new DelayedFieldAccess(obj, field->holder(), field->offset_in_bytes());
+              DelayedFieldAccess* dfa = new DelayedFieldAccess(obj, field->holder(), field->offset_in_bytes(), state_before);
               set_pending_field_access(dfa);
             }
           } else {
@@ -2046,6 +2046,9 @@ void GraphBuilder::access_field(Bytecodes::Code code) {
               set_pending_load_indexed(nullptr);
               need_membar = true;
             } else {
+              if (has_pending_field_access()) {
+                state_before = pending_field_access()->state_before();
+              }
               NewInstance* new_instance = new NewInstance(inline_klass, state_before, false, true);
               _memory->new_instance(new_instance);
               apush(append_split(new_instance));

--- a/src/hotspot/share/c1/c1_GraphBuilder.hpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.hpp
@@ -40,14 +40,17 @@ private:
   Value            _obj;
   ciInstanceKlass* _holder;
   int              _offset;
-public:
-  DelayedFieldAccess(Value obj, ciInstanceKlass* holder, int offset)
-  : _obj(obj), _holder(holder) , _offset(offset) { }
+  ValueStack*      _state_before;
 
-  Value obj() const               { return _obj; }
+public:
+  DelayedFieldAccess(Value obj, ciInstanceKlass* holder, int offset, ValueStack* state_before)
+  : _obj(obj), _holder(holder) , _offset(offset), _state_before(state_before) { }
+
+  Value obj() const { return _obj; }
   ciInstanceKlass* holder() const { return _holder; }
-  int offset() const              { return _offset; }
-  void inc_offset(int offset)     { _offset += offset; }
+  int offset() const { return _offset; }
+  void inc_offset(int offset) { _offset += offset; }
+  ValueStack* state_before() const { return _state_before; }
 };
 
 class GraphBuilder {

--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -139,8 +139,7 @@ bool Instruction::maybe_flat_array() {
     ciType* type = declared_type();
     if (type != nullptr) {
       if (type->is_obj_array_klass()) {
-        // TODO 8325106 Fix comment
-        // The runtime type of [LMyValue might be [QMyValue due to [QMyValue <: [LMyValue.
+        // Due to array covariance, the runtime type might be a flat array.
         ciKlass* element_klass = type->as_obj_array_klass()->element_klass();
         if (element_klass->can_be_inline_klass() && (!element_klass->is_inlinetype() || element_klass->as_inline_klass()->flat_in_array())) {
           return true;

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -124,7 +124,7 @@ uint Runtime1::_arraycopy_checkcast_cnt = 0;
 uint Runtime1::_arraycopy_checkcast_attempt_cnt = 0;
 uint Runtime1::_new_type_array_slowcase_cnt = 0;
 uint Runtime1::_new_object_array_slowcase_cnt = 0;
-uint Runtime1::_new_flat_array_slowcase_cnt = 0;
+uint Runtime1::_new_null_free_array_slowcase_cnt = 0;
 uint Runtime1::_new_instance_slowcase_cnt = 0;
 uint Runtime1::_new_multi_array_slowcase_cnt = 0;
 uint Runtime1::_load_flat_array_slowcase_cnt = 0;
@@ -429,8 +429,8 @@ JRT_ENTRY(void, Runtime1::new_object_array(JavaThread* current, Klass* array_kla
 JRT_END
 
 
-JRT_ENTRY(void, Runtime1::new_flat_array(JavaThread* current, Klass* array_klass, jint length))
-  NOT_PRODUCT(_new_flat_array_slowcase_cnt++;)
+JRT_ENTRY(void, Runtime1::new_null_free_array(JavaThread* current, Klass* array_klass, jint length))
+  NOT_PRODUCT(_new_null_free_array_slowcase_cnt++;)
 
   // Note: no handle for klass needed since they are not used
   //       anymore after new_objArray() and no GC can happen before.
@@ -1696,7 +1696,7 @@ void Runtime1::print_statistics() {
 
   tty->print_cr(" _new_type_array_slowcase_cnt:    %u", _new_type_array_slowcase_cnt);
   tty->print_cr(" _new_object_array_slowcase_cnt:  %u", _new_object_array_slowcase_cnt);
-  tty->print_cr(" _new_flat_array_slowcase_cnt:    %u", _new_flat_array_slowcase_cnt);
+  tty->print_cr(" _new_null_free_array_slowcase_cnt: %u", _new_null_free_array_slowcase_cnt);
   tty->print_cr(" _new_instance_slowcase_cnt:      %u", _new_instance_slowcase_cnt);
   tty->print_cr(" _new_multi_array_slowcase_cnt:   %u", _new_multi_array_slowcase_cnt);
   tty->print_cr(" _load_flat_array_slowcase_cnt:   %u", _load_flat_array_slowcase_cnt);

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -51,7 +51,7 @@ class StubAssembler;
   stub(fast_new_instance_init_check) \
   stub(new_type_array)               \
   stub(new_object_array)             \
-  stub(new_flat_array)               \
+  stub(new_null_free_array)          \
   stub(new_multi_array)              \
   stub(load_flat_array)              \
   stub(store_flat_array)             \
@@ -108,7 +108,7 @@ class Runtime1: public AllStatic {
   static uint _arraycopy_checkcast_attempt_cnt;
   static uint _new_type_array_slowcase_cnt;
   static uint _new_object_array_slowcase_cnt;
-  static uint _new_flat_array_slowcase_cnt;
+  static uint _new_null_free_array_slowcase_cnt;
   static uint _new_instance_slowcase_cnt;
   static uint _new_multi_array_slowcase_cnt;
   static uint _load_flat_array_slowcase_cnt;
@@ -154,7 +154,7 @@ class Runtime1: public AllStatic {
   static void new_instance_no_inline(JavaThread* current, Klass* klass);
   static void new_type_array  (JavaThread* current, Klass* klass, jint length);
   static void new_object_array(JavaThread* current, Klass* klass, jint length);
-  static void new_flat_array (JavaThread* current, Klass* klass, jint length);
+  static void new_null_free_array(JavaThread* current, Klass* klass, jint length);
   static void new_multi_array (JavaThread* current, Klass* klass, int rank, jint* dims);
   static void load_flat_array(JavaThread* current, flatArrayOopDesc* array, int index);
   static void store_flat_array(JavaThread* current, flatArrayOopDesc* array, int index, oopDesc* value);

--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -53,7 +53,7 @@ ciType* ciInstance::java_mirror_type(bool* is_null_free_array) {
   } else {
     Klass* k = java_lang_Class::as_Klass(m);
     assert(k != nullptr, "");
-    if (is_null_free_array != nullptr && (k->is_flatArray_klass() || (k->is_objArray_klass() && ObjArrayKlass::cast(k)->is_null_free_array_klass()))) {
+    if (is_null_free_array != nullptr && (k->is_flatArray_klass() || (k->is_objArray_klass() && k->is_null_free_array_klass()))) {
       *is_null_free_array = true;
     }
     return CURRENT_THREAD_ENV->get_klass(k);

--- a/src/hotspot/share/ci/ciObjArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.cpp
@@ -191,3 +191,7 @@ ciKlass* ciObjArrayKlass::exact_klass() {
   }
   return nullptr;
 }
+
+bool ciObjArrayKlass::is_elem_null_free() const {
+  GUARDED_VM_ENTRY(return get_Klass()->is_null_free_array_klass();)
+}

--- a/src/hotspot/share/ci/ciObjArrayKlass.hpp
+++ b/src/hotspot/share/ci/ciObjArrayKlass.hpp
@@ -80,6 +80,8 @@ public:
   virtual bool can_be_inline_array_klass() {
     return element_klass()->can_be_inline_klass();
   }
+
+  virtual bool is_elem_null_free() const;
 };
 
 #endif // SHARE_CI_CIOBJARRAYKLASS_HPP

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2267,49 +2267,6 @@ void PhaseMacroExpand::mark_eliminated_locking_nodes(AbstractLockNode *alock) {
   }
 }
 
-void PhaseMacroExpand::inline_type_guard(Node** ctrl, LockNode* lock) {
-  Node* obj = lock->obj_node();
-  const TypePtr* obj_type = _igvn.type(obj)->make_ptr();
-  if (!obj_type->can_be_inline_type()) {
-    return;
-  }
-  Node* mark = make_load(*ctrl, lock->memory(), obj, oopDesc::mark_offset_in_bytes(), TypeX_X, TypeX_X->basic_type());
-  Node* value_mask = _igvn.MakeConX(markWord::inline_type_pattern);
-  Node* is_value = _igvn.transform(new AndXNode(mark, value_mask));
-  Node* cmp = _igvn.transform(new CmpXNode(is_value, value_mask));
-  Node* bol = _igvn.transform(new BoolNode(cmp, BoolTest::eq));
-  Node* unc_ctrl = generate_slow_guard(ctrl, bol, nullptr);
-
-  int trap_request = Deoptimization::make_trap_request(Deoptimization::Reason_class_check, Deoptimization::Action_none);
-  address call_addr = SharedRuntime::uncommon_trap_blob()->entry_point();
-  const TypePtr* no_memory_effects = nullptr;
-  CallNode* unc = new CallStaticJavaNode(OptoRuntime::uncommon_trap_Type(), call_addr, "uncommon_trap",
-                                         no_memory_effects);
-  unc->init_req(TypeFunc::Control, unc_ctrl);
-  unc->init_req(TypeFunc::I_O, lock->i_o());
-  unc->init_req(TypeFunc::Memory, lock->memory());
-  unc->init_req(TypeFunc::FramePtr,  lock->in(TypeFunc::FramePtr));
-  unc->init_req(TypeFunc::ReturnAdr, lock->in(TypeFunc::ReturnAdr));
-  unc->init_req(TypeFunc::Parms+0, _igvn.intcon(trap_request));
-  unc->set_cnt(PROB_UNLIKELY_MAG(4));
-  unc->copy_call_debug_info(&_igvn, lock);
-
-  assert(unc->peek_monitor_box() == lock->box_node(), "wrong monitor");
-  assert((obj_type->is_inlinetypeptr() && unc->peek_monitor_obj()->is_SafePointScalarObject()) ||
-         (obj->is_InlineType() && obj->in(1) == unc->peek_monitor_obj()) ||
-         (obj == unc->peek_monitor_obj()), "wrong monitor");
-
-  // pop monitor and push obj back on stack: we trap before the monitorenter
-  unc->pop_monitor();
-  unc->grow_stack(unc->jvms(), 1);
-  unc->set_stack(unc->jvms(), unc->jvms()->stk_size()-1, obj);
-  _igvn.register_new_node_with_optimizer(unc);
-
-  unc_ctrl = _igvn.transform(new ProjNode(unc, TypeFunc::Control));
-  Node* halt = _igvn.transform(new HaltNode(unc_ctrl, lock->in(TypeFunc::FramePtr), "monitor enter on inline type"));
-  _igvn.add_input_to(C->root(), halt);
-}
-
 // we have determined that this lock/unlock can be eliminated, we simply
 // eliminate the node without expanding it.
 //
@@ -2356,9 +2313,6 @@ bool PhaseMacroExpand::eliminate_locking_node(AbstractLockNode *alock) {
   // The input to a Lock is merged memory, so extract its RawMem input
   // (unless the MergeMem has been optimized away.)
   if (alock->is_Lock()) {
-    // Deoptimize and re-execute if object is an inline type
-    inline_type_guard(&ctrl, alock->as_Lock());
-
     // Search for MemBarAcquireLock node and delete it also.
     MemBarNode* membar = fallthroughproj->unique_ctrl_out()->as_MemBar();
     assert(membar != nullptr && membar->Opcode() == Op_MemBarAcquireLock, "");
@@ -2418,9 +2372,6 @@ void PhaseMacroExpand::expand_lock_node(LockNode *lock) {
   // Optimize test; set region slot 2
   slow_path = opt_bits_test(ctrl, region, 2, flock, 0, 0);
   mem_phi->init_req(2, mem);
-
-  // Deoptimize and re-execute if object is an inline type
-  inline_type_guard(&slow_path, lock);
 
   // Make slow path call
   CallNode *call = make_slow_call((CallNode *) lock, OptoRuntime::complete_monitor_enter_Type(),

--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -109,7 +109,6 @@ private:
   void mark_eliminated_locking_nodes(AbstractLockNode *alock);
   bool eliminate_locking_node(AbstractLockNode *alock);
   void expand_lock_node(LockNode *lock);
-  void inline_type_guard(Node** ctrl, LockNode* lock);
   void expand_unlock_node(UnlockNode *unlock);
   void expand_mh_intrinsic_return(CallStaticJavaNode* call);
 

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6512,7 +6512,6 @@ const TypeAryKlassPtr* TypeAryKlassPtr::make(PTR ptr, ciKlass* k, Offset offset,
 }
 
 const TypeAryKlassPtr* TypeAryKlassPtr::make(PTR ptr, ciKlass* k, Offset offset, InterfaceHandling interface_handling) {
-  // TODO 8325106 remove?
   bool null_free = k->as_array_klass()->is_elem_null_free();
   bool not_null_free = (ptr == Constant) ? !null_free : !k->is_flat_array_klass() && (k->is_type_array_klass() || !k->as_array_klass()->element_klass()->can_be_inline_klass(false));
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
@@ -25,8 +25,8 @@ package compiler.valhalla.inlinetypes;
 
 public class InlineTypeRegexes {
     // Regular expressions used to match nodes in the PrintIdeal output
-    private static final String START = "(\\d+ (.*";
-    private static final String MID = ".*)+ ===.*";
+    private static final String START = "(\\d+(\\s){2}(";
+    private static final String MID = ".*)+(\\s){2}===.*";
     private static final String END = ")";
     // Generic allocation
     public static final String ALLOC_G = "(.*call,static.*wrapper for: _new_instance_Java" + END;
@@ -62,7 +62,7 @@ public class InlineTypeRegexes {
     public static final String UNHANDLED_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unhandled" + END;
     public static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
     public static final String MEMBAR = START + "MemBar" + MID + END;
-    public static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*:.*\\R.*(cmp|CMP|CLR))" + END;
+    public static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*:.*\\R(.*(decode|mov|nop).*\\R)*.*(cmp|CMP|CLR))" + END;
     public static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
     public static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
     public static final String FIELD_ACCESS = "(.*Field: *" + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayAccessDeopt.java
@@ -21,9 +21,6 @@
  * questions.
  */
 
-// TODO 8325106 Investigate why this suddenly started to throw java.lang.OutOfMemoryError without -Xmx200m
-// and -XX:-UseCompressedOops -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=0 -Xmx20m -Xmn1m -XX:G1HeapRegionSize=1m -XX:-ReduceInitialCardMarks
-
 /**
  * @test
  * @summary Verify that certain array accesses do not trigger deoptimization.
@@ -31,10 +28,12 @@
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm -Xmx200m TestArrayAccessDeopt
+ * @run main TestArrayAccessDeopt
  */
 
 import java.io.File;
+import java.util.Objects;
+
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -73,7 +72,7 @@ public class TestArrayAccessDeopt {
     }
 
     public static void test6(MyValue1[] va, Object vt) {
-        va[0] = (MyValue1)vt;
+        va[0] = (MyValue1)Objects.requireNonNull(vt);
     }
 
     public static void test7(MyValue1[] va, MyValue1 vt) {
@@ -85,7 +84,7 @@ public class TestArrayAccessDeopt {
     }
 
     public static void test9(MyValue1[] va, MyValue1 vt) {
-        va[0] = (MyValue1)vt;
+        va[0] = Objects.requireNonNull(vt);
     }
 
     public static void test10(Object[] va) {
@@ -104,7 +103,7 @@ public class TestArrayAccessDeopt {
                             "-XX:+TraceDeoptimization", "-Xbatch", "-XX:-MonomorphicArrayCheck", "-Xmixed", "-XX:+ProfileInterpreter", "TestArrayAccessDeopt", "run"};
             OutputAnalyzer oa = ProcessTools.executeTestJava(arg);
             String output = oa.getOutput();
-            oa.shouldNotContain("Uncommon trap occurred");
+            oa.shouldNotContain("UNCOMMON TRAP");
         } else {
             MyValue1[] va = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 1);
             MyValue1[] vaB = new MyValue1[1];

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-// TODO 8325106 Fix and enable _arraycopy intrinsic for this test (fails with -XX:-TieredCompilation). We need more test coverage because other tests don't seem to trigger the failure.
-
 /**
  * @test
  * @bug 8252506
@@ -31,18 +29,15 @@
  * @enablePreview
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_arraycopy
- *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
+ * @run main/othervm -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::create*
  *                   -Xbatch
  *                   compiler.valhalla.inlinetypes.TestArrayCopyWithOops
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_arraycopy
- *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
+ * @run main/othervm -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::test*
  *                   -XX:CompileCommand=dontinline,compiler.valhalla.inlinetypes.TestArrayCopyWithOops::create*
  *                   -Xbatch -XX:FlatArrayElementMaxSize=0
  *                   compiler.valhalla.inlinetypes.TestArrayCopyWithOops
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_arraycopy
- *                   compiler.valhalla.inlinetypes.TestArrayCopyWithOops
+ * @run main/othervm compiler.valhalla.inlinetypes.TestArrayCopyWithOops
  */
 
 package compiler.valhalla.inlinetypes;
@@ -138,11 +133,8 @@ public class TestArrayCopyWithOops {
 
     // Arrays.copyOf tests
 
-    // TODO 8325106 test9/test11 and test10/test12 are equivalent
-    // Using ManyOops[].class in both test9/11 and running with -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation -XX:-DoEscapeAnalysis -XX:+AlwaysIncrementalInline triggers an exception
     static Object[] test9() {
-        ManyOops[] src = createValueClassArray();
-        return Arrays.copyOf(src, LEN, src.getClass());
+        return Arrays.copyOf(createValueClassArray(), LEN, ManyOops[].class);
     }
 
     static Object[] test10() {
@@ -155,7 +147,8 @@ public class TestArrayCopyWithOops {
     }
 
     static Object[] test12() {
-        return Arrays.copyOf(createObjectArray(), LEN, Object[].class);
+        Object[] src = createObjectArray();
+        return Arrays.copyOf(createObjectArray(), LEN, src.getClass());
     }
 
     // System.arraycopy test using generic_copy stub

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -177,7 +177,6 @@ public class TestBasicFunctionality {
     // Create a value object in compiled code and pass it to
     // the interpreter by returning.
     @Test
-    // TODO 8325106 We are hitting 8314999 here and sometimes fail to detect two allocations although there are two.
     @IR(counts = {ALLOC, "<= 2"},
         failOn = {LOAD, TRAP})
     public MyValue1 test7(int x, long y) {
@@ -209,16 +208,16 @@ public class TestBasicFunctionality {
         Asserts.assertEQ(test8(false), hash(rI + 1, rL + 1));
     }
 
+static MyValue1 tmp = null;
     // Merge value objects created from two branches
     @Test
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
         counts = {ALLOC, "= 1", LOAD, "= 19",
                   STORE, "= 3"}, // InitializeNode::coalesce_subword_stores merges stores
         failOn = {TRAP})
-    // TODO 8325106
-    // @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
-    //     counts = {ALLOC, "= 2", STORE, "= 19"},
-    //     failOn = {LOAD, TRAP})
+    @IR(applyIf = {"InlineTypePassFieldsAsArgs", "false"},
+        counts = {ALLOC, "= 2", STORE, "= 19"},
+        failOn = {LOAD, TRAP})
     public MyValue1 test9(boolean b, int localrI, long localrL) {
         MyValue1 v;
         if (b) {
@@ -227,6 +226,7 @@ public class TestBasicFunctionality {
             // some redundant null initializations to be optimized out
             // and matching to fail.
             v = MyValue1.createWithFieldsInline(localrI, localrL);
+            v.hashInterpreted();
         } else {
             // Value object is allocated by the callee
             v = MyValue1.createWithFieldsDontInline(rI + 1, rL + 1);
@@ -512,9 +512,9 @@ public class TestBasicFunctionality {
 
     // Test value class fields in objects
     @Test
-    // TODO 8325106 We already buffer the larval and we had to disable InlineTypeNode::remove_redundant_allocations for larvals
-//    @IR(counts = {ALLOC, "= 2"},
-//        failOn = TRAP)
+    // TODO 8332886 Re-enable this
+    // @IR(counts = {ALLOC, "= 2"},
+    //     failOn = TRAP)
     public long test21(int x, long y) {
         // Compute hash of value class fields
         long result = val1.hash() + val2.hash() + val3.hash() + val4.hash() + val5.hash();
@@ -644,7 +644,7 @@ public class TestBasicFunctionality {
 
     // Check elimination of redundant value class allocations
     @Test
-    // TODO 8325106 With incremental inlining, we already buffer the larval and we had to disable InlineTypeNode::remove_redundant_allocations for larvals
+    // TODO 8332886 Remove the AlwaysIncrementalInline=false condition
     @IR(applyIf = {"AlwaysIncrementalInline", "false"},
         counts = {ALLOC, "= 1"})
     public MyValue3 test28(MyValue3[] va) {
@@ -889,8 +889,6 @@ public class TestBasicFunctionality {
         int y = 0;
     }
 
-// TODO 8325106: Re-enable once JDK-8327695 is fixed
-/*
     @ImplicitlyConstructible
     @LooselyConsistentValue
     value class Test37Value1 {
@@ -910,7 +908,6 @@ public class TestBasicFunctionality {
         Test37Value1 vt = new Test37Value1();
         Asserts.assertEQ(test37(vt), vt);
     }
-*/
 
     // Test elimination of value class allocations without a unique CheckCastPP
     @ImplicitlyConstructible

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestCallingConvention.java
@@ -1110,8 +1110,7 @@ public class TestCallingConvention {
 
     // Empty value class container and mixed container arguments
     @Test
-// TODO 8325106
-//    @IR(failOn = {ALLOC, STORE, TRAP})
+    @IR(failOn = {ALLOC, STORE, TRAP})
     public MyValueEmpty test46(EmptyContainer c1, MixedContainer c2, MyValueEmpty empty) {
         c2 = new MixedContainer(c2.val, c1);
         return c2.getNoInline().getNoInline();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -75,7 +75,8 @@ public class TestFlatInArraysFolding {
         Scenario noFlagsScenario = new Scenario(3);
         TestFramework testFramework = new TestFramework();
         testFramework.setDefaultWarmup(0)
-                .addFlags("--enable-preview",
+                // TODO 8331912 Remove -XX:-ExpandSubTypeCheckAtParseTime
+                .addFlags("--enable-preview", "-XX:-ExpandSubTypeCheckAtParseTime",
                           "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                           "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED")
                 .addScenarios(flatArrayElementMaxSize1Scenario,

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestGenerated.java
@@ -353,7 +353,7 @@ public class TestGenerated {
             t.test13(array5);
             t.test14(false, new MyValue4());
             t.test15();
-            // TODO 8325106 Triggers "nothing between inner and outer loop" assert
+            // TODO 8332814 This triggers the "nothing between inner and outer loop" assert
             // t.test16();
             t.test17();
             t.test18();

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -1371,8 +1371,6 @@ public class TestLWorld {
     }
 
     // Test for bug in Escape Analysis
-    // TODO 8325106 Re-enable
-    /*
     @DontInline
     public void test41_dontinline(Object o) {
         Asserts.assertEQ(o, rI);
@@ -1391,7 +1389,6 @@ public class TestLWorld {
     public void test41_verifier() {
         test41();
     }
-    */
 
     // Test for bug in Escape Analysis
     private static final MyValue1 test42VT1 = MyValue1.createWithFieldsInline(rI, rL);
@@ -3756,14 +3753,11 @@ public class TestLWorld {
     }
 
     @Test
-    // TODO 8325106
-    /*
     @IR(failOn = {LOAD},
         // LockNode keeps MyValue1 allocation alive up until macro expansion which in turn keeps MyValue2
         // alloc alive. Although the MyValue1 allocation is removed (unused), MyValue2 is expanded first
         // and therefore stays.
         counts = {ALLOC, "<= 1", STORE, "<= 1"})
-    */
     public void test130() {
         Object obj = test130_inlinee();
         synchronized (obj) {
@@ -4045,9 +4039,7 @@ public class TestLWorld {
 
     // Test merging of buffered default and non-default inline types
     @Test
-    // TODO 8325106 With incremental inlining, we already buffer the larval which can't use the default oop because it might be overridden.
-    @IR(applyIf = {"AlwaysIncrementalInline", "false"},
-        failOn = {ALLOC_G})
+    @IR(failOn = {ALLOC_G})
     public Object test144(int i) {
         if (i == 0) {
             return MyValue1.createDefaultInline();
@@ -4128,11 +4120,8 @@ public class TestLWorld {
 
     // Test post-parse call devirtualization with inline type receiver
     @Test
-    // TODO 8325106
-    /*
     @IR(applyIf = {"InlineTypePassFieldsAsArgs", "true"},
         failOn = {ALLOC})
-    */
     @IR(failOn = {compiler.lib.ir_framework.IRNode.DYNAMIC_CALL_OF_METHOD, "MyValue2::hash"},
         counts = {compiler.lib.ir_framework.IRNode.STATIC_CALL_OF_METHOD, "MyValue2::hash", "= 1"})
     public long test150() {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorldProfiling.java
@@ -134,11 +134,11 @@ public class TestLWorldProfiling {
         static final long TypeProfileLevel = (Long) WhiteBox.getWhiteBox().getVMFlag("TypeProfileLevel");
     }
 
-    static abstract class NonValueAbstract {
+    static abstract value class ValueAbstract {
 
     }
 
-    static class NonValueClass1 extends NonValueAbstract {
+    static class NonValueClass1 extends ValueAbstract {
         int x;
 
         public NonValueClass1(int x) {
@@ -146,7 +146,7 @@ public class TestLWorldProfiling {
         }
     }
 
-    static class NonValueClass2 extends NonValueAbstract {
+    static class NonValueClass2 extends ValueAbstract {
         int x;
 
         public NonValueClass2(int x) {
@@ -261,20 +261,19 @@ public class TestLWorldProfiling {
     }
 
     @ForceInline
-    public void test6_helper(NonValueAbstract[] arg) {
+    public void test6_helper(ValueAbstract[] arg) {
         if (arg instanceof NonValueClass1[]) {
             test6_no_inline();
         }
     }
 
     @Test
-    // TODO 8325106 double-check rule modifications done by 8325660
     @IR(applyIfOr = {"UseArrayLoadStoreProfile", "true", "TypeProfileLevel", "= 222"},
         counts = {CALL, "= 4", CLASS_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1", RANGE_CHECK_TRAP, "= 1"})
     @IR(applyIfAnd = {"UseArrayLoadStoreProfile", "false", "TypeProfileLevel", "!= 222"},
-        counts = {CALL, "= 3", RANGE_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1"})
-    public Object test6(NonValueAbstract[] array) {
-        NonValueAbstract v = array[0];
+        counts = {CALL, "= 4", RANGE_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1"})
+    public Object test6(ValueAbstract[] array) {
+        ValueAbstract v = array[0];
         test6_helper(array);
         return v;
     }
@@ -295,20 +294,19 @@ public class TestLWorldProfiling {
     }
 
     @ForceInline
-    public void test7_helper(Object arg) {
+    public void test7_helper(ValueAbstract arg) {
         if (arg instanceof NonValueClass1) {
             test7_no_inline();
         }
     }
 
     @Test
-    // TODO 8325106 double-check rule modifications done by 8325660
     @IR(applyIfOr = {"UseArrayLoadStoreProfile", "true", "TypeProfileLevel", "= 222"},
-        counts = {CALL, "= 3", CLASS_CHECK_TRAP, "= 0", NULL_CHECK_TRAP, "= 1", RANGE_CHECK_TRAP, "= 1"})
+        counts = {CALL, "= 4", CLASS_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1", RANGE_CHECK_TRAP, "= 1"})
     @IR(applyIfAnd = {"UseArrayLoadStoreProfile", "false", "TypeProfileLevel", "!= 222"},
-        counts = {CALL, "= 3", RANGE_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1"})
-    public Object test7(NonValueAbstract[] array) {
-        NonValueAbstract v = array[0];
+        counts = {CALL, "= 4", RANGE_CHECK_TRAP, "= 1", NULL_CHECK_TRAP, "= 1"})
+    public Object test7(ValueAbstract[] array) {
+        ValueAbstract v = array[0];
         test7_helper(v);
         return v;
     }
@@ -478,9 +476,7 @@ public class TestLWorldProfiling {
     private static final NotFlattenable[] testNotFlattenableArray = (NotFlattenable[])ValueClass.newNullRestrictedArray(NotFlattenable.class, 1);
 
     @Test
-// TODO 8325106
-//    @IR(applyIfOr = {"UseArrayLoadStoreProfile", "true", "TypeProfileLevel", "= 222"},
-    @IR(applyIf = {"UseArrayLoadStoreProfile", "true"},
+    @IR(applyIfOr = {"UseArrayLoadStoreProfile", "true", "TypeProfileLevel", "= 222"},
         counts = {NULL_CHECK_TRAP, "= 2"},
         failOn = {STORE_UNKNOWN_INLINE})
     @IR(applyIfAnd = {"UseArrayLoadStoreProfile", "false", "TypeProfileLevel", "!= 222"},

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -2236,8 +2236,9 @@ public class TestNullableInlineTypes {
         Asserts.assertEquals(test80(), test80Result);
     }
 
-// TODO 8325106 Fails because they are not compilable with Scenario 3, probably we run out of nodes ...
+// TODO 8325632 Fails with -XX:+UnlockExperimentalVMOptions -XX:PerMethodSpecTrapLimit=0 -XX:PerMethodTrapLimit=0
 /*
+
     @ForceInline
     public Object test81_helper(Object obj, int i) {
         if ((i % 2) == 0) {
@@ -2377,12 +2378,9 @@ public class TestNullableInlineTypes {
         return obj;
     }
 
-// TODO 8325106 Fails because they are not compilable with Scenario 3, probably we run out of nodes ...
-/*
     // Same as test81 but with wrapper
     @Test
-    // TODO 8325106 Fails with Scenario 5
-    // @IR(failOn = {ALLOC, LOAD, STORE})
+    @IR(failOn = {ALLOC, LOAD, STORE})
     public long test85() {
         Object val = new MyValue1Wrapper(null);
         for (int i = 0; i < 10; ++i) {
@@ -2408,7 +2406,6 @@ public class TestNullableInlineTypes {
         }
         Asserts.assertEquals(test85(), test85Result);
     }
-*/
 
     static final class ObjectWrapper {
         public Object obj;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedInlineTypeField.java
@@ -555,14 +555,7 @@ public class TestUnloadedInlineTypeField {
         } else {
             // Make sure klass is resolved
             for (int i = 0; i < 10; ++i) {
-                MyValue13Holder holder = new MyValue13Holder();
-                try {
-                    test13(holder);
-// TODO 8325106
-//                    Asserts.fail("Should have thrown InstantiationError");
-                } catch (InstantiationError e) {
-                    // OK
-                }
+                test13(new MyValue13Holder());
             }
         }
     }
@@ -601,14 +594,7 @@ public class TestUnloadedInlineTypeField {
         } else {
             // Make sure klass is resolved
             for (int i = 0; i < 10; ++i) {
-                MyValue15Holder holder = new MyValue15Holder();
-                try {
-                    test15(holder);
-// TODO 8325106
-//                    Asserts.fail("Should have thrown InstantiationError");
-                } catch (InstantiationError e) {
-                    // OK
-                }
+                test15(new MyValue15Holder());
             }
         }
     }
@@ -639,13 +625,7 @@ public class TestUnloadedInlineTypeField {
         } else {
             // Make sure klass is resolved
             for (int i = 0; i < 10; ++i) {
-                try {
-                    test16(false);
-// TODO 8325106
-//                    Asserts.fail("Should have thrown IncompatibleClassChangeError");
-                } catch (IncompatibleClassChangeError e) {
-                    // OK
-                }
+                test16(false);
             }
         }
     }
@@ -672,13 +652,7 @@ public class TestUnloadedInlineTypeField {
         } else {
             // Make sure klass is resolved
             for (int i = 0; i < 10; ++i) {
-                try {
-                    test17(false);
-// TODO 8325106
-//                    Asserts.fail("Should have thrown IncompatibleClassChangeError");
-                } catch (IncompatibleClassChangeError e) {
-                    // OK
-                }
+                test17(false);
             }
         }
     }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -816,5 +816,5 @@ java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-com/sun/jdi/EATests.java 8331766 generic-all
+com/sun/jdi/EATests.java#id0 8331766 generic-all
 


### PR DESCRIPTION
Fixing a few more test and implementation issues that came with or were triggered by the JEP 401 related changes. The remaining issues / ToDo's will be fixed by [JDK-8325106](https://bugs.openjdk.org/browse/JDK-8325106).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333037](https://bugs.openjdk.org/browse/JDK-8333037): [lworld] Part 2: Prepare compiler implementation and tests for JEP 401 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1110/head:pull/1110` \
`$ git checkout pull/1110`

Update a local copy of the PR: \
`$ git checkout pull/1110` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1110`

View PR using the GUI difftool: \
`$ git pr show -t 1110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1110.diff">https://git.openjdk.org/valhalla/pull/1110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1110#issuecomment-2134796146)