### PR TITLE
8335772: [lworld] fix for JDK-8335641 should have added some classes to GensrcValueClasses.gmk

### DIFF
--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -53,6 +53,11 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/YearMonth.java \
     java/time/Year.java \
     java/time/Period.java \
+    java/time/chrono/ChronoLocalDateImpl \
+    java/time/chrono/MinguoDate \
+    java/time/chrono/HijrahDate \
+    java/time/chrono/JapaneseDate \
+    java/time/chrono/ThaiBuddhistDate \
     #
 
 java.base-VALUE-CLASS-FILES := \

--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -70,7 +70,7 @@ $(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUECLASS_REPLACEMENTS, \
     REPLACEMENTS := \
         public final class => public final value class ; \
         public abstract class => public abstract value class ; \
-        abstract class ChronoLocalDateImpl => abstract value class ChronoLocalDateImpl \
+        abstract class ChronoLocalDateImpl => abstract value class ChronoLocalDateImpl, \
 ))
 
 TARGETS += $(JAVA_BASE_VALUECLASS_REPLACEMENTS)

--- a/make/modules/java.base/gensrc/GensrcValueClasses.gmk
+++ b/make/modules/java.base/gensrc/GensrcValueClasses.gmk
@@ -53,11 +53,11 @@ java.base-VALUE_CLASS-REPLACEMENTS := \
     java/time/YearMonth.java \
     java/time/Year.java \
     java/time/Period.java \
-    java/time/chrono/ChronoLocalDateImpl \
-    java/time/chrono/MinguoDate \
-    java/time/chrono/HijrahDate \
-    java/time/chrono/JapaneseDate \
-    java/time/chrono/ThaiBuddhistDate \
+    java/time/chrono/ChronoLocalDateImpl.java \
+    java/time/chrono/MinguoDate.java \
+    java/time/chrono/HijrahDate.java \
+    java/time/chrono/JapaneseDate.java \
+    java/time/chrono/ThaiBuddhistDate.java \
     #
 
 java.base-VALUE-CLASS-FILES := \
@@ -69,7 +69,8 @@ $(eval $(call SetupTextFileProcessing, JAVA_BASE_VALUECLASS_REPLACEMENTS, \
     OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/gensrc-valueclasses/java.base/, \
     REPLACEMENTS := \
         public final class => public final value class ; \
-        public abstract class => public abstract value class, \
+        public abstract class => public abstract value class ; \
+        abstract class ChronoLocalDateImpl => abstract value class ChronoLocalDateImpl \
 ))
 
 TARGETS += $(JAVA_BASE_VALUECLASS_REPLACEMENTS)


### PR DESCRIPTION
simple fix modifying GensrcValueClasses.gmk so that we can generate the following classes as value classes:

    java.time.chrono.ChronoLocalDateImpl
    java.time.chrono.MinguoDate
    java.time.chrono.HijrahDate
    java.time.chrono.JapaneseDate
    java.time.chrono.ThaiBuddhistDate

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8335772](https://bugs.openjdk.org/browse/JDK-8335772): [lworld] fix for JDK-8335641 should have added some classes to GensrcValueClasses.gmk (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer) ⚠️ Review applies to [6b58a2a6](https://git.openjdk.org/valhalla/pull/1162/files/6b58a2a6e0f3f7fd9594dd0f6e578ec18804c7f4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1162/head:pull/1162` \
`$ git checkout pull/1162`

Update a local copy of the PR: \
`$ git checkout pull/1162` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1162`

View PR using the GUI difftool: \
`$ git pr show -t 1162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1162.diff">https://git.openjdk.org/valhalla/pull/1162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1162#issuecomment-2218535528)