### PR TITLE
8334140: [lworld] -XX:LockingMode=0 ignored makes MapLoops fail

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1830,7 +1830,7 @@ bool Arguments::check_vm_args_consistency() {
   }
 
   // Valhalla missing LM_LIGHTWEIGHT support just now
-  if (EnableValhalla && LockingMode != LM_LEGACY) {
+  if (EnableValhalla && LockingMode == LM_LIGHTWEIGHT ) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
   }
 #if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1830,7 +1830,7 @@ bool Arguments::check_vm_args_consistency() {
   }
 
   // Valhalla missing LM_LIGHTWEIGHT support just now
-  if (EnableValhalla && LockingMode == LM_LIGHTWEIGHT ) {
+  if (EnableValhalla && LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
   }
 #if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)


### PR DESCRIPTION
The MapLoops test uses `-XX:LockingMode=0 -XX:+VerifyHeavyMonitors ` for a debug test run.
However, the LockingMode command line option is overridden in arguments.cpp when 
Valhalla is enabled and it forces the lock mode to be LM_LEGACY.

The default for lightweight locking should only be overridden if Valhalla is enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334140](https://bugs.openjdk.org/browse/JDK-8334140): [lworld] -XX:LockingMode=0 ignored makes MapLoops fail (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - no project role) ⚠️ Review applies to [952ad81f](https://git.openjdk.org/valhalla/pull/1124/files/952ad81f77a78a4daa80691bf21b2aec057d9fb1)
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1124/head:pull/1124` \
`$ git checkout pull/1124`

Update a local copy of the PR: \
`$ git checkout pull/1124` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1124`

View PR using the GUI difftool: \
`$ git pr show -t 1124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1124.diff">https://git.openjdk.org/valhalla/pull/1124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1124#issuecomment-2163832665)