### PR TITLE
8337048: [lworld] ProblemList BasicLayerTest until jtreg LIBARY.properties is supported

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -494,6 +494,9 @@ java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-all
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
 
+java/lang/ModuleLayer/LayerControllerTest.java                  8337048 generic-all
+java/lang/ModuleLayer/BasicLayerTest.java                       8337048 generic-all
+
 ############################################################################
 
 # jdk_instrument


### PR DESCRIPTION
ProblemList intermittent tests until test library compile is made more stable.
 test/jdk/java/lang/ModuleLayer/BasicLayerTest.java
 test/jdk/java/lang/ModuleLayer/LayerControllerTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337048](https://bugs.openjdk.org/browse/JDK-8337048): [lworld] ProblemList BasicLayerTest until jtreg LIBARY.properties is supported (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1176/head:pull/1176` \
`$ git checkout pull/1176`

Update a local copy of the PR: \
`$ git checkout pull/1176` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1176`

View PR using the GUI difftool: \
`$ git pr show -t 1176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1176.diff">https://git.openjdk.org/valhalla/pull/1176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1176#issuecomment-2246096381)