### PR TITLE
8329108: [lworld] valhalla/valuetypes/ObjectMethods.java fails with default CDS archive

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -735,7 +735,7 @@ void InterpreterMacroAssembler::remove_activation(
       Label skip_stress;
       ldr(rscratch1, Address(rfp, frame::interpreter_frame_method_offset * wordSize));
       ldrw(rscratch1, Address(rscratch1, Method::flags_offset()));
-      tstw(rscratch1, ConstMethodFlags::has_scalarized_return_flag());
+      tstw(rscratch1, MethodFlags::has_scalarized_return_flag());
       br(Assembler::EQ, skip_stress);
       load_klass(r0, r0);
       orr(r0, r0, 1);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1158,7 +1158,7 @@ void InterpreterMacroAssembler::remove_activation(
       Label skip_stress;
       movptr(rscratch1, Address(rbp, frame::interpreter_frame_method_offset * wordSize));
       movl(rscratch1, Address(rscratch1, Method::flags_offset()));
-      testl(rcx, ConstMethodFlags::has_scalarized_return_flag());
+      testl(rcx, MethodFlags::has_scalarized_return_flag());
       jcc(Assembler::zero, skip_stress);
       load_klass(rax, rax, rscratch1);
       orptr(rax, 1);

--- a/src/hotspot/share/oops/constMethodFlags.hpp
+++ b/src/hotspot/share/oops/constMethodFlags.hpp
@@ -89,10 +89,6 @@ class ConstMethodFlags {
   CM_FLAGS_DO(CM_FLAGS_GET_SET)
 #undef CM_FLAGS_GET_SET
 
-  static u4 has_scalarized_return_flag() {
-    return _misc_has_scalarized_return;
-  }
-
   int as_int() const { return _flags; }
   void print_on(outputStream* st) const;
 };

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1247,6 +1247,8 @@ void Method::remove_unshareable_flags() {
   set_is_not_c1_compilable(false);
   set_is_not_c2_osr_compilable(false);
   set_on_stack_flag(false);
+  set_has_scalarized_args(false);
+  set_has_scalarized_return(false);
 }
 #endif
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -781,12 +781,6 @@ public:
   bool has_reserved_stack_access() const { return constMethod()->reserved_stack_access(); }
   void set_has_reserved_stack_access() { constMethod()->set_reserved_stack_access(); }
 
-  bool has_scalarized_args() const { return constMethod()->has_scalarized_args(); }
-  void set_has_scalarized_args() { constMethod()->set_has_scalarized_args(); }
-
-  bool has_scalarized_return() const { return constMethod()->has_scalarized_return(); }
-  void set_has_scalarized_return() { constMethod()->set_has_scalarized_return(); }
-
   bool is_scalarized_arg(int idx) const;
 
   bool c1_needs_stack_repair() const { return constMethod()->c1_needs_stack_repair(); }

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -88,6 +88,8 @@ class MethodFlags {
   M_STATUS_DO(M_STATUS_GET_SET)
 #undef M_STATUS_GET_SET
 
+  static u4 has_scalarized_return_flag() { return _misc_has_scalarized_return; }
+
   int as_int() const { return _status; }
   void atomic_set_bits(u4 bits)   { Atomic::fetch_then_or(&_status, bits); }
   void atomic_clear_bits(u4 bits) { Atomic::fetch_then_and(&_status, ~bits); }

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -58,6 +58,8 @@ class MethodFlags {
    status(has_loops_flag              , 1 << 13) /* Method has loops */ \
    status(has_loops_flag_init         , 1 << 14) /* The loop flag has been initialized */ \
    status(on_stack_flag               , 1 << 15) /* RedefineClasses support to keep Metadata from being cleaned */ \
+   status(has_scalarized_args         , 1 << 16) \
+   status(has_scalarized_return       , 1 << 17) \
    /* end of list */
 
 #define M_STATUS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3687,4 +3687,3 @@ JRT_BLOCK_ENTRY(void, SharedRuntime::store_inline_type_fields_to_buf(JavaThread*
   JRT_BLOCK_END;
 }
 JRT_END
-


### PR DESCRIPTION
When this test was run after `java -Xshare:dump --enable-preview`, the test would crash due to a null signature calling convention. This occurred because `has_scalarized_args`, a flag whose value should be determined at runtime when regenerating the method adapter, was stored in ConstMethod and then archived. The resulting mismatch in a subsequent run meant the wrong `sig_cc` would be used. This change moves the flags in question into `method.hpp` and avoids dumping them so they can be properly regenerated at runtime. The test was verified locally and the changes were further verified with tier 1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8329108](https://bugs.openjdk.org/browse/JDK-8329108): [lworld] valhalla/valuetypes/ObjectMethods.java fails with default CDS archive (**Bug** - P2)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1180/head:pull/1180` \
`$ git checkout pull/1180`

Update a local copy of the PR: \
`$ git checkout pull/1180` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1180`

View PR using the GUI difftool: \
`$ git pr show -t 1180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1180.diff">https://git.openjdk.org/valhalla/pull/1180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1180#issuecomment-2248917737)