### PR TITLE
8333865: Unable to load static archive with --enable-preview

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -172,18 +172,16 @@ define CreateCDSArchive
   JRE_TARGETS += $$($1_$2_$3_gen_cds_archive_jre)
 endef
 
-# TODO: add these to below when CDS & --enable-preview is well tested.
-#     $(eval $(call CreateCDSArchive,$v,,_valhalla))
-#     $(eval $(call CreateCDSArchive,$v,_nocoops,_valhalla))
-
 ifeq ($(BUILD_CDS_ARCHIVE), true)
   $(foreach v, $(JVM_VARIANTS), \
     $(eval $(call CreateCDSArchive,$v,,)) \
+    $(eval $(call CreateCDSArchive,$v,,_valhalla)) \
   )
 
   ifeq ($(call isTargetCpuBits, 64), true)
     $(foreach v, $(JVM_VARIANTS), \
       $(eval $(call CreateCDSArchive,$v,_nocoops,)) \
+      $(eval $(call CreateCDSArchive,$v,_nocoops,_valhalla)) \
     )
   endif
 endif


### PR DESCRIPTION
Generation of Valhalla-enabled CDS archives was disabled and this patch enables this feature. Both a standard and Valhalla enabled archive will be created at build time. Verified with tier

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8333865](https://bugs.openjdk.org/browse/JDK-8333865): Unable to load static archive with --enable-preview (**Bug** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1187/head:pull/1187` \
`$ git checkout pull/1187`

Update a local copy of the PR: \
`$ git checkout pull/1187` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1187`

View PR using the GUI difftool: \
`$ git pr show -t 1187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1187.diff">https://git.openjdk.org/valhalla/pull/1187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1187#issuecomment-2258790857)