### PR TITLE
8336029: [lworld] Rename Objects.isIdentity() to hasIdentity()

### DIFF
--- a/src/java.base/share/classes/java/lang/ref/PhantomReference.java
+++ b/src/java.base/share/classes/java/lang/ref/PhantomReference.java
@@ -33,7 +33,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * determines that their referents may otherwise be reclaimed.  Phantom
  * references are most often used to schedule post-mortem cleanup actions.
  * <p>
- * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
+ * The referent must be an {@linkplain Objects#hasIdentity(Object) identity object}.
  *
  * <p> Suppose the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">
@@ -91,7 +91,7 @@ public non-sealed class PhantomReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#isIdentityObject(Object) identity object}
+     *         {@link java.util.Objects#hasIdentity(Object) identity object}
      */
     public PhantomReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -40,9 +40,8 @@ import java.util.Objects;
  * implemented in close cooperation with the garbage collector, this class may
  * not be subclassed directly.
  * <p>
- * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
- * Attempts to create a reference to a {@linkplain Objects#isValueObject value object}
- * results in an {@link IdentityException}.
+ * The referent must be an {@linkplain Objects#hasIdentity(Object) identity object}.
+ * Attempts to create a reference to a value object result in an {@link IdentityException}.
  * @param <T> the type of the referent
  *
  * @author   Mark Reinhold

--- a/src/java.base/share/classes/java/lang/ref/SoftReference.java
+++ b/src/java.base/share/classes/java/lang/ref/SoftReference.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * collector in response to memory demand.  Soft references are most often used
  * to implement memory-sensitive caches.
  * <p>
- * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
+ * The referent must be an {@linkplain Objects#hasIdentity(Object) identity object}.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">softly
@@ -86,7 +86,7 @@ public non-sealed class SoftReference<T> extends Reference<T> {
      *
      * @param referent object the new soft reference will refer to
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#isIdentityObject(Object) identity object}
+     *         {@link java.util.Objects#hasIdentity(Object) identity object}
      */
     public SoftReference(T referent) {
         super(referent);
@@ -101,7 +101,7 @@ public non-sealed class SoftReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#isIdentityObject(Object) identity object}
+     *         {@link java.util.Objects#hasIdentity(Object) identity object}
      */
     public SoftReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/lang/ref/WeakReference.java
+++ b/src/java.base/share/classes/java/lang/ref/WeakReference.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * made finalizable, finalized, and then reclaimed.  Weak references are most
  * often used to implement canonicalizing mappings.
  * <p>
- * The referent must be an {@linkplain Objects#isIdentityObject(Object) identity object}.
+ * The referent must be an {@linkplain Objects#hasIdentity(Object) identity object}.
  *
  * <p> Suppose that the garbage collector determines at a certain point in time
  * that an object is <a href="package-summary.html#reachability">weakly
@@ -58,7 +58,7 @@ public non-sealed class WeakReference<T> extends Reference<T> {
      *
      * @param referent object the new weak reference will refer to
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#isIdentityObject(Object) identity object}
+     *         {@link java.util.Objects#hasIdentity(Object) identity object}
      */
     public WeakReference(T referent) {
         super(referent);
@@ -72,7 +72,7 @@ public non-sealed class WeakReference<T> extends Reference<T> {
      * @param q the queue with which the reference is to be registered,
      *          or {@code null} if registration is not required
      * @throws IdentityException if the referent is not an
-     *         {@link java.util.Objects#isIdentityObject(Object) identity object}
+     *         {@link java.util.Objects#hasIdentity(Object) identity object}
      */
     public WeakReference(T referent, ReferenceQueue<? super T> q) {
         super(referent, q);

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -188,7 +188,7 @@ public final class Objects {
     */
    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 //    @IntrinsicCandidate
-    public static boolean isIdentityObject(Object obj) {
+    public static boolean hasIdentity(Object obj) {
         requireNonNull(obj);
         return obj.getClass().isIdentity() ||  // Before Valhalla all classes are identity classes
                 obj.getClass() == Object.class;
@@ -208,7 +208,7 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj) {
         Objects.requireNonNull(obj);
-        if (!isIdentityObject(obj))
+        if (!hasIdentity(obj))
             throw new IdentityException(obj.getClass());
         return obj;
     }
@@ -229,7 +229,7 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj, String message) {
         Objects.requireNonNull(obj);
-        if (!isIdentityObject(obj))
+        if (!hasIdentity(obj))
             throw new IdentityException(message);
         return obj;
     }
@@ -250,24 +250,10 @@ public final class Objects {
     @ForceInline
     public static <T> T requireIdentity(T obj, Supplier<String> messageSupplier) {
         Objects.requireNonNull(obj);
-        if (!isIdentityObject(obj))
+        if (!hasIdentity(obj))
             throw new IdentityException(messageSupplier == null ?
                     null : messageSupplier.get());
         return obj;
-    }
-
-   /**
-    * {@return {@code true} if the specified object is a {@linkplain Class#isValue value object},
-    * otherwise {@code false}}
-    *
-    * @param obj an object
-    * @throws NullPointerException if {@code obj} is {@code null}
-    */
-   @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
-//    @IntrinsicCandidate
-    public static boolean isValueObject(Object obj) {
-        requireNonNull(obj, "obj");
-        return obj.getClass().isValue();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/WeakHashMap.java
+++ b/src/java.base/share/classes/java/util/WeakHashMap.java
@@ -362,7 +362,7 @@ public class WeakHashMap<K,V>
         // check if the given entry refers to the given key without
         // keeping a strong reference to the entry's referent
         // only identity objects can be compared to a reference
-        if (Objects.isIdentityObject(key) && e.refersTo(key)) return true;
+        if (Objects.hasIdentity(key) && e.refersTo(key)) return true;
 
         // then check for equality if the referent is not cleared
         Object k = e.get();
@@ -531,8 +531,8 @@ public class WeakHashMap<K,V>
      */
     public V put(K key, V value) {
         Object k = maskNull(key);
-        final boolean isValue = Objects.isValueObject(k);
-        if (isValue && valuePolicy == ValuePolicy.DISCARD) {
+        final boolean hasIdentity = Objects.hasIdentity(k);
+        if (!hasIdentity && valuePolicy == ValuePolicy.DISCARD) {
             // put of a value object key with value policy DISCARD is more like remove(key)
             return remove(key);
         }
@@ -550,7 +550,7 @@ public class WeakHashMap<K,V>
         }
 
         Entry<K,V> e = tab[i];
-        e = (isValue) ? newValueEntry(k, value, queue, h, e) : new Entry<>(k, value, queue, h, e);
+        e = hasIdentity ? new Entry<>(k, value, queue, h, e) : newValueEntry(k, value, queue, h, e);
 
         modCount++;
         tab[i] = e;
@@ -1633,7 +1633,7 @@ public class WeakHashMap<K,V>
          * {@return the default policy for retention of keys that are value classes}
          * If the system property "java.util.WeakHashMap.valueKeyRetention"
          * is the name of a {@link ValuePolicy} enum return it,
-         * otherwise return {@link ValuePolicy#SOFT}.
+         * otherwise return {@link ValuePolicy#THROW}.
          */
         private static ValuePolicy initDefaultValuePolicy() {
             try {
@@ -1645,7 +1645,7 @@ public class WeakHashMap<K,V>
             } catch (IllegalArgumentException ex) {
             }
 
-            return SOFT;  // hardcoded default if property not set
+            return THROW;  // hardcoded default if property not set
         }
     }
 

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -134,12 +134,10 @@ public class ObjectMethods {
         Class<?> clazz = obj.getClass();
 
         if (clazz == Object.class) {
-            assertTrue(Objects.isIdentityObject(obj), "Objects.isIdentityObject()");
+            assertTrue(Objects.hasIdentity(obj), "Objects.hasIdentity()");
         } else {
-            assertEquals(identityClass, Objects.isIdentityObject(obj), "Objects.isIdentityObject()");
+            assertEquals(identityClass, Objects.hasIdentity(obj), "Objects.hasIdentity()");
         }
-
-        assertEquals(valueClass, Objects.isValueObject(obj), "Objects.isValueObject()");
 
         assertEquals(identityClass, clazz.isIdentity(), "Class.isIdentity()");
 


### PR DESCRIPTION
Rename Objects.isIdentity() to hasIdentity()
Remove java.util.Objects.isValueObject and replace its use with !hasIdentity(). 
Align the WeakHashMap WeakValuePolicy default with that of java.lang.Reference. 
Namely, throw IdentityException unless the WeakHashMap is created with a different policy. 
WeakHashMapPolicy is a unsupported experimental API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336029](https://bugs.openjdk.org/browse/JDK-8336029): [lworld] Rename Objects.isIdentity() to hasIdentity() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1163/head:pull/1163` \
`$ git checkout pull/1163`

Update a local copy of the PR: \
`$ git checkout pull/1163` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1163`

View PR using the GUI difftool: \
`$ git pr show -t 1163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1163.diff">https://git.openjdk.org/valhalla/pull/1163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1163#issuecomment-2218727818)