### PR TITLE
8294866: [lworld] Array classes access flags should include identity bits

### DIFF
--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -225,7 +225,10 @@ oop ArrayKlass::component_mirror() const {
 }
 
 jint ArrayKlass::compute_modifier_flags() const {
-  return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
+  int identity_flag = (Arguments::enable_preview()) ? JVM_ACC_IDENTITY : 0;
+
+  return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC
+                    | identity_flag;
 }
 
 // JVMTI support

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -434,10 +434,13 @@ GrowableArray<Klass*>* FlatArrayKlass::compute_secondary_supers(int num_extra_sl
 
 jint FlatArrayKlass::compute_modifier_flags() const {
   // The modifier for an flatArray is the same as its element
+  // With the addition of ACC_IDENTITY
   jint element_flags = element_klass()->compute_modifier_flags();
 
+  int identity_flag = (Arguments::enable_preview()) ? JVM_ACC_IDENTITY : 0;
+
   return (element_flags & (JVM_ACC_PUBLIC | JVM_ACC_PRIVATE | JVM_ACC_PROTECTED))
-                        | (JVM_ACC_ABSTRACT | JVM_ACC_FINAL);
+                        | (identity_flag | JVM_ACC_ABSTRACT | JVM_ACC_FINAL);
 }
 
 void FlatArrayKlass::print_on(outputStream* st) const {

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -382,6 +382,7 @@ void ObjArrayKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 
 jint ObjArrayKlass::compute_modifier_flags() const {
   // The modifier for an objectArray is the same as its element
+  // With the addition of ACC_IDENTITY
   if (element_klass() == nullptr) {
     assert(Universe::is_bootstrapping(), "partial objArray only at startup");
     return JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC;
@@ -389,8 +390,10 @@ jint ObjArrayKlass::compute_modifier_flags() const {
   // Return the flags of the bottom element type.
   jint element_flags = bottom_klass()->compute_modifier_flags();
 
+  int identity_flag = (Arguments::enable_preview()) ? JVM_ACC_IDENTITY : 0;
+
   return (element_flags & (JVM_ACC_PUBLIC | JVM_ACC_PRIVATE | JVM_ACC_PROTECTED))
-                        | (JVM_ACC_ABSTRACT | JVM_ACC_FINAL);
+                        | (identity_flag | JVM_ACC_ABSTRACT | JVM_ACC_FINAL);
 }
 
 ModuleEntry* ObjArrayKlass::module() const {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -1477,6 +1477,7 @@ public final class Class<T> implements java.io.Serializable,
      *      {@code true}
      * <li> its interface modifier is always {@code false}, even when
      *      the component type is an interface
+     * <li> its {@code identity} modifier is always true
      * </ul>
      * If this {@code Class} object represents a primitive type or
      * void, its {@code public}, {@code abstract}, and {@code final}
@@ -1514,6 +1515,7 @@ public final class Class<T> implements java.io.Serializable,
      * <li> its {@code ABSTRACT} and {@code FINAL} flags are present
      * <li> its {@code INTERFACE} flag is absent, even when the
      *      component type is an interface
+    * <li> its {@code identity} modifier is always true
      * </ul>
      * If this {@code Class} object represents a primitive type or
      * void, the flags are {@code PUBLIC}, {@code ABSTRACT}, and
@@ -1537,6 +1539,9 @@ public final class Class<T> implements java.io.Serializable,
             AccessFlag.Location.CLASS;
         int accessFlags = (location == AccessFlag.Location.CLASS) ?
                 getClassAccessFlagsRaw() : getModifiers();
+        if (isArray() && PreviewFeatures.isEnabled()) {
+            accessFlags |= Modifier.IDENTITY;
+        }
         var cffv = ClassFileFormatVersion.fromMajor(getClassFileVersion() & 0xffff);
         if (cffv.compareTo(ClassFileFormatVersion.latest()) >= 0) {
             // Ignore unspecified (0x0800) access flag for current version

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -196,7 +196,7 @@ public enum AccessFlag {
             new Function<ClassFileFormatVersion, Set<Location>>() {
             @Override
             public Set<Location> apply(ClassFileFormatVersion cffv) {
-                return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0) &&
+                return (cffv.compareTo(ClassFileFormatVersion.latest()) >= 0) &&
                         PreviewFeatures.isEnabled() ? Location.EMPTY_SET : Location.SET_CLASS;
             }
         }),

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -215,7 +215,7 @@ public enum AccessFlag {
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
-                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0
+                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_23) >= 0
                             && PreviewFeatures.isEnabled())
                             ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;
                 }

--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -215,7 +215,7 @@ public enum AccessFlag {
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
-                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_23) >= 0
+                    return (cffv.compareTo(ClassFileFormatVersion.latest()) >= 0
                             && PreviewFeatures.isEnabled())
                             ? Location.SET_CLASS_INNER_CLASS : Location.EMPTY_SET;
                 }
@@ -381,7 +381,7 @@ public enum AccessFlag {
             new Function<ClassFileFormatVersion, Set<Location>>() {
                 @Override
                 public Set<Location> apply(ClassFileFormatVersion cffv) {
-                    return (cffv.compareTo(ClassFileFormatVersion.RELEASE_22) >= 0
+                    return (cffv.compareTo(ClassFileFormatVersion.latest()) >= 0
                             && PreviewFeatures.isEnabled())
                             ? Location.SET_FIELD : Location.EMPTY_SET;
                 }

--- a/src/java.base/share/classes/java/lang/reflect/Modifier.java
+++ b/src/java.base/share/classes/java/lang/reflect/Modifier.java
@@ -43,8 +43,8 @@ import java.util.StringJoiner;
  * Not all modifiers that are syntactic Java language modifiers are
  * represented in this class, only those modifiers that <em>also</em>
  * have a corresponding JVM {@linkplain AccessFlag access flag} are
- * included. In particular the {@code default} method modifier (JLS
- * {@jls 9.4.3}) and the {@code sealed} and {@code non-sealed} class
+ * included. In particular, the {@code default} method modifier (JLS
+ * {@jls 9.4.3}) and the {@code value}, {@code sealed} and {@code non-sealed} class
  * (JLS {@jls 8.1.1.2}) and interface (JLS {@jls 9.1.1.4}) modifiers
  * are <em>not</em> represented in this class.
  *
@@ -231,7 +231,7 @@ public class Modifier {
      * Return a string describing the access modifier flags in
      * the specified modifier. For example:
      * <blockquote><pre>
-     *    public final synchronized strictfp
+     *    public final synchronized
      * </pre></blockquote>
      * The modifier names are returned in an order consistent with the
      * suggested modifier orderings given in sections 8.1.1, 8.3.1, 8.4.3, 8.8.3, and 9.1.1 of

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266670 8291734 8296743
+ * @bug 8266670 8291734 8296743 8294866
  * @summary Test expected AccessFlag's on classes.
  * @modules java.base/jdk.internal.misc
  * @enablePreview
@@ -171,7 +171,7 @@ public final class ClassAccessFlagPreviewTest {
             Set<AccessFlag> expected = new HashSet<>(4);
             expected.add(AccessFlag.ABSTRACT);
             expected.add(AccessFlag.FINAL);
-            expected.add(AccessFlag.IDENTITY);  // NYI Pending: JDK-8294866
+            expected.add(AccessFlag.IDENTITY);
             if (accessLevel != null)
                 expected.add(accessLevel);
             if (!expected.equals(arrayClass.accessFlags())) {

--- a/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
+++ b/test/jdk/java/lang/reflect/AccessFlag/ClassAccessFlagPreviewTest.java
@@ -171,7 +171,7 @@ public final class ClassAccessFlagPreviewTest {
             Set<AccessFlag> expected = new HashSet<>(4);
             expected.add(AccessFlag.ABSTRACT);
             expected.add(AccessFlag.FINAL);
-//            expected.add(AccessFlag.IDENTITY);  // NYI Pending: JDK-8294866
+            expected.add(AccessFlag.IDENTITY);  // NYI Pending: JDK-8294866
             if (accessLevel != null)
                 expected.add(accessLevel);
             if (!expected.equals(arrayClass.accessFlags())) {


### PR DESCRIPTION
Update java.lang.reflect.AccessFlag to return IDENTITY for array classes.
The access flag bits for arrays come from the VM, hence the changes to HotSpot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294866](https://bugs.openjdk.org/browse/JDK-8294866): [lworld] Array classes access flags should include identity bits (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role) ⚠️ Review applies to [9e0368fc](https://git.openjdk.org/valhalla/pull/1141/files/9e0368fc40607bd47071ee3fe0b9299850c61c8e)
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role) ⚠️ Review applies to [9e0368fc](https://git.openjdk.org/valhalla/pull/1141/files/9e0368fc40607bd47071ee3fe0b9299850c61c8e)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - Committer) ⚠️ Review applies to [9e0368fc](https://git.openjdk.org/valhalla/pull/1141/files/9e0368fc40607bd47071ee3fe0b9299850c61c8e)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [9e0368fc](https://git.openjdk.org/valhalla/pull/1141/files/9e0368fc40607bd47071ee3fe0b9299850c61c8e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1141/head:pull/1141` \
`$ git checkout pull/1141`

Update a local copy of the PR: \
`$ git checkout pull/1141` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1141`

View PR using the GUI difftool: \
`$ git pr show -t 1141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1141.diff">https://git.openjdk.org/valhalla/pull/1141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1141#issuecomment-2180886133)