### PR TITLE
8333376: [lworld] runtime/cds/appcds/RewriteBytecodesInlineTest.java fails because of missing preview mode

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/RewriteBytecodesInlineTest.java
@@ -34,7 +34,7 @@
  * @compile test-classes/RewriteBytecodesInline.java test-classes/Util.java test-classes/Point.java test-classes/WithInlinedField.java RewriteBytecodesInlineTest.java
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run driver RewriteBytecodesInlineTest
+ * @run main/othervm RewriteBytecodesInlineTest
  */
 
 import java.io.File;


### PR DESCRIPTION
Change test invocation method to enable preview mode in the VM analyzing the output of the test.

Tested with Mach5 on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333376](https://bugs.openjdk.org/browse/JDK-8333376): [lworld] runtime/cds/appcds/RewriteBytecodesInlineTest.java fails because of missing preview mode (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1112/head:pull/1112` \
`$ git checkout pull/1112`

Update a local copy of the PR: \
`$ git checkout pull/1112` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1112`

View PR using the GUI difftool: \
`$ git pr show -t 1112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1112.diff">https://git.openjdk.org/valhalla/pull/1112.diff</a>

</details>
