### PR TITLE
8333889: [lworld] C2: Hoisting speculative array access type check wrongly moves array access before its range check

### DIFF
--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -498,6 +498,7 @@ class Parse : public GraphKit {
   void array_store(BasicType etype);
   // Helper function to compute array addressing
   Node* array_addressing(BasicType type, int vals, const Type*& elemtype);
+  bool needs_range_check(const TypeInt* size_type, const Node* index) const;
   Node* create_speculative_inline_type_array_checks(Node* array, const TypeAryPtr* array_type, const Type*& element_type);
   Node* cast_to_speculative_array_type(Node* array, const TypeAryPtr*& array_type, const Type*& element_type);
   Node* cast_to_profiled_array_type(Node* const array);

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -498,6 +498,12 @@ class Parse : public GraphKit {
   void array_store(BasicType etype);
   // Helper function to compute array addressing
   Node* array_addressing(BasicType type, int vals, const Type*& elemtype);
+  Node* create_speculative_inline_type_array_checks(Node* array, const TypeAryPtr* array_type, const Type*& element_type);
+  Node* cast_to_speculative_array_type(Node* array, const TypeAryPtr*& array_type, const Type*& element_type);
+  Node* cast_to_profiled_array_type(Node* const array);
+  Node* speculate_non_null_free_array(Node* array, const TypeAryPtr*& array_type);
+  Node* speculate_non_flat_array(Node* array, const TypeAryPtr* array_type);
+  void create_range_check(Node* idx, Node* ary, const TypeInt* sizetype);
   Node* record_profile_for_speculation_at_array_load(Node* ld);
 
   void clinit_deopt();

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -373,169 +373,14 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
     return top();
   }
 
-  // Do the range check
-  if (need_range_check) {
-    Node* tst;
-    if (sizetype->_hi <= 0) {
-      // The greatest array bound is negative, so we can conclude that we're
-      // compiling unreachable code, but the unsigned compare trick used below
-      // only works with non-negative lengths.  Instead, hack "tst" to be zero so
-      // the uncommon_trap path will always be taken.
-      tst = _gvn.intcon(0);
-    } else {
-      // Range is constant in array-oop, so we can use the original state of mem
-      Node* len = load_array_length(ary);
+  ary = create_speculative_inline_type_array_checks(ary, arytype, elemtype);
 
-      // Test length vs index (standard trick using unsigned compare)
-      Node* chk = _gvn.transform( new CmpUNode(idx, len) );
-      BoolTest::mask btest = BoolTest::lt;
-      tst = _gvn.transform( new BoolNode(chk, btest) );
-    }
-    RangeCheckNode* rc = new RangeCheckNode(control(), tst, PROB_MAX, COUNT_UNKNOWN);
-    _gvn.set_type(rc, rc->Value(&_gvn));
-    if (!tst->is_Con()) {
-      record_for_igvn(rc);
-    }
-    set_control(_gvn.transform(new IfTrueNode(rc)));
-    // Branch to failure if out of bounds
-    {
-      PreserveJVMState pjvms(this);
-      set_control(_gvn.transform(new IfFalseNode(rc)));
-      if (C->allow_range_check_smearing()) {
-        // Do not use builtin_throw, since range checks are sometimes
-        // made more stringent by an optimistic transformation.
-        // This creates "tentative" range checks at this point,
-        // which are not guaranteed to throw exceptions.
-        // See IfNode::Ideal, is_range_check, adjust_check.
-        uncommon_trap(Deoptimization::Reason_range_check,
-                      Deoptimization::Action_make_not_entrant,
-                      nullptr, "range_check");
-      } else {
-        // If we have already recompiled with the range-check-widening
-        // heroic optimization turned off, then we must really be throwing
-        // range check exceptions.
-        builtin_throw(Deoptimization::Reason_range_check);
-      }
-    }
+  if (need_range_check) {
+    create_range_check(idx, ary, sizetype);
   }
+
   // Check for always knowing you are throwing a range-check exception
   if (stopped())  return top();
-
-  // This could be an access to an inline type array. We can't tell if it's
-  // flat or not. Knowing the exact type avoids runtime checks and leads to
-  // a much simpler graph shape. Check profile information.
-  if (!arytype->is_flat() && !arytype->is_not_flat()) {
-    // First check the speculative type
-    Deoptimization::DeoptReason reason = Deoptimization::Reason_speculate_class_check;
-    ciKlass* array_type = arytype->speculative_type();
-    if (too_many_traps_or_recompiles(reason) || array_type == nullptr) {
-      // No speculative type, check profile data at this bci
-      array_type = nullptr;
-      reason = Deoptimization::Reason_class_check;
-      if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
-        ciKlass* element_type = nullptr;
-        ProfilePtrKind element_ptr = ProfileMaybeNull;
-        bool flat_array = true;
-        bool null_free_array = true;
-        method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-      }
-    }
-    if (array_type != nullptr) {
-      // Speculate that this array has the exact type reported by profile data
-      Node* better_ary = nullptr;
-      DEBUG_ONLY(Node* old_control = control();)
-      Node* slow_ctl = type_check_receiver(ary, array_type, 1.0, &better_ary);
-      if (stopped()) {
-        // The check always fails and therefore profile information is incorrect. Don't use it.
-        assert(old_control == slow_ctl, "type check should have been removed");
-        set_control(slow_ctl);
-      } else if (!slow_ctl->is_top()) {
-        { PreserveJVMState pjvms(this);
-          set_control(slow_ctl);
-          uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
-        }
-        replace_in_map(ary, better_ary);
-        ary = better_ary;
-        arytype  = _gvn.type(ary)->is_aryptr();
-        elemtype = arytype->elem();
-      }
-    }
-  } else if (UseTypeSpeculation && UseArrayLoadStoreProfile) {
-    // No need to speculate: feed profile data at this bci for the
-    // array to type speculation
-    ciKlass* array_type = nullptr;
-    ciKlass* element_type = nullptr;
-    ProfilePtrKind element_ptr = ProfileMaybeNull;
-    bool flat_array = true;
-    bool null_free_array = true;
-    method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-    if (array_type != nullptr) {
-      ary = record_profile_for_speculation(ary, array_type, ProfileMaybeNull);
-    }
-  }
-
-  // We have no exact array type from profile data. Check profile data
-  // for a non null-free or non flat array. Non null-free implies non
-  // flat so check this one first. Speculating on a non null-free
-  // array doesn't help aaload but could be profitable for a
-  // subsequent aastore.
-  if (!arytype->is_null_free() && !arytype->is_not_null_free()) {
-    bool null_free_array = true;
-    Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
-    if (arytype->speculative() != nullptr &&
-        arytype->speculative()->is_aryptr()->is_not_null_free() &&
-        !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
-      null_free_array = false;
-      reason = Deoptimization::Reason_speculate_class_check;
-    } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
-      ciKlass* array_type = nullptr;
-      ciKlass* element_type = nullptr;
-      ProfilePtrKind element_ptr = ProfileMaybeNull;
-      bool flat_array = true;
-      method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-      reason = Deoptimization::Reason_class_check;
-    }
-    if (!null_free_array) {
-      { // Deoptimize if null-free array
-        BuildCutout unless(this, null_free_array_test(ary, /* null_free = */ false), PROB_MAX);
-        uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
-      }
-      assert(!stopped(), "null-free array should have been caught earlier");
-      Node* better_ary = _gvn.transform(new CheckCastPPNode(control(), ary, arytype->cast_to_not_null_free()));
-      replace_in_map(ary, better_ary);
-      ary = better_ary;
-      arytype = _gvn.type(ary)->is_aryptr();
-    }
-  }
-
-  if (!arytype->is_flat() && !arytype->is_not_flat()) {
-    bool flat_array = true;
-    Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
-    if (arytype->speculative() != nullptr &&
-        arytype->speculative()->is_aryptr()->is_not_flat() &&
-        !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
-      flat_array = false;
-      reason = Deoptimization::Reason_speculate_class_check;
-    } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
-      ciKlass* array_type = nullptr;
-      ciKlass* element_type = nullptr;
-      ProfilePtrKind element_ptr = ProfileMaybeNull;
-      bool null_free_array = true;
-      method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
-      reason = Deoptimization::Reason_class_check;
-    }
-    if (!flat_array) {
-      { // Deoptimize if flat array
-        BuildCutout unless(this, flat_array_test(ary, /* flat = */ false), PROB_MAX);
-        uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
-      }
-      assert(!stopped(), "flat array should have been caught earlier");
-      Node* better_ary = _gvn.transform(new CheckCastPPNode(control(), ary, arytype->cast_to_not_flat()));
-      replace_in_map(ary, better_ary);
-      ary = better_ary;
-      arytype = _gvn.type(ary)->is_aryptr();
-    }
-  }
 
   // Make array address computation control dependent to prevent it
   // from floating above the range check during loop optimizations.
