### PR TITLE
8337115: [lworld] Whitebox API does not require --enable-preview

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -50,7 +50,6 @@ $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
     DISABLED_WARNINGS := deprecation removal preview, \
-    JAVAC_FLAGS := --enable-preview, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -48,7 +48,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -65,7 +64,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -82,7 +80,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -99,7 +96,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -117,7 +113,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  *          java.base/jdk.internal.vm.annotation
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile Person.java InlineOops.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineTypesTest.java
@@ -57,7 +57,6 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  * @modules java.base/jdk.internal.value
  * @library /test/lib /test/jdk/java/lang/invoke/common
  * @modules java.base/jdk.internal.vm.annotation
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile InlineTypesTest.java
  * @run main/othervm -Xmx128m -XX:+ExplicitGCInvokesConcurrent

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ObjectMethods.java
@@ -30,7 +30,6 @@ import test.java.lang.invoke.lib.InstructionHelper;
  * @test ObjectMethods
  * @summary Check object methods implemented by the VM behave with value types
  * @library /test/lib /test/jdk/java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @compile ObjectMethods.java
  * @run main/othervm -XX:+UseCompressedClassPointers runtime.valhalla.inlinetypes.ObjectMethods

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ToggleNotifyJvmtiTest/ToggleNotifyJvmtiTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ToggleNotifyJvmtiTest/ToggleNotifyJvmtiTest.java
@@ -26,7 +26,6 @@
  * @summary Verifies JVMTI works for agents loaded into running VM
  * @requires vm.jvmti
  * @requires vm.continuations
- * @enablePreview
  * @library /test/lib /test/hotspot/jtreg
  * @build jdk.test.whitebox.WhiteBox
  *

--- a/test/jdk/java/lang/invoke/condy/BootstrapMethodJumboArgsTest.java
+++ b/test/jdk/java/lang/invoke/condy/BootstrapMethodJumboArgsTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test bootstrap methods throwing an exception
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng BootstrapMethodJumboArgsTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 BootstrapMethodJumboArgsTest

--- a/test/jdk/java/lang/invoke/condy/CondyBSMException.java
+++ b/test/jdk/java/lang/invoke/condy/CondyBSMException.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test bootstrap methods throwing an exception
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyBSMException
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyBSMException

--- a/test/jdk/java/lang/invoke/condy/CondyBSMInvocation.java
+++ b/test/jdk/java/lang/invoke/condy/CondyBSMInvocation.java
@@ -26,7 +26,6 @@
  * @bug 8186046 8199875
  * @summary Test basic invocation of bootstrap methods
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyBSMInvocation
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyBSMInvocation

--- a/test/jdk/java/lang/invoke/condy/CondyBSMValidationTest.java
+++ b/test/jdk/java/lang/invoke/condy/CondyBSMValidationTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test invalid name in name and type
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyBSMValidationTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyBSMValidationTest

--- a/test/jdk/java/lang/invoke/condy/CondyInterfaceWithOverpassMethods.java
+++ b/test/jdk/java/lang/invoke/condy/CondyInterfaceWithOverpassMethods.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test for an interface using condy with default overpass methods
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyInterfaceWithOverpassMethods
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyInterfaceWithOverpassMethods

--- a/test/jdk/java/lang/invoke/condy/CondyNameValidationTest.java
+++ b/test/jdk/java/lang/invoke/condy/CondyNameValidationTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test invalid name in name and type
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyNameValidationTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyNameValidationTest

--- a/test/jdk/java/lang/invoke/condy/CondyStaticArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/condy/CondyStaticArgumentsTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test bootstrap arguments for condy
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyStaticArgumentsTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyStaticArgumentsTest

--- a/test/jdk/java/lang/invoke/condy/CondyTypeValidationTest.java
+++ b/test/jdk/java/lang/invoke/condy/CondyTypeValidationTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test invalid name in name and type
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyTypeValidationTest
  */

--- a/test/jdk/java/lang/invoke/condy/CondyWithGarbageTest.java
+++ b/test/jdk/java/lang/invoke/condy/CondyWithGarbageTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Stress test ldc to ensure HotSpot correctly manages oop maps
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyWithGarbageTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyWithGarbageTest

--- a/test/jdk/java/lang/invoke/condy/CondyWrongType.java
+++ b/test/jdk/java/lang/invoke/condy/CondyWrongType.java
@@ -26,7 +26,6 @@
  * @bug 8186046
  * @summary Test bootstrap methods returning the wrong type
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng CondyWrongType
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 CondyWrongType

--- a/test/jdk/java/lang/invoke/condy/ConstantBootstrapsTest.java
+++ b/test/jdk/java/lang/invoke/condy/ConstantBootstrapsTest.java
@@ -26,7 +26,6 @@
  * @bug 8186046 8195694
  * @summary Test dynamic constant bootstraps
  * @library /java/lang/invoke/common
- * @build test.java.lang.invoke.lib.InstructionHelper
  * @enablePreview
  * @run testng ConstantBootstrapsTest
  * @run testng/othervm -XX:+UnlockDiagnosticVMOptions -XX:UseBootstrapCallInfo=3 ConstantBootstrapsTest


### PR DESCRIPTION
Remove enable preview for WhiteBox, and some unnecessary @build InstructionHelper (its in the test lib already)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337115](https://bugs.openjdk.org/browse/JDK-8337115): [lworld] Whitebox API does not require --enable-preview (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1184/head:pull/1184` \
`$ git checkout pull/1184`

Update a local copy of the PR: \
`$ git checkout pull/1184` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1184`

View PR using the GUI difftool: \
`$ git pr show -t 1184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1184.diff">https://git.openjdk.org/valhalla/pull/1184.diff</a>

</details>
