### PR TITLE
8308779: [lworld] jshell test failures after jdk-21+14

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -53,13 +53,6 @@ jdk/jshell/UserInputTest.java                                                   
 jdk/jshell/ToolBasicTest.java                                                   8265357    macosx-aarch64
 jdk/jshell/HighlightUITest.java                                                 8284144    generic-all
 
-jdk/jshell/UserExecutionControlTest.java                                        8308779    generic-all
-jdk/jshell/ToolLocalSimpleTest.java                                             8308779    generic-all
-jdk/jshell/SimpleRegressionTest.java                                            8308779    generic-all
-jdk/jshell/ExecutionControlSpecTest.java                                        8308779    generic-all
-jdk/jshell/ExceptionMessageTest.java                                            8308779    generic-all
-jdk/jshell/ClassMembersTest.java                                                8308779    generic-all
-
 ###########################################################################
 #
 # javac


### PR DESCRIPTION
the tests are passing now, this fix is only removing them from the problem list

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8308779](https://bugs.openjdk.org/browse/JDK-8308779): [lworld] jshell test failures after jdk-21+14 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1123/head:pull/1123` \
`$ git checkout pull/1123`

Update a local copy of the PR: \
`$ git checkout pull/1123` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1123`

View PR using the GUI difftool: \
`$ git pr show -t 1123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1123.diff">https://git.openjdk.org/valhalla/pull/1123.diff</a>

</details>
