### PR TITLE
8337148: [lworld] Not all references to Preload attribute have been renamed

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3955,7 +3955,7 @@ void ClassFileParser::parse_classfile_attributes(const ClassFileStream* const cf
             }
             if (EnableValhalla && tag == vmSymbols::tag_loadable_descriptors()) {
               if (parsed_loadable_descriptors_attribute) {
-                classfile_parse_error("Multiple Preload attributes in class file %s", CHECK);
+                classfile_parse_error("Multiple LoadableDescriptors attributes in class file %s", CHECK);
                 return;
               }
               parsed_loadable_descriptors_attribute = true;
@@ -6526,7 +6526,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
         _inline_type_field_klasses->at_put(fieldinfo.index(), vk);
         log_info(class, preload)("Preloading of class %s during loading of class %s (cause: null-free non-static field) succeeded", s->as_C_string(), _class_name->as_C_string());
       } else if (Signature::has_envelope(sig)) {
-        // Preloading classes for nullable fields that are listed in the Preload attribute
+        // Preloading classes for nullable fields that are listed in the LoadableDescriptors attribute
         // Those classes would be required later for the flattening of nullable inline type fields
         TempNewSymbol name = Signature::strip_envelope(sig);
         if (name != _class_name && is_class_in_loadable_descriptors_attribute(sig)) {
@@ -6545,7 +6545,7 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
             log_warning(class, preload)("Preloading of class %s during loading of class %s (cause: field type in LoadableDescriptors attribute) failed : %s",
                                           name->as_C_string(), _class_name->as_C_string(), PENDING_EXCEPTION->klass()->name()->as_C_string());
           }
-          // Loads triggered by the preload attribute are speculative, failures must not impact loading of current class
+          // Loads triggered by the LoadableDescriptors attribute are speculative, failures must not impact loading of current class
           if (HAS_PENDING_EXCEPTION) {
             CLEAR_PENDING_EXCEPTION;
           }

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -357,7 +357,7 @@ class ClassFileParser {
                                                     TRAPS);
 
   u2 parse_classfile_loadable_descriptors_attribute(const ClassFileStream* const cfs,
-                                                    const u1* const preload_attribute_start,
+                                                    const u1* const loadable_descriptors_attribute_start,
                                                     TRAPS);
 
   u4 parse_classfile_record_attribute(const ClassFileStream* const cfs,

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1021,7 +1021,7 @@ bool InstanceKlass::link_class_impl(TRAPS) {
       }
     }
 
-    // Aggressively preloading all classes from the Preload attribute
+    // Aggressively preloading all classes from the LoadableDescriptors attribute
     if (loadable_descriptors() != nullptr) {
       HandleMark hm(THREAD);
       for (int i = 0; i < loadable_descriptors()->length(); i++) {
@@ -3952,7 +3952,7 @@ void InstanceKlass::print_on(outputStream* st) const {
     st->print(BULLET"record components:     "); record_components()->print_value_on(st);     st->cr();
   }
   st->print(BULLET"permitted subclasses:     "); permitted_subclasses()->print_value_on(st);     st->cr();
-  st->print(BULLET"preload classes:     "); loadable_descriptors()->print_value_on(st); st->cr();
+  st->print(BULLET"loadable descriptors:     "); loadable_descriptors()->print_value_on(st); st->cr();
   if (java_mirror() != nullptr) {
     st->print(BULLET"java mirror:       ");
     java_mirror()->print_value_on(st);

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -1936,8 +1936,8 @@ bool VM_RedefineClasses::rewrite_cp_refs(InstanceKlass* scratch_class) {
     return false;
   }
 
-  // rewrite constant pool references in the Preload attribute:
-  if (!rewrite_cp_refs_in_preload_attribute(scratch_class)) {
+  // rewrite constant pool references in the LoadableDescriptors attribute:
+  if (!rewrite_cp_refs_in_loadable_descriptors_attribute(scratch_class)) {
     // propagate failure back to caller
     return false;
   }
@@ -2090,8 +2090,8 @@ bool VM_RedefineClasses::rewrite_cp_refs_in_permitted_subclasses_attribute(
   return true;
 }
 
-// Rewrite constant pool references in the Preload attribute.
-bool VM_RedefineClasses::rewrite_cp_refs_in_preload_attribute(
+// Rewrite constant pool references in the LoadableDescriptors attribute.
+bool VM_RedefineClasses::rewrite_cp_refs_in_loadable_descriptors_attribute(
        InstanceKlass* scratch_class) {
 
   Array<u2>* loadable_descriptors = scratch_class->loadable_descriptors();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.hpp
@@ -471,7 +471,7 @@ class VM_RedefineClasses: public VM_Operation {
   bool rewrite_cp_refs_in_nest_attributes(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_record_attribute(InstanceKlass* scratch_class);
   bool rewrite_cp_refs_in_permitted_subclasses_attribute(InstanceKlass* scratch_class);
-  bool rewrite_cp_refs_in_preload_attribute(InstanceKlass* scratch_class);
+  bool rewrite_cp_refs_in_loadable_descriptors_attribute(InstanceKlass* scratch_class);
 
   void rewrite_cp_refs_in_method(methodHandle method,
     methodHandle * new_method_p, TRAPS);


### PR DESCRIPTION
More renaming of the Preload attribute into LoadableDescriptors attribute.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337148](https://bugs.openjdk.org/browse/JDK-8337148): [lworld] Not all references to Preload attribute have been renamed (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1179/head:pull/1179` \
`$ git checkout pull/1179`

Update a local copy of the PR: \
`$ git checkout pull/1179` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1179`

View PR using the GUI difftool: \
`$ git pr show -t 1179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1179.diff">https://git.openjdk.org/valhalla/pull/1179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1179#issuecomment-2248782559)