### PR TITLE
8333563: [lworld] do not strip the @MigratedValueClass annotation when generating ct.sym

### DIFF
--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -1252,6 +1252,12 @@ public class CreateSymbols {
             annotationType = VALUE_BASED_ANNOTATION_INTERNAL;
         }
 
+        if (MIGRATED_VALUE_CLASS_ANNOTATION.equals(annotationType)) {
+            //the non-public MigratedValueClass annotation will not be available in ct.sym,
+            //replace with purely synthetic javac-internal annotation:
+            annotationType = MIGRATED_VALUE_CLASS_ANNOTATION_INTERNAL;
+        }
+
         return new Annotation(null,
                               addString(constantPool, annotationType),
                               createElementPairs(constantPool, values));

--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -344,12 +344,17 @@ public class CreateSymbols {
             "Ljdk/internal/ValueBased;";
     private static final String VALUE_BASED_ANNOTATION_INTERNAL =
             "Ljdk/internal/ValueBased+Annotation;";
+    private static final String MIGRATED_VALUE_CLASS_ANNOTATION =
+            "Ljdk/internal/MigratedValueClass;";
+    private static final String MIGRATED_VALUE_CLASS_ANNOTATION_INTERNAL =
+            "Ljdk/internal/MigratedValueClass+Annotation;";
     public static final Set<String> HARDCODED_ANNOTATIONS = new HashSet<>(
             List.of("Ljdk/Profile+Annotation;",
                     "Lsun/Proprietary+Annotation;",
                     PREVIEW_FEATURE_ANNOTATION_OLD,
                     PREVIEW_FEATURE_ANNOTATION_NEW,
-                    VALUE_BASED_ANNOTATION));
+                    VALUE_BASED_ANNOTATION,
+                    MIGRATED_VALUE_CLASS_ANNOTATION));
 
     private void stripNonExistentAnnotations(LoadDescriptions data) {
         Set<String> allClasses = data.classes.name2Class.keySet();


### PR DESCRIPTION
do not strip @MigratedValueClass when generating ct.sym

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333563](https://bugs.openjdk.org/browse/JDK-8333563): [lworld] do not strip the @<!---->MigratedValueClass annotation when generating ct.sym (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1113/head:pull/1113` \
`$ git checkout pull/1113`

Update a local copy of the PR: \
`$ git checkout pull/1113` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1113`

View PR using the GUI difftool: \
`$ git pr show -t 1113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1113.diff">https://git.openjdk.org/valhalla/pull/1113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1113#issuecomment-2148194237)