### PR TITLE
8333087: [lworld] Undo problem listing and remove assert added due to JDK-8331766

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -527,7 +527,6 @@ void ObjectSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread* lock
   // the locking_thread with respect to the current thread. Currently only used when
   // deoptimizing and re-locking locks. See Deoptimization::relock_objects
   assert(locking_thread == Thread::current() || locking_thread->is_obj_deopt_suspend(), "must be");
-  assert(locking_thread == Thread::current() || !EnableValhalla, "not supported, fix needed: JDK-8331766");
   JavaThread* current = locking_thread;
   CHECK_THROW_NOSYNC_IMSE(obj);
   if (!enter_fast_impl(obj, lock, locking_thread)) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -180,8 +180,6 @@ serviceability/sa/TestPrintMdo.java 8190936 generic-all
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java 8190936 generic-all
 serviceability/sa/ClhsdbDumpclass.java 8190936 generic-all
 
-serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoWithEATest.java 8331766 generic-all
-serviceability/jvmti/GetOwnedMonitorStackDepthInfo/GetOwnedMonitorStackDepthInfoWithEATest.java 8331766 generic-all
 
 #############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -816,5 +816,3 @@ java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-com/sun/jdi/EATests.java#id0 8331766 generic-all
-


### PR DESCRIPTION
The issue described by [JDK-8331766](https://bugs.openjdk.org/browse/JDK-8331766) does not reproduce anymore. Undo the problem listing and remove the corresponding assert.

Thanks,
Tobias