### PR TITLE
8334678: [lworld] some javac tests are failing intermittently due to a VM warning

### DIFF
--- a/test/langtools/tools/javac/lib/JavacTestingAbstractProcessor.java
+++ b/test/langtools/tools/javac/lib/JavacTestingAbstractProcessor.java
@@ -98,10 +98,11 @@ public abstract class JavacTestingAbstractProcessor extends AbstractProcessor {
         for (String packageName : packageNames) {
             try {
                 ModuleLayer layer = ModuleLayer.boot();
-                Optional<Module> m = layer.findModule(moduleName);
-                if (!m.isPresent())
+                // removing dependency on java.util.Optional, valhalla only, to avoid VM warnings
+                Module m = layer.findModule(moduleName).get();
+                if (m == null)
                     throw new Error("module not found: " + moduleName);
-                m.get().addExports(packageName, getClass().getModule());
+                m.addExports(packageName, getClass().getModule());
             } catch (Exception e) {
                 throw new Error("failed to add exports for " + moduleName + "/" + packageName);
             }


### PR DESCRIPTION
Several tests using library class JavacTestingAbstractProcessor are failing intermittently as JavacTestingAbstractProcessor uses Optional. Optional has two versions: one is a value class and the other one is not. The VM issues a warning if the loaded class is not the value version. The tests failing have a golden file and the presence or not of the warning can make them fail. The proposed fix, temporary, is to remove the dependency on Optional.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334678](https://bugs.openjdk.org/browse/JDK-8334678): [lworld] some javac tests are failing intermittently due to a VM warning (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1142/head:pull/1142` \
`$ git checkout pull/1142`

Update a local copy of the PR: \
`$ git checkout pull/1142` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1142`

View PR using the GUI difftool: \
`$ git pr show -t 1142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1142.diff">https://git.openjdk.org/valhalla/pull/1142.diff</a>

</details>
