### PR TITLE
8333435: [lworld] javap prints strict field incorrectly

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -203,7 +203,7 @@ public enum AccessFlag {
 
     /**
      * The access flag {@code ACC_IDENTITY}, corresponding to the
-     * source modifier {@link Modifier#IDENTITY identity}, with a mask
+     * modifier {@link Modifier#IDENTITY identity}, with a mask
      * value of <code>{@value "0x%04x" Modifier#IDENTITY}</code>.
      * @jvms 4.1 -B. Class access and property modifiers
      *
@@ -367,6 +367,30 @@ public enum AccessFlag {
                        Location.SET_METHOD:
                        Location.EMPTY_SET;}
            }),
+
+    /**
+     * The access flag {@code ACC_STRICT}, with a mask
+     * value of <code>{@value "0x%04x" Modifier#STRICT}</code>.
+     * @jvms 4.5 Fields
+     *
+     * @since Valhalla
+     */
+    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS, reflective=true)
+    STRICT_FIELD(Modifier.STRICT, false,
+            PreviewFeatures.isEnabled() ? Location.SET_FIELD : Location.EMPTY_SET,
+            new Function<ClassFileFormatVersion, Set<Location>>() {
+                @Override
+                public Set<Location> apply(ClassFileFormatVersion cffv) {
+                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0
+                            && PreviewFeatures.isEnabled())
+                            ? Location.SET_FIELD : Location.EMPTY_SET;
+                }
+            }) {
+        @Override
+        public String toString() {
+            return "STRICT";
+        }
+    },
 
     /**
      * The access flag {@code ACC_SYNTHETIC} with a mask value of
@@ -702,7 +726,7 @@ public enum AccessFlag {
                           entry(Location.FIELD,
                                 Set.of(PUBLIC, PRIVATE, PROTECTED,
                                        STATIC, FINAL, VOLATILE,
-                                       TRANSIENT, SYNTHETIC, ENUM, STRICT)),
+                                       TRANSIENT, SYNTHETIC, ENUM, STRICT_FIELD)),
                           entry(Location.METHOD,
                                 Set.of(PUBLIC, PRIVATE, PROTECTED,
                                        STATIC, FINAL, SYNCHRONIZED,

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -390,7 +390,7 @@ public class Modifier {
     /**
      * The {@code int} value representing the {@code strictfp}
      * modifier.
-     * @see AccessFlag#STRICT
+     * @see AccessFlag#STRICT and AccessFlag#STRICT_FIELD
      */
     public static final int STRICT           = 0x00000800;
 
@@ -463,7 +463,7 @@ public class Modifier {
     private static final int FIELD_MODIFIERS =
         Modifier.PUBLIC         | Modifier.PROTECTED    | Modifier.PRIVATE |
         Modifier.STATIC         | Modifier.FINAL        | Modifier.TRANSIENT |
-        Modifier.VOLATILE;
+        Modifier.VOLATILE       | Modifier.STRICT;
 
     /**
      * The Java source modifiers that can be applied to a method or constructor parameter.

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -423,7 +423,7 @@ public class ClassWriter extends BasicWriter {
 
         if (options.verbose)
             writeList(String.format("flags: (0x%04x) ", flags.flagsMask()),
-                    flags.flags().stream().map(fl -> "ACC_" + fl.name()).toList(),
+                    flags.flags().stream().map(fl -> "ACC_" + fl.toString()).toList(),
                     "\n");
 
         if (options.showAllAttrs) {

--- a/test/langtools/tools/javac/patterns/BreakAndLoops.java
+++ b/test/langtools/tools/javac/patterns/BreakAndLoops.java
@@ -31,6 +31,7 @@
  *      jdk.compiler/com.sun.tools.javac.file
  *      jdk.compiler/com.sun.tools.javac.main
  *      jdk.compiler/com.sun.tools.javac.util
+ * @enablePreview
  * @build toolbox.ToolBox toolbox.JavacTask
  * @build combo.ComboTestHelper
  * @compile BreakAndLoops.java


### PR DESCRIPTION
fixing a bug in javap for which is was incorrectly showing the flags associated to strict fields

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333435](https://bugs.openjdk.org/browse/JDK-8333435): [lworld] javap prints strict field incorrectly (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1126/head:pull/1126` \
`$ git checkout pull/1126`

Update a local copy of the PR: \
`$ git checkout pull/1126` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1126`

View PR using the GUI difftool: \
`$ git pr show -t 1126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1126.diff">https://git.openjdk.org/valhalla/pull/1126.diff</a>

</details>
