### PR TITLE
8334294: [lworld] several javac tests are failing in valhalla

### DIFF
--- a/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
+++ b/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8234899
  * @summary Verify behavior w.r.t. preview feature API errors and warnings
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      java.base/jdk.internal

--- a/test/langtools/tools/javac/DefiniteAssignment/T8204610.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/T8204610.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8204610
  * @summary Compiler confused by parenthesized "this" in final fields assignments
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/T7093325.java
+++ b/test/langtools/tools/javac/T7093325.java
@@ -26,8 +26,8 @@
  * @bug 7093325 8006694 8129962
  * @summary Redundant entry in bytecode exception table
  *  temporarily workaround combo tests are causing time out in several platforms
- * @library /tools/javac/lib
  * @enablePreview
+ * @library /tools/javac/lib
  * @modules java.base/jdk.internal.classfile.impl
  *          jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/cast/intersection/IntersectionTypeCastTest.java
+++ b/test/langtools/tools/javac/cast/intersection/IntersectionTypeCastTest.java
@@ -26,6 +26,7 @@
  * @bug 8002099 8006694 8129962
  * @summary Add support for intersection types in cast expression
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/defaultMethods/static/hiding/InterfaceMethodHidingTest.java
+++ b/test/langtools/tools/javac/defaultMethods/static/hiding/InterfaceMethodHidingTest.java
@@ -26,6 +26,7 @@
  * @bug 8005166 8129962
  * @summary Add support for static interface methods
  *          Smoke test for static interface method hiding
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/defaultMethods/super/TestDefaultSuperCall.java
+++ b/test/langtools/tools/javac/defaultMethods/super/TestDefaultSuperCall.java
@@ -26,6 +26,7 @@
  * @bug 7192246 8006694 8129962
  * @summary Automatic test for checking correctness of default super/this resolution
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/failover/CheckAttributedTree.java
+++ b/test/langtools/tools/javac/failover/CheckAttributedTree.java
@@ -26,6 +26,7 @@
  * @bug 6970584 8006694 8062373 8129962
  * @summary assorted position errors in compiler syntax trees
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library ../lib
  * @modules java.desktop
  *          jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/generics/diamond/7046778/DiamondAndInnerClassTest.java
+++ b/test/langtools/tools/javac/generics/diamond/7046778/DiamondAndInnerClassTest.java
@@ -26,6 +26,7 @@
  * @bug 7046778 8006694 8129962
  * @summary Project Coin: problem with diamond and member inner classes
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/generics/inference/8176534/TestUncheckedCalls.java
+++ b/test/langtools/tools/javac/generics/inference/8176534/TestUncheckedCalls.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
  * @test
  * @bug 8176534
  * @summary Missing check against target-type during applicability inference
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/generics/rawOverride/7062745/GenericOverrideTest.java
+++ b/test/langtools/tools/javac/generics/rawOverride/7062745/GenericOverrideTest.java
@@ -27,6 +27,7 @@
  * @summary  Regression: difference in overload resolution when two methods
  *  are maximally specific
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/FunctionalInterfaceConversionTest.java
+++ b/test/langtools/tools/javac/lambda/FunctionalInterfaceConversionTest.java
@@ -27,6 +27,7 @@
  * @summary Add lambda tests
  *  perform several automated checks in lambda conversion, esp. around accessibility
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/LambdaParserTest.java
+++ b/test/langtools/tools/javac/lambda/LambdaParserTest.java
@@ -27,6 +27,7 @@
  * @summary Add lambda tests
  *  Add parser support for lambda expressions
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/MethodReferenceParserTest.java
+++ b/test/langtools/tools/javac/lambda/MethodReferenceParserTest.java
@@ -27,6 +27,7 @@
  * @summary Add lambda tests
  *  Add parser support for method references
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/T8235564.java
+++ b/test/langtools/tools/javac/lambda/T8235564.java
@@ -26,6 +26,7 @@
  * @bug 8235564
  * @summary Verify that passing member references to a method not accepting
  *          functional interface does not crash the compiler.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/TestLambdaToMethodStats.java
