### PR TITLE
8336672: [lworld] Tests of spliterators and streams fail when value objects are used with WeakHashmap

### DIFF
--- a/test/jdk/java/util/Spliterator/SpliteratorCharacteristics.java
+++ b/test/jdk/java/util/Spliterator/SpliteratorCharacteristics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8020156 8020009 8022326 8012913 8024405 8024408 8071477
+ * @bug 8020156 8020009 8022326 8012913 8024405 8024408 8071477 8336672
  * @run testng SpliteratorCharacteristics
  */
 
@@ -111,7 +111,7 @@ public class SpliteratorCharacteristics {
     }
 
     public void testSpliteratorFromCollection() {
-        List<Integer> l = Arrays.asList(1, 2, 3, 4);
+        List<String> l = Arrays.asList("A", "B", "C", "D");
 
         {
             Spliterator<?> s = Spliterators.spliterator(l, 0);
@@ -291,7 +291,7 @@ public class SpliteratorCharacteristics {
     }
 
     public void testConcurrentSkipListMapWithComparator() {
-        assertSortedMapCharacteristics(new ConcurrentSkipListMap<>(Comparator.<Integer>reverseOrder()),
+        assertSortedMapCharacteristics(new ConcurrentSkipListMap<>(Comparator.<String>reverseOrder()),
                                        Spliterator.CONCURRENT | Spliterator.NONNULL |
                                        Spliterator.DISTINCT | Spliterator.SORTED |
                                        Spliterator.ORDERED);
@@ -315,11 +315,11 @@ public class SpliteratorCharacteristics {
     //
 
 
-    void assertMapCharacteristics(Map<Integer, String> m, int keyCharacteristics) {
+    void assertMapCharacteristics(Map<String, String> m, int keyCharacteristics) {
         assertMapCharacteristics(m, keyCharacteristics, 0);
     }
 
-    void assertMapCharacteristics(Map<Integer, String> m, int keyCharacteristics, int notValueCharacteristics) {
+    void assertMapCharacteristics(Map<String, String> m, int keyCharacteristics, int notValueCharacteristics) {
         initMap(m);
 
         assertCharacteristics(m.keySet(), keyCharacteristics);
@@ -336,7 +336,7 @@ public class SpliteratorCharacteristics {
         }
     }
 
-    void assertSetCharacteristics(Set<Integer> s, int keyCharacteristics) {
+    void assertSetCharacteristics(Set<String> s, int keyCharacteristics) {
         initSet(s);
 
         assertCharacteristics(s, keyCharacteristics);
@@ -346,10 +346,10 @@ public class SpliteratorCharacteristics {
         }
     }
 
-    void assertSortedMapCharacteristics(SortedMap<Integer, String> m, int keyCharacteristics) {
+    void assertSortedMapCharacteristics(SortedMap<String, String> m, int keyCharacteristics) {
         assertMapCharacteristics(m, keyCharacteristics, Spliterator.SORTED);
 
-        Set<Integer> keys = m.keySet();
+        Set<String> keys = m.keySet();
         if (m.comparator() != null) {
             assertNotNullComparator(keys);
         }
@@ -362,7 +362,7 @@ public class SpliteratorCharacteristics {
         assertNotNullComparator(m.entrySet());
     }
 
-    void assertSortedSetCharacteristics(SortedSet<Integer> s, int keyCharacteristics) {
+    void assertSortedSetCharacteristics(SortedSet<String> s, int keyCharacteristics) {
         assertSetCharacteristics(s, keyCharacteristics);
 
         if (s.comparator() != null) {
@@ -373,15 +373,15 @@ public class SpliteratorCharacteristics {
         }
     }
 
-    void initMap(Map<Integer, String> m) {
-        m.put(1, "4");
-        m.put(2, "3");
-        m.put(3, "2");
-        m.put(4, "1");
+    void initMap(Map<String, String> m) {
+        m.put("A", "4");
+        m.put("B", "3");
+        m.put("C", "2");
+        m.put("D", "1");
     }
 
-    void initSet(Set<Integer> s) {
-        s.addAll(Arrays.asList(1, 2, 3, 4));
+    void initSet(Set<String> s) {
+        s.addAll(Arrays.asList("A", "B", "C", "D"));
     }
 
     void assertCharacteristics(Collection<?> c, int expectedCharacteristics) {

--- a/test/jdk/java/util/Spliterator/SpliteratorFailFastTest.java
+++ b/test/jdk/java/util/Spliterator/SpliteratorFailFastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertThrows;
 
 /**
  * @test
- * @bug 8148748
+ * @bug 8148748 8336672
  * @summary Spliterator fail-fast tests
  * @run testng SpliteratorFailFastTest
  */
@@ -64,8 +64,8 @@ public class SpliteratorFailFastTest extends SpliteratorLateBindingFailFastHelpe
         }
 
         List<Object[]> data = new ArrayList<>();
-        SpliteratorDataBuilder<Integer> db =
-                new SpliteratorDataBuilder<>(data, 5, Arrays.asList(1, 2, 3, 4));
+        SpliteratorDataBuilder<String> db =
+                new SpliteratorDataBuilder<>(data, "Z", Arrays.asList("A", "B", "C", "D"));
 
         // Collections
 
@@ -84,7 +84,7 @@ public class SpliteratorFailFastTest extends SpliteratorLateBindingFailFastHelpe
         db.addCollection(TreeSet::new);
 
         db.addCollection(c -> {
-            Stack<Integer> s = new Stack<>();
+            Stack<String> s = new Stack<>();
             s.addAll(c);
             return s;
         });
@@ -106,7 +106,7 @@ public class SpliteratorFailFastTest extends SpliteratorLateBindingFailFastHelpe
         // This fails when run through jtreg but passes when run through
         // ant
 //        db.addMap(IdentityHashMap::new);
-
+        // BUG: Assumes identity
         db.addMap(WeakHashMap::new);
 
         // @@@  Descending maps etc

--- a/test/jdk/java/util/Spliterator/SpliteratorLateBindingFailFastHelper.java
+++ b/test/jdk/java/util/Spliterator/SpliteratorLateBindingFailFastHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,26 +182,26 @@ class SpliteratorLateBindingFailFastHelper {
         }
     }
 
-    static class AbstractRandomAccessListImpl extends AbstractList<Integer> implements RandomAccess {
-        List<Integer> l;
+    static class AbstractRandomAccessListImpl<T> extends AbstractList<T> implements RandomAccess {
+        List<T> l;
 
-        AbstractRandomAccessListImpl(Collection<Integer> c) {
+        AbstractRandomAccessListImpl(Collection<T> c) {
             this.l = new ArrayList<>(c);
         }
 
         @Override
-        public boolean add(Integer integer) {
+        public boolean add(T value) {
             modCount++;
-            return l.add(integer);
+            return l.add(value);
         }
 
         @Override
-        public Iterator<Integer> iterator() {
+        public Iterator<T> iterator() {
             return l.iterator();
         }
 
         @Override
-        public Integer get(int index) {
+        public T get(int index) {
             return l.get(index);
         }
 
@@ -217,7 +217,7 @@ class SpliteratorLateBindingFailFastHelper {
         }
 
         @Override
-        public List<Integer> subList(int fromIndex, int toIndex) {
+        public List<T> subList(int fromIndex, int toIndex) {
             return l.subList(fromIndex, toIndex);
         }
     }

--- a/test/jdk/java/util/Spliterator/SpliteratorLateBindingTest.java
+++ b/test/jdk/java/util/Spliterator/SpliteratorLateBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * @test
- * @bug 8148748 8170155
+ * @bug 8148748 8170155 8336672
  * @summary Spliterator last-binding tests
  * @run testng SpliteratorLateBindingTest
  */
@@ -69,8 +69,8 @@ public class SpliteratorLateBindingTest extends SpliteratorLateBindingFailFastHe
         }
 
         List<Object[]> data = new ArrayList<>();
-        SpliteratorDataBuilder<Integer> db =
-                new SpliteratorDataBuilder<>(data, 5, Arrays.asList(1, 2, 3, 4));
+        SpliteratorDataBuilder<String> db =
+                new SpliteratorDataBuilder<>(data, "Z", Arrays.asList("A", "B", "C", "D"));
 
         // Collections
 
@@ -89,7 +89,7 @@ public class SpliteratorLateBindingTest extends SpliteratorLateBindingFailFastHe
         db.addCollection(TreeSet::new);
 
         db.addCollection(c -> {
-            Stack<Integer> s = new Stack<>();
+            Stack<String> s = new Stack<>();
             s.addAll(c);
             return s;
         });
@@ -106,6 +106,7 @@ public class SpliteratorLateBindingTest extends SpliteratorLateBindingFailFastHe
 
         db.addMap(IdentityHashMap::new);
 
+        // BUG: Assumes identity
         db.addMap(WeakHashMap::new);
 
         // @@@  Descending maps etc
@@ -113,6 +114,7 @@ public class SpliteratorLateBindingTest extends SpliteratorLateBindingFailFastHe
 
         // BitSet
 
+        // BUG: Assumes identity in WeakHashMap
         List<Integer> bits = List.of(0, 1, 2);
         Function<BitSet, Spliterator.OfInt> bitsSource = bs -> bs.stream().spliterator();
         db.add("new BitSet.stream().spliterator() ADD",

--- a/test/jdk/java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java
+++ b/test/jdk/java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,15 @@
  * @test
  * @summary Spliterator traversing and splitting tests
  * @library /lib/testlibrary/bootlib
+ * @modules java.base/jdk.internal.misc
  * @build java.base/java.util.SpliteratorOfIntDataBuilder
  *        java.base/java.util.SpliteratorTestHelper
  * @run testng SpliteratorTraversingAndSplittingTest
- * @bug 8020016 8071477 8072784 8169838
+ * @run testng/othervm --enable-preview SpliteratorTraversingAndSplittingTest
+ * @bug 8020016 8071477 8072784 8169838 8336672
  */
+
+import jdk.internal.misc.PreviewFeatures;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -628,16 +632,19 @@ public class SpliteratorTraversingAndSplittingTest extends SpliteratorTestHelper
 
             db.addMap(IdentityHashMap::new);
 
-            db.addMap(WeakHashMap::new);
+            if (!PreviewFeatures.isEnabled()) {
+                // With --enable-preview, WeakHashmap is not tested with Integer, a value class
+                db.addMap(WeakHashMap::new);
 
-            db.addMap(m -> {
-                // Create a Map ensuring that for large sizes
-                // buckets will be consist of 2 or more entries
-                WeakHashMap<Integer, Integer> cm = new WeakHashMap<>(1, m.size() + 1);
-                for (Map.Entry<Integer, Integer> e : m.entrySet())
-                    cm.put(e.getKey(), e.getValue());
-                return cm;
-            }, "new java.util.WeakHashMap(1, size + 1)");
+                db.addMap(m -> {
+                    // Create a Map ensuring that for large sizes
+                    // buckets will consist of 2 or more entries
+                    WeakHashMap<Integer, Integer> cm = new WeakHashMap<>(1, m.size() + 1);
+                    for (Map.Entry<Integer, Integer> e : m.entrySet())
+                        cm.put(e.getKey(), e.getValue());
+                    return cm;
+                }, "new java.util.WeakHashMap(1, size + 1)");
+            }
 
             // @@@  Descending maps etc
             db.addMap(TreeMap::new);

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/CollectionAndMapModifyStreamTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/CollectionAndMapModifyStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,14 +28,13 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.function.Supplier;
-import java.util.stream.LambdaTestHelpers;
+import java.util.stream.IntStream;
+
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -45,46 +44,53 @@ import java.util.stream.Stream;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+/*
+ * @test
+ * @summary Tests laziness of stream operations
+ * @bug 8336672
+ */
+
 /**
  * Tests laziness of stream operations -- mutations to the source after the stream() but prior to terminal operations
  * are reflected in the stream contents.
  */
 @Test
 public class CollectionAndMapModifyStreamTest {
+    // Well known Identity instances; needed for IdentityHashMap
+    static List<String> CONTENT = IntStream.range(0, 10).mapToObj(i -> "BASE-" + i).toList();
 
     @DataProvider(name = "collections")
     public Object[][] createCollections() {
-        List<Integer> content = LambdaTestHelpers.countTo(10);
 
-        List<Collection<Integer>> collections = new ArrayList<>();
-        collections.add(new ArrayList<>(content));
-        collections.add(new LinkedList<>(content));
-        collections.add(new Vector<>(content));
+        List<Collection<String>> collections = new ArrayList<>();
+        collections.add(new ArrayList<>(CONTENT));
+        collections.add(new LinkedList<>(CONTENT));
+        collections.add(new Vector<>(CONTENT));
 
-        collections.add(new HashSet<>(content));
-        collections.add(new LinkedHashSet<>(content));
-        collections.add(new TreeSet<>(content));
+        collections.add(new HashSet<>(CONTENT));
+        collections.add(new LinkedHashSet<>(CONTENT));
+        collections.add(new TreeSet<>(CONTENT));
 
-        Stack<Integer> stack = new Stack<>();
-        stack.addAll(content);
+        Stack<String> stack = new Stack<>();
+        stack.addAll(CONTENT);
         collections.add(stack);
-        collections.add(new PriorityQueue<>(content));
-        collections.add(new ArrayDeque<>(content));
+        collections.add(new PriorityQueue<>(CONTENT));
+        collections.add(new ArrayDeque<>(CONTENT));
 
         // Concurrent collections
 
-        collections.add(new ConcurrentSkipListSet<>(content));
+        collections.add(new ConcurrentSkipListSet<>(CONTENT));
 
-        ArrayBlockingQueue<Integer> arrayBlockingQueue = new ArrayBlockingQueue<>(content.size());
-        for (Integer i : content)
+        ArrayBlockingQueue<String> arrayBlockingQueue = new ArrayBlockingQueue<>(CONTENT.size());
+        for (String i : CONTENT)
             arrayBlockingQueue.add(i);
         collections.add(arrayBlockingQueue);
-        collections.add(new PriorityBlockingQueue<>(content));
-        collections.add(new LinkedBlockingQueue<>(content));
-        collections.add(new LinkedTransferQueue<>(content));
-        collections.add(new ConcurrentLinkedQueue<>(content));
-        collections.add(new LinkedBlockingDeque<>(content));
-        collections.add(new ConcurrentLinkedDeque<>(content));
+        collections.add(new PriorityBlockingQueue<>(CONTENT));
+        collections.add(new LinkedBlockingQueue<>(CONTENT));
+        collections.add(new LinkedTransferQueue<>(CONTENT));
+        collections.add(new ConcurrentLinkedQueue<>(CONTENT));
+        collections.add(new LinkedBlockingDeque<>(CONTENT));
+        collections.add(new ConcurrentLinkedDeque<>(CONTENT));
 
         Object[][] params = new Object[collections.size()][];
         for (int i = 0; i < collections.size(); i++) {
@@ -95,22 +101,23 @@ public class CollectionAndMapModifyStreamTest {
     }
 
     @Test(dataProvider = "collections")
-    public void testCollectionSizeRemove(String name, Collection<Integer> c) {
-        assertTrue(c.remove(1));
-        Stream<Integer> s = c.stream();
-        assertTrue(c.remove(2));
+    public void testCollectionSizeRemove(String name, Collection<String> c) {
+        assertTrue(c.remove(CONTENT.get(0)));
+        Stream<String> s = c.stream();
+        assertTrue(c.remove(CONTENT.get(1)));
         Object[] result = s.toArray();
         assertEquals(result.length, c.size());
     }
 
     @DataProvider(name = "maps")
     public Object[][] createMaps() {
-        Map<Integer, Integer> content = new HashMap<>();
+        Map<String, String> content = new HashMap<>();
         for (int i = 0; i < 10; i++) {
-            content.put(i, i);
+            var ix = CONTENT.get(i);
+            content.put(ix, ix);
         }
 
-        Map<String, Supplier<Map<Integer, Integer>>> maps = new HashMap<>();
+        Map<String, Supplier<Map<String, String>>> maps = new HashMap<>();
 
         maps.put(HashMap.class.getName(), () -> new HashMap<>(content));
         maps.put(LinkedHashMap.class.getName(), () -> new LinkedHashMap<>(content));
@@ -132,34 +139,33 @@ public class CollectionAndMapModifyStreamTest {
 
         Object[][] params = new Object[maps.size()][];
         int i = 0;
-        for (Map.Entry<String, Supplier<Map<Integer, Integer>>> e : maps.entrySet()) {
+        for (Map.Entry<String, Supplier<Map<String, String>>> e : maps.entrySet()) {
             params[i++] = new Object[]{e.getKey(), e.getValue()};
-
         }
 
         return params;
     }
 
     @Test(dataProvider = "maps", groups = { "serialization-hostile" })
-    public void testMapKeysSizeRemove(String name, Supplier<Map<Integer, Integer>> c) {
+    public void testMapKeysSizeRemove(String name, Supplier<Map<String, String>> c) {
         testCollectionSizeRemove(name + " key set", c.get().keySet());
     }
 
     @Test(dataProvider = "maps", groups = { "serialization-hostile" })
-    public void testMapValuesSizeRemove(String name, Supplier<Map<Integer, Integer>> c) {
+    public void testMapValuesSizeRemove(String name, Supplier<Map<String, String>> c) {
         testCollectionSizeRemove(name + " value set", c.get().values());
     }
 
     @Test(dataProvider = "maps")
-    public void testMapEntriesSizeRemove(String name, Supplier<Map<Integer, Integer>> c) {
+    public void testMapEntriesSizeRemove(String name, Supplier<Map<String, String>> c) {
         testEntrySetSizeRemove(name + " entry set", c.get().entrySet());
     }
 
-    private void testEntrySetSizeRemove(String name, Set<Map.Entry<Integer, Integer>> c) {
-        Map.Entry<Integer, Integer> first = c.iterator().next();
+    private void testEntrySetSizeRemove(String name, Set<Map.Entry<String, String>> c) {
+        Map.Entry<String, String> first = c.iterator().next();
         assertTrue(c.remove(first));
-        Stream<Map.Entry<Integer, Integer>> s = c.stream();
-        Map.Entry<Integer, Integer> second = c.iterator().next();
+        Stream<Map.Entry<String, String>> s = c.stream();
+        Map.Entry<String, String> second = c.iterator().next();
         assertTrue(c.remove(second));
         Object[] result = s.toArray();
         assertEquals(result.length, c.size());


### PR DESCRIPTION
Update stream and spliterator tests of WeakHashmap that use Integer, a value class, as test data. 

The Integers are replaced with Strings as test data in most tests. 
In others, the intersection of Collections with value classes (Integer) are disabled when running with --enable-preview.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336672](https://bugs.openjdk.org/browse/JDK-8336672): [lworld] Tests of spliterators and streams fail when value objects are used with WeakHashmap (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1178/head:pull/1178` \
`$ git checkout pull/1178`

Update a local copy of the PR: \
`$ git checkout pull/1178` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1178`

View PR using the GUI difftool: \
`$ git pr show -t 1178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1178.diff">https://git.openjdk.org/valhalla/pull/1178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1178#issuecomment-2248057636)