### PR TITLE
8282106: [lworld] IdentityException should identify the value class

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -330,7 +330,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
 
   CodeStub* throw_ie_stub =
       x->maybe_inlinetype() ?
-      new SimpleExceptionStub(Runtime1::throw_identity_exception_id, LIR_OprFact::illegalOpr, state_for(x)) :
+      new SimpleExceptionStub(Runtime1::throw_identity_exception_id, obj.result(), state_for(x)) :
       nullptr;
 
   // this CodeEmitInfo must not have the xhandlers because here the

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -930,7 +930,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
     case throw_identity_exception_id:
       { StubFrame f(sasm, "throw_identity_exception", dont_gc_arguments);
-        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), false);
+        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), true);
       }
       break;
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -4237,7 +4237,7 @@ void TemplateTable::monitorenter()
 
   __ bind(is_inline_type);
   __ call_VM(noreg, CAST_FROM_FN_PTR(address,
-                    InterpreterRuntime::throw_identity_exception));
+                    InterpreterRuntime::throw_identity_exception), r0);
   __ should_not_reach_here();
 }
 

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -339,7 +339,7 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
 
   CodeStub* throw_ie_stub = x->maybe_inlinetype() ?
       new SimpleExceptionStub(Runtime1::throw_identity_exception_id,
-                              LIR_OprFact::illegalOpr, state_for(x))
+                              obj.result(), state_for(x))
     : nullptr;
 
   // this CodeEmitInfo must not have the xhandlers because here the

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1349,7 +1349,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
     case throw_identity_exception_id:
       { StubFrame f(sasm, "throw_identity_exception", dont_gc_arguments);
-        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), false);
+        oop_maps = generate_exception_throw(sasm, CAST_FROM_FN_PTR(address, throw_identity_exception), true);
       }
       break;
 

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4707,7 +4707,7 @@ void TemplateTable::monitorenter() {
 
   __ bind(is_inline_type);
   __ call_VM(noreg, CAST_FROM_FN_PTR(address,
-                    InterpreterRuntime::throw_identity_exception));
+                    InterpreterRuntime::throw_identity_exception), rax);
   __ should_not_reach_here();
 }
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -886,10 +886,11 @@ JRT_ENTRY(void, Runtime1::throw_illegal_monitor_state_exception(JavaThread* curr
   SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_IllegalMonitorStateException());
 JRT_END
 
-JRT_ENTRY(void, Runtime1::throw_identity_exception(JavaThread* current))
+JRT_ENTRY(void, Runtime1::throw_identity_exception(JavaThread* current, oopDesc* object))
   NOT_PRODUCT(_throw_identity_exception_count++;)
   ResourceMark rm(current);
-  SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_IdentityException());
+  char* message = SharedRuntime::generate_identity_exception_message(current, object->klass());
+  SharedRuntime::throw_and_post_jvmti_exception(current, vmSymbols::java_lang_IdentityException(), message);
 JRT_END
 
 JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, BasicObjectLock* lock))

