### PR TITLE
8336390: [lworld] jdk/internal/util/ReferencedKeyTest.java fails with --enable-preview

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import jdk.internal.access.SharedSecrets;
  * remove entries automatically when the key is garbage collected. This is
  * accomplished by using a backing map where the keys are either a
  * {@link WeakReference} or a {@link SoftReference}.
+ * Keys must be {@linkplain Class#isIdentity() identity objects.}
  * <p>
  * To create a {@link ReferencedKeyMap} the user must provide a {@link Supplier}
  * of the backing map and whether {@link WeakReference} or


### PR DESCRIPTION
ReferencedKeyTest uses Long to test the key maps.
However, with --enable-preview Long is a value class and cannot be used with Weak or Soft references.

Replace use of Long with String (an Identity class)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336390](https://bugs.openjdk.org/browse/JDK-8336390): [lworld] jdk/internal/util/ReferencedKeyTest.java fails with --enable-preview (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1177/head:pull/1177` \
`$ git checkout pull/1177`

Update a local copy of the PR: \
`$ git checkout pull/1177` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1177`

View PR using the GUI difftool: \
`$ git pr show -t 1177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1177.diff">https://git.openjdk.org/valhalla/pull/1177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1177#issuecomment-2246106640)