### PR TITLE
8328162: [lworld] ClassAccessFlagsRawTest "expected 0x1, got 0x21 for class SUPERnotset"

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/ClassAccessFlagsRawTest.java
@@ -23,7 +23,6 @@
  */
 
 /**
- * @ignore Fix 8328162
  * @test
  * @bug 8291360 8293448
  * @summary Test getting a class's raw access flags using java.lang.Class API


### PR DESCRIPTION
The issue has already been fixed.
Re-enabling the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328162](https://bugs.openjdk.org/browse/JDK-8328162): [lworld] ClassAccessFlagsRawTest "expected 0x1, got 0x21 for class SUPERnotset" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1166/head:pull/1166` \
`$ git checkout pull/1166`

Update a local copy of the PR: \
`$ git checkout pull/1166` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1166`

View PR using the GUI difftool: \
`$ git pr show -t 1166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1166.diff">https://git.openjdk.org/valhalla/pull/1166.diff</a>

</details>