@@ -545,6 +390,198 @@ Node* Parse::array_addressing(BasicType type, int vals, const Type*& elemtype) {
   return ptr;
 }
 
+void Parse::create_range_check(Node* idx, Node* ary, const TypeInt* sizetype) {
+  Node* tst;
+  if (sizetype->_hi <= 0) {
+    // The greatest array bound is negative, so we can conclude that we're
+    // compiling unreachable code, but the unsigned compare trick used below
+    // only works with non-negative lengths.  Instead, hack "tst" to be zero so
+    // the uncommon_trap path will always be taken.
+    tst = _gvn.intcon(0);
+  } else {
+    // Range is constant in array-oop, so we can use the original state of mem
+    Node* len = load_array_length(ary);
+
+    // Test length vs index (standard trick using unsigned compare)
+    Node* chk = _gvn.transform(new CmpUNode(idx, len) );
+    BoolTest::mask btest = BoolTest::lt;
+    tst = _gvn.transform(new BoolNode(chk, btest) );
+  }
+  RangeCheckNode* rc = new RangeCheckNode(control(), tst, PROB_MAX, COUNT_UNKNOWN);
+  _gvn.set_type(rc, rc->Value(&_gvn));
+  if (!tst->is_Con()) {
+    record_for_igvn(rc);
+  }
+  set_control(_gvn.transform(new IfTrueNode(rc)));
+  // Branch to failure if out of bounds
+  {
+    PreserveJVMState pjvms(this);
+    set_control(_gvn.transform(new IfFalseNode(rc)));
+    if (C->allow_range_check_smearing()) {
+      // Do not use builtin_throw, since range checks are sometimes
+      // made more stringent by an optimistic transformation.
+      // This creates "tentative" range checks at this point,
+      // which are not guaranteed to throw exceptions.
+      // See IfNode::Ideal, is_range_check, adjust_check.
+      uncommon_trap(Deoptimization::Reason_range_check,
+                    Deoptimization::Action_make_not_entrant,
+                    nullptr, "range_check");
+    } else {
+      // If we have already recompiled with the range-check-widening
+      // heroic optimization turned off, then we must really be throwing
+      // range check exceptions.
+      builtin_throw(Deoptimization::Reason_range_check);
+    }
+  }
+}
+
+// For inline type arrays, we can use the profiling information for array accesses to speculate on the type, flatness,
+// and null-freeness. This avoids runtime checks and leads to a much simpler graph shape. We emit traps if the profiling
+// information turns out to be wrong at runtime.
+Node* Parse::create_speculative_inline_type_array_checks(Node* array, const TypeAryPtr* array_type,
+                                                         const Type*& element_type) {
+  if (!array_type->is_flat() && !array_type->is_not_flat()) {
+    // For array accesses, it can be useful to speculate on flatness such that we can fix the data layout. We only want
+    // to do that when we know nothing about flatness since it requires a trap when profiling turns out to be wrong.
+    array = cast_to_speculative_array_type(array, array_type, element_type);
+  } else if (UseTypeSpeculation && UseArrayLoadStoreProfile) {
+    // Array is known to be either flat or not flat. If possible, update the speculative type by using the profile data
+    // at this bci.
+    array = cast_to_profiled_array_type(array);
+  }
+
+  // Even though the type does not tell us whether we have an inline type or not, we can still check the profile data
+  // whether we have a non-null-free or non-flat array. Since non-null-free implies non-flat, we check this first.
+  // Speculating on a non-null-free array doesn't help aaload but could be profitable for a subsequent aastore.
+  if (!array_type->is_null_free() && !array_type->is_not_null_free()) {
+    array = speculate_non_null_free_array(array, array_type);
+  }
+
+  if (!array_type->is_flat() && !array_type->is_not_flat()) {
+    array = speculate_non_flat_array(array, array_type);
+  }
+  return array;
+}
+
+// Speculate that the array has the exact type reported in the profile data. We emit a trap when this turns out to be
+// wrong. On the fast path, we add a CheckCastPP to use the exact type.
+Node* Parse::cast_to_speculative_array_type(Node* const array, const TypeAryPtr*& array_type, const Type*& element_type) {
+  Deoptimization::DeoptReason reason = Deoptimization::Reason_speculate_class_check;
+  ciKlass* speculative_array_type = array_type->speculative_type();
+  if (too_many_traps_or_recompiles(reason) || speculative_array_type == nullptr) {
+    // No speculative type, check profile data at this bci
+    speculative_array_type = nullptr;
+    reason = Deoptimization::Reason_class_check;
+    if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
+      ciKlass* profiled_element_type = nullptr;
+      ProfilePtrKind element_ptr = ProfileMaybeNull;
+      bool flat_array = true;
+      bool null_free_array = true;
+      method()->array_access_profiled_type(bci(), speculative_array_type, profiled_element_type, element_ptr, flat_array,
+                                           null_free_array);
+    }
+  }
+  if (speculative_array_type != nullptr) {
+    // Speculate that this array has the exact type reported by profile data
+    Node* casted_array = nullptr;
+    DEBUG_ONLY(Node* old_control = control();)
+    Node* slow_ctl = type_check_receiver(array, speculative_array_type, 1.0, &casted_array);
+    if (stopped()) {
+      // The check always fails and therefore profile information is incorrect. Don't use it.
+      assert(old_control == slow_ctl, "type check should have been removed");
+      set_control(slow_ctl);
+    } else if (!slow_ctl->is_top()) {
+      { PreserveJVMState pjvms(this);
+        set_control(slow_ctl);
+        uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
+      }
+      replace_in_map(array, casted_array);
+      array_type = _gvn.type(casted_array)->is_aryptr();
+      element_type = array_type->elem();
+      return casted_array;
+    }
+  }
+  return array;
+}
+
+// Create a CheckCastPP when the speculative type can improve the current type.
+Node* Parse::cast_to_profiled_array_type(Node* const array) {
+  ciKlass* array_type = nullptr;
+  ciKlass* element_type = nullptr;
+  ProfilePtrKind element_ptr = ProfileMaybeNull;
+  bool flat_array = true;
+  bool null_free_array = true;
+  method()->array_access_profiled_type(bci(), array_type, element_type, element_ptr, flat_array, null_free_array);
+  if (array_type != nullptr) {
+    return record_profile_for_speculation(array, array_type, ProfileMaybeNull);
+  }
+  return array;
+}
+
+// Speculate that the array is non-null-free. This will imply non-flatness. We emit a trap when this turns out to be
+// wrong. On the fast path, we add a CheckCastPP to use the non-null-free type.
+Node* Parse::speculate_non_null_free_array(Node* const array, const TypeAryPtr*& array_type) {
+  bool null_free_array = true;
+  Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
+  if (array_type->speculative() != nullptr &&
+      array_type->speculative()->is_aryptr()->is_not_null_free() &&
+      !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
+    null_free_array = false;
+    reason = Deoptimization::Reason_speculate_class_check;
+  } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(Deoptimization::Reason_class_check)) {
+    ciKlass* profiled_array_type = nullptr;
+    ciKlass* profiled_element_type = nullptr;
+    ProfilePtrKind element_ptr = ProfileMaybeNull;
+    bool flat_array = true;
+    method()->array_access_profiled_type(bci(), profiled_array_type, profiled_element_type, element_ptr, flat_array,
+                                         null_free_array);
+    reason = Deoptimization::Reason_class_check;
+  }
+  if (!null_free_array) {
+    { // Deoptimize if null-free array
+      BuildCutout unless(this, null_free_array_test(array, /* null_free = */ false), PROB_MAX);
+      uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
+    }
+    assert(!stopped(), "null-free array should have been caught earlier");
+    Node* casted_array = _gvn.transform(new CheckCastPPNode(control(), array, array_type->cast_to_not_null_free()));
+    replace_in_map(array, casted_array);
+    array_type = _gvn.type(casted_array)->is_aryptr();
+    return casted_array;
+  }
+  return array;
+}
+
+// Speculate that the array is non-flat. We emit a trap when this turns out to be wrong. On the fast path, we add a
+// CheckCastPP to use the non-flat type..
+Node* Parse::speculate_non_flat_array(Node* const array, const TypeAryPtr* const array_type) {
+  bool flat_array = true;
+  Deoptimization::DeoptReason reason = Deoptimization::Reason_none;
+  if (array_type->speculative() != nullptr &&
+      array_type->speculative()->is_aryptr()->is_not_flat() &&
+      !too_many_traps_or_recompiles(Deoptimization::Reason_speculate_class_check)) {
+    flat_array = false;
+    reason = Deoptimization::Reason_speculate_class_check;
+  } else if (UseArrayLoadStoreProfile && !too_many_traps_or_recompiles(reason)) {
+    ciKlass* profiled_array_type = nullptr;
+    ciKlass* profiled_element_type = nullptr;
+    ProfilePtrKind element_ptr = ProfileMaybeNull;
+    bool null_free_array = true;
+    method()->array_access_profiled_type(bci(), profiled_array_type, profiled_element_type, element_ptr, flat_array,
+                                         null_free_array);
+    reason = Deoptimization::Reason_class_check;
+  }
+  if (!flat_array) {
+    { // Deoptimize if flat array
+      BuildCutout unless(this, flat_array_test(array, /* flat = */ false), PROB_MAX);
+      uncommon_trap_exact(reason, Deoptimization::Action_maybe_recompile);
+    }
+    assert(!stopped(), "flat array should have been caught earlier");
+    Node* casted_array = _gvn.transform(new CheckCastPPNode(control(), array, array_type->cast_to_not_flat()));
+    replace_in_map(array, casted_array);
+    return casted_array;
+  }
+  return array;
+}
 
 // returns IfNode
 IfNode* Parse::jump_if_fork_int(Node* a, Node* b, BoolTest::mask mask, float prob, float cnt) {

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -450,7 +450,7 @@ Node* Parse::create_speculative_inline_type_array_checks(Node* array, const Type
     array = cast_to_profiled_array_type(array);
   }
 
-  // Even though the type does not tell us whether we have an inline type or not, we can still check the profile data
+  // Even though the type does not tell us whether we have an inline type array or not, we can still check the profile data
   // whether we have a non-null-free or non-flat array. Since non-null-free implies non-flat, we check this first.
   // Speculating on a non-null-free array doesn't help aaload but could be profitable for a subsequent aastore.
   if (!array_type->is_null_free() && !array_type->is_not_null_free()) {
@@ -552,7 +552,7 @@ Node* Parse::speculate_non_null_free_array(Node* const array, const TypeAryPtr*&
 }
 
 // Speculate that the array is non-flat. We emit a trap when this turns out to be wrong. On the fast path, we add a
-// CheckCastPP to use the non-flat type..
+// CheckCastPP to use the non-flat type.
 Node* Parse::speculate_non_flat_array(Node* const array, const TypeAryPtr* const array_type) {
   bool flat_array = true;
   Deoptimization::DeoptReason reason = Deoptimization::Reason_none;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSpeculateArrayAccess.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSpeculateArrayAccess.java
@@ -67,7 +67,7 @@ public class TestSpeculateArrayAccess {
             // - If-Speculative-Array-Type hoisted and CastII and LoadN ends up before loop
             //
             // Running with -XX:+StressGCM: We could execute the LoadN before entering the loop.
-            // This crashes when iFld = -1 becauase we then access an out-of-bounds element.
+            // This crashes when iFld = -1 because we then access an out-of-bounds element.
             Object o = oA[(int)i*iFld];
             o.toString(); // Use the object with its speculated type.
         }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSpeculateArrayAccess.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestSpeculateArrayAccess.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key stress randomness
+ * @bug 8333889
+ * @summary Test that speculative array access checks do not cause a load to be wrongly hoisted before its range check.
+ * @run main/othervm -XX:CompileCommand=dontinline,*::* -XX:CompileCommand=compileonly,*TestSpeculateArrayAccess::test
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=1202682944
+ *                   compiler.valhalla.inlinetypes.TestSpeculateArrayAccess
+ * @run main/othervm -XX:CompileCommand=dontinline,*::* -XX:CompileCommand=compileonly,*TestSpeculateArrayAccess::test
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
+ *                   compiler.valhalla.inlinetypes.TestSpeculateArrayAccess
+ */
+
+package compiler.valhalla.inlinetypes;
+
+public class TestSpeculateArrayAccess {
+    static Object[] oArr = new Object[100];
+    static int iFld = 100;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 100; i++) {
+            oArr[i] = new Object();
+        }
+        iFld = 1;
+        for (int i = 0; i < 1000; i++) {
+            test();
+        }
+        iFld = -1;
+
+        try {
+            test();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // Expected.
+        }
+    }
+
+    static void test() {
+        Object[] oA = oArr; // Load here to avoid G1 barriers being expanded inside loop which prevents Loop Predication.
+        for (float i = 0; i < 100; i++) {
+            // RangeCheck -> If-Speculative-Array-Type -> CastII
+            //
+            // At Loop Predication:
+            // - RangeCheck not hoisted because loop dependent
+            // - If-Speculative-Array-Type hoisted and CastII and LoadN ends up before loop
+            //
+            // Running with -XX:+StressGCM: We could execute the LoadN before entering the loop.
+            // This crashes when iFld = -1 becauase we then access an out-of-bounds element.
+            Object o = oA[(int)i*iFld];
+            o.toString(); // Use the object with its speculated type.
+        }
+    }
+}
+


### PR DESCRIPTION
#### Speculative Inline Type Checks for `aaload`

In `Parse::array_addressing()`, we emit speculative inline type checks (about non-flatness and non-null-freeness) with traps based on profiling information. These checks are emitted directly after the `RangeCheck`. This will lead to the situation that the `CastII` and actual `LoadN` nodes are disconnected from the `RangeCheck` true projection:

![image](https://github.com/openjdk/valhalla/assets/17833009/b82e4b5c-20b5-4c0f-8099-57883aae19d1)

#### Known Problem when Load is Disconnected from Range Check

This disconnection of the load from its range check is a known general problem and could lead to the situation where the actual load ends up before the range check due to some optimizations. As a result, we could crash due to an unprotected out-of-bounds access when the load is actually scheduled before the range check with an invalid index. This was observed before on several occasions in mainline and was being fixed there (e.g. [JDK-8323274](https://bugs.openjdk.org/browse/JDK-8323274)). 

#### How this Problem Manifests in Valhalla

In the test case, the very same is happening:

1. Loop Predication hoists `237 If` out of the loop since it's invariant.
2. `108 RangeCheck` cannot be hoisted since it's not invariant and we have a non-counted loop with a `float` iv phi.
3. By hoisting `237 If` out of the loop, we also rewire the data dependencies (i.e. `140 CastII` and `146 LoadN`) out of the loop. These now end up before the range check which is still inside the loop.
4. When running with `-XX:+StressGCM`, the `LoadN` could be scheduled before the actual `RangeCheck` inside the loop and we crash when using an invalid out-of-bounds array index.

 #### Solution: Swap `RangeCheck` and Speculative Inline Type Traps
The fix is straight forward to first emit the speculative inline type checks with its traps and only then emit the `RangeCheck` such that it does not lose the connection to the actual load. 

I've additionally done some refactoring and added some comments which helped me to better understand the code.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333889](https://bugs.openjdk.org/browse/JDK-8333889): [lworld] C2: Hoisting speculative array access type check wrongly moves array access before its range check (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1127/head:pull/1127` \
`$ git checkout pull/1127`

Update a local copy of the PR: \
`$ git checkout pull/1127` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1127`

View PR using the GUI difftool: \
`$ git pr show -t 1127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1127.diff">https://git.openjdk.org/valhalla/pull/1127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1127#issuecomment-2167391279)