### PR TITLE
8310023: [lworld] Implement alternative fast-locking scheme in Valhalla

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1829,10 +1829,6 @@ bool Arguments::check_vm_args_consistency() {
     warning("InlineTypeReturnedAsFields is not supported on this platform");
   }
 
-  // Valhalla missing LM_LIGHTWEIGHT support just now
-  if (EnableValhalla && LockingMode == LM_LIGHTWEIGHT) {
-    FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
-  }
 #if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)
   if (LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);


### PR DESCRIPTION
I don't see anything missing for implementing the test for inline types for lightweight locking.  The only thing broken seems to be JNI monitorenter should throw IdentityException.  I added some comments and asserts when I figured out the interpreter and c1/c2 don't get to ObjectSynchronizer::enter.
Tested with tier1 with LM_LIGHTWEIGHT as the default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8310023](https://bugs.openjdk.org/browse/JDK-8310023): [lworld] Implement alternative fast-locking scheme in Valhalla (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1158/head:pull/1158` \
`$ git checkout pull/1158`

Update a local copy of the PR: \
`$ git checkout pull/1158` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1158`

View PR using the GUI difftool: \
`$ git pr show -t 1158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1158.diff">https://git.openjdk.org/valhalla/pull/1158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1158#issuecomment-2211962063)