### PR TITLE
8334321: [lworld] add more javadoc and javax.lang.model tests for value classes

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
@@ -47,7 +47,7 @@ public class TestValueClasses extends JavadocTester {
     private final ToolBox tb = new ToolBox();
 
     @Test
-    public void testValueClassModifiers(Path base) throws IOException {
+    public void testConcreteValueClass(Path base) throws IOException {
         Path src = base.resolve("src");
         tb.writeJavaFiles(src,
                 "package p; public value class ValueClass {}");
@@ -61,6 +61,42 @@ public class TestValueClasses extends JavadocTester {
         checkOutput("p/ValueClass.html", true,
                 """
                 <div class="type-signature"><span class="modifiers">public value final class </span><span class="element-name type-name-label">ValueClass</span>
+                """);
+    }
+
+    @Test
+    public void testAbstractValueClass(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                "package p; public abstract value class ValueClass {}");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "--enable-preview", "-source", String.valueOf(Runtime.version().feature()),
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/ValueClass.html", true,
+                """
+                <div class="type-signature"><span class="modifiers">public abstract value class </span><span class="element-name type-name-label">ValueClass</span>
+                """);
+    }
+
+    @Test
+    public void testValueRecord(Path base) throws IOException {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                "package p; public value record ValueRecord() {}");
+
+        javadoc("-d", base.resolve("out").toString(),
+                "--enable-preview", "-source", String.valueOf(Runtime.version().feature()),
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/ValueRecord.html", true,
+                """
+                <div class="type-signature"><span class="modifiers">public value record </span><span class="element-name type-name-label">ValueRecord</span>()
                 """);
     }
 }

--- a/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
+++ b/test/langtools/tools/javac/processing/model/element/TestValueClasses.java
@@ -104,6 +104,8 @@ public class TestValueClasses extends TestRunner {
                 value class ValueClass {}
 
                 class IdentityClass {}
+
+                value record ValueRecord() {}
                 """
         );
 
@@ -112,6 +114,8 @@ public class TestValueClasses extends TestRunner {
                 "- compiler.note.proc.messager: visiting: ValueClass Modifiers: [value, final]",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
                 "- compiler.note.proc.messager: visiting: IdentityClass Modifiers: []",
+                "- compiler.note.proc.messager:     constructor modifiers: []",
+                "- compiler.note.proc.messager: visiting: ValueRecord Modifiers: [value, final]",
                 "- compiler.note.proc.messager:     constructor modifiers: []",
                 "- compiler.note.preview.filename: Interface.java, DEFAULT",
                 "- compiler.note.preview.recompile"


### PR DESCRIPTION
adding more tests for value classes javadoc and javax.lang.model

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334321](https://bugs.openjdk.org/browse/JDK-8334321): [lworld] add more javadoc and javax.lang.model tests for value classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1134/head:pull/1134` \
`$ git checkout pull/1134`

Update a local copy of the PR: \
`$ git checkout pull/1134` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1134`

View PR using the GUI difftool: \
`$ git pr show -t 1134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1134.diff">https://git.openjdk.org/valhalla/pull/1134.diff</a>

</details>
