### PR TITLE
8334345: [lworld] fix for JDK-8334336 introduced a regression

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -738,12 +738,7 @@ public enum AccessFlag {
                                        BRIDGE, VARARGS, NATIVE,
                                        ABSTRACT, STRICT, SYNTHETIC)),
                           entry(Location.INNER_CLASS,
-                                  PreviewFeatures.isEnabled() ?
-                                          // IDENTITY should be included only if preview is enabled
-                                          Set.of(PUBLIC, PRIVATE, PROTECTED, IDENTITY,
-                                                  STATIC, FINAL, INTERFACE, ABSTRACT,
-                                                  SYNTHETIC, ANNOTATION, ENUM) :
-                                          Set.of(PUBLIC, PRIVATE, PROTECTED,
+                                          Set.of(PUBLIC, PRIVATE, PROTECTED, (PreviewFeatures.isEnabled() ? IDENTITY : SUPER),
                                                   STATIC, FINAL, INTERFACE, ABSTRACT,
                                                   SYNTHETIC, ANNOTATION, ENUM)),
                           entry(Location.METHOD_PARAMETER,

--- a/test/langtools/tools/javap/T4975569.java
+++ b/test/langtools/tools/javap/T4975569.java
@@ -51,9 +51,6 @@ public class T4975569 {
         verify(E.class.getName(), PreviewFeatures.isEnabled()
                 ? "flags: \\(0x4030\\) ACC_FINAL, ACC_IDENTITY, ACC_ENUM"
                 : "flags: \\(0x4030\\) ACC_FINAL, ACC_SUPER, ACC_ENUM");
-        verify(E.class.getName(),    PreviewFeatures.isEnabled()
-                ? "flags: \\(0x4030\\) ACC_FINAL, ACC_IDENTITY, ACC_ENUM"
-                : "flags: \\(0x4030\\) ACC_FINAL, ACC_SUPER, ACC_ENUM");
         verify(S.class.getName(),    "flags: \\(0x1040\\) ACC_BRIDGE, ACC_SYNTHETIC",
                                      "InnerClasses:\n  static [# =\\w]+; +// ");
         verify(V.class.getName(),    "void m\\(java.lang.String...\\)",


### PR DESCRIPTION
fixing regression introduced by JDK-8334336

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334345](https://bugs.openjdk.org/browse/JDK-8334345): [lworld] fix for JDK-8334336 introduced a regression (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1138/head:pull/1138` \
`$ git checkout pull/1138`

Update a local copy of the PR: \
`$ git checkout pull/1138` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1138`

View PR using the GUI difftool: \
`$ git pr show -t 1138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1138.diff">https://git.openjdk.org/valhalla/pull/1138.diff</a>

</details>
