### PR TITLE
8334336: [lworld] map locationToFlags in j.l.r.AccessFlag is being added value classes related flags even if preview features are not enabled

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1542,9 +1542,6 @@ public final class Class<T> implements java.io.Serializable,
             // Ignore unspecified (0x0800) access flag for current version
             accessFlags &= ~0x0800;
         }
-        if (!PreviewFeatures.isEnabled() && location == AccessFlag.Location.INNER_CLASS) {
-            accessFlags &= ~Modifier.IDENTITY; // drop ACC_IDENTITY bit in inner class if not in preview
-        }
         return AccessFlag.maskToAccessFlags(accessFlags, location, cffv);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -724,18 +724,28 @@ public enum AccessFlag {
                                        SYNTHETIC, ANNOTATION,
                                        ENUM, AccessFlag.MODULE)),
                           entry(Location.FIELD,
-                                Set.of(PUBLIC, PRIVATE, PROTECTED,
-                                       STATIC, FINAL, VOLATILE,
-                                       TRANSIENT, SYNTHETIC, ENUM, STRICT_FIELD)),
+                                PreviewFeatures.isEnabled() ?
+                                        // STRICT_FIELD should be included only if preview is enabled
+                                        Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                            STATIC, FINAL, VOLATILE,
+                                            TRANSIENT, SYNTHETIC, ENUM, STRICT_FIELD) :
+                                        Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                                STATIC, FINAL, VOLATILE,
+                                                TRANSIENT, SYNTHETIC, ENUM)),
                           entry(Location.METHOD,
                                 Set.of(PUBLIC, PRIVATE, PROTECTED,
                                        STATIC, FINAL, SYNCHRONIZED,
                                        BRIDGE, VARARGS, NATIVE,
                                        ABSTRACT, STRICT, SYNTHETIC)),
                           entry(Location.INNER_CLASS,
-                                Set.of(PUBLIC, PRIVATE, PROTECTED, IDENTITY,
-                                       STATIC, FINAL, INTERFACE, ABSTRACT,
-                                       SYNTHETIC, ANNOTATION, ENUM)),
+                                  PreviewFeatures.isEnabled() ?
+                                          // IDENTITY should be included only if preview is enabled
+                                          Set.of(PUBLIC, PRIVATE, PROTECTED, IDENTITY,
+                                                  STATIC, FINAL, INTERFACE, ABSTRACT,
+                                                  SYNTHETIC, ANNOTATION, ENUM) :
+                                          Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                                  STATIC, FINAL, INTERFACE, ABSTRACT,
+                                                  SYNTHETIC, ANNOTATION, ENUM)),
                           entry(Location.METHOD_PARAMETER,
                                 Set.of(FINAL, SYNTHETIC, MANDATED)),
                           entry(Location.MODULE,

--- a/test/jdk/java/lang/reflect/valhalla/ValueClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/valhalla/ValueClassesReflectionTest.java
@@ -35,6 +35,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.testng.annotations.*;
 import static org.testng.Assert.*;
 
@@ -52,6 +53,8 @@ public class ValueClassesReflectionTest {
     }
     value record ValueRecord(int i, String s) {}
 
+    class Inner {}
+
     @DataProvider(name = "valueClasses")
     public Object[][] valueClassesData() {
         return List.of(
@@ -65,11 +68,14 @@ public class ValueClassesReflectionTest {
     public void testValueClasses(Class<?> cls) {
         assertTrue(cls.isValue());
         assertTrue(!cls.isIdentity());
+        Set<AccessFlag> accessFlagSet = cls.accessFlags();
+        assertTrue(!accessFlagSet.contains(AccessFlag.IDENTITY));
     }
 
     @DataProvider(name = "notValueClasses")
     public Object[][] notSealedClassesData() {
         return List.of(
+                Inner.class,
                 Object.class,
                 Void.class, Void[].class,
                 byte[].class, Byte[].class,


### PR DESCRIPTION
some valhalla related access flags were being added to AccessFlags::locationToFlags without checking if preview features were enabled or not

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334336](https://bugs.openjdk.org/browse/JDK-8334336): [lworld] map locationToFlags in j.l.r.AccessFlag is being added value classes related flags even if preview features are not enabled (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1137/head:pull/1137` \
`$ git checkout pull/1137`

Update a local copy of the PR: \
`$ git checkout pull/1137` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1137`

View PR using the GUI difftool: \
`$ git pr show -t 1137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1137.diff">https://git.openjdk.org/valhalla/pull/1137.diff</a>

</details>
