### PR TITLE
8335770: [lworld] improve javap code coverage

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -756,8 +756,8 @@ public class ClassWriter {
 
         @Override
         public Void visitLoadableDescriptors(LoadableDescriptors_attribute attr, ClassOutputStream out) {
-            out.writeShort(attr.descriptor_info_index.length);
-            for (int index: attr.descriptor_info_index)
+            out.writeShort(attr.descriptors.length);
+            for (int index: attr.descriptors)
                 out.writeShort(index);
             return null;
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/LoadableDescriptors_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/LoadableDescriptors_attribute.java
@@ -37,9 +37,9 @@ public class LoadableDescriptors_attribute extends Attribute {
     LoadableDescriptors_attribute(ClassReader cr, int name_index, int length) throws IOException {
         super(name_index, length);
         number_of_descriptors = cr.readUnsignedShort();
-        descriptor_info_index = new int[number_of_descriptors];
+        descriptors = new int[number_of_descriptors];
         for (int i = 0; i < number_of_descriptors; i++)
-            descriptor_info_index[i] = cr.readUnsignedShort();
+            descriptors[i] = cr.readUnsignedShort();
     }
 
     public <R, D> R accept(Visitor<R, D> visitor, D data) {
@@ -47,5 +47,5 @@ public class LoadableDescriptors_attribute extends Attribute {
     }
 
     public final int number_of_descriptors;
-    public final int descriptor_info_index[];
+    public final int descriptors[];
 }

--- a/test/langtools/tools/javap/value_classes/ValueClassesJavapTest.java
+++ b/test/langtools/tools/javap/value_classes/ValueClassesJavapTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test 8335770
+ * @summary improve javap code coverage for value classes
+ * @enablePreview
+ * @library /tools/lib
+ * @modules jdk.jdeps/com.sun.tools.javap
+ * @build toolbox.ToolBox toolbox.JavapTask
+ * @run main ValueClassesJavapTest
+ */
+
+import java.nio.file.*;
+import java.util.*;
+
+import toolbox.JavapTask;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+import toolbox.Task;
+
+public class ValueClassesJavapTest extends TestRunner {
+    ToolBox tb = new ToolBox();
+
+    abstract value class AbstractValueClass {}
+    value class ValueClass {}
+    class IdentityClass {
+        ValueClass val;
+    }
+    class IdentityClass2 {
+        void m(ValueClass param) {}
+    }
+
+    private static final List<String> expectedOutput1 = List.of(
+            "Compiled from \"ValueClassesJavapTest.java\"",
+            "final value class ValueClassesJavapTest$ValueClass {",
+            "  ValueClassesJavapTest$ValueClass(ValueClassesJavapTest);",
+            "}");
+    private static final List<String> expectedOutput2 = List.of(
+            "Compiled from \"ValueClassesJavapTest.java\"",
+            "abstract value class ValueClassesJavapTest$AbstractValueClass {",
+            "  ValueClassesJavapTest$AbstractValueClass(ValueClassesJavapTest);",
+            "}");
+    private static final List<String> expectedOutput3 = List.of(
+            "LoadableDescriptors:",
+            "  LValueClassesJavapTest$ValueClass;"
+    );
+
+    ValueClassesJavapTest() throws Exception {
+        super(System.err);
+    }
+
+    public static void main(String... args) throws Exception {
+        ValueClassesJavapTest tester = new ValueClassesJavapTest();
+        tester.runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testMain(Path base) throws Exception {
+        Path testClassesPath = Paths.get(System.getProperty("test.classes"));
+        List<String> output = new JavapTask(tb)
+                .options("-p", testClassesPath.resolve(this.getClass().getSimpleName() + "$ValueClass.class").toString())
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        System.out.println(output);
+        if (!output.equals(expectedOutput1)) {
+            throw new AssertionError(String.format("unexpected output:\n %s", output));
+        }
+
+        output = new JavapTask(tb)
+                .options("-p", testClassesPath.resolve(this.getClass().getSimpleName() + "$AbstractValueClass.class").toString())
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        System.out.println(output);
+        if (!output.equals(expectedOutput2)) {
+            throw new AssertionError(String.format("unexpected output:\n %s", output));
+        }
+
+        output = new JavapTask(tb)
+                .options("-p", "-v", testClassesPath.resolve(this.getClass().getSimpleName() + "$IdentityClass.class").toString())
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        System.out.println(output);
+        if (!output.containsAll(expectedOutput3)) {
+            throw new AssertionError(String.format("unexpected output:\n %s", output));
+        }
+
+        output = new JavapTask(tb)
+                .options("-p", "-v", testClassesPath.resolve(this.getClass().getSimpleName() + "$IdentityClass2.class").toString())
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+        System.out.println(output);
+        if (!output.containsAll(expectedOutput3)) {
+            throw new AssertionError(String.format("unexpected output:\n %s", output));
+        }
+    }
+}


### PR DESCRIPTION
adding tests to improve javap code coverage for value classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335770](https://bugs.openjdk.org/browse/JDK-8335770): [lworld] improve javap code coverage (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1157/head:pull/1157` \
`$ git checkout pull/1157`

Update a local copy of the PR: \
`$ git checkout pull/1157` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1157`

View PR using the GUI difftool: \
`$ git pr show -t 1157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1157.diff">https://git.openjdk.org/valhalla/pull/1157.diff</a>

</details>
