### PR TITLE
8335641: [lworld] add the MigratedValueClass annotation to some classes missing it, some bug fixes

### DIFF
--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -131,6 +131,7 @@ import java.util.regex.Pattern;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class Duration
         implements TemporalAmount, Comparable<Duration>, Serializable {
 

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -207,6 +207,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class Instant
         implements Temporal, TemporalAdjuster, Comparable<Instant>, Serializable {
 

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -137,6 +137,7 @@ import java.util.stream.Stream;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class LocalDate
         implements Temporal, TemporalAdjuster, ChronoLocalDate, Serializable {
 

--- a/src/java.base/share/classes/java/time/LocalDateTime.java
+++ b/src/java.base/share/classes/java/time/LocalDateTime.java
@@ -133,6 +133,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class LocalDateTime
         implements Temporal, TemporalAdjuster, ChronoLocalDateTime<LocalDate>, Serializable {
 

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -123,6 +123,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class LocalTime
         implements Temporal, TemporalAdjuster, Comparable<LocalTime>, Serializable {
 

--- a/src/java.base/share/classes/java/time/MonthDay.java
+++ b/src/java.base/share/classes/java/time/MonthDay.java
@@ -125,6 +125,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class MonthDay
         implements TemporalAccessor, TemporalAdjuster, Comparable<MonthDay>, Serializable {
 

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -126,6 +126,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class OffsetDateTime
         implements Temporal, TemporalAdjuster, Comparable<OffsetDateTime>, Serializable {
 

--- a/src/java.base/share/classes/java/time/OffsetTime.java
+++ b/src/java.base/share/classes/java/time/OffsetTime.java
@@ -116,6 +116,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class OffsetTime
         implements Temporal, TemporalAdjuster, Comparable<OffsetTime>, Serializable {
 

--- a/src/java.base/share/classes/java/time/Period.java
+++ b/src/java.base/share/classes/java/time/Period.java
@@ -131,6 +131,7 @@ import java.util.regex.Pattern;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class Period
         implements ChronoPeriod, Serializable {
 

--- a/src/java.base/share/classes/java/time/Year.java
+++ b/src/java.base/share/classes/java/time/Year.java
@@ -133,6 +133,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class Year
         implements Temporal, TemporalAdjuster, Comparable<Year>, Serializable {
 

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -129,6 +129,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class YearMonth
         implements Temporal, TemporalAdjuster, Comparable<YearMonth>, Serializable {
 

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -162,6 +162,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class ZonedDateTime
         implements Temporal, ChronoZonedDateTime<LocalDate>, Serializable {
 

--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
@@ -140,6 +140,7 @@ import java.util.Objects;
  * @param <D> the ChronoLocalDate of this date-time
  * @since 1.8
  */
+@jdk.internal.MigratedValueClass
 abstract class ChronoLocalDateImpl<D extends ChronoLocalDate>
         implements ChronoLocalDate, Temporal, TemporalAdjuster, Serializable {
 

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -117,6 +117,7 @@ import java.time.temporal.ValueRange;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class HijrahDate
         extends ChronoLocalDateImpl<HijrahDate>
         implements ChronoLocalDate, Serializable {

--- a/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
@@ -124,6 +124,7 @@ import sun.util.calendar.LocalGregorianCalendar;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class JapaneseDate
         extends ChronoLocalDateImpl<JapaneseDate>
         implements ChronoLocalDate, Serializable {

--- a/src/java.base/share/classes/java/time/chrono/MinguoDate.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoDate.java
@@ -104,6 +104,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class MinguoDate
         extends ChronoLocalDateImpl<MinguoDate>
         implements ChronoLocalDate, Serializable {

--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
@@ -104,6 +104,7 @@ import java.util.Objects;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class ThaiBuddhistDate
         extends ChronoLocalDateImpl<ThaiBuddhistDate>
         implements ChronoLocalDate, Serializable {

--- a/src/java.base/share/classes/java/util/OptionalDouble.java
+++ b/src/java.base/share/classes/java/util/OptionalDouble.java
@@ -56,6 +56,7 @@ import java.util.stream.DoubleStream;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class OptionalDouble {
     /**
      * Common instance for {@code empty()}.

--- a/src/java.base/share/classes/java/util/OptionalInt.java
+++ b/src/java.base/share/classes/java/util/OptionalInt.java
@@ -56,6 +56,7 @@ import java.util.stream.IntStream;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class OptionalInt {
     /**
      * Common instance for {@code empty()}.

--- a/src/java.base/share/classes/java/util/OptionalLong.java
+++ b/src/java.base/share/classes/java/util/OptionalLong.java
@@ -56,6 +56,7 @@ import java.util.stream.LongStream;
  * @since 1.8
  */
 @jdk.internal.ValueBased
+@jdk.internal.MigratedValueClass
 public final class OptionalLong {
     /**
      * Common instance for {@code empty()}.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -3174,7 +3174,7 @@ public class ClassReader {
             flags &= ~ACC_MODULE;
             flags |= MODULE;
         }
-        if (((flags & ACC_IDENTITY) != 0 && !isMigratedValueClass(flags)) || (majorVersion < V66.major && (flags & INTERFACE) == 0)) {
+        if (((flags & ACC_IDENTITY) != 0 && !isMigratedValueClass(flags)) || (majorVersion < V67.major && (flags & INTERFACE) == 0)) {
             flags |= IDENTITY_TYPE;
         } else if (needsValueFlag(c, flags)) {
             flags |= VALUE_CLASS;
@@ -3186,8 +3186,8 @@ public class ClassReader {
     private boolean needsValueFlag(Symbol c, long flags) {
         boolean previewClassFile = minorVersion == ClassFile.PREVIEW_MINOR_VERSION;
         if (allowValueClasses) {
-            if (previewClassFile && majorVersion >= V66.major && (flags & INTERFACE) == 0 ||
-                    majorVersion >= V66.major && isMigratedValueClass(flags)) {
+            if (previewClassFile && majorVersion >= V67.major && (flags & INTERFACE) == 0 ||
+                    majorVersion >= V67.major && isMigratedValueClass(flags)) {
                 return true;
             }
         }

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -447,58 +447,65 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                         }
                     }
                     """
+            ),
+            new TestData(
+                    "compiler.err.type.found.req", // --enable-preview -source"
+                    """
+                    import java.time.*;
+                    class V {
+                        final Duration val = Duration.ZERO;
+                        void test() {
+                            synchronized (val) { // warn
+                            }
+                        }
+                    }
+                    """,
+                    false // cant do local as there is an import statement
+            ),
+            new TestData(
+                    "compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class", // empty options
+                    """
+                    class V {
+                        final Integer val = Integer.valueOf(42);
+                        void test() {
+                            synchronized (val) { // warn
+                            }
+                        }
+                    }
+                    """,
+                    new String[] {}
+            ),
+            new TestData(
+                    "compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class", // --source
+                    """
+                    class V {
+                        final Integer val = Integer.valueOf(42);
+                        void test() {
+                            synchronized (val) { // warn
+                            }
+                        }
+                    }
+                    """,
+                    new String[] {"--source", Integer.toString(Runtime.version().feature())}
+            ),
+            new TestData(
+                    "compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class", // --source
+                    """
+                    class V {
+                        final Integer val = Integer.valueOf(42);
+                        void test() {
+                            synchronized (val) { // warn
+                            }
+                        }
+                    }
+                    """,
+                    new String[] {"--source", Integer.toString(Runtime.version().feature())}
             )
     );
 
     @Test
     void testSemanticsViolations() {
         testHelper(semanticsViolations);
-        testHelper(
-                List.of(
-                        new TestData(
-                                "compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class", // empty options
-                                """
-                                class V {
-                                    final Integer val = Integer.valueOf(42);
-                                    void test() {
-                                        synchronized (val) { // warn
-                                        }
-                                    }
-                                }
-                                """,
-                                new String[] {}
-                        ),
-                        new TestData(
-                                "compiler.warn.attempt.to.synchronize.on.instance.of.value.based.class", // --source
-                                """
-                                class V {
-                                    final Integer val = Integer.valueOf(42);
-                                    void test() {
-                                        synchronized (val) { // warn
-                                        }
-                                    }
-                                }
-                                """,
-                                new String[] {"--source", Integer.toString(Runtime.version().feature())}
-                        ),
-                        new TestData(
-                                "compiler.err.type.found.req", // --enable-preview --source
-                                """
-                                class V {
-                                    final Integer val = Integer.valueOf(42);
-                                    void test() {
-                                        synchronized (val) { // warn
-                                        }
-                                    }
-                                }
-                                """,
-                                new String[] {"--enable-preview", "--source", Integer.toString(Runtime.version().feature())}
-                        )
-                        /* we should add tests for --release and --release --enable-preview once the stubs used for the latest
-                         * release have been updated, right now they are the same as those for 22
-                         */
-                )
-        );
     }
 
     private static final List<TestData> sealedClassesData = List.of(


### PR DESCRIPTION
adding the MigratedValueClass annotation so some classes missing it, plus minor bug fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335641](https://bugs.openjdk.org/browse/JDK-8335641): [lworld] add the MigratedValueClass annotation to some classes missing it, some bug fixes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1155/head:pull/1155` \
`$ git checkout pull/1155`

Update a local copy of the PR: \
`$ git checkout pull/1155` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1155`

View PR using the GUI difftool: \
`$ git pr show -t 1155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1155.diff">https://git.openjdk.org/valhalla/pull/1155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1155#issuecomment-2207191013)