### PR TITLE
8334546: [lworld] C2: Calling clone() on non-allocated inline types fails with "Should have been buffered"

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5348,6 +5348,12 @@ bool LibraryCallKit::inline_native_clone(bool is_virtual) {
     if (stopped())  return true;
 
     const TypeOopPtr* obj_type = _gvn.type(obj)->is_oopptr();
+    if (obj_type->is_inlinetypeptr()) {
+      // If the object to clone is an inline type, we can simply return it (i.e. a nop) since inline types have
+      // no identity.
+      set_result(obj);
+      return true;
+    }
 
     // If we are going to clone an instance, we need its exact type to
     // know the number and types of fields to convert the clone to

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestIntrinsics.java
@@ -1672,4 +1672,33 @@ public class TestIntrinsics {
             }
         }
     }
+
+    static value class MyValueClonable implements Cloneable {
+        int x;
+
+        MyValueClonable(int x) {
+            this.x = x;
+        }
+
+        @Override
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.ALLOC, "1"})
+    public Object testClone() throws CloneNotSupportedException {
+        MyValueClonable obj = new MyValueClonable(3);
+        return obj.clone();
+    }
+
+    @Run(test = "testClone")
+    public void testClone_verifier() {
+        try {
+            testClone();
+        } catch (Exception e) {
+            Asserts.fail("testClone() failed", e);
+        }
+    }
 }


### PR DESCRIPTION
We are currently not handling inline types in the `clone()` instrinsic because it was not possible for a value class to implement `Cloneable`. This changed with [JDK-8332243](https://bugs.openjdk.org/browse/JDK-8332243). A value class now trivially returns the inline type because it has no identity. We need to do the same in the C2 intrinsic for `clone()` when we have an inline type (currently, we are hitting an assert later).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8334546](https://bugs.openjdk.org/browse/JDK-8334546): [lworld] C2: Calling clone() on non-allocated inline types fails with "Should have been buffered" (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1149/head:pull/1149` \
`$ git checkout pull/1149`

Update a local copy of the PR: \
`$ git checkout pull/1149` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1149`

View PR using the GUI difftool: \
`$ git pr show -t 1149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1149.diff">https://git.openjdk.org/valhalla/pull/1149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1149#issuecomment-2194710701)