+++ b/test/langtools/tools/javac/lambda/TestLambdaToMethodStats.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8013576 8129962
  * @summary Add stat support to LambdaToMethod
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/bytecode/TestLambdaBytecode.java
+++ b/test/langtools/tools/javac/lambda/bytecode/TestLambdaBytecode.java
@@ -26,8 +26,8 @@
  * @bug 8009649 8129962 8238358
  * @summary Lambda back-end should generate invokevirtual for method handles referring to
  *          private instance methods as lambda proxy is a nestmate of the target clsas
- * @library /tools/javac/lib
  * @enablePreview
+ * @library /tools/javac/lib
  * @modules java.base/jdk.internal.classfile.impl
  *          jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/bytecode/TestLambdaBytecodeTargetRelease14.java
+++ b/test/langtools/tools/javac/lambda/bytecode/TestLambdaBytecodeTargetRelease14.java
@@ -26,8 +26,8 @@
  * @bug 8238358
  * @summary Lambda back-end should generate invokespecial for method handles referring to
  *          private instance methods when compiling with --release 14
- * @library /tools/javac/lib
  * @enablePreview
+ * @library /tools/javac/lib
  * @modules java.base/jdk.internal.classfile.impl
  *          jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/mostSpecific/StructuralMostSpecificTest.java
+++ b/test/langtools/tools/javac/lambda/mostSpecific/StructuralMostSpecificTest.java
@@ -27,6 +27,7 @@
  * @summary Add lambda tests
  *  Automatic test for checking correctness of structural most specific test routine
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/lambda/typeInference/combo/TypeInferenceComboTest.java
+++ b/test/langtools/tools/javac/lambda/typeInference/combo/TypeInferenceComboTest.java
@@ -28,6 +28,7 @@
  *  perform automated checks in type inference in lambda expressions
  *  in different contexts
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/multicatch/7030606/DisjunctiveTypeWellFormednessTest.java
+++ b/test/langtools/tools/javac/multicatch/7030606/DisjunctiveTypeWellFormednessTest.java
@@ -26,6 +26,7 @@
  * @bug 7030606 8006694 8129962
  * @summary Project-coin: multi-catch types should be pairwise disjoint
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/patterns/BindingsInitializer.java
+++ b/test/langtools/tools/javac/patterns/BindingsInitializer.java
@@ -26,6 +26,7 @@
  * @bug 8278834
  * @summary Verify pattern matching nested inside initializers of classes nested in methods
  *          works correctly.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/BreakAndLoops.java
+++ b/test/langtools/tools/javac/patterns/BreakAndLoops.java
@@ -25,13 +25,13 @@
  * @test
  * @bug 8234922
  * @summary Verify proper scope of binding related to loops and breaks.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api
  *      jdk.compiler/com.sun.tools.javac.file
  *      jdk.compiler/com.sun.tools.javac.main
  *      jdk.compiler/com.sun.tools.javac.util
- * @enablePreview
  * @build toolbox.ToolBox toolbox.JavacTask
  * @build combo.ComboTestHelper
  * @compile BreakAndLoops.java

--- a/test/langtools/tools/javac/patterns/CaseStructureTest.java
+++ b/test/langtools/tools/javac/patterns/CaseStructureTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8269146 8290709
  * @summary Check compilation outcomes for various combinations of case label element.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/ConditionalTest.java
+++ b/test/langtools/tools/javac/patterns/ConditionalTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8236670
  * @summary Verify proper scope of binding related to loops and breaks.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/LocalVariableReuse.java
+++ b/test/langtools/tools/javac/patterns/LocalVariableReuse.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8260593
  * @summary Verify that a temporary storage variable is or is not used as needed when pattern matching.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfComboTest.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfComboTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8304487
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/patterns/ScopeResizeTest.java
+++ b/test/langtools/tools/javac/patterns/ScopeResizeTest.java
@@ -26,6 +26,7 @@
  * @bug 8292756
  * @summary Verify the Scope can be safely and correctly resized to accommodate pattern binding variables
  *          when the Scope for a guard is constructed.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/processing/GenerateAndError.java
