### PR TITLE
8310655: [lworld] ShouldNotReachHere() error in ObjectSynchronizer::FastHashCode

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMapTable.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.cpp
@@ -69,7 +69,7 @@ unsigned JvmtiTagMapKey::get_hash(const JvmtiTagMapKey& entry) {
   assert(obj != nullptr, "must lookup obj to hash");
   if (obj->is_inline_type()) {
     // For inline types, use the klass as a hash code and let the equals match the obj.
-    // It might have a long bucket but sobeit.
+    // It might have a long bucket but TBD to improve this if a customer situation arises.
     return (unsigned)((int64_t)obj->klass() >> 3);
   } else {
     return (unsigned)obj->identity_hash();

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,11 +52,7 @@ class JvmtiTagMapKey : public CHeapObj<mtServiceability> {
   oop object_no_keepalive() const;
   void release_weak_handle();
 
-  static unsigned get_hash(const JvmtiTagMapKey& entry) {
-    assert(entry._obj != nullptr, "must lookup obj to hash");
-    return (unsigned)entry._obj->identity_hash();
-  }
-
+  static unsigned get_hash(const JvmtiTagMapKey& entry);
   static bool equals(const JvmtiTagMapKey& lhs, const JvmtiTagMapKey& rhs) {
     oop lhs_obj = lhs._obj != nullptr ? lhs._obj : lhs.object_no_keepalive();
     oop rhs_obj = rhs._obj != nullptr ? rhs._obj : rhs.object_no_keepalive();


### PR DESCRIPTION
This change uses the klass as the hashcode for inline objects.  It might have some negative performance impact if there are a lot of objects of the same type in the heap walk but it's better than crashing.
Tested with vmTestbase/nsk/jvmti tests locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310655](https://bugs.openjdk.org/browse/JDK-8310655): [lworld] ShouldNotReachHere() error in ObjectSynchronizer::FastHashCode (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1156/head:pull/1156` \
`$ git checkout pull/1156`

Update a local copy of the PR: \
`$ git checkout pull/1156` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1156`

View PR using the GUI difftool: \
`$ git pr show -t 1156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1156.diff">https://git.openjdk.org/valhalla/pull/1156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1156#issuecomment-2211075882)