### PR TITLE
8331912: [lworld] C2: assert(!had_error) failed: bad dominance with TestFlatInArraysFolding.java

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -768,9 +768,6 @@
   product(bool, UseACmpProfile, true,                                       \
           "Take advantage of profiling at acmp")                            \
                                                                             \
-  product(bool, ExpandSubTypeCheckAtParseTime, false, DIAGNOSTIC,           \
-          "Do not use subtype check macro node")                            \
-                                                                            \
   develop(uintx, StressLongCountedLoop, 0,                                  \
           "if > 0, convert int counted loops to long counted loops"         \
           "to stress handling of long counted loops: run inner loop"        \

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2855,6 +2855,13 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
     //    Foo[] fa = blah(); Foo x = fa[0]; fa[1] = x;
     // Here, the type of 'fa' is often exact, so the store check
     // of fa[1]=x will fold up, without testing the nullness of x.
+
+    // At macro expansion, we would have already folded the SubTypeCheckNode
+    // being expanded here because we always perform the static sub type
+    // check in SubTypeCheckNode::sub() regardless of whether
+    //
+    // StressReflectiveCode is set or not. We can therefore skip this
+    // static check when StressReflectiveCode is on.
     switch (C->static_subtype_check(superk, subk)) {
     case Compile::SSC_always_false:
       {
@@ -3041,8 +3048,7 @@ Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
     sub_t = TypeKlassPtr::make(sub_t->inline_klass());
     obj_or_subklass = makecon(sub_t);
   }
-  bool expand_subtype_check = C->post_loop_opts_phase() ||   // macro node expansion is over
-                              ExpandSubTypeCheckAtParseTime; // forced expansion
+  bool expand_subtype_check = C->post_loop_opts_phase(); // macro node expansion is over
   if (expand_subtype_check) {
     MergeMemNode* mem = merged_memory();
     Node* ctrl = control();

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
  * @run main/othervm -XX:-BackgroundCompilation
  *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
- *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
  *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java
@@ -75,8 +75,7 @@ public class TestFlatInArraysFolding {
         Scenario noFlagsScenario = new Scenario(3);
         TestFramework testFramework = new TestFramework();
         testFramework.setDefaultWarmup(0)
-                // TODO 8331912 Remove -XX:-ExpandSubTypeCheckAtParseTime
-                .addFlags("--enable-preview", "-XX:-ExpandSubTypeCheckAtParseTime",
+                .addFlags("--enable-preview",
                           "--add-exports", "java.base/jdk.internal.value=ALL-UNNAMED",
                           "--add-exports", "java.base/jdk.internal.vm.annotation=ALL-UNNAMED")
                 .addScenarios(flatArrayElementMaxSize1Scenario,


### PR DESCRIPTION
In this bug, we have a broken graph due to data being folded while control is not. 

#### A Problem that's (almost) Fixed 

In this particular case, a `CheckCastPP` pinned to a sub type check becomes top due not non-matching (i.e impossible) flatness information but the sub type check fails to detect that and is not being folded. This was actually fixed with [JDK-8321734](https://bugs.openjdk.org/browse/JDK-8321734) such that the `SubTypeCheckNode` is properly folded as well.

#### Still a Problem with `ExpandSubTypeCheckAtParseTime`
This bug manifests when running the following test case of JDK-8321734 with `ExpandSubTypeCheckAtParseTime`:

https://github.com/openjdk/valhalla/blob/ec59503cc04b0a4b15f21a8d8727c6c92924d052/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestFlatInArraysFolding.java#L99-L104

We load an element from `oArrArr` which could be an inline type and thus be flat in array - but we do not know that. Therefore, we have a `Phi` that merges a flat-in-array version and a normal version.

#### How Does `ExpandSubTypeCheckAtParseTime` Work
Setting `ExpandSubTypeCheckAtParseTime` will eagerly expand any sub type check at parse time. This means that we do not emit any `SubTypeCheckNode` but instead directly expand it. We only check once if the sub type check could be statically determined to be true or false and thus be removed:

https://github.com/openjdk/valhalla/blob/ec59503cc04b0a4b15f21a8d8727c6c92924d052/src/hotspot/share/opto/graphKit.cpp#L2858-L2879

If that's not the case - as in `testSubTypeCheck()` - we emit all the expanded nodes like checking the secondary super cache etc.

#### The Actual Problem With Eager Sub Type Check Expansion

Later, when unswitching the loop, we have one version of the loop where the `CheckCastPP` for `oArrArr[i]` is flat-in-array which goes into `373 CheckCastPP` with an array type:

![image](https://github.com/openjdk/valhalla/assets/17833009/23109401-8f4c-46b4-a13a-c9cbc83954b6)

Arrays can never be flat in array, so the `373 CheckCastPP` is replaced by top. The corresponding `SubTypeCheckNode` would also detect this - but there is none since we already expanded it. This improved flat-in-array type information is not propagated to `365 CmpP` through the emitted sub type check nodes (e.g. secondary super cache checks etc.) after the expansion. As a result, we fail to fold the check.

#### Solution
There is no good solution to fix this but to just not run with `ExpandSubTypeCheckAtParseTime`. We've removed `ExpandSubTypeCheckAtParseTime` in mainline with [JDK-8332032](https://bugs.openjdk.org/browse/JDK-8332032) due to this reason and other maintenance cost considerations in general. I'm therefore now downstreaming this patch already to fix this. It needed some adaptations due to missing code in Valhalla and Valhalla specific occurrences.

Thanks,
Christian