### PR TITLE
8338102: x86 backend support for newly added Float16 intrinsics.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -7396,12 +7396,92 @@ void Assembler::evaddph(XMMRegister dst, XMMRegister nds, XMMRegister src, int v
   emit_int16(0x58, (0xC0 | encode));
 }
 
-void Assembler::evaddsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+void Assembler::evsubph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(vector_len, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5C, (0xC0 | encode));
+}
+
+void Assembler::evmulph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(vector_len, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x59, (0xC0 | encode));
+}
+
+void Assembler::evminph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(vector_len, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5D, (0xC0 | encode));
+}
+
+void Assembler::evmaxph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(vector_len, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5F, (0xC0 | encode));
+}
+
+void Assembler::evdivph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(vector_len, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_NONE, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5E, (0xC0 | encode));
+}
+
+void Assembler::eaddsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
   assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
   InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
   attributes.set_is_evex_instruction();
   int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
   emit_int16(0x58, (0xC0 | encode));
+}
+
+void Assembler::esubsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5C, (0xC0 | encode));
+}
+
+void Assembler::edivsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5E, (0xC0 | encode));
+}
+
+void Assembler::emulsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x59, (0xC0 | encode));
+}
+
+void Assembler::emaxsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5F, (0xC0 | encode));
+}
+
+void Assembler::eminsh(XMMRegister dst, XMMRegister nds, XMMRegister src) {
+  assert(VM_Version::supports_avx512_fp16(), "requires AVX512-FP16");
+  InstructionAttr attributes(AVX_128bit, false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ false);
+  attributes.set_is_evex_instruction();
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_F3, VEX_OPCODE_MAP5, &attributes);
+  emit_int16(0x5D, (0xC0 | encode));
 }
 
 void Assembler::psubb(XMMRegister dst, XMMRegister src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2405,8 +2405,18 @@ private:
   void vpaddw(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
   void vpaddd(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
   void vpaddq(XMMRegister dst, XMMRegister nds, Address src, int vector_len);
-  void evaddsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void eaddsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void esubsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void emulsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void edivsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void emaxsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
+  void eminsh(XMMRegister dst, XMMRegister nds, XMMRegister src);
   void evaddph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evsubph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evdivph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evmulph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evminph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void evmaxph(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
   // Leaf level assembler routines for masked operations.
   void evpaddb(XMMRegister dst, KRegister mask, XMMRegister nds, XMMRegister src, bool merge, int vector_len);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -6301,3 +6301,27 @@ void C2_MacroAssembler::vector_rearrange_int_float(BasicType bt, XMMRegister dst
     vpermps(dst, shuffle, src, vlen_enc);
   }
 }
+
+void C2_MacroAssembler::efp16sh(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2) {
+  switch(opcode) {
+    case Op_AddHF: eaddsh(dst, src1, src2); break;
+    case Op_SubHF: esubsh(dst, src1, src2); break;
+    case Op_MulHF: emulsh(dst, src1, src2); break;
+    case Op_DivHF: edivsh(dst, src1, src2); break;
+    case Op_MaxHF: eminsh(dst, src1, src2); break;
+    case Op_MinHF: emaxsh(dst, src1, src2); break;
+    default: assert(false, "%s", NodeClassNames[opcode]); break;
+  }
+}
+
+void C2_MacroAssembler::evfp16ph(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc) {
+  switch(opcode) {
+    case Op_AddVHF: evaddph(dst, src1, src2, vlen_enc); break;
+    case Op_SubVHF: evsubph(dst, src1, src2, vlen_enc); break;
+    case Op_MulVHF: evmulph(dst, src1, src2, vlen_enc); break;
+    case Op_DivVHF: evdivph(dst, src1, src2, vlen_enc); break;
+    case Op_MaxVHF: evminph(dst, src1, src2, vlen_enc); break;
+    case Op_MinVHF: evmaxph(dst, src1, src2, vlen_enc); break;
+    default: assert(false, "%s", NodeClassNames[opcode]); break;
+  }
+}

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -497,4 +497,8 @@ public:
   void vector_rearrange_int_float(BasicType bt, XMMRegister dst, XMMRegister shuffle,
                                   XMMRegister src, int vlen_enc);
 
+  void efp16sh(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2);
+
+  void evfp16ph(int opcode, XMMRegister dst, XMMRegister src1, XMMRegister src2, int vlen_enc);
+
 #endif // CPU_X86_C2_MACROASSEMBLER_X86_HPP

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1735,6 +1735,11 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
   int size_in_bits = vlen * type2aelembytes(bt) * BitsPerByte;
   switch (opcode) {
     case Op_AddVHF:
+    case Op_SubVHF:
+    case Op_MulVHF:
+    case Op_DivVHF:
+    case Op_MaxVHF:
+    case Op_MinVHF:
       if (!VM_Version::supports_avx512_fp16()) {
         return false;
       }
@@ -10225,23 +10230,35 @@ instruct reinterpretH2S (rRegI dst, regF src)
   ins_pipe(pipe_slow);
 %}
 
-instruct addFP16_scalar (regF dst, regF src1, regF src2)
+instruct fp16_scalar_ops (regF dst, regF src1, regF src2)
 %{
   match(Set dst (AddHF src1 src2));
-  format %{ "vaddsh $dst, $src1, $src2" %}
+  match(Set dst (SubHF src1 src2));
+  match(Set dst (MulHF src1 src2));
+  match(Set dst (DivHF src1 src2));
+  match(Set dst (MinHF src1 src2));
+  match(Set dst (MaxHF src1 src2));
+  format %{ "efp16sh $dst, $src1, $src2" %}
   ins_encode %{
-    __ evaddsh($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister);
+    int opcode = this->ideal_Opcode();
+    __ efp16sh(opcode, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister);
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vaddVHF (vec dst, vec src1, vec src2)
+instruct fp16_vector_ops (vec dst, vec src1, vec src2)
 %{
   match(Set dst (AddVHF src1 src2));
-  format %{ "vaddph $dst, $src1, $src2" %}
+  match(Set dst (SubVHF src1 src2));
+  match(Set dst (MulVHF src1 src2));
+  match(Set dst (DivVHF src1 src2));
+  match(Set dst (MaxVHF src1 src2));
+  match(Set dst (MinVHF src1 src2));
+  format %{ "evfp16ph $dst, $src1, $src2" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    __ evaddph($dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
+    int opcode = this->ideal_Opcode();
+    __ evfp16ph(opcode, $dst$$XMMRegister, $src1$$XMMRegister, $src2$$XMMRegister, vlen_enc);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1464,6 +1464,11 @@ bool Matcher::match_rule_supported(int opcode) {
       }
       break;
     case Op_AddHF:
+    case Op_SubHF:
+    case Op_MulHF:
+    case Op_DivHF:
+    case Op_MaxHF:
+    case Op_MinHF:
     case Op_ReinterpretS2HF:
     case Op_ReinterpretHF2S:
       if (!VM_Version::supports_avx512_fp16()) {

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestFP16ScalarOps.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestFP16ScalarOps.java
@@ -83,6 +83,8 @@ public class TestFP16ScalarOps {
 
     @Test
     @IR(counts = {IRNode.SUB_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.SUB_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void testSub() {
         Float16 res = shortBitsToFloat16((short)0);
@@ -93,6 +95,8 @@ public class TestFP16ScalarOps {
     }
 
     @Test
+    @IR(counts = {IRNode.MUL_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(counts = {IRNode.MUL_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void testMul() {
@@ -105,6 +109,8 @@ public class TestFP16ScalarOps {
 
     @Test
     @IR(counts = {IRNode.DIV_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.DIV_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void testDiv() {
         Float16 res = shortBitsToFloat16((short)0);
@@ -116,6 +122,8 @@ public class TestFP16ScalarOps {
 
     @Test
     @IR(counts = {IRNode.MAX_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.MAX_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void testMax() {
         Float16 res = shortBitsToFloat16((short)0);
@@ -126,6 +134,8 @@ public class TestFP16ScalarOps {
     }
 
     @Test
+    @IR(counts = {IRNode.MIN_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(counts = {IRNode.MIN_HF, "> 0", IRNode.REINTERPRET_S2HF, "> 0", IRNode.REINTERPRET_HF2S, "> 0"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void testMin() {

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOps.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOps.java
@@ -59,6 +59,8 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.ADD_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.ADD_VHF, ">= 1"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.ADD_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
@@ -80,6 +82,8 @@ public class TestFloat16VectorOps {
 
     @Test
     @Warmup(10000)
+    @IR(counts = {IRNode.SUB_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(counts = {IRNode.SUB_VHF, ">= 1"},
         applyIfCPUFeature = {"sve", "true"})
     @IR(counts = {IRNode.SUB_VHF, ">= 1"},
@@ -103,6 +107,8 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MUL_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.MUL_VHF, ">= 1"},
         applyIfCPUFeature = {"sve", "true"})
     @IR(counts = {IRNode.MUL_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
@@ -124,6 +130,8 @@ public class TestFloat16VectorOps {
 
     @Test
     @Warmup(10000)
+    @IR(counts = {IRNode.DIV_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(counts = {IRNode.DIV_VHF, ">= 1"},
         applyIfCPUFeature = {"sve", "true"})
     @IR(counts = {IRNode.DIV_VHF, ">= 1"},
@@ -147,6 +155,8 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MIN_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
+    @IR(counts = {IRNode.MIN_VHF, ">= 1"},
         applyIfCPUFeature = {"sve", "true"})
     @IR(counts = {IRNode.MIN_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
@@ -168,6 +178,8 @@ public class TestFloat16VectorOps {
 
     @Test
     @Warmup(10000)
+    @IR(counts = {IRNode.MAX_VHF, ">= 1"},
+        applyIfCPUFeature = {"avx512_fp16", "true"})
     @IR(counts = {IRNode.MAX_VHF, ">= 1"},
         applyIfCPUFeature = {"sve", "true"})
     @IR(counts = {IRNode.MAX_VHF, ">= 1"},

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOps.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorOps.java
@@ -59,8 +59,6 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.ADD_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.ADD_VHF, ">= 1"},
         applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.ADD_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
@@ -83,9 +81,7 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.SUB_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.SUB_VHF, ">= 1"},
-        applyIfCPUFeature = {"sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.SUB_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorSubFloat16() {
@@ -107,9 +103,7 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MUL_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.MUL_VHF, ">= 1"},
-        applyIfCPUFeature = {"sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.MUL_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMulFloat16() {
@@ -131,9 +125,7 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.DIV_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.DIV_VHF, ">= 1"},
-        applyIfCPUFeature = {"sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.DIV_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorDivFloat16() {
@@ -155,9 +147,7 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MIN_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.MIN_VHF, ">= 1"},
-        applyIfCPUFeature = {"sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.MIN_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMinFloat16() {
@@ -179,9 +169,7 @@ public class TestFloat16VectorOps {
     @Test
     @Warmup(10000)
     @IR(counts = {IRNode.MAX_VHF, ">= 1"},
-        applyIfCPUFeature = {"avx512_fp16", "true"})
-    @IR(counts = {IRNode.MAX_VHF, ">= 1"},
-        applyIfCPUFeature = {"sve", "true"})
+        applyIfCPUFeatureOr = {"avx512_fp16", "true", "sve", "true"})
     @IR(counts = {IRNode.MAX_VHF, ">= 1"},
         applyIfCPUFeatureAnd = {"fphp", "true", "asimdhp", "true"})
     public void vectorMaxFloat16() {


### PR DESCRIPTION
This patch enables newly added Float16 intrinsicfication support added by [JDK-8336406](https://bugs.openjdk.org/browse/JDK-8336406) for x86 targets supporting AVX512_FP16 feature.

Kindly review and approve.

Best Regards,
Jatin

Hi @Bhavana-Kilambi, 
On a second thought, do you see a possibility of sharing the IR nodes by appending secondary opcode to shared IR node in applicable scenarios, so we can have one IR for each class of operations (unary / binary / ternary).  It may need defining following new matcher routines and some more interfaces:- 
```
   match_rule_supported_shared(int primary_opcode, int secondary_opcode)
   match_rule_supported_vector_shared (int primary_opcode, int secondary_opcode, int vlen, BasicType bt)
   VectorNode::opcode(int popc, int sopc, BasicType bt)

BinaryOpNode (Dst, Src1, Src2, immI_Opcode);   

```
Secondary opcode being a immediate operand can be accessed by encoding routines. WDYT ?

Another possibility could be to encode both primary and secondary opcodes in existing opcode without disturbing the interfaces and add relevant helper routines to extract primary / secondary opcodes, I think opcodes are never -ve values, hence secondary opcode could be accommodated into higher order bits starting from (MSB-1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338102](https://bugs.openjdk.org/browse/JDK-8338102): x86 backend support for newly added Float16 intrinsics. (**Enhancement** - P4)


### Reviewers
 * [Bhavana Kilambi](https://openjdk.org/census#bkilambi) (@Bhavana-Kilambi - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1196/head:pull/1196` \
`$ git checkout pull/1196`

Update a local copy of the PR: \
`$ git checkout pull/1196` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1196`

View PR using the GUI difftool: \
`$ git pr show -t 1196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1196.diff">https://git.openjdk.org/valhalla/pull/1196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1196#issuecomment-2277668392)