### PR TITLE
8334240: [lworld] cannot find symbol PreloadAttribute (renamed to LoadableDescriptors)

### DIFF
--- a/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
+++ b/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
@@ -484,6 +484,7 @@ class RebuildingTransformation {
                             ici.outerClass().map(ClassEntry::asSymbol),
                             ici.innerName().map(Utf8Entry::stringValue),
                             ici.flagsMask())).toArray(InnerClassInfo[]::new)));
+                    case LoadableDescriptorsAttribute a -> clb.with(LoadableDescriptorsAttribute.of(a.loadableDescriptors()));
                     case ModuleAttribute a -> clb.with(ModuleAttribute.of(a.moduleName().asSymbol(), mob -> {
                         mob.moduleFlags(a.moduleFlagsMask());
                         a.moduleVersion().ifPresent(v -> mob.moduleVersion(v.stringValue()));
@@ -502,7 +503,6 @@ class RebuildingTransformation {
                     case NestHostAttribute a -> clb.with(NestHostAttribute.of(a.nestHost().asSymbol()));
                     case NestMembersAttribute a -> clb.with(NestMembersAttribute.ofSymbols(a.nestMembers().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new)));
                     case PermittedSubclassesAttribute a -> clb.with(PermittedSubclassesAttribute.ofSymbols(a.permittedSubclasses().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new)));
-                    case PreloadAttribute a -> clb.with(PreloadAttribute.ofSymbols(a.preloads().stream().map(ClassEntry::asSymbol).toArray(ClassDesc[]::new)));
                     case RecordAttribute a -> clb.with(RecordAttribute.of(a.components().stream().map(rci ->
                             RecordComponentInfo.of(rci.name().stringValue(), rci.descriptorSymbol(), rci.attributes().stream().mapMulti((rca, rcac) -> {
                                     switch(rca) {


### PR DESCRIPTION
Renamed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334240](https://bugs.openjdk.org/browse/JDK-8334240): [lworld] cannot find symbol PreloadAttribute (renamed to LoadableDescriptors) (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1125/head:pull/1125` \
`$ git checkout pull/1125`

Update a local copy of the PR: \
`$ git checkout pull/1125` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1125`

View PR using the GUI difftool: \
`$ git pr show -t 1125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1125.diff">https://git.openjdk.org/valhalla/pull/1125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1125#issuecomment-2166006635)