### PR TITLE
8334034: [lworld] The JVM must recognize the new format of the Preaload/LoadableDescriptors attribute

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -110,7 +110,7 @@ bool MetaspaceShared::_use_optimized_module_handling = true;
 // These regions are aligned with MetaspaceShared::core_region_alignment().
 //
 // These 2 regions are populated in the following steps:
-// [0] All classes are loaded in MetaspaceShared::preload_classes(). All metadata are
+// [0] All classes are loaded in MetaspaceShared::loadable_descripptors(). All metadata are
 //     temporarily allocated outside of the shared regions.
 // [1] We enter a safepoint and allocate a buffer for the rw/ro regions.
 // [2] C++ vtables are copied into the rw region.
@@ -727,7 +727,7 @@ void MetaspaceShared::get_default_classlist(char* default_classlist, const size_
   }
 }
 
-void MetaspaceShared::preload_classes(TRAPS) {
+void MetaspaceShared::loadable_descripptors(TRAPS) {
   char default_classlist[JVM_MAXPATHLEN];
   const char* classlist_path;
 
@@ -764,7 +764,7 @@ void MetaspaceShared::preload_classes(TRAPS) {
 }
 
 void MetaspaceShared::preload_and_dump_impl(TRAPS) {
-  preload_classes(CHECK);
+  loadable_descripptors(CHECK);
 
   if (SharedArchiveConfigFile) {
     log_info(cds)("Reading extra data from %s ...", SharedArchiveConfigFile);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -110,7 +110,7 @@ bool MetaspaceShared::_use_optimized_module_handling = true;
 // These regions are aligned with MetaspaceShared::core_region_alignment().
 //
 // These 2 regions are populated in the following steps:
-// [0] All classes are loaded in MetaspaceShared::loadable_descripptors(). All metadata are
+// [0] All classes are loaded in MetaspaceShared::loadable_descriptors(). All metadata are
 //     temporarily allocated outside of the shared regions.
 // [1] We enter a safepoint and allocate a buffer for the rw/ro regions.
 // [2] C++ vtables are copied into the rw region.
@@ -727,7 +727,7 @@ void MetaspaceShared::get_default_classlist(char* default_classlist, const size_
   }
 }
 
-void MetaspaceShared::loadable_descripptors(TRAPS) {
+void MetaspaceShared::loadable_descriptors(TRAPS) {
   char default_classlist[JVM_MAXPATHLEN];
   const char* classlist_path;
 
@@ -764,7 +764,7 @@ void MetaspaceShared::loadable_descripptors(TRAPS) {
 }
 
 void MetaspaceShared::preload_and_dump_impl(TRAPS) {
-  loadable_descripptors(CHECK);
+  loadable_descriptors(CHECK);
 
   if (SharedArchiveConfigFile) {
     log_info(cds)("Reading extra data from %s ...", SharedArchiveConfigFile);

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -72,7 +72,7 @@ class MetaspaceShared : AllStatic {
 
 private:
   static void preload_and_dump_impl(TRAPS) NOT_CDS_RETURN;
-  static void loadable_descripptors(TRAPS) NOT_CDS_RETURN;
+  static void loadable_descriptors(TRAPS) NOT_CDS_RETURN;
 
 public:
   static Symbol* symbol_rs_base() {

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -72,7 +72,7 @@ class MetaspaceShared : AllStatic {
 
 private:
   static void preload_and_dump_impl(TRAPS) NOT_CDS_RETURN;
-  static void preload_classes(TRAPS) NOT_CDS_RETURN;
+  static void loadable_descripptors(TRAPS) NOT_CDS_RETURN;
 
 public:
   static Symbol* symbol_rs_base() {

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3394,6 +3394,7 @@ u2 ClassFileParser::parse_classfile_loadable_descriptors_attribute(const ClassFi
           vmSymbols::java_lang_ClassFormatError(),
           "Descriptor from LoadableDescriptors attribute at index \"%d\" in class %s has illegal signature \"%s\"",
           descriptor_index, _class_name->as_C_string(), descriptor->as_C_string());
+        return 0;
       }
       loadable_descriptors->at_put(index++, descriptor_index);
     }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3364,29 +3364,38 @@ u2 ClassFileParser::parse_classfile_permitted_subclasses_attribute(const ClassFi
   return length;
 }
 
-u2 ClassFileParser::parse_classfile_preload_attribute(const ClassFileStream* const cfs,
-                                                                   const u1* const preload_attribute_start,
+u2 ClassFileParser::parse_classfile_loadable_descriptors_attribute(const ClassFileStream* const cfs,
+                                                                   const u1* const loadable_descriptors_attribute_start,
                                                                    TRAPS) {
   const u1* const current_mark = cfs->current();
   u2 length = 0;
-  if (preload_attribute_start != nullptr) {
-    cfs->set_current(preload_attribute_start);
+  if (loadable_descriptors_attribute_start != nullptr) {
+    cfs->set_current(loadable_descriptors_attribute_start);
     cfs->guarantee_more(2, CHECK_0);  // length
     length = cfs->get_u2_fast();
   }
   const int size = length;
-  Array<u2>* const preload_classes = MetadataFactory::new_array<u2>(_loader_data, size, CHECK_0);
-  _preload_classes = preload_classes;
+  Array<u2>* const loadable_descriptors = MetadataFactory::new_array<u2>(_loader_data, size, CHECK_0);
+  _loadable_descriptors = loadable_descriptors;
   if (length > 0) {
     int index = 0;
     cfs->guarantee_more(2 * length, CHECK_0);
     for (int n = 0; n < length; n++) {
-      const u2 class_info_index = cfs->get_u2_fast();
+      const u2 descriptor_index = cfs->get_u2_fast();
       check_property(
-        valid_klass_reference_at(class_info_index),
-        "Preload class_info_index %u has bad constant type in class file %s",
-        class_info_index, CHECK_0);
-      preload_classes->at_put(index++, class_info_index);
+        valid_symbol_at(descriptor_index),
+        "LoadableDescriptors descriptor_index %u has bad constant type in class file %s",
+        descriptor_index, CHECK_0);
+      Symbol* descriptor = _cp->symbol_at(descriptor_index);
+      bool valid = legal_field_signature(descriptor, CHECK_0);
+      if(!valid) {
+        ResourceMark rm(THREAD);
+        Exceptions::fthrow(THREAD_AND_LOCATION,
+          vmSymbols::java_lang_ClassFormatError(),
+          "Descriptor from LoadableDescriptors attribute at index \"%d\" in class %s has illegal signature \"%s\"",
+          descriptor_index, _class_name->as_C_string(), descriptor->as_C_string());
+      }
+      loadable_descriptors->at_put(index++, descriptor_index);
     }
     assert(index == size, "wrong size");
   }
@@ -3681,15 +3690,15 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
   _nest_members = Universe::the_empty_short_array();
   // Set _permitted_subclasses attribute to default sentinel
   _permitted_subclasses = Universe::the_empty_short_array();
-  // Set _preload_classes attribute to default sentinel
-  _preload_classes = Universe::the_empty_short_array();
+  // Set _loadable_descriptors attribute to default sentinel
+  _loadable_descriptors = Universe::the_empty_short_array();
   cfs->guarantee_more(2, CHECK);  // attributes_count
   u2 attributes_count = cfs->get_u2_fast();
   bool parsed_sourcefile_attribute = false;
   bool parsed_innerclasses_attribute = false;
   bool parsed_nest_members_attribute = false;
   bool parsed_permitted_subclasses_attribute = false;
-  bool parsed_preload_attribute = false;
+  bool parsed_loadable_descriptors_attribute = false;
   bool parsed_nest_host_attribute = false;
   bool parsed_record_attribute = false;
   bool parsed_enclosingmethod_attribute = false;
@@ -3715,8 +3724,8 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
   u4  record_attribute_length = 0;
   const u1* permitted_subclasses_attribute_start = nullptr;
   u4  permitted_subclasses_attribute_length = 0;
-  const u1* preload_attribute_start = nullptr;
-  u4  preload_attribute_length = 0;
+  const u1* loadable_descriptors_attribute_start = nullptr;
+  u4  loadable_descriptors_attribute_length = 0;
 
   // Iterate over attributes
   while (attributes_count--) {
@@ -3943,14 +3952,14 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
               permitted_subclasses_attribute_start = cfs->current();
               permitted_subclasses_attribute_length = attribute_length;
             }
-            if (EnableValhalla && tag == vmSymbols::tag_preload()) {
-              if (parsed_preload_attribute) {
+            if (EnableValhalla && tag == vmSymbols::tag_loadable_descriptors()) {
+              if (parsed_loadable_descriptors_attribute) {
                 classfile_parse_error("Multiple Preload attributes in class file %s", CHECK);
                 return;
               }
-              parsed_preload_attribute = true;
-              preload_attribute_start = cfs->current();
-              preload_attribute_length = attribute_length;
+              parsed_loadable_descriptors_attribute = true;
+              loadable_descriptors_attribute_start = cfs->current();
+              loadable_descriptors_attribute_length = attribute_length;
             }
           }
           // Skip attribute_length for any attribute where major_verson >= JAVA_17_VERSION
@@ -4032,15 +4041,15 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
     }
   }
 
-  if (parsed_preload_attribute) {
-    const u2 num_classes = parse_classfile_preload_attribute(
+  if (parsed_loadable_descriptors_attribute) {
+    const u2 num_classes = parse_classfile_loadable_descriptors_attribute(
                             cfs,
-                            preload_attribute_start,
+                            loadable_descriptors_attribute_start,
                             CHECK);
     if (_need_verify) {
       guarantee_property(
-        preload_attribute_length == sizeof(num_classes) + sizeof(u2) * num_classes,
-        "Wrong Preload attribute length in class file %s", CHECK);
+        loadable_descriptors_attribute_length == sizeof(num_classes) + sizeof(u2) * num_classes,
+        "Wrong LoadableDescriptors attribute length in class file %s", CHECK);
     }
   }
 
@@ -4109,7 +4118,7 @@ void ClassFileParser::apply_parsed_class_metadata(
   this_klass->set_inner_classes(_inner_classes);
   this_klass->set_nest_members(_nest_members);
   this_klass->set_nest_host_index(_nest_host);
-  this_klass->set_preload_classes(_preload_classes);
+  this_klass->set_loadable_descriptors(_loadable_descriptors);
   this_klass->set_annotations(_combined_annotations);
   this_klass->set_permitted_subclasses(_permitted_subclasses);
   this_klass->set_record_components(_record_components);
@@ -5026,10 +5035,10 @@ bool ClassFileParser::verify_unqualified_name(const char* name,
   return true;
 }
 
-bool ClassFileParser::is_class_in_preload_attribute(Symbol *klass) {
-  if (_preload_classes == nullptr) return false;
-  for (int i = 0; i < _preload_classes->length(); i++) {
-        Symbol* class_name = _cp->klass_at_noresolve(_preload_classes->at(i));
+bool ClassFileParser::is_class_in_loadable_descriptors_attribute(Symbol *klass) {
+  if (_loadable_descriptors == nullptr) return false;
+  for (int i = 0; i < _loadable_descriptors->length(); i++) {
+        Symbol* class_name = _cp->symbol_at(_loadable_descriptors->at(i));
         if (class_name == klass) return true;
   }
   return false;
@@ -5300,6 +5309,16 @@ void ClassFileParser::verify_legal_method_name(const Symbol* name, TRAPS) const 
   }
 }
 
+bool ClassFileParser::legal_field_signature(const Symbol* signature, TRAPS) const {
+  const char* const bytes = (const char*)signature->bytes();
+  const unsigned int length = signature->utf8_length();
+  const char* const p = skip_over_field_signature(bytes, false, length, CHECK_false);
+
+  if (p == nullptr || (p - bytes) != (int)length) {
+    return false;
+  }
+  return true;
+}
 
 // Checks if signature is a legal field signature.
 void ClassFileParser::verify_legal_field_signature(const Symbol* name,
@@ -5575,7 +5594,7 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik,
   assert(nullptr == _methods, "invariant");
   assert(nullptr == _inner_classes, "invariant");
   assert(nullptr == _nest_members, "invariant");
-  assert(nullptr == _preload_classes, "invariant");
+  assert(nullptr == _loadable_descriptors, "invariant");
   assert(nullptr == _combined_annotations, "invariant");
   assert(nullptr == _record_components, "invariant");
   assert(nullptr == _permitted_subclasses, "invariant");
@@ -5846,7 +5865,7 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
   _nest_members(nullptr),
   _nest_host(0),
   _permitted_subclasses(nullptr),
-  _preload_classes(nullptr),
+  _loadable_descriptors(nullptr),
   _record_components(nullptr),
   _local_interfaces(nullptr),
   _local_interface_indexes(nullptr),
@@ -5949,7 +5968,7 @@ void ClassFileParser::clear_class_metadata() {
   _inner_classes = nullptr;
   _nest_members = nullptr;
   _permitted_subclasses = nullptr;
-  _preload_classes = nullptr;
+  _loadable_descriptors = nullptr;
   _combined_annotations = nullptr;
   _class_annotations = _class_type_annotations = nullptr;
   _fields_annotations = _fields_type_annotations = nullptr;
@@ -6004,8 +6023,8 @@ ClassFileParser::~ClassFileParser() {
     MetadataFactory::free_array<u2>(_loader_data, _permitted_subclasses);
   }
 
-  if (_preload_classes != nullptr && _preload_classes != Universe::the_empty_short_array()) {
-    MetadataFactory::free_array<u2>(_loader_data, _preload_classes);
+  if (_loadable_descriptors != nullptr && _loadable_descriptors != Universe::the_empty_short_array()) {
+    MetadataFactory::free_array<u2>(_loader_data, _loadable_descriptors);
   }
 
   // Free interfaces
@@ -6521,20 +6540,20 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         // Preloading classes for nullable fields that are listed in the Preload attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
-        if (name != _class_name && is_class_in_preload_attribute(name)) {
-          log_info(class, preload)("Preloading class %s during loading of class %s. Cause: field type in Preload attribute", name->as_C_string(), _class_name->as_C_string());
+        if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
+          log_info(class, preload)("Preloading class %s during loading of class %s. Cause: field type in LoadableDescriptors attribute", name->as_C_string(), _class_name->as_C_string());
           oop loader = loader_data()->class_loader();
           Klass* klass = SystemDictionary::resolve_with_circularity_detection_or_fail(_class_name, name, Handle(THREAD, loader), _protection_domain, false, THREAD);
           if (klass != nullptr) {
             if (klass->is_inline_klass()) {
               _inline_type_field_klasses->at_put(fieldinfo.index(), InlineKlass::cast(klass));
-              log_info(class, preload)("Preloading of class %s during loading of class %s (cause: field type in Preload attribute) succeeded", name->as_C_string(), _class_name->as_C_string());
+              log_info(class, preload)("Preloading of class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) succeeded", name->as_C_string(), _class_name->as_C_string());
             } else {
               // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during loading of class %s (cause: field type in Preload attribute) but loaded class is not a value class", name->as_C_string(), _class_name->as_C_string());
+              log_warning(class, preload)("Preloading class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) but loaded class is not a value class", name->as_C_string(), _class_name->as_C_string());
             }
             } else {
-            log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: field type in Preload attribute) failed : %s",
+            log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) failed : %s",
                                           name->as_C_string(), _class_name->as_C_string(), PENDING_EXCEPTION->klass()->name()->as_C_string());
           }
           // Loads triggered by the preload attribute are speculative, failures must not impact loading of current class

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -132,7 +132,7 @@ class ClassFileParser {
   Array<u2>* _nest_members;
   u2 _nest_host;
   Array<u2>* _permitted_subclasses;
-  Array<u2>* _preload_classes;
+  Array<u2>* _loadable_descriptors;
   Array<RecordComponent*>* _record_components;
   Array<InstanceKlass*>* _local_interfaces;
   GrowableArray<u2>* _local_interface_indexes;
@@ -356,7 +356,7 @@ class ClassFileParser {
                                                     const u1* const permitted_subclasses_attribute_start,
                                                     TRAPS);
 
-  u2 parse_classfile_preload_attribute(const ClassFileStream* const cfs,
+  u2 parse_classfile_loadable_descriptors_attribute(const ClassFileStream* const cfs,
                                                     const u1* const preload_attribute_start,
                                                     TRAPS);
 
@@ -493,6 +493,8 @@ class ClassFileParser {
   void verify_legal_field_name(const Symbol* name, TRAPS) const;
   void verify_legal_method_name(const Symbol* name, TRAPS) const;
 
+  bool legal_field_signature(const Symbol* signature, TRAPS) const;
+
   void verify_legal_field_signature(const Symbol* fieldname,
                                     const Symbol* signature,
                                     TRAPS) const;
@@ -617,7 +619,7 @@ class ClassFileParser {
 
   bool is_internal() const { return INTERNAL == _pub_level; }
 
-  bool is_class_in_preload_attribute(Symbol *klass);
+  bool is_class_in_loadable_descriptors_attribute(Symbol *klass);
 
   static bool verify_unqualified_name(const char* name, unsigned int length, int type);
 

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1158,7 +1158,7 @@ InstanceKlass* SystemDictionary::load_shared_class(InstanceKlass* ik,
         }
       } else if (Signature::has_envelope(sig)) {
         TempNewSymbol name = Signature::strip_envelope(sig);
-        if (name != ik->name() && ik->is_class_in_preload_attribute(name)) {
+        if (name != ik->name() && ik->is_class_in_loadable_descriptors_attribute(name)) {
           Klass* real_k = SystemDictionary::resolve_with_circularity_detection_or_fail(ik->name(), name,
             class_loader, protection_domain, false, THREAD);
           if (HAS_PENDING_EXCEPTION) {

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -184,7 +184,7 @@ class SerializeClosure;
   template(tag_inner_classes,                         "InnerClasses")                             \
   template(tag_nest_members,                          "NestMembers")                              \
   template(tag_nest_host,                             "NestHost")                                 \
-  template(tag_preload,                               "Preload")                                  \
+  template(tag_loadable_descriptors,                  "LoadableDescriptors")                      \
   template(tag_constant_value,                        "ConstantValue")                            \
   template(tag_code,                                  "Code")                                     \
   template(tag_exceptions,                            "Exceptions")                               \

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -172,10 +172,10 @@ bool InstanceKlass::field_is_null_free_inline_type(int index) const {
   return field(index).field_flags().is_null_free_inline_type();
 }
 
-bool InstanceKlass::is_class_in_preload_attribute(Symbol* name) const {
-  if (_preload_classes == nullptr) return false;
-  for (int i = 0; i < _preload_classes->length(); i++) {
-        Symbol* class_name = _constants->klass_at_noresolve(_preload_classes->at(i));
+bool InstanceKlass::is_class_in_loadable_descriptors_attribute(Symbol* name) const {
+  if (_loadable_descriptors == nullptr) return false;
+  for (int i = 0; i < _loadable_descriptors->length(); i++) {
+        Symbol* class_name = _constants->klass_at_noresolve(_loadable_descriptors->at(i));
         if (class_name == name) return true;
   }
   return false;
@@ -568,7 +568,7 @@ InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassKind kind, Refe
   _init_thread(nullptr),
   _inline_type_field_klasses(nullptr),
   _null_marker_offsets(nullptr),
-  _preload_classes(nullptr),
+  _loadable_descriptors(nullptr),
   _adr_inlineklass_fixed_block(nullptr)
 {
   set_vtable_length(parser.vtable_size());
@@ -761,10 +761,10 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
   }
   set_permitted_subclasses(nullptr);
 
-  if (preload_classes() != nullptr &&
-      preload_classes() != Universe::the_empty_short_array() &&
-      !preload_classes()->is_shared()) {
-    MetadataFactory::free_array<jushort>(loader_data, preload_classes());
+  if (loadable_descripptors() != nullptr &&
+      loadable_descripptors() != Universe::the_empty_short_array() &&
+      !loadable_descripptors()->is_shared()) {
+    MetadataFactory::free_array<jushort>(loader_data, loadable_descripptors());
   }
 
   // We should deallocate the Annotations instance if it's not in shared spaces.
@@ -1011,13 +1011,13 @@ bool InstanceKlass::link_class_impl(TRAPS) {
     }
 
     // Aggressively preloading all classes from the Preload attribute
-    if (preload_classes() != nullptr) {
+    if (loadable_descripptors() != nullptr) {
       HandleMark hm(THREAD);
-      for (int i = 0; i < preload_classes()->length(); i++) {
-        if (constants()->tag_at(preload_classes()->at(i)).is_klass()) continue;
-        Symbol* class_name = constants()->klass_at_noresolve(preload_classes()->at(i));
+      for (int i = 0; i < loadable_descripptors()->length(); i++) {
+        Symbol* sig = constants()->symbol_at(loadable_descripptors()->at(i));
+        Symbol* class_name = Signature::strip_envelope(sig);  // TempSymbol?
         if (class_name == name()) continue;
-        log_info(class, preload)("Preloading class %s during linking of class %s because of the class is listed in the Preload attribute", class_name->as_C_string(), name()->as_C_string());
+        log_info(class, preload)("Preloading class %s during linking of class %s because of the class is listed in the LoadableDescriptors attribute", sig->as_C_string(), name()->as_C_string());
         oop loader = class_loader();
         oop protection_domain = this->protection_domain();
         Klass* klass = SystemDictionary::resolve_or_null(class_name,
@@ -1026,13 +1026,13 @@ bool InstanceKlass::link_class_impl(TRAPS) {
           CLEAR_PENDING_EXCEPTION;
         }
         if (klass != nullptr) {
-          log_info(class, preload)("Preloading of class %s during linking of class %s (cause: Preload attribute) succeeded", class_name->as_C_string(), name()->as_C_string());
+          log_info(class, preload)("Preloading of class %s during linking of class %s (cause: LoadableDescriptors attribute) succeeded", class_name->as_C_string(), name()->as_C_string());
           if (!klass->is_inline_klass()) {
             // Non value class are allowed by the current spec, but it could be an indication of an issue so let's log a warning
-              log_warning(class, preload)("Preloading class %s during linking of class %s (cause: Preload attribute) but loaded class is not a value class", class_name->as_C_string(), name()->as_C_string());
+              log_warning(class, preload)("Preloading class %s during linking of class %s (cause: LoadableDescriptors attribute) but loaded class is not a value class", class_name->as_C_string(), name()->as_C_string());
           }
         } else {
-          log_warning(class, preload)("Preloading of class %s during linking of class %s (cause: Preload attribute) failed", class_name->as_C_string(), name()->as_C_string());
+          log_warning(class, preload)("Preloading of class %s during linking of class %s (cause: LoadableDescriptors attribute) failed", class_name->as_C_string(), name()->as_C_string());
         }
       }
     }
@@ -2836,7 +2836,7 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 
   it->push(&_nest_members);
   it->push(&_permitted_subclasses);
-  it->push(&_preload_classes);
+  it->push(&_loadable_descriptors);
   it->push(&_record_components);
 
   it->push(&_inline_type_field_klasses, MetaspaceClosure::_writable);
@@ -3950,7 +3950,7 @@ void InstanceKlass::print_on(outputStream* st) const {
     st->print(BULLET"record components:     "); record_components()->print_value_on(st);     st->cr();
   }
   st->print(BULLET"permitted subclasses:     "); permitted_subclasses()->print_value_on(st);     st->cr();
-  st->print(BULLET"preload classes:     "); preload_classes()->print_value_on(st); st->cr();
+  st->print(BULLET"preload classes:     "); loadable_descripptors()->print_value_on(st); st->cr();
   if (java_mirror() != nullptr) {
     st->print(BULLET"java mirror:       ");
     java_mirror()->print_value_on(st);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -761,10 +761,10 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
   }
   set_permitted_subclasses(nullptr);
 
-  if (loadable_descripptors() != nullptr &&
-      loadable_descripptors() != Universe::the_empty_short_array() &&
-      !loadable_descripptors()->is_shared()) {
-    MetadataFactory::free_array<jushort>(loader_data, loadable_descripptors());
+  if (loadable_descriptors() != nullptr &&
+      loadable_descriptors() != Universe::the_empty_short_array() &&
+      !loadable_descriptors()->is_shared()) {
+    MetadataFactory::free_array<jushort>(loader_data, loadable_descriptors());
   }
 
   // We should deallocate the Annotations instance if it's not in shared spaces.
@@ -1011,11 +1011,11 @@ bool InstanceKlass::link_class_impl(TRAPS) {
     }
 
     // Aggressively preloading all classes from the Preload attribute
-    if (loadable_descripptors() != nullptr) {
+    if (loadable_descriptors() != nullptr) {
       HandleMark hm(THREAD);
-      for (int i = 0; i < loadable_descripptors()->length(); i++) {
-        Symbol* sig = constants()->symbol_at(loadable_descripptors()->at(i));
-        Symbol* class_name = Signature::strip_envelope(sig);  // TempSymbol?
+      for (int i = 0; i < loadable_descriptors()->length(); i++) {
+        Symbol* sig = constants()->symbol_at(loadable_descriptors()->at(i));
+        TempNewSymbol class_name = Signature::strip_envelope(sig);
         if (class_name == name()) continue;
         log_info(class, preload)("Preloading class %s during linking of class %s because of the class is listed in the LoadableDescriptors attribute", sig->as_C_string(), name()->as_C_string());
         oop loader = class_loader();
@@ -3950,7 +3950,7 @@ void InstanceKlass::print_on(outputStream* st) const {
     st->print(BULLET"record components:     "); record_components()->print_value_on(st);     st->cr();
   }
   st->print(BULLET"permitted subclasses:     "); permitted_subclasses()->print_value_on(st);     st->cr();
-  st->print(BULLET"preload classes:     "); loadable_descripptors()->print_value_on(st); st->cr();
+  st->print(BULLET"preload classes:     "); loadable_descriptors()->print_value_on(st); st->cr();
   if (java_mirror() != nullptr) {
     st->print(BULLET"java mirror:       ");
     java_mirror()->print_value_on(st);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -300,7 +300,7 @@ class InstanceKlass: public Klass {
 
   Array<InlineKlass*>* _inline_type_field_klasses; // For "inline class" fields, null if none present
   Array<int>* _null_marker_offsets; // for flat fields with a null marker
-  Array<u2>* _preload_classes;
+  Array<u2>* _loadable_descriptors;
   const InlineKlassFixedBlock* _adr_inlineklass_fixed_block;
 
   // embedded Java vtable follows here
@@ -448,7 +448,7 @@ class InstanceKlass: public Klass {
   bool field_is_flat(int index) const { return field_flags(index).is_flat(); }
   bool field_has_null_marker(int index) const { return field_flags(index).has_null_marker(); }
   bool field_is_null_free_inline_type(int index) const;
-  bool is_class_in_preload_attribute(Symbol* name) const;
+  bool is_class_in_loadable_descriptors_attribute(Symbol* name) const;
 
   // Number of Java declared fields
   int java_fields_count() const;
@@ -460,8 +460,8 @@ class InstanceKlass: public Klass {
   Array<FieldStatus>* fields_status() const {return _fields_status; }
   void set_fields_status(Array<FieldStatus>* array) { _fields_status = array; }
 
-  Array<u2>* preload_classes() const { return _preload_classes; }
-  void set_preload_classes(Array<u2>* c) { _preload_classes = c; }
+  Array<u2>* loadable_descripptors() const { return _loadable_descriptors; }
+  void set_loadable_descriptors(Array<u2>* c) { _loadable_descriptors = c; }
 
   // inner classes
   Array<u2>* inner_classes() const       { return _inner_classes; }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -460,7 +460,7 @@ class InstanceKlass: public Klass {
   Array<FieldStatus>* fields_status() const {return _fields_status; }
   void set_fields_status(Array<FieldStatus>* array) { _fields_status = array; }
 
-  Array<u2>* loadable_descripptors() const { return _loadable_descriptors; }
+  Array<u2>* loadable_descriptors() const { return _loadable_descriptors; }
   void set_loadable_descriptors(Array<u2>* c) { _loadable_descriptors = c; }
 
   // inner classes

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -929,8 +929,8 @@ static jvmtiError check_preload_attribute(InstanceKlass* the_class,
   // Check whether the class Preload attribute has been changed.
   return check_attribute_arrays("Preload",
                                 the_class, scratch_class,
-                                the_class->preload_classes(),
-                                scratch_class->preload_classes());
+                                the_class->loadable_descripptors(),
+                                scratch_class->loadable_descripptors());
 }
 
 static bool can_add_or_delete(Method* m) {
@@ -2103,11 +2103,11 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_permitted_subclasses_attribute(
 bool VM_RedefineClasses::rewrite_cp_refs_in_preload_attribute(
        InstanceKlass* scratch_class) {
 
-  Array<u2>* preload_classes = scratch_class->preload_classes();
-  assert(preload_classes != nullptr, "unexpected null preload_classes");
-  for (int i = 0; i < preload_classes->length(); i++) {
-    u2 cp_index = preload_classes->at(i);
-    preload_classes->at_put(i, find_new_index(cp_index));
+  Array<u2>* loadable_descripptors = scratch_class->loadable_descripptors();
+  assert(loadable_descripptors != nullptr, "unexpected null loadable_descripptors");
+  for (int i = 0; i < loadable_descripptors->length(); i++) {
+    u2 cp_index = loadable_descripptors->at(i);
+    loadable_descripptors->at_put(i, find_new_index(cp_index));
   }
   return true;
 }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -929,8 +929,8 @@ static jvmtiError check_preload_attribute(InstanceKlass* the_class,
   // Check whether the class Preload attribute has been changed.
   return check_attribute_arrays("Preload",
                                 the_class, scratch_class,
-                                the_class->loadable_descripptors(),
-                                scratch_class->loadable_descripptors());
+                                the_class->loadable_descriptors(),
+                                scratch_class->loadable_descriptors());
 }
 
 static bool can_add_or_delete(Method* m) {
@@ -2103,11 +2103,11 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_permitted_subclasses_attribute(
 bool VM_RedefineClasses::rewrite_cp_refs_in_preload_attribute(
        InstanceKlass* scratch_class) {
 
-  Array<u2>* loadable_descripptors = scratch_class->loadable_descripptors();
-  assert(loadable_descripptors != nullptr, "unexpected null loadable_descripptors");
-  for (int i = 0; i < loadable_descripptors->length(); i++) {
-    u2 cp_index = loadable_descripptors->at(i);
-    loadable_descripptors->at_put(i, find_new_index(cp_index));
+  Array<u2>* loadable_descriptors = scratch_class->loadable_descriptors();
+  assert(loadable_descriptors != nullptr, "unexpected null loadable_descriptors");
+  for (int i = 0; i < loadable_descriptors->length(); i++) {
+    u2 cp_index = loadable_descriptors->at(i);
+    loadable_descriptors->at_put(i, find_new_index(cp_index));
   }
   return true;
 }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedInlineClass.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnresolvedInlineClass.java
@@ -57,7 +57,7 @@ public class TestUnresolvedInlineClass {
 
             // Verify that a warning is printed
             String output = oa.getOutput();
-            oa.shouldContain("Preloading of class SimpleInlineType during linking of class TestUnresolvedInlineClass (cause: Preload attribute) failed");
+            oa.shouldContain("Preloading of class SimpleInlineType during linking of class TestUnresolvedInlineClass (cause: LoadableDescriptors attribute) failed");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/PreloadCircularityTest.java
@@ -96,8 +96,8 @@ public class PreloadCircularityTest {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class1a");
         out.shouldHaveExitValue(0);
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class1b during loading of class PreloadCircularityTest$Class1a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b. Cause: field type in Preload attribute");
-        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b (cause: field type in Preload attribute) succeeded");
+        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1c during loading of class PreloadCircularityTest$Class1b (cause: field type in LoadableDescriptors attribute) succeeded");
         out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class1b during loading of class PreloadCircularityTest$Class1a (cause: null-free non-static field) succeeded");
     }
 
@@ -150,8 +150,8 @@ public class PreloadCircularityTest {
         out.shouldHaveExitValue(0);
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3a. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3c during loading of class PreloadCircularityTest$Class3b. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c. Cause: field type in Preload attribute");
-        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c (cause: field type in Preload attribute) failed : java/lang/ClassCircularityError");
+        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3c (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class3c during loading of class PreloadCircularityTest$Class3b (cause: null-free non-static field) succeeded");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class3b during loading of class PreloadCircularityTest$Class3a (cause: null-free non-static field) succeeded");
     }
@@ -201,19 +201,19 @@ public class PreloadCircularityTest {
     void test_5() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class5a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a. Cause: field type in Preload attribute");
+        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
-        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a (cause: field type in Preload attribute) failed : java/lang/ClassCircularityError");
+        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5a (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
         out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5c during loading of class PreloadCircularityTest$Class5a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c. Cause: field type in Preload attribute");
+        out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5d during loading of class PreloadCircularityTest$Class5b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
-        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c (cause: field type in Preload attribute) failed : java/lang/ClassCircularityError");
+        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class5b during loading of class PreloadCircularityTest$Class5c (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class5c during loading of class PreloadCircularityTest$Class5a (cause: null-free non-static field) succeeded");
     }
 
@@ -244,8 +244,8 @@ public class PreloadCircularityTest {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class6a");
         out.shouldHaveExitValue(1);
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6a. Cause: a null-free non-static field is declared with this type");
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b. Cause: field type in Preload attribute");
-        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b (cause: field type in Preload attribute) succeeded");
+        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b. Cause: field type in LoadableDescriptors attribute");
+        out.shouldContain("[info][class,preload] Preloading of class PreloadCircularityTest$Class6c during loading of class PreloadCircularityTest$Class6b (cause: field type in LoadableDescriptors attribute) succeeded");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6d during loading of class PreloadCircularityTest$Class6b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6d. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class6b during loading of class PreloadCircularityTest$Class6d (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
@@ -397,10 +397,10 @@ public class PreloadCircularityTest {
     void test_53() throws Exception {
         OutputAnalyzer out = tryLoadingClass("PreloadCircularityTest$Class53a");
         out.shouldHaveExitValue(0);
-        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a. Cause: field type in Preload attribute");
+        out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a. Cause: field type in LoadableDescriptors attribute");
         out.shouldContain("[info][class,preload] Preloading class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b (cause: null-free non-static field) failed: java/lang/ClassCircularityError");
-        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a (cause: field type in Preload attribute) failed : java/lang/ClassCircularityError");
+        out.shouldContain("[warning][class,preload] Preloading of class PreloadCircularityTest$Class53b during loading of class PreloadCircularityTest$Class53a (cause: field type in LoadableDescriptors attribute) failed : java/lang/ClassCircularityError");
         out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class53b during linking of class PreloadCircularityTest$Class53a. Cause: a null-free static field is declared with this type");
         out.shouldContain("[info   ][class,preload] Preloading class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b. Cause: a null-free non-static field is declared with this type");
         out.shouldContain("[info   ][class,preload] Preloading of class PreloadCircularityTest$Class53a during loading of class PreloadCircularityTest$Class53b (cause: null-free non-static field) succeeded");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadClient1.jcod
@@ -69,9 +69,8 @@
     Utf8 "([Ljava/lang/String;)V"; // #28
     Utf8 "SourceFile"; // #29
     Utf8 "ValuePreloadClient1.java"; // #30
-    Utf8 "Preload"; // #31
-    class #33; // #32
-    Utf8 "PreloadValue1"; // #33
+    Utf8 "LoadableDescriptors"; // #31
+    Utf8 "LPreloadValue1;"; // #32
   } // Constant Pool
 
   0x0021; // access
@@ -148,8 +147,8 @@
       #30;
     } // end SourceFile
     ;
-    Attr(#31) { // Preload
+    Attr(#31) { // LoadableDescriptors
       0x00010020;
-    } // end Preload
+    } // end LoadableDescriptors
   } // Attributes
 } // end class ValuePreloadClient1

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ValuePreloadTest.java
@@ -54,9 +54,9 @@ public class ValuePreloadTest {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = exec("-Xlog:class+preload","ValuePreloadClient0");
-        checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during loading of class ValuePreloadClient0. Cause: field type in Preload attribute");
+        checkFor(pb, "[info][class,preload] Preloading class PreloadValue0 during loading of class ValuePreloadClient0. Cause: field type in LoadableDescriptors attribute");
 
         pb = exec("-Xlog:class+preload","ValuePreloadClient1");
-        checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (cause: Preload attribute) failed");
+        checkFor(pb, "[warning][class,preload] Preloading of class PreloadValue1 during linking of class ValuePreloadClient1 (cause: LoadableDescriptors attribute) failed");
     }
 }


### PR DESCRIPTION
VM side changes following JDK-8333757.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334034](https://bugs.openjdk.org/browse/JDK-8334034): [lworld] The JVM must recognize the new format of the Preaload/LoadableDescriptors attribute (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1122/head:pull/1122` \
`$ git checkout pull/1122`

Update a local copy of the PR: \
`$ git checkout pull/1122` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1122`

View PR using the GUI difftool: \
`$ git pr show -t 1122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1122.diff">https://git.openjdk.org/valhalla/pull/1122.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1122#issuecomment-2161297839)