### PR TITLE
8328438: [lworld] Reimplement VTAssignability for JEP401

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTAssignability.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/VTAssignability.java
@@ -22,7 +22,6 @@
  */
 
 /*
- * @ignore Fix JDK-8328438
  * @test
  * @summary Test basic verifier assignability of inline types.
  * @enablePreview
@@ -31,11 +30,13 @@
  */
 
 // Test that an inline type is assignable to itself, to java.lang.Object,
-// and to an interface,
+// to an abstract super type and to an interface,
 //
 interface II { }
 
-public primitive final class VTAssignability implements II {
+abstract value class AbstractValue { }
+
+public value  class VTAssignability extends AbstractValue implements II {
     final int x;
     final int y;
 
@@ -59,8 +60,12 @@ public primitive final class VTAssignability implements II {
         }
     }
 
+    public void takesAbstractSuper(AbstractValue val) {
+        System.out.println("Test passes for abstract super");
+    }
+
     public void takesInterface(II i) {
-        System.out.println("Test passes!!");
+        System.out.println("Test passes for interfaces");
     }
 
     public static void main(String[] args) {
@@ -72,6 +77,9 @@ public primitive final class VTAssignability implements II {
 
         // Test assignability of an inline type to java.lang.Object.
         res = b.equals(a);
+
+        // Test assignability of an inline type to an abstract super type.
+        a.takesAbstractSuper(b);
 
         // Test assignability of an inline type to an interface.
         a.takesInterface(b);


### PR DESCRIPTION
Update test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8328438](https://bugs.openjdk.org/browse/JDK-8328438): [lworld] Reimplement VTAssignability for JEP401 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1168/head:pull/1168` \
`$ git checkout pull/1168`

Update a local copy of the PR: \
`$ git checkout pull/1168` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1168`

View PR using the GUI difftool: \
`$ git pr show -t 1168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1168.diff">https://git.openjdk.org/valhalla/pull/1168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1168#issuecomment-2226226436)