### PR TITLE
8334340: [lworld] javac code clean-up

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1687,9 +1687,6 @@ public class Types {
                 if (isSubtype(erasure(ts.type), erasure(ss.type))) {
                     return false;
                 }
-                if (isSubtype(erasure(ts.type), erasure(ss.type))) {
-                    return false;
-                }
                 // if both are classes or both are interfaces, shortcut
                 if (ts.isInterface() == ss.isInterface() && isSubtype(erasure(ss.type), erasure(ts.type))) {
                     return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1346,8 +1346,7 @@ public class Attr extends JCTree.Visitor {
                 return true;
             }
         }
-        // isValueObject is not included in Object yet so we need a work around
-        return name == names.isValueObject;
+        return false;
     }
 
     Fragment canInferLocalVarType(JCVariableDecl tree) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1355,9 +1355,6 @@ public class Check {
             if ((flags & (ABSTRACT | INTERFACE | VALUE_CLASS)) == VALUE_CLASS) {
                 implicit |= FINAL;
             }
-
-            // TYPs can't be declared synchronized
-            mask &= ~SYNCHRONIZED;
             break;
         default:
             throw new AssertionError();
@@ -1389,10 +1386,6 @@ public class Check {
                                FINAL | NATIVE | SYNCHRONIZED)
                  &&
                  checkDisjoint(pos, flags,
-                        INTERFACE,
-                        VALUE_CLASS)
-                 &&
-                 checkDisjoint(pos, flags,
                                PUBLIC,
                                PRIVATE | PROTECTED)
                  &&
@@ -1400,7 +1393,7 @@ public class Check {
                                PRIVATE,
                                PUBLIC | PROTECTED)
                  &&
-                 checkDisjoint(pos, (flags | implicit), // complain against volatile & implcitly final entities too.
+                 checkDisjoint(pos, flags,
                                FINAL,
                                VOLATILE)
                  &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2382,7 +2382,7 @@ public class Flow {
                         clearPendingExits(false);
                     });
 
-                    // verify all static final fields got initailized
+                    // verify all static final fields got initialized
                     for (int i = firstadr; i < nextadr; i++) {
                         JCVariableDecl vardecl = vardecls[i];
                         VarSymbol var = vardecl.sym;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -103,6 +103,7 @@ public class Lower extends TreeTranslator {
     private final boolean optimizeOuterThis;
     private final boolean useMatchException;
     private final HashMap<TypePairs, String> typePairToName;
+    private final boolean allowValueClasses;
 
     @SuppressWarnings("this-escape")
     protected Lower(Context context) {
@@ -135,6 +136,8 @@ public class Lower extends TreeTranslator {
         useMatchException = Feature.PATTERN_SWITCH.allowedInSource(source) &&
                             (preview.isEnabled() || !preview.isPreview(Feature.PATTERN_SWITCH));
         typePairToName = TypePairs.initialize(syms);
+        this.allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
+                Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     /** The currently enclosing class.
@@ -912,6 +915,7 @@ public class Lower extends TreeTranslator {
             if (isTranslatedClassAvailable(c))
                 continue;
             // Create class definition tree.
+            // IDENTITY_TYPE will be interpreted as ACC_SUPER for older class files so we are fine
             JCClassDecl cdec = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE,
                     c.outermostClass(), c.flatname, false);
             swapAccessConstructorTag(c, cdec.sym);
@@ -1396,6 +1400,7 @@ public class Lower extends TreeTranslator {
                                             i);
             ClassSymbol ctag = chk.getCompiled(topModle, flatname);
             if (ctag == null)
+                // IDENTITY_TYPE will be interpreted as ACC_SUPER for older class files so we are fine
                 ctag = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, topClass).sym;
             else if (!ctag.isAnonymous())
                 continue;
@@ -1637,7 +1642,7 @@ public class Lower extends TreeTranslator {
      *  @param owner      The class in which the definition goes.
      */
     JCVariableDecl outerThisDef(int pos, ClassSymbol owner) {
-        VarSymbol outerThis = makeOuterThisVarSymbol(owner, FINAL | SYNTHETIC | (owner.isValueClass() ? STRICT : 0));
+        VarSymbol outerThis = makeOuterThisVarSymbol(owner, FINAL | SYNTHETIC | (allowValueClasses && owner.isValueClass() ? STRICT : 0));
         return makeOuterThisVarDecl(pos, outerThis);
     }
 
@@ -1844,7 +1849,6 @@ public class Lower extends TreeTranslator {
         List<VarSymbol> ots = outerThisStack;
         if (ots.isEmpty()) {
             log.error(pos, Errors.NoEnclInstanceOfTypeInScope(c));
-            Assert.error();
             return makeNull();
         }
         VarSymbol ot = ots.head;
@@ -1970,6 +1974,7 @@ public class Lower extends TreeTranslator {
             if (sym.kind == TYP &&
                 sym.name == names.empty &&
                 (sym.flags() & INTERFACE) == 0) return (ClassSymbol) sym;
+        // IDENTITY_TYPE will be interpreted as ACC_SUPER for older class files so we are fine
         return makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, clazz).sym;
     }
 
@@ -2022,6 +2027,7 @@ public class Lower extends TreeTranslator {
     private ClassSymbol assertionsDisabledClass() {
         if (assertionsDisabledClassCache != null) return assertionsDisabledClassCache;
 
+        // IDENTITY_TYPE will be interpreted as ACC_SUPER for older class files so we are fine
         assertionsDisabledClassCache = makeEmptyClass(STATIC | SYNTHETIC | IDENTITY_TYPE, outermostClassDef.sym).sym;
 
         return assertionsDisabledClassCache;
@@ -2310,7 +2316,7 @@ public class Lower extends TreeTranslator {
 
         // If this is a local class, define proxies for all its free variables.
         List<JCVariableDecl> fvdefs = freevarDefs(
-            tree.pos, freevars(currentClass), currentClass, currentClass.isValueClass() ? STRICT : 0);
+            tree.pos, freevars(currentClass), currentClass, allowValueClasses && currentClass.isValueClass() ? STRICT : 0);
 
         // Recursively translate superclass, interfaces.
         tree.extending = translate(tree.extending);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -575,7 +575,6 @@ public class ClassReader {
             throw badClassFile("bad.class.signature", quoteBadSignature());
         sigp++;
         Type outer = Type.noType;
-        Name name;
         int startSbp = sbp;
 
         while (true) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Target.java
@@ -217,7 +217,7 @@ public enum Target {
     /** Does the target VM support value classes
      */
     public boolean hasValueClasses() {
-        return compareTo(JDK1_19) >= 0;
+        return compareTo(JDK1_23) >= 0;
     }
 
     /** Is the ACC_STRICT bit redundant and obsolete

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -220,7 +220,8 @@ public class JavacParser implements Parser {
         this.allowYieldStatement = Feature.SWITCH_EXPRESSION.allowedInSource(source);
         this.allowRecords = Feature.RECORDS.allowedInSource(source);
         this.allowSealedTypes = Feature.SEALED_CLASSES.allowedInSource(source);
-        this.allowValueClasses = parser.allowValueClasses;
+        this.allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
+                Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     protected AbstractEndPosTable newEndPosTable(boolean keepEndPositions) {
@@ -3828,9 +3829,9 @@ public class JavacParser implements Parser {
         }
         if (name == names.value) {
             if (allowValueClasses) {
-                return Source.JDK22;
+                return Source.JDK23;
             } else if (shouldWarn) {
-                log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.JDK22));
+                log.warning(pos, Warnings.RestrictedTypeNotAllowedPreview(name, Source.JDK23));
             }
         }
         if (name == names.sealed) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Names.java
@@ -107,7 +107,6 @@ public class Names {
     public final Name values;
     public final Name readResolve;
     public final Name readObject;
-    public final Name isValueObject;
 
     // class names
     public final Name java_io_Serializable;
@@ -309,7 +308,6 @@ public class Names {
         values = fromString("values");
         readResolve = fromString("readResolve");
         readObject = fromString("readObject");
-        isValueObject = fromString("isValueObject");
         dollarThis = fromString("$this");
 
         // class names

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -98,7 +98,7 @@ class RecordCompilationTests extends CompilationTestCase {
     private static String[] OPTIONS_WITH_AP = {"-processor", SimplestAP.class.getName()};
 
     private static final List<String> BAD_COMPONENT_NAMES = List.of(
-            "clone", "finalize", "getClass", "hashCode", "isValueObject",
+            "clone", "finalize", "getClass", "hashCode",
             "notify", "notifyAll", "toString", "wait");
 
     /* simplest annotation processor just to force a round of annotation processing for all tests


### PR DESCRIPTION
remove old code and unnecessary differences with jdk/master

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334340](https://bugs.openjdk.org/browse/JDK-8334340): [lworld] javac code clean-up (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1139/head:pull/1139` \
`$ git checkout pull/1139`

Update a local copy of the PR: \
`$ git checkout pull/1139` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1139`

View PR using the GUI difftool: \
`$ git pr show -t 1139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1139.diff">https://git.openjdk.org/valhalla/pull/1139.diff</a>

</details>
