### PR TITLE
8336829: [lworld] serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java gets Metaspace OOM

### DIFF
--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -318,9 +318,11 @@ void InlineKlass::initialize_calling_convention(TRAPS) {
 void InlineKlass::deallocate_contents(ClassLoaderData* loader_data) {
   if (extended_sig() != nullptr) {
     MetadataFactory::free_array<SigEntry>(loader_data, extended_sig());
+    *((Array<SigEntry>**)adr_extended_sig()) = nullptr;
   }
   if (return_regs() != nullptr) {
     MetadataFactory::free_array<VMRegPair>(loader_data, return_regs());
+    *((Array<VMRegPair>**)adr_return_regs()) = nullptr;
   }
   cleanup_blobs();
   InstanceKlass::deallocate_contents(loader_data);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -720,11 +720,12 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
 
   if (inline_type_field_klasses_array() != nullptr) {
     MetadataFactory::free_array<InlineKlass*>(loader_data, inline_type_field_klasses_array());
+    set_inline_type_field_klasses_array(nullptr);
   }
-  set_inline_type_field_klasses_array(nullptr);
 
   if (null_marker_offsets_array() != nullptr) {
     MetadataFactory::free_array<int>(loader_data, null_marker_offsets_array());
+    set_null_marker_offsets_array(nullptr);
   }
 
   // If a method from a redefined class is using this constant pool, don't
@@ -766,6 +767,7 @@ void InstanceKlass::deallocate_contents(ClassLoaderData* loader_data) {
       !loadable_descriptors()->is_shared()) {
     MetadataFactory::free_array<jushort>(loader_data, loadable_descriptors());
   }
+  set_loadable_descriptors(nullptr);
 
   // We should deallocate the Annotations instance if it's not in shared spaces.
   if (annotations() != nullptr && !annotations()->is_shared()) {


### PR DESCRIPTION
Run all versions of this test with -Xmx23m so that if CDS is off, the InMemoryCompiler will load without a Metaspace OOM.  Also add a test to verify that new metadata created by inline/value classes are reclaimed, which I verified in gdb.  Zeroed deallocated fields to help with manual verification.
Tested with jtreg/serviceability/jvmti/RedefineClasses tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336829](https://bugs.openjdk.org/browse/JDK-8336829): [lworld] serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java gets Metaspace OOM (**Enhancement** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1174/head:pull/1174` \
`$ git checkout pull/1174`

Update a local copy of the PR: \
`$ git checkout pull/1174` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1174`

View PR using the GUI difftool: \
`$ git pr show -t 1174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1174.diff">https://git.openjdk.org/valhalla/pull/1174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1174#issuecomment-2243301767)