### PR TITLE
8335483: [lworld] identity class extending Number should not get the new serialization related warning

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -254,6 +254,7 @@ public class Symtab {
     public final Type strictType;
     /** The symbol representing the finalize method on Object */
     public final MethodSymbol objectFinalize;
+    public final Type numberType;
 
     /** The symbol representing the length field of an array.
      */
@@ -661,6 +662,8 @@ public class Symtab {
         templateRuntimeType = enterClass("java.lang.runtime.TemplateRuntime");
         processorType = enterClass("java.lang.StringTemplate$Processor");
         linkageType = enterClass("java.lang.StringTemplate$Processor$Linkage");
+
+        numberType = enterClass("java.lang.Number");
 
         // Enter a synthetic class that is used to mark internal
         // proprietary classes in ct.sym.  This class does not have a

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -5202,7 +5202,7 @@ public class Check {
                 });
             }
             if (!hasWriteReplace[0] &&
-                    (c.isValueClass() || hasAbstractValueSuperClass(c)) &&
+                    (c.isValueClass() || hasAbstractValueSuperClass(c, Set.of(syms.numberType.tsym))) &&
                     !c.isAbstract() && !c.isRecord() &&
                     types.unboxedType(c.type) == Type.noType) {
                 // we need to check if the class is inheriting an appropriate writeReplace method
@@ -5228,7 +5228,7 @@ public class Check {
             return type.isPrimitive() || rs.isSerializable(type);
         }
 
-        private boolean hasAbstractValueSuperClass(Symbol c) {
+        private boolean hasAbstractValueSuperClass(Symbol c, Set<Symbol> excluding) {
             while (c.getKind() == ElementKind.CLASS) {
                 Type sup = ((ClassSymbol)c).getSuperclass();
                 if (!sup.hasTag(CLASS) || sup.isErroneous() ||
@@ -5236,7 +5236,7 @@ public class Check {
                     return false;
                 }
                 // if it is a value super class it has to be abstract
-                if (sup.isValueClass()) {
+                if (sup.isValueClass() && !excluding.contains(sup.tsym)) {
                     return true;
                 }
                 c = sup.tsym;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1141,6 +1141,22 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                         private static final long serialVersionUID = 1;
                     }
                     """);
+            assertOK(
+                    // Number is a special case, no warning for identity classes extending it
+                    """
+                    class NumberSubClass extends Number {
+                        private static final long serialVersionUID = 0L;
+                        @Override
+                        public double doubleValue() { return 0; }
+                        @Override
+                        public int intValue() { return 0; }
+                        @Override
+                        public long longValue() { return 0; }
+                        @Override
+                        public float floatValue() { return 0; }
+                    }
+                    """
+            );
         } finally {
             setCompileOptions(previousOptions);
         }


### PR DESCRIPTION
no serialization warning for identity classes extending Number

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335483](https://bugs.openjdk.org/browse/JDK-8335483): [lworld] identity class extending Number should not get the new serialization related warning (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1153/head:pull/1153` \
`$ git checkout pull/1153`

Update a local copy of the PR: \
`$ git checkout pull/1153` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1153`

View PR using the GUI difftool: \
`$ git pr show -t 1153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1153.diff">https://git.openjdk.org/valhalla/pull/1153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1153#issuecomment-2201675231)