### PR TITLE
8336669: [lworld] Some Collection tests fail when run with migrated classes because they assume wrapper classes instances have identity

### DIFF
--- a/test/jdk/java/util/Collection/IteratorAtEnd.java
+++ b/test/jdk/java/util/Collection/IteratorAtEnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6529795
+ * @bug 6529795 8336669
  * @summary next() does not change iterator state if throws NoSuchElementException
  * @author Martin Buchholz
  */
@@ -99,7 +99,7 @@ public class IteratorAtEnd {
     static void testMap(Map m) {
         try {
             for (int i = 0; i < 3*SIZE; i++)
-                m.put(i, i);
+                m.put("BASE-" + i, i);
             test(m.values());
             test(m.keySet());
             test(m.entrySet());

--- a/test/jdk/java/util/Collections/CheckedIdentityMap.java
+++ b/test/jdk/java/util/Collections/CheckedIdentityMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6585904
+ * @bug 6585904 8336669
  * @run testng CheckedIdentityMap
  * @summary Checked collections with underlying maps with identity comparisons
  */
@@ -41,18 +41,18 @@ public class CheckedIdentityMap {
 
     @Test
     public void testHashCode() {
-        Map<Integer, Integer> m1 = checkedMap(
-            new IdentityHashMap<Integer, Integer>(),
-            Integer.class, Integer.class);
-        Map<Integer, Integer> m2 = checkedMap(
-            new IdentityHashMap<Integer, Integer>(),
-            Integer.class, Integer.class);
-        // NB: these are unique instances. Compare vs. Integer.valueOf(1)
-        m1.put(new Integer(1), new Integer(1));
-        m2.put(new Integer(1), new Integer(1));
+        Map<String, String> m1 = checkedMap(
+            new IdentityHashMap<>(),
+            String.class, String.class);
+        Map<String, String> m2 = checkedMap(
+            new IdentityHashMap<>(),
+            String.class, String.class);
+        // NB: these are unique instances. Compare vs. "A"
+        m1.put(new String("A"), new String("A"));
+        m2.put(new String("A"), new String("A"));
 
-        Map.Entry<Integer, Integer> e1 = m1.entrySet().iterator().next();
-        Map.Entry<Integer, Integer> e2 = m2.entrySet().iterator().next();
+        Map.Entry<String, String> e1 = m1.entrySet().iterator().next();
+        Map.Entry<String, String> e2 = m2.entrySet().iterator().next();
 
         assertNotEquals(e1, e2);
         assertEquals(e1.hashCode(), hashCode(e1));

--- a/test/jdk/java/util/Collections/CheckedListBash.java
+++ b/test/jdk/java/util/Collections/CheckedListBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     4904067
+ * @bug     4904067 8336669
  * @summary Unit test for Collections.checkedList
  * @author  Josh Bloch
  * @key randomness
@@ -109,7 +109,7 @@ public class CheckedListBash {
 
         List s = newList();
         for (int i=0; i<listSize; i++)
-            s.add(new Integer(i));
+            s.add(i);
         if (s.size() != listSize)
             fail("Size of [0..n-1] != n");
 
@@ -147,13 +147,8 @@ public class CheckedListBash {
         itAll = all.listIterator();
         while (itAll.hasNext()) {
             Integer i = (Integer)itAll.next();
-            itAll.set(new Integer(i.intValue()));
+            itAll.set(i);
         }
-        itAll = all.listIterator();
-        it = s.iterator();
-        while (it.hasNext())
-            if (it.next()==itAll.next())
-                fail("Iterator.set failed to change value.");
         if (!all.equals(s))
             fail("Failed to reconstruct ints with ListIterator.");
 
@@ -181,7 +176,7 @@ public class CheckedListBash {
         if (ia != ib || !l.equals(Arrays.asList(ia)))
             fail("toArray(Object[]) is hosed (2)");
         ia = new Integer[listSize+1];
-        ia[listSize] = new Integer(69);
+        ia[listSize] = 69;
         ib = (Integer[]) l.toArray(ia);
         if (ia != ib || ia[listSize] != null
             || !l.equals(Arrays.asList(ia).subList(0, listSize)))

--- a/test/jdk/java/util/HashMap/ToArray.java
+++ b/test/jdk/java/util/HashMap/ToArray.java
@@ -43,10 +43,7 @@ public class ToArray {
     record Int(int intValue) implements Comparable<Int> {
         @Override
         public int compareTo(Int o) {
-            if (!(o instanceof Int other)) {
-                throw new IllegalArgumentException("Incomparable type: " + o.getClass().getName());
-            }
-            return Integer.compare(intValue, other.intValue);
+            return Integer.compare(intValue, o.intValue);
         }
     }
 

--- a/test/jdk/java/util/HashMap/ToArray.java
+++ b/test/jdk/java/util/HashMap/ToArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,22 @@ import java.util.stream.LongStream;
 
 /*
  * @test
+ * @bug 8336669
  * @summary HashMap.toArray() behavior tests
  * @author tvaleev
  */
 public class ToArray {
+    // An interned identity class holding an int (like non-Preview Integer)
+    record Int(int intValue) implements Comparable<Int> {
+        @Override
+        public int compareTo(Int o) {
+            if (!(o instanceof Int other)) {
+                throw new IllegalArgumentException("Incomparable type: " + o.getClass().getName());
+            }
+            return Integer.compare(intValue, other.intValue);
+        }
+    }
+
     public static void main(String[] args) {
         checkMap(false);
         checkMap(true);

--- a/test/jdk/java/util/Map/Get.java
+++ b/test/jdk/java/util/Map/Get.java
@@ -47,10 +47,7 @@ public class Get {
     record Char(char c) implements Comparable<Char> {
         @Override
         public int compareTo(Char ch) {
-            if (!(ch instanceof Char other)) {
-                throw new IllegalArgumentException("Incomparable type: " + ch.getClass().getName());
-            }
-            return Character.compare(c, other.c);
+            return Character.compare(c, ch.c);
         }
     }
 

--- a/test/jdk/java/util/Map/LockStep.java
+++ b/test/jdk/java/util/Map/LockStep.java
@@ -53,7 +53,7 @@ public class LockStep {
     // interned for IdentityHashMap
     // identity for WeakHashMap
     private record Int(int intValue) implements Comparable<Int> {
-        private static Map<Integer, Int> interned = new HashMap<>(100);
+        private static final Map<Integer, Int> interned = new HashMap<>(100);
 
         // Return a unique Ini for each int.
         static Int intern(int intValue) {
@@ -62,10 +62,7 @@ public class LockStep {
 
         @Override
         public int compareTo(Int o) {
-            if (!(o instanceof Int other)) {
-                throw new IllegalArgumentException("Incomparable type: " + o.getClass().getName());
-            }
-            return Integer.compare(intValue, other.intValue);
+            return Integer.compare(intValue, o.intValue);
         }
     }
 

--- a/test/jdk/java/util/Map/LockStep.java
+++ b/test/jdk/java/util/Map/LockStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6612102
+ * @bug 6612102 8336669
  * @summary Test Map implementations for mutual compatibility
  * @key randomness
  */
@@ -49,6 +49,26 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * It would be good to add more "Lockstep-style" tests to this file.
  */
 public class LockStep {
+    // An interned identity class holding an int (like non-Preview Integer)
+    // interned for IdentityHashMap
+    // identity for WeakHashMap
+    private record Int(int intValue) implements Comparable<Int> {
+        private static Map<Integer, Int> interned = new HashMap<>(100);
+
+        // Return a unique Ini for each int.
+        static Int intern(int intValue) {
+            return interned.computeIfAbsent(intValue, (i) -> new Int(i));
+        }
+
+        @Override
+        public int compareTo(Int o) {
+            if (!(o instanceof Int other)) {
+                throw new IllegalArgumentException("Incomparable type: " + o.getClass().getName());
+            }
+            return Integer.compare(intValue, other.intValue);
+        }
+    }
+
     void mapsEqual(Map m1, Map m2) {
         equal(m1, m2);
         equal(m2, m1);
@@ -112,15 +132,15 @@ public class LockStep {
                 new TreeMap(),
                 new ConcurrentHashMap(16),
                 new ConcurrentSkipListMap(),
-                Collections.checkedMap(new HashMap(16), Integer.class, Integer.class),
-                Collections.checkedSortedMap(new TreeMap(), Integer.class, Integer.class),
-                Collections.checkedNavigableMap(new TreeMap(), Integer.class, Integer.class),
+                Collections.checkedMap(new HashMap(16), Int.class, Integer.class),
+                Collections.checkedSortedMap(new TreeMap(), Int.class, Integer.class),
+                Collections.checkedNavigableMap(new TreeMap(), Int.class, Integer.class),
                 Collections.synchronizedMap(new HashMap(16)),
                 Collections.synchronizedSortedMap(new TreeMap()),
                 Collections.synchronizedNavigableMap(new TreeMap()));
 
             for (int j = 0; j < 10; j++)
-                put(maps, r.nextInt(100), r.nextInt(100));
+                put(maps, Int.intern(r.nextInt(100)), r.nextInt(100));
             removeLastTwo(maps);
         }
     }

--- a/test/jdk/java/util/Map/ToArray.java
+++ b/test/jdk/java/util/Map/ToArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8008785
+ * @bug 8008785 8336669
  * @summary Ensure toArray() implementations return correct results.
  * @author Mike Duigou
  */
@@ -38,8 +38,12 @@ public class ToArray {
      */
     private static final int TEST_SIZE = 5000;
 
+    static String genString(int i) {
+        return "BASE-" + HexFormat.of().toHexDigits(i);
+    }
+
     private static void realMain(String[] args) throws Throwable {
-        Map<Integer, Long>[] maps = (Map<Integer, Long>[]) new Map[]{
+        Map<String, Long>[] maps = (Map<String, Long>[]) new Map[]{
                     new HashMap<>(),
                     new Hashtable<>(),
                     new IdentityHashMap<>(),
@@ -51,7 +55,7 @@ public class ToArray {
                 };
 
         // for each map type.
-        for (Map<Integer, Long> map : maps) {
+        for (Map<String, Long> map : maps) {
              try {
                 testMap(map);
              } catch(Exception all) {
@@ -60,19 +64,20 @@ public class ToArray {
         }
     }
 
-    private static final Integer[] KEYS = new Integer[TEST_SIZE];
+    private static final String[] KEYS = new String[TEST_SIZE];
 
     private static final Long[] VALUES = new Long[TEST_SIZE];
 
     static {
         for (int each = 0; each < TEST_SIZE; each++) {
-            KEYS[each]   = Integer.valueOf(each);
+            // BUG: WeakHashMap of value object!
+            KEYS[each]   = genString(each);
             VALUES[each] = Long.valueOf(each + TEST_SIZE);
         }
     }
 
 
-    private static void testMap(Map<Integer, Long> map) {
+    private static void testMap(Map<String, Long> map) {
         System.out.println("Testing " + map.getClass());
         System.out.flush();
 
@@ -98,9 +103,9 @@ public class ToArray {
         }
 
         // check the entries
-        Map.Entry<Integer,Long>[] entries = map.entrySet().toArray(new Map.Entry[TEST_SIZE]);
-        Arrays.sort( entries,new Comparator<Map.Entry<Integer,Long>>() {
-                public int compare(Map.Entry<Integer,Long> o1, Map.Entry<Integer,Long> o2) {
+        Map.Entry<String,Long>[] entries = map.entrySet().toArray(new Map.Entry[TEST_SIZE]);
+        Arrays.sort( entries,new Comparator<Map.Entry<String,Long>>() {
+                public int compare(Map.Entry<String,Long> o1, Map.Entry<String,Long> o2) {
                         return o1.getKey().compareTo(o2.getKey());
                 }});
 

--- a/test/jdk/java/util/Map/ToArray.java
+++ b/test/jdk/java/util/Map/ToArray.java
@@ -43,7 +43,7 @@ public class ToArray {
     }
 
     private static void realMain(String[] args) throws Throwable {
-        Map<String, Long>[] maps = (Map<String, Long>[]) new Map[]{
+        Map<String, Long>[] maps = (Map<String, Long>[]) new Map<?,?>[]{
                     new HashMap<>(),
                     new Hashtable<>(),
                     new IdentityHashMap<>(),


### PR DESCRIPTION
Updated tests not not assume Integer has identity.

	modified:   test/jdk/java/util/Collection/IteratorAtEnd.java
	modified:   test/jdk/java/util/Collections/CheckedIdentityMap.java
	modified:   test/jdk/java/util/Collections/CheckedListBash.java
	modified:   test/jdk/java/util/HashMap/ToArray.java
	modified:   test/jdk/java/util/Map/Get.java
	modified:   test/jdk/java/util/Map/LockStep.java
	modified:   test/jdk/java/util/Map/ToArray.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336669](https://bugs.openjdk.org/browse/JDK-8336669): [lworld] Some Collection tests fail when run with migrated classes because they assume wrapper classes instances have identity (**Bug** - P3)


### Reviewers
 * [Rémi Forax](https://openjdk.org/census#forax) (@forax - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1181/head:pull/1181` \
`$ git checkout pull/1181`

Update a local copy of the PR: \
`$ git checkout pull/1181` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1181`

View PR using the GUI difftool: \
`$ git pr show -t 1181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1181.diff">https://git.openjdk.org/valhalla/pull/1181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1181#issuecomment-2250114347)