### PR TITLE
8336028: [lworld] Serialization should throw exceptions for non-migrated value classes

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2280,15 +2280,18 @@ public class ObjectInputStream
                 handles.setObject(passHandle, obj);
         } else if (desc.isExternalizable()) {
             if (desc.isValue()) {
-                throw new NotSerializableException("Externalizable not valid for value class "
+                throw new InvalidClassException("Externalizable not valid for value class "
                         + cl.getName());
             }
             if (!unshared)
                 handles.setObject(passHandle, obj);
             readExternalData((Externalizable) obj, desc);
         } else if (desc.isValue()) {
+            if (obj == null) {
+                throw new InvalidClassException("Serializable not valid for value class "
+                        + cl.getName());
+            }
             // For value objects, read the fields and finish the buffer before publishing the ref
-            assert obj != null : "obj == null: " + desc;
             readSerialData(obj, desc);
             obj = desc.finishValue(obj);
             if (!unshared)

--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1198,6 +1198,9 @@ public class ObjectOutputStream
             } else if (obj instanceof Enum) {
                 writeEnum((Enum<?>) obj, desc, unshared);
             } else if (obj instanceof Serializable) {
+                if (cl.isValue() && !desc.isInstantiable()) {
+                    throw new NotSerializableException(cl.getName());
+                }
                 writeOrdinaryObject(obj, desc, unshared);
             } else {
                 if (extendedDebugInfo) {

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jdk.internal.MigratedValueClass;
 import jdk.internal.event.SerializationMisdeclarationEvent;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.reflect.CallerSensitive;
@@ -414,7 +415,7 @@ public final class ObjectStreamClass implements Serializable {
                         canonicalCtr = canonicalRecordCtr(cl);
                         deserializationCtrs = new DeserializationConstructorsCache();
                     } else if (isValue) {
-                        // Value objects are created using Unsafe.
+                        // Value object instance creation is specialized in newInstance()
                         cons = null;
                     } else if (externalizable) {
                         cons = getExternalizableConstructor(cl);
@@ -965,12 +966,13 @@ public final class ObjectStreamClass implements Serializable {
      * be instantiated by the serialization runtime--i.e., if it is
      * externalizable and defines a public no-arg constructor, if it is
      * non-externalizable and its first non-serializable superclass defines an
-     * accessible no-arg constructor, or if the class is a value class.
+     * accessible no-arg constructor, or if the class is a migrated value class.
      * Otherwise, returns false.
      */
     boolean isInstantiable() {
         requireInitialized();
-        return (cons != null | isValue);
+        return (cons != null |
+                (isValue && cl != null && cl.isAnnotationPresent(jdk.internal.MigratedValueClass.class)));
     }
 
     /**

--- a/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SimpleValueGraphs.java
@@ -26,10 +26,10 @@
  * @library /test/lib
  * @summary Serialize and deserialize value objects
  * @enablePreview
+ * @modules java.base/jdk.internal
  * @run testng/othervm SimpleValueGraphs
  */
 
-import java.lang.StackOverflowError;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
@@ -40,7 +40,6 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.InvalidClassException;
-import java.io.InvalidObjectException;
 import java.io.NotSerializableException;
 
 import java.util.Arrays;
@@ -48,6 +47,8 @@ import java.util.function.BiFunction;
 import java.util.Objects;
 
 import java.nio.charset.StandardCharsets;
+
+import jdk.internal.MigratedValueClass;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -308,6 +309,7 @@ public class SimpleValueGraphs implements Serializable {
         }
     }
 
+    @jdk.internal.MigratedValueClass
     static value class TreeV implements Tree, Serializable {
 
         private static final long serialVersionUID = 2L;
@@ -359,7 +361,7 @@ public class SimpleValueGraphs implements Serializable {
     void testExternalizableNotSer() {
         var obj = new ValueExt();
         var ex = Assert.expectThrows(NotSerializableException.class, () -> serialize(obj));
-        Assert.assertTrue(ex.getMessage().contains("Externalizable not valid for value class"));
+        Assert.assertEquals(ex.getMessage(), ValueExt.class.getName());
     }
 
     @Test
@@ -367,7 +369,7 @@ public class SimpleValueGraphs implements Serializable {
         var obj = new IdentExt();
         byte[] bytes = serialize(obj);
         byte[] newBytes = patchBytes(bytes, "IdentExt", "ValueExt");
-        var ex = Assert.expectThrows(NotSerializableException.class, () -> deserialize(newBytes));
+        var ex = Assert.expectThrows(InvalidClassException.class, () -> deserialize(newBytes));
         Assert.assertTrue(ex.getMessage().contains("Externalizable not valid for value class"));
     }
 

--- a/test/jdk/java/io/Serializable/valueObjects/ValueSerialization.java
+++ b/test/jdk/java/io/Serializable/valueObjects/ValueSerialization.java
@@ -25,6 +25,7 @@
  * @test
  * @summary ValueSerialization support of value classes
  * @enablePreview
+ * @modules java.base/jdk.internal
  * @compile ValueSerialization.java
  * @run testng/othervm ValueSerialization
  */
@@ -90,6 +91,7 @@ public class ValueSerialization {
     }
 
     /** A Serializable value class Point */
+    @jdk.internal.MigratedValueClass
     static value class SerializablePoint implements Serializable {
         public int x;
         public int y;
@@ -99,6 +101,7 @@ public class ValueSerialization {
     }
 
     /** A Serializable value class Point */
+    @jdk.internal.MigratedValueClass
     static value class SerializablePrimitivePoint implements Serializable {
         public int x;
         public int y;


### PR DESCRIPTION
The java.base classes being migrated to value classes when using --enable-preview use a temporary adhoc unsafe mechanism to be serialized and deserialized. Only classes that are annotated with `jdk.internal.MigratedValueClass` can be serialized and deserialized. All other value classes can not be serialized or deserialized and the respective APIs throw exceptions. Subsequent Valhalla work will provide the missing support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336028](https://bugs.openjdk.org/browse/JDK-8336028): [lworld] Serialization should throw exceptions for non-migrated value classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1164/head:pull/1164` \
`$ git checkout pull/1164`

Update a local copy of the PR: \
`$ git checkout pull/1164` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1164`

View PR using the GUI difftool: \
`$ git pr show -t 1164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1164.diff">https://git.openjdk.org/valhalla/pull/1164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1164#issuecomment-2218742343)