### PR TITLE
8314993: [lworld] Add support for runtime/cds/CDSMapTest.java

### DIFF
--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -212,5 +212,4 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
       break;
     }
   }
-  st->cr();
 }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -123,7 +123,6 @@ containers/docker/TestMemoryAwareness.java 8303470 linux-all
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
 runtime/valhalla/inlinetypes/InlineOops.java#ZGen 8313607 linux-aarch64,macosx-aarch64
-runtime/cds/CDSMapTest.java 8314993 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
CDSMapTest.java was previously problem listed due to differences in the output generated by `fieldDescriptor::print_on_for()`. This change partially reverts the change to that method to match the output from mainline and removes the test from the problem list. Verified with tier1-5 tests and CDSMapTest.java passes on tested platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8314993](https://bugs.openjdk.org/browse/JDK-8314993): [lworld] Add support for runtime/cds/CDSMapTest.java (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1170/head:pull/1170` \
`$ git checkout pull/1170`

Update a local copy of the PR: \
`$ git checkout pull/1170` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1170`

View PR using the GUI difftool: \
`$ git pr show -t 1170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1170.diff">https://git.openjdk.org/valhalla/pull/1170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1170#issuecomment-2231519347)