### PR TITLE
8337747: [lworld] Refactor Loop Unswitching code after merging in JDK-8325746

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -42,6 +42,7 @@ class OuterStripMinedLoopEndNode;
 class PredicateBlock;
 class PathFrequency;
 class PhaseIdealLoop;
+class UnswitchCandidate;
 class UnswitchedLoopSelector;
 class VectorSet;
 class VSharedData;
@@ -691,6 +692,7 @@ public:
   // Return TRUE or FALSE if the loop should be unswitched -- clone
   // loop with an invariant test
   bool policy_unswitching( PhaseIdealLoop *phase ) const;
+  bool no_unswitch_candidate() const;
 
   // Micro-benchmark spamming.  Remove empty loops.
   bool do_remove_empty_loop( PhaseIdealLoop *phase );
@@ -1422,24 +1424,24 @@ public:
   // execute.
   void do_unswitching(IdealLoopTree* loop, Node_List& old_new);
 
-  // Find candidate "if" for unswitching
-  IfNode* find_unswitch_candidate(const IdealLoopTree* loop, Node_List& unswitch_iffs) const;
+  IfNode* find_unswitch_candidates(const IdealLoopTree* loop, Node_List& flat_array_checks) const;
+  IfNode* find_unswitch_candidate_from_idoms(const IdealLoopTree* loop) const;
 
  private:
   static bool has_control_dependencies_from_predicates(LoopNode* head);
   static void revert_to_normal_loop(const LoopNode* loop_head);
 
   void hoist_invariant_check_casts(const IdealLoopTree* loop, const Node_List& old_new,
-                                   const UnswitchedLoopSelector& unswitched_loop_selector);
+                                   const UnswitchCandidate& unswitch_candidate, const IfNode* loop_selector);
   void add_unswitched_loop_version_bodies_to_igvn(IdealLoopTree* loop, const Node_List& old_new);
   static void increment_unswitch_counts(LoopNode* original_head, LoopNode* new_head);
   void remove_unswitch_candidate_from_loops(const Node_List& old_new, const UnswitchedLoopSelector& unswitched_loop_selector);
 #ifndef PRODUCT
-  static void trace_loop_unswitching_count(IdealLoopTree* loop, LoopNode* original_head, const Node_List& unswitch_iffs);
+  static void trace_loop_unswitching_count(IdealLoopTree* loop, LoopNode* original_head);
   static void trace_loop_unswitching_impossible(const LoopNode* original_head);
   static void trace_loop_unswitching_result(const UnswitchedLoopSelector& unswitched_loop_selector,
-                                            const LoopNode* original_head, const LoopNode* new_head,
-                                            const Node_List& old_new);
+                                            const UnswitchCandidate& unswitch_candidate,
+                                            const LoopNode* original_head, const LoopNode* new_head);
 #endif
 
  public:
@@ -1774,6 +1776,8 @@ public:
   bool can_move_to_inner_loop(Node* n, LoopNode* n_loop, Node* x);
 
   void pin_array_access_nodes_dependent_on(Node* ctrl);
+
+  void collect_flat_array_checks(const IdealLoopTree* loop, Node_List& flat_array_checks) const;
 };
 
 


### PR DESCRIPTION
In the merge of JDK-8325746 for tag jdk-23+12, I've applied just a minimal refactoring to get things to work with as few changes as possible in Valhalla and decided to make a full refactoring separately with this patch.

This patch includes the following:
- Improved/updated comments
- New `UnswitchCandidate` class:
  - Since we can have multiple unswitch candidates with flat array checks, I've introduced a new class `UnswitchCandidate` which finds either a unique candidate or a list of flat array checks which can also be queried from this class.
  - Offers methods `update_in_false/true_path_loop()` methods to remove the dominated unswitch candidates (previously in `OriginalLoop::remove_unswitch_candidate_from_loops()`
  - Offers method `merge_flat_array_checks()` to create a merged flat array check bool (previously in `UnswitchedLoopSelector::find_unswitch_candidate()`)
- Updated `UnswitchedLoopSelector` class:
  - Now only responsible for creating the loop unswitching loop selector and not for finding the unswitch candidate - this is passed into the class now.   
- Clean up `PhaseIdealLoop::find_unswitch_candidates()`
- Clean up printing for `TraceLoopOpts` and `TraceLoopUnswitching`. Now the details are only guarded with `TraceLoopUnswitching` to reduce the noise with `TraceLoopOpts`. Example output with `TraceLoopUnswitching`:
```
Loop Unswitching:
- Unswitch-Candidate-If: 519 If
- Loop-Selector-If: 2094 If
- True-Path-Loop (=Orig): 1346 Loop
- False-Path-Loop (=Clone): 2221 Loop
- Unswitched Flat Array Checks:
  - 519 If  ->  2226 If
  - 922 If  ->  2208 If
  - 685 If  ->  2359 If
  - 580 If  ->  2388 If
```

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8337747](https://bugs.openjdk.org/browse/JDK-8337747): [lworld] Refactor Loop Unswitching code after merging in JDK-8325746 (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1194/head:pull/1194` \
`$ git checkout pull/1194`

Update a local copy of the PR: \
`$ git checkout pull/1194` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1194`

View PR using the GUI difftool: \
`$ git pr show -t 1194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1194.diff">https://git.openjdk.org/valhalla/pull/1194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1194#issuecomment-2271036450)