### PR TITLE
8334313: [lworld] only concrete value classes should be listed in the LoadableDescriptors attribute

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -35,6 +35,7 @@ import sun.security.action.GetBooleanAction;
 
 import java.io.Serializable;
 import java.lang.constant.ConstantDescs;
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -356,14 +357,16 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
             generateSerializationHostileMethods();
 
         // generate LoadableDescriptors attribute if it references any value class
-        LoadableDescriptorsAttributeBuilder builder = new LoadableDescriptorsAttributeBuilder(targetClass);
-        builder.add(factoryType)
-               .add(interfaceMethodType)
-               .add(implMethodType)
-               .add(dynamicMethodType)
-               .add(altMethods);
-        if (!builder.isEmpty())
-            cw.visitAttribute(builder.build());
+        if (PreviewFeatures.isEnabled()) {
+            LoadableDescriptorsAttributeBuilder builder = new LoadableDescriptorsAttributeBuilder(targetClass);
+            builder.add(factoryType)
+                    .add(interfaceMethodType)
+                    .add(implMethodType)
+                    .add(dynamicMethodType)
+                    .add(altMethods);
+            if (!builder.isEmpty())
+                cw.visitAttribute(builder.build());
+        }
 
         cw.visitEnd();
 
@@ -615,7 +618,7 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         }
 
         boolean requiresLoadableDescriptors(Class<?> cls) {
-            return cls.isValue();
+            return cls.isValue() && cls.accessFlags().contains(AccessFlag.FINAL);
         }
 
         boolean isEmpty() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -243,7 +243,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
     public boolean requiresLoadableDescriptors(Symbol referringClass) {
         if (this.tsym == referringClass)
             return false; // pointless
-        return this.isValueClass();
+        return this.isValueClass() && this.isFinal();
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1115,7 +1115,7 @@ public class Gen extends JCTree.Visitor {
         checkDimension(tree.pos(), v.type);
         Type localType = v.erasure(types);
         if (localType.requiresLoadableDescriptors(env.enclClass.sym)) {
-            poolWriter.enterLoadableDescriptorsClass((ClassSymbol) localType.tsym);
+            poolWriter.enterLoadableDescriptorsClass(localType.tsym);
         }
     }
 

--- a/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttributeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/LoadableDescriptorsAttributeTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8280164
+ * @bug 8280164 8334313
  * @summary Check emission of LoadableDescriptors attribute
  * @modules jdk.jdeps/com.sun.tools.classfile
  * @enablePreview
@@ -35,15 +35,16 @@ import com.sun.tools.classfile.ConstantPool.CONSTANT_Utf8_info;
 
 public class LoadableDescriptorsAttributeTest {
 
-    final value class V1 {}
-    final value class V2 {}
-    final value class V3 {}
-    final value class V4 {}
-    final value class V5 {}
-    final value class V6 {}
-    final value class V7 {}
-    final value class V8 {}
-    final value class V9 {}
+    value class V1 {}
+    value class V2 {}
+    value class V3 {}
+    value class V4 {}
+    value class V5 {}
+    value class V6 {}
+    value class V7 {}
+    value class V8 {}
+    value class V9 {}
+    abstract value class V10 {}
 
     static final value class X {
         final V1 [] v1 = null; // field descriptor, encoding array type - no LoadableDescriptors.
@@ -67,6 +68,7 @@ public class LoadableDescriptorsAttributeTest {
         V8 [] goo(V9 [] v9) { // neither V8 nor V9 call for preload being array component types
             return null;
         }
+        V10 v10 = null; // abstract shouldn't be in the loadable descriptors attr
     }
     // So we expect ONLY V2, V3 V5, V7 to be in LoadableDescriptors list
 


### PR DESCRIPTION
do not add abstract value classes to the LoadableDescriptors attribute

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334313](https://bugs.openjdk.org/browse/JDK-8334313): [lworld] only concrete value classes should be listed in the LoadableDescriptors attribute (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1135/head:pull/1135` \
`$ git checkout pull/1135`

Update a local copy of the PR: \
`$ git checkout pull/1135` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1135`

View PR using the GUI difftool: \
`$ git pr show -t 1135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1135.diff">https://git.openjdk.org/valhalla/pull/1135.diff</a>

</details>
