### PR TITLE
8337210: [lworld] Incorrect IC check leads to continuous cache misses

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2171,12 +2171,7 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   C2_MacroAssembler _masm(&cbuf);
 
   if (!_verified) {
-    Label skip;
-    __ cmp_klass(j_rarg0, rscratch2, rscratch1);
-    __ br(Assembler::EQ, skip);
-      __ far_jump(RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
-    __ bind(skip);
-
+    __ ic_check(1);
   } else {
     // insert a nop at the start of the prolog so we can patch in a
     // branch if we need to invalidate the method later

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1452,13 +1452,7 @@ void MachVEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   C2_MacroAssembler _masm(&cbuf);
   uint insts_size = cbuf.insts_size();
   if (!_verified) {
-    if (UseCompressedClassPointers) {
-      __ load_klass(rscratch1, j_rarg0, rscratch2);
-      __ cmpptr(rax, rscratch1);
-    } else {
-      __ cmpptr(rax, Address(j_rarg0, oopDesc::klass_offset_in_bytes()));
-    }
-    __ jump_cc(Assembler::notEqual, RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
+    __ ic_check(1);
   } else {
     // TODO 8284443 Avoid creation of temporary frame
     if (ra_->C->stub_function() == nullptr) {

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3514,13 +3514,6 @@ void PhaseOutput::install_code(ciMethod*         target,
       _code_offsets.set_value(CodeOffsets::Verified_Entry, 0);
       _code_offsets.set_value(CodeOffsets::OSR_Entry, _first_block_size);
     } else {
-      if (!target->is_static()) {
-        // The UEP of an nmethod ensures that the VEP is padded. However, the padding of the UEP is placed
-        // before the inline cache check, so we don't have to execute any nop instructions when dispatching
-        // through the UEP, yet we can ensure that the VEP is aligned appropriately.
-        // TODO 8325106 Check this
-        // _code_offsets.set_value(CodeOffsets::Entry, _first_block_size - MacroAssembler::ic_check_size());
-      }
       _code_offsets.set_value(CodeOffsets::Verified_Entry, _first_block_size);
       if (_code_offsets.value(CodeOffsets::Verified_Inline_Entry) == -1) {
         _code_offsets.set_value(CodeOffsets::Verified_Inline_Entry, _first_block_size);


### PR DESCRIPTION
Fixes an incorrect merge of [JDK-8322630](https://bugs.openjdk.org/browse/JDK-8322630) into Valhalla, breaking IC miss resolution and leading to continuous re-resolution of IC calls.

Incorrect IC check:
```
   0x7f9184adfd04:	mov    0x8(%rsi),%r10d
   0x7f9184adfd08:	cmp    %r10,%rax
   0x7f9184adfd0b:	jne    0x7f918465b520
```

Correct IC check:
```
  0x7f2b90ae1d04:   mov    0x8(%rsi),%r10d
  0x7f2b90ae1d08:   cmp    0x8(%rax),%r10d
  0x7f2b90ae1d0c:   jne    0x00007f2b9065a820
```

I intentionally left out the test that reproduces this because it's a very specific issue and the test would require parsing the output of `-XX:+TraceCallFixup` which is error prone (stress flags might trigger resolution unexpectedly).

Thanks to @chhagedorn for helping to narrow this down!

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337210](https://bugs.openjdk.org/browse/JDK-8337210): [lworld] Incorrect IC check leads to continuous cache misses (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1182/head:pull/1182` \
`$ git checkout pull/1182`

Update a local copy of the PR: \
`$ git checkout pull/1182` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1182`

View PR using the GUI difftool: \
`$ git pr show -t 1182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1182.diff">https://git.openjdk.org/valhalla/pull/1182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1182#issuecomment-2250326782)