### PR TITLE
8333712: [lworld] update and rename test IllegalMonitorStateExceptionTest.java to check for IdentityException

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/IdentityExceptionTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/IdentityExceptionTest.java
@@ -24,21 +24,21 @@
 /*
  * @test
  * @bug 8329400
- * @summary test to check that IllegalMonitorStateException is thrown for value objects
+ * @summary test to check that IdentityException is thrown for value objects
  * @enablePreview
- * @run main IllegalMonitorStateExceptionTest
+ * @run main IdentityExceptionTest
  */
 
-public value class IllegalMonitorStateExceptionTest {
+public value class IdentityExceptionTest {
     void m(Object o) {
         synchronized (o) {}
     }
 
     public static void main(String[] args) throws Exception {
-        IllegalMonitorStateExceptionTest v = new IllegalMonitorStateExceptionTest();
+        IdentityExceptionTest v = new IdentityExceptionTest();
         try {
             v.m(v);
-            throw new AssertionError("should have failed with IllegalMonitorStateExceptionTest");
+            throw new AssertionError("should have failed with IdentityException");
         } catch (IdentityException e) {
             // as expected
         }


### PR DESCRIPTION
adapting test IllegalMonitorStateExceptionTest.java to latest spec changes, now the IdentityException will be thrown instead

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333712](https://bugs.openjdk.org/browse/JDK-8333712): [lworld] update and rename test IllegalMonitorStateExceptionTest.java to check for IdentityException (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1115/head:pull/1115` \
`$ git checkout pull/1115`

Update a local copy of the PR: \
`$ git checkout pull/1115` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1115`

View PR using the GUI difftool: \
`$ git pr show -t 1115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1115.diff">https://git.openjdk.org/valhalla/pull/1115.diff</a>

</details>