+++ b/test/langtools/tools/javac/processing/GenerateAndError.java
@@ -26,6 +26,7 @@
  * @bug 8217381
  * @summary Check error are convenient when AP generates a source file and
  *          an error in the same round
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler
  * @build JavacTestingAbstractProcessor GenerateAndError

--- a/test/langtools/tools/javac/processing/errors/TestErrorCount.java
+++ b/test/langtools/tools/javac/processing/errors/TestErrorCount.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 6988079
  * @summary Errors reported via Messager.printMessage(ERROR,"error message") are not tallied correctly
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/werror/WErrorLast.java
+++ b/test/langtools/tools/javac/processing/werror/WErrorLast.java
@@ -24,6 +24,7 @@
 /*
  * @test 6403456
  * @summary -Werror should work with annotation processing
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/records/LocalStaticDeclarations.java
+++ b/test/langtools/tools/javac/records/LocalStaticDeclarations.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8242293 8246774
  * @summary allow for local interfaces and enums plus nested records, interfaces and enums
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/records/mandated_members/CheckRecordMembers.java
+++ b/test/langtools/tools/javac/records/mandated_members/CheckRecordMembers.java
@@ -28,6 +28,7 @@
  * @bug 8246774
  * @summary check that the accessors, equals, hashCode and toString methods
  *          work as expected
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.file
  *          jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/recovery/ClassBlockExits.java
+++ b/test/langtools/tools/javac/recovery/ClassBlockExits.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8243047
  * @summary javac should not crash while processing exits in class initializers in Flow
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/resolve/BitWiseOperators.java
+++ b/test/langtools/tools/javac/resolve/BitWiseOperators.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8082311 8129962
  * @summary Verify that bitwise operators don't allow to mix numeric and boolean operands.
+ * @enablePreview
  * @library ../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
+++ b/test/langtools/tools/javac/switchexpr/SwitchExpressionNoValue.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8276836
  * @summary Check that switch expression with no value does not crash the compiler.
+ * @enablePreview
  * @library /tools/lib /tools/javac/lib
  * @modules
  *      java.base/jdk.internal

--- a/test/langtools/tools/javac/tree/MakeTypeTest.java
+++ b/test/langtools/tools/javac/tree/MakeTypeTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug     8042239
  * @summary Verify that TreeMaker.Type(Type) can handle all reasonable types
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.code

--- a/test/langtools/tools/javac/varargs/7042566/T7042566.java
+++ b/test/langtools/tools/javac/varargs/7042566/T7042566.java
@@ -26,8 +26,8 @@
  * @bug 7042566 8006694 8129962
  * @summary Unambiguous varargs method calls flagged as ambiguous
  *  temporarily workaround combo tests are causing time out in several platforms
- * @library /tools/javac/lib
  * @enablePreview
+ * @library /tools/javac/lib
  * @modules java.base/jdk.internal.classfile.impl
  *          jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/varargs/warning/Warn4.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn4.java
@@ -26,6 +26,7 @@
  * @bug     6945418 6993978 8006694 7196160 8129962
  * @summary Project Coin: Simplified Varargs Method Invocation
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file

--- a/test/langtools/tools/javac/varargs/warning/Warn5.java
+++ b/test/langtools/tools/javac/varargs/warning/Warn5.java
@@ -26,6 +26,7 @@
  * @bug     6993978 7097436 8006694 7196160
  * @summary Project Coin: Annotation to reduce varargs warnings
  *  temporarily workaround combo tests are causing time out in several platforms
+ * @enablePreview
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file


### PR DESCRIPTION
adding @enablePreview to several tests, they are not explicitly using any preview feature but the libs they depend on do use classes like `java.util.Optional` which is a value based class

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334294](https://bugs.openjdk.org/browse/JDK-8334294): [lworld] several javac tests are failing in valhalla (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1130/head:pull/1130` \
`$ git checkout pull/1130`

Update a local copy of the PR: \
`$ git checkout pull/1130` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1130`

View PR using the GUI difftool: \
`$ git pr show -t 1130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1130.diff">https://git.openjdk.org/valhalla/pull/1130.diff</a>

</details>
