### PR TITLE
8337605: Update description of constants in Float16

### DIFF
--- a/src/java.base/share/classes/java/lang/Float16.java
+++ b/src/java.base/share/classes/java/lang/Float16.java
@@ -102,18 +102,27 @@ public final class Float16
     /**
      * A constant holding the positive infinity of type {@code
      * Float16}.
+     *
+     * @see Float#POSITIVE_INFINITY
+     * @see Double#POSITIVE_INFINITY
      */
     public static final Float16 POSITIVE_INFINITY = valueOf(Float.POSITIVE_INFINITY);
 
     /**
      * A constant holding the negative infinity of type {@code
      * Float16}.
+     *
+     * @see Float#NEGATIVE_INFINITY
+     * @see Double#NEGATIVE_INFINITY
      */
     public static final Float16 NEGATIVE_INFINITY = valueOf(Float.NEGATIVE_INFINITY);
 
     /**
      * A constant holding a Not-a-Number (NaN) value of type {@code
      * Float16}.
+     *
+     * @see Float#NaN
+     * @see Double#NaN
      */
     public static final Float16 NaN = valueOf(Float.NaN);
 
@@ -121,24 +130,36 @@ public final class Float16
      * A constant holding the largest positive finite value of type
      * {@code Float16},
      * (2-2<sup>-10</sup>)&middot;2<sup>15</sup>, numerically equal to 65504.0.
+     *
+     * @see Float#MAX_VALUE
+     * @see Double#MAX_VALUE
      */
     public static final Float16 MAX_VALUE = valueOf(0x1.ffcp15f);
 
     /**
      * A constant holding the smallest positive normal value of type
      * {@code Float16}, 2<sup>-14</sup>.
+     *
+     * @see Float#MIN_NORMAL
+     * @see Double#MIN_NORMAL
      */
     public static final Float16 MIN_NORMAL = valueOf(0x1.0p-14f);
 
     /**
      * A constant holding the smallest positive nonzero value of type
      * {@code Float16}, 2<sup>-24</sup>.
+     *
+     * @see Float#MIN_VALUE
+     * @see Double#MIN_VALUE
      */
     public static final Float16 MIN_VALUE = valueOf(0x1.0p-24f);
 
     /**
      * The number of bits used to represent a {@code Float16} value,
      * {@value}.
+     *
+     * @see Float#SIZE
+     * @see Double#SIZE
      */
     public static final int SIZE = 16;
 
@@ -146,24 +167,38 @@ public final class Float16
      * The number of bits in the significand of a {@code Float16}
      * value, {@value}.  This corresponds to parameter N in section
      * {@jls 4.2.3} of <cite>The Java Language Specification</cite>.
+     *
+     * @see Float#PRECISION
+     * @see Double#PRECISION
      */
     public static final int PRECISION = 11;
 
     /**
      * Maximum exponent a finite {@code Float16} variable may have,
-     * {@value}.
+     * {@value}. It is equal to the value returned by {@code
+     * Float16.getExponent(Float16.MAX_VALUE)}.
+     *
+     * @see Float#MAX_EXPONENT
+     * @see Double#MAX_EXPONENT
      */
     public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 15
 
     /**
      * Minimum exponent a normalized {@code Float16} variable may
-     * have, {@value}.
+     * have, {@value}.  It is equal to the value returned by {@code
+     * Float16.getExponent(Float16.MIN_NORMAL)}.
+     *
+     * @see Float#MIN_EXPONENT
+     * @see Double#MIN_EXPONENT
      */
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -14
 
     /**
      * The number of bytes used to represent a {@code Float16} value,
      * {@value}.
+     *
+     * @see Float#BYTES
+     * @see Double#BYTES
      */
     public static final int BYTES = SIZE / Byte.SIZE;
 


### PR DESCRIPTION
Align wording or Float16 constants more closely with wording used in Float/Double, add links to corresponding Float/Double constants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337605](https://bugs.openjdk.org/browse/JDK-8337605): Update description of constants in Float16 (**Enhancement** - P4)


### Reviewers
 * [Bhavana Kilambi](https://openjdk.org/census#bkilambi) (@Bhavana-Kilambi - no project role)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - no project role)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1191/head:pull/1191` \
`$ git checkout pull/1191`

Update a local copy of the PR: \
`$ git checkout pull/1191` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1191`

View PR using the GUI difftool: \
`$ git pr show -t 1191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1191.diff">https://git.openjdk.org/valhalla/pull/1191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1191#issuecomment-2261728325)