### PR TITLE
8338013: [lworld] User defined value classes cannot extend j.l.Number

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1527,6 +1527,7 @@ public class ClassReader {
                 sym.flags_field |= MIGRATED_VALUE_CLASS;
                 if (needsValueFlag(sym, sym.flags_field)) {
                     sym.flags_field |= VALUE_CLASS;
+                    sym.flags_field &= ~IDENTITY_TYPE;
                 }
             } else if (proxy.type.tsym.flatName() == syms.restrictedType.tsym.flatName()) {
                 Assert.check(sym.kind == MTH);
@@ -1548,6 +1549,7 @@ public class ClassReader {
                     sym.flags_field |= MIGRATED_VALUE_CLASS;
                     if (needsValueFlag(sym, sym.flags_field)) {
                         sym.flags_field |= VALUE_CLASS;
+                        sym.flags_field &= ~IDENTITY_TYPE;
                     }
                 }  else if (proxy.type.tsym == syms.restrictedType.tsym) {
                     Assert.check(sym.kind == MTH);
@@ -3178,6 +3180,7 @@ public class ClassReader {
             flags |= IDENTITY_TYPE;
         } else if (needsValueFlag(c, flags)) {
             flags |= VALUE_CLASS;
+            flags &= ~IDENTITY_TYPE;
         }
         flags &= ~ACC_IDENTITY; // ACC_IDENTITY and SYNCHRONIZED bits overloaded
         return flags;

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -191,6 +191,16 @@ class ValueObjectCompilationTests extends CompilationTestCase {
             ),
             new TestData(
                     """
+                    value class One extends Number {
+                        public int intValue() { return 0; }
+                        public long longValue() { return 0; }
+                        public float floatValue() { return 0; }
+                        public double doubleValue() { return 0; }
+                    }
+                    """
+            ),
+            new TestData(
+                    """
                     value class V extends Object {}
                     """
             ),


### PR DESCRIPTION
When adding the value flag to migrated value classes we need to unset the identity flag if it was previously set

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338013](https://bugs.openjdk.org/browse/JDK-8338013): [lworld] User defined value classes cannot extend j.l.Number (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1195/head:pull/1195` \
`$ git checkout pull/1195`

Update a local copy of the PR: \
`$ git checkout pull/1195` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1195`

View PR using the GUI difftool: \
`$ git pr show -t 1195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1195.diff">https://git.openjdk.org/valhalla/pull/1195.diff</a>

</details>
