### PR TITLE
8335545: [lworld] JNI MonitorEnter doesn't throw the right exception

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -306,6 +306,21 @@ jlong ObjectSynchronizer::_last_async_deflation_time_ns = 0;
 static uintx _no_progress_cnt = 0;
 static bool _no_progress_skip_increment = false;
 
+#define CHECK_THROW_NOSYNC_IE(obj) \
+  if (obj->klass()->is_inline_klass()) { \
+    ResourceMark rm(THREAD); \
+    const char* desc = "Cannot synchronize on an instance of value class "; \
+    const char* className = obj->klass()->external_name(); \
+    size_t msglen = strlen(desc) + strlen(className) + 1; \
+    char* message = NEW_RESOURCE_ARRAY(char, msglen); \
+    if (nullptr == message) { \
+      THROW_MSG(vmSymbols::java_lang_IdentityException(), className); \
+    } else { \
+      jio_snprintf(message, msglen, "%s%s", desc, className); \
+      THROW_MSG(vmSymbols::java_lang_IdentityException(), message); \
+    } \
+  }
+
 #define CHECK_THROW_NOSYNC_IMSE(obj)  \
   if (EnableValhalla && (obj)->mark().is_inline_type()) {  \
     JavaThread* THREAD = current;           \
@@ -540,8 +555,10 @@ void ObjectSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread* lock
   // the locking_thread with respect to the current thread. Currently only used when
   // deoptimizing and re-locking locks. See Deoptimization::relock_objects
   assert(locking_thread == Thread::current() || locking_thread->is_obj_deopt_suspend(), "must be");
-  JavaThread* current = locking_thread;
-  CHECK_THROW_NOSYNC_IMSE(obj);
+  if (obj->klass()->is_inline_klass()) {
+    // JITed code should never have locked an instance of a value class
+    ShouldNotReachHere();
+  }
   if (!enter_fast_impl(obj, lock, locking_thread)) {
     // Inflated ObjectMonitor::enter_for is required
 
@@ -560,7 +577,8 @@ void ObjectSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread* lock
 
 void ObjectSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* current) {
   assert(current == Thread::current(), "must be");
-  CHECK_THROW_NOSYNC_IMSE(obj);
+  JavaThread* THREAD = current;
+  CHECK_THROW_NOSYNC_IE(obj);
   if (!enter_fast_impl(obj, lock, current)) {
     // Inflated ObjectMonitor::enter is required
 
@@ -764,10 +782,12 @@ void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* current) 
 // JNI locks on java objects
 // NOTE: must use heavy weight monitor to handle jni monitor enter
 void ObjectSynchronizer::jni_enter(Handle obj, JavaThread* current) {
+  JavaThread* THREAD = current;
   if (obj->klass()->is_value_based()) {
     handle_sync_on_value_based_class(obj, current);
   }
-  CHECK_THROW_NOSYNC_IMSE(obj);
+
+  CHECK_THROW_NOSYNC_IE(obj);
 
   // the current locking is from JNI instead of Java code
   current->set_current_pending_monitor_is_from_java(false);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -561,7 +561,6 @@ void ObjectSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread* lock
 
 void ObjectSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* current) {
   assert(current == Thread::current(), "must be");
-  JavaThread* THREAD = current;
   assert(!EnableValhalla || !obj->klass()->is_inline_klass(), "This method should never be called on an instance of an inline class");
   if (!enter_fast_impl(obj, lock, current)) {
     // Inflated ObjectMonitor::enter is required

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineWithJni.java
@@ -24,10 +24,14 @@
 package runtime.valhalla.inlinetypes;
 
 /* @test
- * @summary test JNI functions with inline types
+ * @summary test JNI functions with instances of value classes
+ * @library /test/lib
  * @enablePreview
  * @run main/othervm/native runtime.valhalla.inlinetypes.InlineWithJni
  */
+
+ import jdk.test.lib.Asserts;
+
 public value class InlineWithJni {
 
     static {
@@ -48,30 +52,19 @@ public value class InlineWithJni {
     public native void doJniMonitorExit();
 
     public static void testJniMonitorOps() {
+        boolean sawIe = false;
         boolean sawImse = false;
         try {
             new InlineWithJni(0).doJniMonitorEnter();
-        } catch (Throwable t) {
-            sawImse = checkImse(t);
+        } catch (IdentityException ie) {
+            sawIe = true;
         }
-        if (!sawImse) {
-            throw new RuntimeException("JNI MonitorEnter did not fail");
-        }
-        sawImse = false;
+        Asserts.assertTrue(sawIe, "Missing IdentityException");
         try {
             new InlineWithJni(0).doJniMonitorExit();
-        } catch (Throwable t) {
-            sawImse = checkImse(t);
+        } catch (IllegalMonitorStateException imse) {
+            sawImse = true;
         }
-        if (!sawImse) {
-            throw new RuntimeException("JNI MonitorExit did not fail");
-        }
-    }
-
-    static boolean checkImse(Throwable t) {
-        if (t instanceof IllegalMonitorStateException) {
-            return true;
-        }
-        throw new RuntimeException(t);
+        Asserts.assertTrue(sawImse, "Missing IllegalMonitorStateException");
     }
 }


### PR DESCRIPTION
Fix JNI's MonitorEnter to throw IdentityException instead of IllegalMonitorStateException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335545](https://bugs.openjdk.org/browse/JDK-8335545): [lworld] JNI MonitorEnter doesn't throw the right exception (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - no project role) ⚠️ Review applies to [18d72953](https://git.openjdk.org/valhalla/pull/1160/files/18d729533f410a216389f505ae4c27c038468f07)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1160/head:pull/1160` \
`$ git checkout pull/1160`

Update a local copy of the PR: \
`$ git checkout pull/1160` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1160`

View PR using the GUI difftool: \
`$ git pr show -t 1160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1160.diff">https://git.openjdk.org/valhalla/pull/1160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1160#issuecomment-2217874309)