### PR TITLE
8334747: [lworld] C1 needs adjustments after JDK-8294866

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/CanonicalizeGetModifiers.java
+++ b/test/hotspot/jtreg/compiler/c1/CanonicalizeGetModifiers.java
@@ -26,6 +26,7 @@
  * @test
  * @author Yi Yang
  * @summary Canonicalizes Foo.class.getModifiers() with interpreter mode
+ * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @enablePreview
  * @run main/othervm -Xint
@@ -37,6 +38,7 @@
  * @test
  * @author Yi Yang
  * @summary Canonicalizes Foo.class.getModifiers() with C1 mode
+ * @modules java.base/jdk.internal.misc
  * @requires vm.compiler1.enabled
  * @library /test/lib
  * @enablePreview
@@ -49,6 +51,7 @@
  * @test
  * @author Yi Yang
  * @summary Canonicalizes Foo.class.getModifiers() with C2 mode
+ * @modules java.base/jdk.internal.misc
  * @requires vm.compiler2.enabled
  * @library /test/lib
  * @enablePreview
@@ -63,6 +66,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.AccessFlag;
 
 import jdk.test.lib.Asserts;
+import jdk.internal.misc.PreviewFeatures;
 
 public class CanonicalizeGetModifiers {
     public static class T1 {
@@ -100,15 +104,15 @@ public class CanonicalizeGetModifiers {
         Asserts.assertEQ(byte.class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
         Asserts.assertEQ(short.class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
         Asserts.assertEQ(void.class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(int[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(long[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(double[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(float[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(char[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(byte[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(short[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(Object[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
-        Asserts.assertEQ(CanonicalizeGetModifiers[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL);
+        Asserts.assertEQ(int[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(long[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(double[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(float[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(char[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(byte[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(short[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(Object[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
+        Asserts.assertEQ(CanonicalizeGetModifiers[].class.getModifiers(), Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.FINAL | (PreviewFeatures.isEnabled() ? Modifier.IDENTITY : 0));
 
         Asserts.assertEQ(new CanonicalizeGetModifiers().getClass().getModifiers(), Modifier.PUBLIC | Modifier.IDENTITY);
         Asserts.assertEQ(new T1().getClass().getModifiers(), Modifier.PUBLIC | Modifier.STATIC | Modifier.IDENTITY);

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/TestGetModifiers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/TestGetModifiers.java
@@ -26,6 +26,7 @@
  * @test
  * @library /test/lib
  * @enablePreview
+ * @modules java.base/jdk.internal.misc
  * @run main/othervm -Xint
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers
@@ -36,6 +37,7 @@
  * @requires vm.compiler1.enabled
  * @library /test/lib
  * @enablePreview
+ * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+TieredCompilation
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers
@@ -46,6 +48,7 @@
  * @requires vm.compiler2.enabled
  * @library /test/lib
  * @enablePreview
+ * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:-TieredCompilation
  *                   -XX:CompileCommand=dontinline,*TestGetModifiers.test
  *                   compiler.intrinsics.klass.TestGetModifiers
@@ -57,6 +60,7 @@ import java.lang.reflect.Modifier;
 import static java.lang.reflect.Modifier.*;
 
 import jdk.test.lib.Asserts;
+import jdk.internal.misc.PreviewFeatures;
 
 public class TestGetModifiers {
     public static class T1 {
@@ -81,7 +85,7 @@ public class TestGetModifiers {
         for (int i = 0; i < 100_000; i++) {
             int actualMods = cl.getModifiers();
             if (actualMods != expectedMods) {
-                throw new IllegalStateException("Error with: " + cl);
+                throw new IllegalStateException("Error with: " + cl + " : " + actualMods  + " vs " + expectedMods);
             }
         }
     }
@@ -91,7 +95,7 @@ public class TestGetModifiers {
         test(T2.class,                                      PUBLIC | FINAL | STATIC | IDENTITY);
         test(T3.class,                                      PRIVATE | STATIC | IDENTITY);
         test(T4.class,                                      PROTECTED | STATIC | IDENTITY);
-        test(new TestGetModifiers().new T5().getClass(),    IDENTITY);
+        test(new TestGetModifiers().new T5().getClass(),       IDENTITY);
         test(T6.class,                                      ABSTRACT | STATIC | INTERFACE);
 
         test(int.class,                                     PUBLIC | ABSTRACT | FINAL);
@@ -102,15 +106,15 @@ public class TestGetModifiers {
         test(byte.class,                                    PUBLIC | ABSTRACT | FINAL);
         test(short.class,                                   PUBLIC | ABSTRACT | FINAL);
         test(void.class,                                    PUBLIC | ABSTRACT | FINAL);
-        test(int[].class,                                   PUBLIC | ABSTRACT | FINAL);
-        test(long[].class,                                  PUBLIC | ABSTRACT | FINAL);
-        test(double[].class,                                PUBLIC | ABSTRACT | FINAL);
-        test(float[].class,                                 PUBLIC | ABSTRACT | FINAL);
-        test(char[].class,                                  PUBLIC | ABSTRACT | FINAL);
-        test(byte[].class,                                  PUBLIC | ABSTRACT | FINAL);
-        test(short[].class,                                 PUBLIC | ABSTRACT | FINAL);
-        test(Object[].class,                                PUBLIC | ABSTRACT | FINAL);
-        test(TestGetModifiers[].class,                      PUBLIC | ABSTRACT | FINAL);
+        test(int[].class,                                   PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(long[].class,                                  PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(double[].class,                                PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(float[].class,                                 PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(char[].class,                                  PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(byte[].class,                                  PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(short[].class,                                 PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(Object[].class,                                PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
+        test(TestGetModifiers[].class,                      PUBLIC | ABSTRACT | FINAL | (PreviewFeatures.isEnabled() ? IDENTITY : 0));
 
         test(new TestGetModifiers().getClass(),             PUBLIC | IDENTITY);
         test(new T1().getClass(),                           PUBLIC | STATIC | IDENTITY);


### PR DESCRIPTION
Adjustments in C1 after the addition of ACC_IDENTITY to arrays' modifiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334747](https://bugs.openjdk.org/browse/JDK-8334747): [lworld] C1 needs adjustments after JDK-8294866 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1146/head:pull/1146` \
`$ git checkout pull/1146`

Update a local copy of the PR: \
`$ git checkout pull/1146` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1146`

View PR using the GUI difftool: \
`$ git pr show -t 1146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1146.diff">https://git.openjdk.org/valhalla/pull/1146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1146#issuecomment-2189884337)