### PR TITLE
8335439: [lworld] ValueFieldInheritanceTest.java fails with -XX:-UseCompressedClassPointers

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1016,7 +1016,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
     if (_is_abstract_value && _has_nonstatic_fields) {
       _alignment = type2aelembytes(BasicType::T_LONG);
     }
-    assert(_layout->start()->next_block()->kind() == LayoutRawBlock::EMPTY, "Unexpected");
+    assert(_layout->start()->next_block()->kind() == LayoutRawBlock::EMPTY || !UseCompressedClassPointers, "Unexpected");
     LayoutRawBlock* first_empty = _layout->start()->next_block();
     if (first_empty->offset() % _alignment != 0) {
       LayoutRawBlock* padding = new LayoutRawBlock(LayoutRawBlock::PADDING, _alignment - (first_empty->offset() % _alignment));

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
@@ -51,6 +51,16 @@
  * @run main/othervm NullMarkersTest 2
  */
 
+/*
+ * @test id=NullMarker64NoCompressedOopsNoCompressedKlassPointers
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @compile FieldLayoutAnalyzer.java NullMarkersTest.java
+ * @run main/othervm NullMarkersTest 3
+ */
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -275,7 +285,7 @@ public class NullMarkersTest {
     Asserts.assertTrue(fb1.hasNullMarker());
   }
 
-  static ProcessBuilder exec(String compressedOopsArg, String... args) throws Exception {
+  static ProcessBuilder exec(String compressedOopsArg, String compressedKlassPointersArg, String... args) throws Exception {
     List<String> argsList = new ArrayList<>();
     Collections.addAll(argsList, "--enable-preview");
     Collections.addAll(argsList, "-Xint");
@@ -283,6 +293,9 @@ public class NullMarkersTest {
     Collections.addAll(argsList, "-XX:+PrintFieldLayout");
     if (compressedOopsArg != null) {
       Collections.addAll(argsList, compressedOopsArg);
+    }
+    if (compressedKlassPointersArg != null) {
+      Collections.addAll(argsList, compressedKlassPointersArg);
     }
     Collections.addAll(argsList, "-Xmx256m");
     Collections.addAll(argsList, "-XX:+EnableNullableFieldFlattening");
@@ -293,13 +306,20 @@ public class NullMarkersTest {
 
   public static void main(String[] args) throws Exception {
     String compressedOopsArg;
+    String compressedKlassPointersArg;
 
     switch(args[0]) {
       case "0": compressedOopsArg = null;
+                compressedKlassPointersArg = null;
                 break;
       case "1": compressedOopsArg = "-XX:+UseCompressedOops";
+                compressedKlassPointersArg =  "-XX:+UseCompressedClassPointers";
                 break;
       case "2": compressedOopsArg = "-XX:-UseCompressedOops";
+                compressedKlassPointersArg = "-XX:+UseCompressedClassPointers";
+                break;
+      case "3": compressedOopsArg = "-XX:-UseCompressedOops";
+                compressedKlassPointersArg = "-XX:-UseCompressedClassPointers";
                 break;
       default: throw new RuntimeException("Unrecognized configuration");
     }
@@ -308,9 +328,12 @@ public class NullMarkersTest {
     NullMarkersTest fat = new NullMarkersTest();
 
     // Execute the test runner in charge of loading all test classes
-    ProcessBuilder pb = exec(compressedOopsArg, "NullMarkersTest$TestRunner");
+    ProcessBuilder pb = exec(compressedOopsArg, compressedKlassPointersArg, "NullMarkersTest$TestRunner");
     OutputAnalyzer out = new OutputAnalyzer(pb.start());
 
+    if (out.getExitValue() != 0) {
+      out.outputTo(System.out);
+    }
     Asserts.assertEquals(out.getExitValue(), 0, "Something went wrong while running the tests");
 
     // Get and parse the test output

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java
@@ -51,6 +51,16 @@
  * @run main/othervm -Xint ValueFieldInheritanceTest 2
  */
 
+/*
+ * @test id=64bitsNoCompressedOopsNoCompressKlassPointers
+ * @requires vm.bits == 64
+ * @library /test/lib
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @compile FieldLayoutAnalyzer.java ValueFieldInheritanceTest.java
+ * @run main/othervm -Xint ValueFieldInheritanceTest 3
+ */
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -161,13 +171,16 @@ public class ValueFieldInheritanceTest {
     }
   }
 
-  static ProcessBuilder exec(String compressedOopsArg, String... args) throws Exception {
+  static ProcessBuilder exec(String compressedOopsArg, String compressedKlassPointersArg, String... args) throws Exception {
     List<String> argsList = new ArrayList<>();
     Collections.addAll(argsList, "--enable-preview");
     Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
     Collections.addAll(argsList, "-XX:+PrintFieldLayout");
     if (compressedOopsArg != null) {
       Collections.addAll(argsList, compressedOopsArg);
+    }
+    if (compressedKlassPointersArg != null) {
+      Collections.addAll(argsList, compressedKlassPointersArg);
     }
     Collections.addAll(argsList, "-Xmx256m");
     Collections.addAll(argsList, "-cp", System.getProperty("java.class.path") + ":.");
@@ -177,13 +190,20 @@ public class ValueFieldInheritanceTest {
 
   public static void main(String[] args) throws Exception {
     String compressedOopsArg;
+    String compressedKlassPointersArg;
 
     switch(args[0]) {
       case "0": compressedOopsArg = null;
+                compressedKlassPointersArg = null;
                 break;
       case "1": compressedOopsArg = "-XX:+UseCompressedOops";
+                compressedKlassPointersArg =  "-XX:+UseCompressedClassPointers";
                 break;
       case "2": compressedOopsArg = "-XX:-UseCompressedOops";
+                compressedKlassPointersArg = "-XX:+UseCompressedClassPointers";
+                break;
+      case "3": compressedOopsArg = "-XX:-UseCompressedOops";
+                compressedKlassPointersArg = "-XX:-UseCompressedClassPointers";
                 break;
       default: throw new RuntimeException("Unrecognized configuration");
     }
@@ -192,7 +212,7 @@ public class ValueFieldInheritanceTest {
     // NullMarkersTest fat = new NullMarkersTest();
 
     // Execute the test runner in charge of loading all test classes
-    ProcessBuilder pb = exec(compressedOopsArg, "ValueFieldInheritanceTest$TestRunner");
+    ProcessBuilder pb = exec(compressedOopsArg, compressedKlassPointersArg, "ValueFieldInheritanceTest$TestRunner");
     OutputAnalyzer out = new OutputAnalyzer(pb.start());
 
     if (out.getExitValue() != 0) {


### PR DESCRIPTION
Fix an assert invalid when class pointers are not compressed, extend testing to cover this case systematically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335439](https://bugs.openjdk.org/browse/JDK-8335439): [lworld] ValueFieldInheritanceTest.java fails with -XX:-UseCompressedClassPointers (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1159/head:pull/1159` \
`$ git checkout pull/1159`

Update a local copy of the PR: \
`$ git checkout pull/1159` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1159`

View PR using the GUI difftool: \
`$ git pr show -t 1159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1159.diff">https://git.openjdk.org/valhalla/pull/1159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1159#issuecomment-2217794626)