### PR TITLE
8336682: [lworld] java/lang/instrument/IsModifiableClassAgent.java test fails when run with migrates classes

### DIFF
--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,6 +473,26 @@ void JvmtiClassFileReconstituter::write_permitted_subclasses_attribute() {
   }
 }
 
+// LoadableDescriptors {
+//   u2 attribute_name_index;
+//   u4 attribute_length;
+//   u2 number_of_descriptors;
+//   u2 descriptors[number_of_descriptors];
+// }
+void JvmtiClassFileReconstituter::write_loadable_descriptors_attribute() {
+  Array<u2>* loadable_descriptors = ik()->loadable_descriptors();
+  int number_of_descriptors = loadable_descriptors->length();
+  int length = sizeof(u2) * (1 + number_of_descriptors); // '1 +' is for number_of_descriptors field
+
+  write_attribute_name_index("LoadableDescriptors");
+  write_u4(length);
+  write_u2(checked_cast<u2>(number_of_descriptors));
+  for (int i = 0; i < number_of_descriptors; i++) {
+    u2 utf8_index = loadable_descriptors->at(i);
+    write_u2(utf8_index);
+  }
+}
+
 //  Record {
 //    u2 attribute_name_index;
 //    u4 attribute_length;
@@ -809,6 +829,9 @@ void JvmtiClassFileReconstituter::write_class_attributes() {
   if (ik()->permitted_subclasses() != Universe::the_empty_short_array()) {
     ++attr_count;
   }
+  if (ik()->loadable_descriptors() != Universe::the_empty_short_array()) {
+    ++attr_count;
+  }
   if (ik()->record_components() != nullptr) {
     ++attr_count;
   }
@@ -838,6 +861,9 @@ void JvmtiClassFileReconstituter::write_class_attributes() {
   }
   if (ik()->permitted_subclasses() != Universe::the_empty_short_array()) {
     write_permitted_subclasses_attribute();
+  }
+  if (ik()->loadable_descriptors() != Universe::the_empty_short_array()) {
+    write_loadable_descriptors_attribute();
   }
   if (ik()->record_components() != nullptr) {
     write_record_attribute();

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,7 @@ class JvmtiClassFileReconstituter : public JvmtiConstantPoolReconstituter {
   void write_nest_members_attribute();
   void write_permitted_subclasses_attribute();
   void write_record_attribute();
+  void write_loadable_descriptors_attribute();
 
   address writeable_address(size_t size);
   void write_u1(u1 x);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -762,7 +762,7 @@ static int symcmp(const void* a, const void* b) {
 // The caller must have an active ResourceMark.
 static jvmtiError check_attribute_arrays(const char* attr_name,
            InstanceKlass* the_class, InstanceKlass* scratch_class,
-           Array<u2>* the_array, Array<u2>* scr_array) {
+           Array<u2>* the_array, Array<u2>* scr_array, bool is_klass = true) {
   bool the_array_exists = the_array != Universe::the_empty_short_array();
   bool scr_array_exists = scr_array != Universe::the_empty_short_array();
 
@@ -790,8 +790,13 @@ static jvmtiError check_attribute_arrays(const char* attr_name,
     for (int i = 0; i < array_len; i++) {
       int the_cp_index = the_array->at(i);
       int scr_cp_index = scr_array->at(i);
-      the_syms[i] = the_class->constants()->klass_name_at(the_cp_index);
-      scr_syms[i] = scratch_class->constants()->klass_name_at(scr_cp_index);
+      if (is_klass) {
+        the_syms[i] = the_class->constants()->klass_name_at(the_cp_index);
+        scr_syms[i] = scratch_class->constants()->klass_name_at(scr_cp_index);
+      } else {
+        the_syms[i] = the_class->constants()->symbol_at(the_cp_index);
+        scr_syms[i] = scratch_class->constants()->symbol_at(scr_cp_index);
+      }
     }
 
     qsort(the_syms, array_len, sizeof(Symbol*), symcmp);
@@ -923,16 +928,16 @@ static jvmtiError check_permitted_subclasses_attribute(InstanceKlass* the_class,
                                 scratch_class->permitted_subclasses());
 }
 
-static jvmtiError check_preload_attribute(InstanceKlass* the_class,
-                                          InstanceKlass* scratch_class) {
+static jvmtiError check_loadable_descriptors_attribute(InstanceKlass* the_class,
+                                                       InstanceKlass* scratch_class) {
   Thread* thread = Thread::current();
   ResourceMark rm(thread);
 
-  // Check whether the class Preload attribute has been changed.
-  return check_attribute_arrays("Preload",
+  // Check whether the class LoadableDescriptors attribute has been changed.
+  return check_attribute_arrays("LoadableDescriptors",
                                 the_class, scratch_class,
                                 the_class->loadable_descriptors(),
-                                scratch_class->loadable_descriptors());
+                                scratch_class->loadable_descriptors(), /*is_klass*/ false);
 }
 
 static bool can_add_or_delete(Method* m) {
@@ -1015,7 +1020,7 @@ jvmtiError VM_RedefineClasses::compare_and_normalize_class_versions(
   }
 
   // Check whether the Preload attribute has been changed.
-  err = check_preload_attribute(the_class, scratch_class);
+  err = check_loadable_descriptors_attribute(the_class, scratch_class);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }

--- a/src/java.instrument/share/native/libinstrument/JavaExceptions.c
+++ b/src/java.instrument/share/native/libinstrument/JavaExceptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,7 +216,7 @@ createThrowableFromJVMTIErrorCode(JNIEnv * jnienv, jvmtiError errorCode) {
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED:
                 throwableClassName = "java/lang/UnsupportedOperationException";
-                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record, PermittedSubclasses or LoadableDescrriptors attribute";
+                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record or PermittedSubclasses attribute";
                 break;
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_METHOD_MODIFIERS_CHANGED:

--- a/src/java.instrument/share/native/libinstrument/JavaExceptions.c
+++ b/src/java.instrument/share/native/libinstrument/JavaExceptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,7 +216,7 @@ createThrowableFromJVMTIErrorCode(JNIEnv * jnienv, jvmtiError errorCode) {
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED:
                 throwableClassName = "java/lang/UnsupportedOperationException";
-                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record, or PermittedSubclasses attribute";
+                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record, PermittedSubclasses or LoadableDescrriptors attribute";
                 break;
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_METHOD_MODIFIERS_CHANGED:

--- a/src/java.instrument/share/native/libinstrument/JavaExceptions.c
+++ b/src/java.instrument/share/native/libinstrument/JavaExceptions.c
@@ -216,7 +216,7 @@ createThrowableFromJVMTIErrorCode(JNIEnv * jnienv, jvmtiError errorCode) {
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_CLASS_ATTRIBUTE_CHANGED:
                 throwableClassName = "java/lang/UnsupportedOperationException";
-                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record or PermittedSubclasses attribute";
+                message = "class redefinition failed: attempted to change the class NestHost, NestMembers, Record, or PermittedSubclasses attribute";
                 break;
 
         case JVMTI_ERROR_UNSUPPORTED_REDEFINITION_METHOD_MODIFIERS_CHANGED:


### PR DESCRIPTION
The test uses the class file reconstituter to provide the redefined bytecodes, leaving out the LoadableDescriptors.  Adding them to the reconsistituted class file makes the test pass, also fix the verification code since these descriptors are utf8s now.  Tested with java/lang/instrument with --enable-preview.  Should write a test but I don't know how, and the code is already tested with permitted subclasses and other attributes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336682](https://bugs.openjdk.org/browse/JDK-8336682): [lworld] java/lang/instrument/IsModifiableClassAgent.java test fails when run with migrates classes (**Bug** - P3)


### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - no project role)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1172/head:pull/1172` \
`$ git checkout pull/1172`

Update a local copy of the PR: \
`$ git checkout pull/1172` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1172`

View PR using the GUI difftool: \
`$ git pr show -t 1172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1172.diff">https://git.openjdk.org/valhalla/pull/1172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1172#issuecomment-2239016488)