--- a/src/hotspot/share/c1/c1_Runtime1.hpp
+++ b/src/hotspot/share/c1/c1_Runtime1.hpp
@@ -175,7 +175,7 @@ class Runtime1: public AllStatic {
   static void throw_class_cast_exception(JavaThread* current, oopDesc* object);
   static void throw_incompatible_class_change_error(JavaThread* current);
   static void throw_illegal_monitor_state_exception(JavaThread* current);
-  static void throw_identity_exception(JavaThread* current);
+  static void throw_identity_exception(JavaThread* current, oopDesc* object);
   static void throw_array_store_exception(JavaThread* current, oopDesc* object);
 
   static void monitorenter(JavaThread* current, oopDesc* obj, BasicObjectLock* lock);

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -975,8 +975,20 @@ JRT_ENTRY(void, InterpreterRuntime::new_illegal_monitor_state_exception(JavaThre
   current->set_vm_result(exception());
 JRT_END
 
-JRT_ENTRY(void, InterpreterRuntime::throw_identity_exception(JavaThread* current))
-  THROW(vmSymbols::java_lang_IdentityException());
+JRT_ENTRY(void, InterpreterRuntime::throw_identity_exception(JavaThread* current, oopDesc* obj))
+  Klass* klass = cast_to_oop(obj)->klass();
+  ResourceMark rm(THREAD);
+  const char* desc = "Cannot synchronize on an instance of value class ";
+  const char* className = klass->external_name();
+  size_t msglen = strlen(desc) + strlen(className) + 1;
+  char* message = NEW_RESOURCE_ARRAY(char, msglen);
+  if (nullptr == message) {
+    // Out of memory: can't create detailed error message
+    THROW_MSG(vmSymbols::java_lang_IdentityException(), className);
+  } else {
+    jio_snprintf(message, msglen, "%s%s", desc, className);
+    THROW_MSG(vmSymbols::java_lang_IdentityException(), message);
+  }
 JRT_END
 
 //------------------------------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -119,7 +119,7 @@ class InterpreterRuntime: AllStatic {
 
   static void    throw_illegal_monitor_state_exception(JavaThread* current);
   static void    new_illegal_monitor_state_exception(JavaThread* current);
-  static void    throw_identity_exception(JavaThread* current);
+  static void    throw_identity_exception(JavaThread* current, oopDesc* obj);
 
   // Breakpoints
   static void _breakpoint(JavaThread* current, Method* method, address bcp);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1972,6 +1972,21 @@ char* SharedRuntime::generate_class_cast_message(
   return message;
 }
 
+char* SharedRuntime::generate_identity_exception_message(JavaThread* current, Klass* klass) {
+  assert(klass->is_inline_klass(), "Must be a concrete value class");
+  const char* desc = "Cannot synchronize on an instance of value class ";
+  const char* className = klass->external_name();
+  size_t msglen = strlen(desc) + strlen(className) + 1;
+  char* message = NEW_RESOURCE_ARRAY(char, msglen);
+  if (nullptr == message) {
+    // Out of memory: can't create detailed error message
+    message = const_cast<char*>(klass->external_name());
+  } else {
+    jio_snprintf(message, msglen, "%s%s", desc, className);
+  }
+  return message;
+}
+
 JRT_LEAF(void, SharedRuntime::reguard_yellow_pages())
   (void) JavaThread::current()->stack_overflow_state()->reguard_stack();
 JRT_END

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -319,6 +319,8 @@ class SharedRuntime: AllStatic {
   //
   static char* generate_class_cast_message(Klass* caster_klass, Klass* target_klass, Symbol* target_klass_name = nullptr);
 
+  static char* generate_identity_exception_message(JavaThread* thr, Klass* klass);
+
   // Resolves a call site- may patch in the destination of the call into the
   // compiled code.
   static methodHandle resolve_helper(bool is_virtual, bool is_optimized, bool& caller_is_c1, TRAPS);

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
@@ -1,0 +1,79 @@
+/*
+* Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+*
+* This code is free software; you can redistribute it and/or modify it
+* under the terms of the GNU General Public License version 2 only, as
+* published by the Free Software Foundation.
+*
+* This code is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+* version 2 for more details (a copy is included in the LICENSE file that
+* accompanied this code).
+*
+* You should have received a copy of the GNU General Public License version
+* 2 along with this work; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+* or visit www.oracle.com if you need additional information or have any
+* questions.
+*/
+
+/**
+* @test TestCloneableValue
+* @library /test/lib
+* @enablePreview
+* @compile TestCloneableValue.java
+* @run main/othervm -XX:LockingMode=0 runtime.valhalla.inlinetypes.TestCloneableValue
+*/
+
+/**
+* @test TestCloneableValue
+* @library /test/lib
+* @enablePreview
+* @compile TestCloneableValue.java
+* @run main/othervm -XX:LockingMode=1 runtime.valhalla.inlinetypes.TestCloneableValue
+*/
+
+/**
+* @test TestCloneableValue
+* @library /test/lib
+* @enablePreview
+* @compile TestCloneableValue.java
+* @run main/othervm -XX:LockingMode=2 runtime.valhalla.inlinetypes.TestCloneableValue
+*/
+
+package runtime.valhalla.inlinetypes;
+
+import jdk.test.lib.Asserts;
+
+public class MonitorEnterTest {
+
+  static void monitorEnter(Object o, boolean expectSuccess, String message) {
+    try {
+      synchronized(o) {
+        Asserts.assertFalse(expectSuccess, "MonitorEnter should not have succeeded on an instance of " + o.getClass().getName());
+      }
+    } catch (IdentityException e) {
+      Asserts.assertTrue(expectSuccess, "Unexpected IdentityException with an instance of " + o.getClass().getName());
+      if (message != null) {
+        Asserts.assertEQ(e.getMessage(), message, "Exception message mismatch");
+      }
+    }
+  }
+
+  static value class MyValue { }
+
+  public static void main(String[] args) {
+    // Attempts to lock the instance are repeated many time to ensure that the different paths
+    // are used: interpreter, C1, and C2 (which deopt to the interpreter in this case)
+    for (int i = 0; i <  20000; i++) {
+      monitorEnter(new Object(), true);
+      monitorEnter(new String(), true);
+      monitorEnter(new MyValue(), false, "Cannot synchronize on an instance of value class MonitorEnterTest$MyValue");
+      monitorEnter(Integer.valueOf(42), false, "Cannot synchronize on an instance of value class java.lang.Integer");
+    }
+  }
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
@@ -52,28 +52,28 @@ import jdk.test.lib.Asserts;
 public class MonitorEnterTest {
 
   static void monitorEnter(Object o, boolean expectSuccess, String message) {
-    try {
-      synchronized(o) {
-        Asserts.assertFalse(expectSuccess, "MonitorEnter should not have succeeded on an instance of " + o.getClass().getName());
+      try {
+          synchronized(o) {
+            Asserts.assertFalse(expectSuccess, "MonitorEnter should not have succeeded on an instance of " + o.getClass().getName());
+          }
+      } catch (IdentityException e) {
+          Asserts.assertTrue(expectSuccess, "Unexpected IdentityException with an instance of " + o.getClass().getName());
+          if (message != null) {
+              Asserts.assertEQ(e.getMessage(), message, "Exception message mismatch");
+          }
       }
-    } catch (IdentityException e) {
-      Asserts.assertTrue(expectSuccess, "Unexpected IdentityException with an instance of " + o.getClass().getName());
-      if (message != null) {
-        Asserts.assertEQ(e.getMessage(), message, "Exception message mismatch");
-      }
-    }
   }
 
   static value class MyValue { }
 
-  public static void main(String[] args) {
-    // Attempts to lock the instance are repeated many time to ensure that the different paths
-    // are used: interpreter, C1, and C2 (which deopt to the interpreter in this case)
-    for (int i = 0; i <  20000; i++) {
-      monitorEnter(new Object(), true);
-      monitorEnter(new String(), true);
-      monitorEnter(new MyValue(), false, "Cannot synchronize on an instance of value class MonitorEnterTest$MyValue");
-      monitorEnter(Integer.valueOf(42), false, "Cannot synchronize on an instance of value class java.lang.Integer");
+    public static void main(String[] args) {
+        // Attempts to lock the instance are repeated many time to ensure that the different paths
+        // are used: interpreter, C1, and C2 (which deopt to the interpreter in this case)
+        for (int i = 0; i <  20000; i++) {
+            monitorEnter(new Object(), true);
+            monitorEnter(new String(), true);
+            monitorEnter(new MyValue(), false, "Cannot synchronize on an instance of value class MonitorEnterTest$MyValue");
+            monitorEnter(Integer.valueOf(42), false, "Cannot synchronize on an instance of value class java.lang.Integer");
+        }
     }
-  }
 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/MonitorEnterTest.java
@@ -22,27 +22,27 @@
 */
 
 /**
-* @test TestCloneableValue
+* @test MonitorEnterTest
 * @library /test/lib
 * @enablePreview
-* @compile TestCloneableValue.java
-* @run main/othervm -XX:LockingMode=0 runtime.valhalla.inlinetypes.TestCloneableValue
+* @compile MonitorEnterTest.java
+* @run main/othervm -XX:LockingMode=0 runtime.valhalla.inlinetypes.MonitorEnterTest
 */
 
 /**
-* @test TestCloneableValue
+* @test MonitorEnterTest
 * @library /test/lib
 * @enablePreview
-* @compile TestCloneableValue.java
-* @run main/othervm -XX:LockingMode=1 runtime.valhalla.inlinetypes.TestCloneableValue
+* @compile MonitorEnterTest.java
+* @run main/othervm -XX:LockingMode=1 runtime.valhalla.inlinetypes.MonitorEnterTest
 */
 
 /**
-* @test TestCloneableValue
+* @test MonitorEnterTest
 * @library /test/lib
 * @enablePreview
-* @compile TestCloneableValue.java
-* @run main/othervm -XX:LockingMode=2 runtime.valhalla.inlinetypes.TestCloneableValue
+* @compile MonitorEnterTest.java
+* @run main/othervm -XX:LockingMode=2 runtime.valhalla.inlinetypes.MonitorEnterTest
 */
 
 package runtime.valhalla.inlinetypes;
@@ -54,10 +54,10 @@ public class MonitorEnterTest {
   static void monitorEnter(Object o, boolean expectSuccess, String message) {
       try {
           synchronized(o) {
-            Asserts.assertFalse(expectSuccess, "MonitorEnter should not have succeeded on an instance of " + o.getClass().getName());
+            Asserts.assertTrue(expectSuccess, "MonitorEnter should not have succeeded on an instance of " + o.getClass().getName());
           }
       } catch (IdentityException e) {
-          Asserts.assertTrue(expectSuccess, "Unexpected IdentityException with an instance of " + o.getClass().getName());
+          Asserts.assertFalse(expectSuccess, "Unexpected IdentityException with an instance of " + o.getClass().getName());
           if (message != null) {
               Asserts.assertEQ(e.getMessage(), message, "Exception message mismatch");
           }
@@ -70,9 +70,9 @@ public class MonitorEnterTest {
         // Attempts to lock the instance are repeated many time to ensure that the different paths
         // are used: interpreter, C1, and C2 (which deopt to the interpreter in this case)
         for (int i = 0; i <  20000; i++) {
-            monitorEnter(new Object(), true);
-            monitorEnter(new String(), true);
-            monitorEnter(new MyValue(), false, "Cannot synchronize on an instance of value class MonitorEnterTest$MyValue");
+            monitorEnter(new Object(), true, "");
+            monitorEnter(new String(), true, "");
+            monitorEnter(new MyValue(), false, "Cannot synchronize on an instance of value class runtime.valhalla.inlinetypes.MonitorEnterTest$MyValue");
             monitorEnter(Integer.valueOf(42), false, "Cannot synchronize on an instance of value class java.lang.Integer");
         }
     }


### PR DESCRIPTION
Improve the message of IdentityException by including the class of the instance that triggered the exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8282106](https://bugs.openjdk.org/browse/JDK-8282106): [lworld] IdentityException should identify the value class (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1150/head:pull/1150` \
`$ git checkout pull/1150`

Update a local copy of the PR: \
`$ git checkout pull/1150` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1150`

View PR using the GUI difftool: \
`$ git pr show -t 1150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1150.diff">https://git.openjdk.org/valhalla/pull/1150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1150#issuecomment-2195661554)