### PR TITLE
8336312: [lworld] compiler/c1/Test8267042.java crashes with --enable-preview

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -438,6 +438,7 @@ JRT_ENTRY(jboolean, InterpreterRuntime::is_substitutable(JavaThread* current, oo
   args.push_oop(ha);
   args.push_oop(hb);
   methodHandle method(current, Universe::is_substitutable_method());
+  method->method_holder()->initialize(CHECK_false); // Ensure class ValueObjectMethods is initialized
   JavaCalls::call(&result, method, &args, THREAD);
   if (HAS_PENDING_EXCEPTION) {
     // Something really bad happened because isSubstitutable() should not throw exceptions


### PR DESCRIPTION
Ensure class java/lang/runtime/ValueObjectMethods is initialize before calling its static method isSubstitutable().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336312](https://bugs.openjdk.org/browse/JDK-8336312): [lworld] compiler/c1/Test8267042.java crashes with --enable-preview (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1169/head:pull/1169` \
`$ git checkout pull/1169`

Update a local copy of the PR: \
`$ git checkout pull/1169` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1169`

View PR using the GUI difftool: \
`$ git pr show -t 1169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1169.diff">https://git.openjdk.org/valhalla/pull/1169.diff</a>

</details>
