### PR TITLE
8334746: [lworld] GTestWrapper.java fails because of LogSelectionList

### DIFF
--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -37,7 +37,7 @@ class LogTagSet;
 // Consists of ordered LogSelections, i.e. "tag1+tag2=level1,tag3*=level2".
 class LogSelectionList : public StackObj {
  public:
-  static const size_t MaxSelections = 256;
+  static const size_t MaxSelections = 320;
 
  private:
   friend void LogConfiguration::configure_stdout(LogLevelType, int, ...);


### PR DESCRIPTION
Simple fix copied from JDK-8327098.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334746](https://bugs.openjdk.org/browse/JDK-8334746): [lworld] GTestWrapper.java fails because of LogSelectionList (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1145/head:pull/1145` \
`$ git checkout pull/1145`

Update a local copy of the PR: \
`$ git checkout pull/1145` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1145`

View PR using the GUI difftool: \
`$ git pr show -t 1145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1145.diff">https://git.openjdk.org/valhalla/pull/1145.diff</a>

</details>
