### PR TITLE
8335279: [lworld] javac should attribute instance initializers according to their final location relative to the super ctor invocation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1318,10 +1318,19 @@ public class Attr extends JCTree.Visitor {
                     // declaration position to maximal possible value, effectively
                     // marking the variable as undefined.
                     initEnv.info.enclVar = v;
-                    attribExpr(tree.init, initEnv, v.type);
-                    if (tree.isImplicitlyTyped()) {
-                        //fixup local variable type
-                        v.type = chk.checkLocalVarType(tree, tree.init.type, tree.name);
+                    boolean previousCtorPrologue = initEnv.info.ctorPrologue;
+                    try {
+                        if (v.owner.kind == TYP && v.owner.isValueClass() && !v.isStatic()) {
+                            // strict instance initializer in a value class
+                            initEnv.info.ctorPrologue = true;
+                        }
+                        attribExpr(tree.init, initEnv, v.type);
+                        if (tree.isImplicitlyTyped()) {
+                            //fixup local variable type
+                            v.type = chk.checkLocalVarType(tree, tree.init.type, tree.name);
+                        }
+                    } finally {
+                        initEnv.info.ctorPrologue = previousCtorPrologue;
                     }
                 }
                 if (tree.isImplicitlyTyped()) {

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -736,6 +736,14 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                 }
                 """
         );
+        assertFail("compiler.err.cant.ref.before.ctor.called",
+                """
+                value class Test {
+                    Test t = null;
+                    Runnable r = () -> { System.err.println(t); };
+                }
+                """
+        );
     }
 
     @Test


### PR DESCRIPTION
this code:

```
value class Test {
    Test t = null;
    Runnable r = () -> { System.err.println(t); };
}
```
was being accepted by javac but then failed with a verifier error at run time. When attributing instance initializers javac should take into account the position they will have in the constructor relative to the super constructor invocation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335279](https://bugs.openjdk.org/browse/JDK-8335279): [lworld] javac should attribute instance initializers according to their final location relative to the super ctor invocation (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1151/head:pull/1151` \
`$ git checkout pull/1151`

Update a local copy of the PR: \
`$ git checkout pull/1151` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1151`

View PR using the GUI difftool: \
`$ git pr show -t 1151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1151.diff">https://git.openjdk.org/valhalla/pull/1151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1151#issuecomment-2198333575)