### PR TITLE
8334692: [lworld] add missing compiler warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -228,7 +228,6 @@ public class Symtab {
     public final Type constantBootstrapsType;
     public final Type classDescType;
     public final Type enumDescType;
-    public final Type numberType;
 
     // For serialization lint checking
     public final Type objectStreamFieldType;
@@ -629,7 +628,6 @@ public class Symtab {
         restrictedType = enterClass("jdk.internal.javac.Restricted");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
-        numberType = enterClass("java.lang.Number");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");
         constantBootstrapsType = enterClass("java.lang.invoke.ConstantBootstraps");
         valueBasedType = enterClass("jdk.internal.ValueBased");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -228,6 +228,7 @@ public class Symtab {
     public final Type constantBootstrapsType;
     public final Type classDescType;
     public final Type enumDescType;
+    public final Type numberType;
 
     // For serialization lint checking
     public final Type objectStreamFieldType;
@@ -252,6 +253,8 @@ public class Symtab {
     public final Type migratedValueClassType;
     public final Type migratedValueClassInternalType;
     public final Type strictType;
+    /** The symbol representing the final finalize method on Object */
+    public final MethodSymbol objectFinalize;
 
     /** The symbol representing the length field of an array.
      */
@@ -550,6 +553,12 @@ public class Symtab {
 
         // Enter predefined classes. All are assumed to be in the java.base module.
         objectType = enterClass("java.lang.Object");
+        throwableType = enterClass("java.lang.Throwable");
+        objectFinalize = new MethodSymbol(PROTECTED,
+                names.finalize,
+                new MethodType(List.nil(), voidType,
+                        List.of(throwableType), methodClass),
+                objectType.tsym);
         objectMethodsType = enterClass("java.lang.runtime.ObjectMethods");
         exactConversionsSupportType = enterClass("java.lang.runtime.ExactConversionsSupport");
         objectsType = enterClass("java.util.Objects");
@@ -558,7 +567,6 @@ public class Symtab {
         stringBufferType = enterClass("java.lang.StringBuffer");
         stringBuilderType = enterClass("java.lang.StringBuilder");
         cloneableType = enterClass("java.lang.Cloneable");
-        throwableType = enterClass("java.lang.Throwable");
         serializableType = enterClass("java.io.Serializable");
         serializedLambdaType = enterClass("java.lang.invoke.SerializedLambda");
         varHandleType = enterClass("java.lang.invoke.VarHandle");
@@ -621,6 +629,7 @@ public class Symtab {
         restrictedType = enterClass("jdk.internal.javac.Restricted");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
+        numberType = enterClass("java.lang.Number");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");
         constantBootstrapsType = enterClass("java.lang.invoke.ConstantBootstraps");
         valueBasedType = enterClass("jdk.internal.ValueBased");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -252,7 +252,7 @@ public class Symtab {
     public final Type migratedValueClassType;
     public final Type migratedValueClassInternalType;
     public final Type strictType;
-    /** The symbol representing the final finalize method on Object */
+    /** The symbol representing the finalize method on Object */
     public final MethodSymbol objectFinalize;
 
     /** The symbol representing the length field of an array.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5688,7 +5688,7 @@ public class Attr extends JCTree.Visitor {
         if (env.info.lint.isEnabled(LintCategory.SERIAL)
                 && rs.isSerializable(c.type)
                 && !c.isAnonymous()) {
-            chk.checkSerialStructure(tree, c);
+            chk.checkSerialStructure(env, tree, c);
         }
         // Correctly organize the positions of the type annotations
         typeAnnotations.organizeTypeAnnotationsBodies(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -28,7 +28,6 @@ package com.sun.tools.javac.comp;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntBiFunction;
@@ -79,11 +78,8 @@ import static com.sun.tools.javac.code.TypeTag.WILDCARD;
 
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.ElementKindVisitor14;
 
 /** Type checking helper class for the attribution phase.
@@ -184,6 +180,8 @@ public class Check {
         allowModules = Feature.MODULES.allowedInSource(source);
         allowRecords = Feature.RECORDS.allowedInSource(source);
         allowSealed = Feature.SEALED_CLASSES.allowedInSource(source);
+        allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
+                Feature.VALUE_CLASSES.allowedInSource(source);
     }
 
     /** Character for synthetic names
@@ -226,6 +224,10 @@ public class Check {
     /** Are sealed classes allowed
      */
     private final boolean allowSealed;
+
+    /** Are value classes allowed
+     */
+    private final boolean allowValueClasses;
 
 /* *************************************************************************
  * Errors and Warnings
@@ -2233,6 +2235,11 @@ public class Check {
             if (m.overrides(syms.enumFinalFinalize, origin, types, false)) {
                 log.error(tree.pos(), Errors.EnumNoFinalize);
                 return;
+            }
+        }
+        if (allowValueClasses && origin.isValueClass() && names.finalize.equals(m.name)) {
+            if (m.overrides(syms.objectFinalize, origin, types, false)) {
+                log.warning(tree.pos(), Warnings.ValueFinalize);
             }
         }
         if (allowRecords && origin.isRecord()) {
@@ -5016,8 +5023,8 @@ public class Check {
     /**
      * Check structure of serialization declarations.
      */
-    public void checkSerialStructure(JCClassDecl tree, ClassSymbol c) {
-        (new SerialTypeVisitor()).visit(c, tree);
+    public void checkSerialStructure(Env<AttrContext> env, JCClassDecl tree, ClassSymbol c) {
+        (new SerialTypeVisitor(env)).visit(c, tree);
     }
 
     /**
@@ -5048,8 +5055,10 @@ public class Check {
      * public void readExternal(ObjectInput) throws IOException
      */
     private class SerialTypeVisitor extends ElementKindVisitor14<Void, JCClassDecl> {
-        SerialTypeVisitor() {
+        Env<AttrContext> env;
+        SerialTypeVisitor(Env<AttrContext> env) {
             this.lint = Check.this.lint;
+            this.env = env;
         }
 
         private static final Set<String> serialMethodNames =
@@ -5109,6 +5118,7 @@ public class Check {
 
             // Check declarations of serialization-related methods and
             // fields
+            final boolean[] hasWriteReplace = {false};
             for(Symbol el : c.getEnclosedElements()) {
                 runUnderLint(el, p, (enclosed, tree) -> {
                     String name = null;
@@ -5183,7 +5193,7 @@ public class Check {
                         if (serialMethodNames.contains(name)) {
                             switch (name) {
                             case "writeObject"      -> checkWriteObject(tree, e, method);
-                            case "writeReplace"     -> checkWriteReplace(tree,e, method);
+                            case "writeReplace"     -> {hasWriteReplace[0] = true; hasAppropriateWriteReplace(tree, method, true);}
                             case "readObject"       -> checkReadObject(tree,e, method);
                             case "readObjectNoData" -> checkReadObjectNoData(tree, e, method);
                             case "readResolve"      -> checkReadResolve(tree, e, method);
@@ -5194,12 +5204,46 @@ public class Check {
                     }
                 });
             }
-
+            if (!hasWriteReplace[0] &&
+                    (c.isValueClass() || hasAbstractValueSuperClass(c)) &&
+                    !c.isAbstract() && !c.isRecord() &&
+                    types.unboxedType(c.type) == Type.noType) {
+                // we need to check if the class is inheriting an appropriate writeReplace method
+                MethodSymbol ms = null;
+                Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log);
+                try {
+                    ms = rs.resolveInternalMethod(env.tree, env, c.type, names.writeReplace, List.nil(), List.nil());
+                } catch (FatalError fe) {
+                    // ignore no method was found
+                } finally {
+                    log.popDiagnosticHandler(discardHandler);
+                }
+                if (ms == null || !hasAppropriateWriteReplace(p, ms, false)) {
+                    log.warning(LintCategory.SERIAL, p,
+                            c.isValueClass() ? Warnings.SerializableValueClassWithoutWriteReplace1 :
+                                    Warnings.SerializableValueClassWithoutWriteReplace2);
+                }
+            }
             return null;
         }
 
         boolean canBeSerialized(Type type) {
             return type.isPrimitive() || rs.isSerializable(type);
+        }
+
+        private boolean hasAbstractValueSuperClass(Symbol c) {
+            while (c.getKind() == ElementKind.CLASS) {
+                Type sup = ((ClassSymbol)c).getSuperclass();
+                if (!sup.hasTag(CLASS) || sup.isErroneous() ||
+                        sup.tsym == syms.objectType.tsym) {
+                    return false;
+                }
+                if (sup.isValueClass()) {
+                    return true;
+                }
+                c = sup.tsym;
+            }
+            return false;
         }
 
         /**
@@ -5325,22 +5369,22 @@ public class Check {
 
             // private void writeObject(ObjectOutputStream stream) throws IOException
             checkPrivateNonStaticMethod(tree, method);
-            checkReturnType(tree, e, method, syms.voidType);
+            isExpectedReturnType(tree, method, syms.voidType, true);
             checkOneArg(tree, e, method, syms.objectOutputStreamType);
-            checkExceptions(tree, e, method, syms.ioExceptionType);
+            hasExpectedExceptions(tree, method, true, syms.ioExceptionType);
             checkExternalizable(tree, e, method);
         }
 
-        private void checkWriteReplace(JCClassDecl tree, Element e, MethodSymbol method) {
+        private boolean hasAppropriateWriteReplace(JCClassDecl tree, MethodSymbol method, boolean warn) {
             // ANY-ACCESS-MODIFIER Object writeReplace() throws
             // ObjectStreamException
 
             // Excluding abstract, could have a more complicated
             // rule based on abstract-ness of the class
-            checkConcreteInstanceMethod(tree, e, method);
-            checkReturnType(tree, e, method, syms.objectType);
-            checkNoArgs(tree, e, method);
-            checkExceptions(tree, e, method, syms.objectStreamExceptionType);
+            return isConcreteInstanceMethod(tree, method, warn) &&
+                    isExpectedReturnType(tree, method, syms.objectType, warn) &&
+                    hasNoArgs(tree, method, warn) &&
+                    hasExpectedExceptions(tree, method, warn, syms.objectStreamExceptionType);
         }
 
         private void checkReadObject(JCClassDecl tree, Element e, MethodSymbol method) {
@@ -5351,18 +5395,18 @@ public class Check {
             // private void readObject(ObjectInputStream stream)
             //   throws IOException, ClassNotFoundException
             checkPrivateNonStaticMethod(tree, method);
-            checkReturnType(tree, e, method, syms.voidType);
+            isExpectedReturnType(tree, method, syms.voidType, true);
             checkOneArg(tree, e, method, syms.objectInputStreamType);
-            checkExceptions(tree, e, method, syms.ioExceptionType, syms.classNotFoundExceptionType);
+            hasExpectedExceptions(tree, method, true, syms.ioExceptionType, syms.classNotFoundExceptionType);
             checkExternalizable(tree, e, method);
         }
 
         private void checkReadObjectNoData(JCClassDecl tree, Element e, MethodSymbol method) {
             // private void readObjectNoData() throws ObjectStreamException
             checkPrivateNonStaticMethod(tree, method);
-            checkReturnType(tree, e, method, syms.voidType);
-            checkNoArgs(tree, e, method);
-            checkExceptions(tree, e, method, syms.objectStreamExceptionType);
+            isExpectedReturnType(tree, method, syms.voidType, true);
+            hasNoArgs(tree, method, true);
+            hasExpectedExceptions(tree, method, true, syms.objectStreamExceptionType);
             checkExternalizable(tree, e, method);
         }
 
@@ -5372,10 +5416,10 @@ public class Check {
 
             // Excluding abstract, could have a more complicated
             // rule based on abstract-ness of the class
-            checkConcreteInstanceMethod(tree, e, method);
-            checkReturnType(tree,e, method, syms.objectType);
-            checkNoArgs(tree, e, method);
-            checkExceptions(tree, e, method, syms.objectStreamExceptionType);
+            isConcreteInstanceMethod(tree, method, true);
+            isExpectedReturnType(tree, method, syms.objectType, true);
+            hasNoArgs(tree, method, true);
+            hasExpectedExceptions(tree, method, true, syms.objectStreamExceptionType);
         }
 
         private void checkWriteExternalRecord(JCClassDecl tree, Element e, MethodSymbol method, boolean isExtern) {
@@ -5625,7 +5669,7 @@ public class Check {
                     case METHOD -> {
                         var method = (MethodSymbol)enclosed;
                         switch(name) {
-                        case "writeReplace" -> checkWriteReplace(tree, e, method);
+                        case "writeReplace" -> hasAppropriateWriteReplace(tree, method, true);
                         case "readResolve"  -> checkReadResolve(tree, e, method);
 
                         case "writeExternal" -> checkWriteExternalRecord(tree, e, method, isExtern);
@@ -5643,20 +5687,24 @@ public class Check {
             return null;
         }
 
-        void checkConcreteInstanceMethod(JCClassDecl tree,
-                                         Element enclosing,
-                                         MethodSymbol method) {
+        boolean isConcreteInstanceMethod(JCClassDecl tree,
+                                         MethodSymbol method,
+                                         boolean warn) {
             if ((method.flags() & (STATIC | ABSTRACT)) != 0) {
+                if (warn) {
                     log.warning(LintCategory.SERIAL,
-                                TreeInfo.diagnosticPositionFor(method, tree),
-                                Warnings.SerialConcreteInstanceMethod(method.getSimpleName()));
+                            TreeInfo.diagnosticPositionFor(method, tree),
+                            Warnings.SerialConcreteInstanceMethod(method.getSimpleName()));
+                }
+                return false;
             }
+            return true;
         }
 
-        private void checkReturnType(JCClassDecl tree,
-                                     Element enclosing,
-                                     MethodSymbol method,
-                                     Type expectedReturnType) {
+        private boolean isExpectedReturnType(JCClassDecl tree,
+                                          MethodSymbol method,
+                                          Type expectedReturnType,
+                                          boolean warn) {
             // Note: there may be complications checking writeReplace
             // and readResolve since they return Object and could, in
             // principle, have covariant overrides and any synthetic
@@ -5664,11 +5712,15 @@ public class Check {
             // checking.
             Type rtype = method.getReturnType();
             if (!types.isSameType(expectedReturnType, rtype)) {
-                log.warning(LintCategory.SERIAL,
+                if (warn) {
+                    log.warning(LintCategory.SERIAL,
                             TreeInfo.diagnosticPositionFor(method, tree),
                             Warnings.SerialMethodUnexpectedReturnType(method.getSimpleName(),
-                                                                      rtype, expectedReturnType));
+                                    rtype, expectedReturnType));
+                }
+                return false;
             }
+            return true;
         }
 
         private void checkOneArg(JCClassDecl tree,
@@ -5706,13 +5758,17 @@ public class Check {
         }
 
 
-        private void checkNoArgs(JCClassDecl tree, Element enclosing, MethodSymbol method) {
+        boolean hasNoArgs(JCClassDecl tree, MethodSymbol method, boolean warn) {
             var parameters = method.getParameters();
             if (!parameters.isEmpty()) {
-                log.warning(LintCategory.SERIAL,
+                if (warn) {
+                    log.warning(LintCategory.SERIAL,
                             TreeInfo.diagnosticPositionFor(parameters.get(0), tree),
                             Warnings.SerialMethodNoArgs(method.getSimpleName()));
+                }
+                return false;
             }
+            return true;
         }
 
         private void checkExternalizable(JCClassDecl tree, Element enclosing, MethodSymbol method) {
@@ -5725,10 +5781,10 @@ public class Check {
             return;
         }
 
-        private void checkExceptions(JCClassDecl tree,
-                                     Element enclosing,
-                                     MethodSymbol method,
-                                     Type... declaredExceptions) {
+        private boolean hasExpectedExceptions(JCClassDecl tree,
+                                              MethodSymbol method,
+                                              boolean warn,
+                                              Type... declaredExceptions) {
             for (Type thrownType: method.getThrownTypes()) {
                 // For each exception in the throws clause of the
                 // method, if not an Error and not a RuntimeException,
@@ -5747,14 +5803,17 @@ public class Check {
                         }
                     }
                     if (!declared) {
-                        log.warning(LintCategory.SERIAL,
+                        if (warn) {
+                            log.warning(LintCategory.SERIAL,
                                     TreeInfo.diagnosticPositionFor(method, tree),
                                     Warnings.SerialMethodUnexpectedException(method.getSimpleName(),
-                                                                             thrownType));
+                                            thrownType));
+                        }
+                        return false;
                     }
                 }
             }
-            return;
+            return true;
         }
 
         private <E extends Element> Void runUnderLint(E symbol, JCClassDecl p, BiConsumer<E, JCClassDecl> task) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5238,6 +5238,7 @@ public class Check {
                         sup.tsym == syms.objectType.tsym) {
                     return false;
                 }
+                // if it is a value super class it has to be abstract
                 if (sup.isValueClass()) {
                     return true;
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -5111,10 +5111,6 @@ public class Resolve {
         DeferredAttr.AttrMode attrMode() {
             return attrMode;
         }
-
-        boolean internal() {
-            return internalResolution;
-        }
     }
 
     MethodResolutionContext currentResolutionContext = null;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2075,6 +2075,12 @@ compiler.warn.non.private.method.weaker.access=\
 compiler.warn.default.ineffective=\
     serialization-related default method from an interface will not be run by serialization for an implementing class
 
+compiler.warn.serializable.value.class.without.write.replace.1=\
+    serializable value class does not declare, or inherits, a writeReplace method
+
+compiler.warn.serializable.value.class.without.write.replace.2=\
+    serializable class does not declare, or inherits, a writeReplace method
+
 # 0: symbol, 1: symbol, 2: symbol, 3: symbol
 compiler.warn.potentially.ambiguous.overload=\
     {0} in {1} is potentially ambiguous with {2} in {3}
@@ -4122,3 +4128,6 @@ compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class=\
 compiler.err.enclosing.class.type.non.denotable=\
     enclosing class type: {0}\n\
     is non-denotable, try casting to a denotable type
+
+compiler.warn.value.finalize=\
+    value classes should not have finalize methods, they are not invoked

--- a/test/langtools/tools/javac/diags/examples/SerializableIdentityClass.java
+++ b/test/langtools/tools/javac/diags/examples/SerializableIdentityClass.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.serializable.value.class.without.write.replace.2
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: -Xlint:serial --enable-preview -source ${jdk.version}
+
+import java.io.Serializable;
+
+abstract value class ValueSuper implements Serializable {
+    private static final long serialVersionUID = 1;
+}
+
+class SerializableIdentityClass extends ValueSuper {
+    private static final long serialVersionUID = 1;
+}

--- a/test/langtools/tools/javac/diags/examples/SerializableValueClass.java
+++ b/test/langtools/tools/javac/diags/examples/SerializableValueClass.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.serializable.value.class.without.write.replace.1
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: -Xlint:serial --enable-preview -source ${jdk.version}
+
+import java.io.Serializable;
+
+value class SerializableValueClass implements Serializable {
+    private static final long serialVersionUID = 1;
+}

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithFinalizeMethod.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithFinalizeMethod.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.value.finalize
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// key: compiler.warn.has.been.deprecated.for.removal
+// options: --enable-preview  -source ${jdk.version}
+
+value class ValueWithFinalizeMethod {
+    protected void finalize() throws Throwable { }
+}

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -890,7 +890,7 @@ class ValueObjectCompilationTests extends CompilationTestCase {
             assertOK(
                     """
                     import java.io.*;
-                    abstract value class AVC implements Serializable {} 
+                    abstract value class AVC implements Serializable {}
                     """);
             assertOKWithWarning("compiler.warn.serializable.value.class.without.write.replace.1",
                     """


### PR DESCRIPTION
adding warning for value classes declaring a `finalize` method and warnings related to the new serialization

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334692](https://bugs.openjdk.org/browse/JDK-8334692): [lworld] add missing compiler warnings (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1147/head:pull/1147` \
`$ git checkout pull/1147`

Update a local copy of the PR: \
`$ git checkout pull/1147` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1147`

View PR using the GUI difftool: \
`$ git pr show -t 1147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1147.diff">https://git.openjdk.org/valhalla/pull/1147.diff</a>

</details>
