### PR TITLE
8336779: [lworld] C2 compilations hits "what's left behind is null" assert in do_checkcast

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1299,6 +1299,7 @@ Node* GraphKit::null_check_common(Node* value, BasicType type,
       // vtptr = InlineTypeNode::make_null(_gvn, vtptr->type()->inline_klass());
       // replace_in_map(value, vtptr);
       // return vtptr;
+      replace_in_map(value, null());
       return null();
     }
     bool do_replace_in_map = (null_control == nullptr || (*null_control) == top());

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -112,6 +112,7 @@ bool InlineTypeNode::has_phi_inputs(Node* region) {
 
 // Merges 'this' with 'other' by updating the input PhiNodes added by 'clone_with_phis'
 InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* other, int pnum, bool transform) {
+  // TODO assert that either both or neither are larvals
   // Merge oop inputs
   PhiNode* phi = get_oop()->as_Phi();
   phi->set_req(pnum, other->get_oop());

--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -112,7 +112,6 @@ bool InlineTypeNode::has_phi_inputs(Node* region) {
 
 // Merges 'this' with 'other' by updating the input PhiNodes added by 'clone_with_phis'
 InlineTypeNode* InlineTypeNode::merge_with(PhaseGVN* gvn, const InlineTypeNode* other, int pnum, bool transform) {
-  // TODO assert that either both or neither are larvals
   // Merge oop inputs
   PhiNode* phi = get_oop()->as_Phi();
   phi->set_req(pnum, other->get_oop());

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedCastType.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestUnloadedCastType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test casting of value objects to an unloaded type.
+ * @enablePreview
+ * @library /test/lib
+ * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,TestUnloadedCastType::test*
+ *                   TestUnloadedCastType
+ */
+
+import jdk.test.lib.Asserts;
+
+public class TestUnloadedCastType {
+
+    static value class MyValue {
+        int x = 0;
+    }
+
+    static class Unloaded { }
+
+    public static Object test(MyValue val) {
+        Object obj = val;
+        return (Unloaded)obj;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; ++i) {
+            Asserts.assertEQ(test(null), null);
+        }
+        try {
+            test(new MyValue());
+            throw new RuntimeException("No ClassCastException thrown");
+        } catch (ClassCastException e) {
+            // Expected
+        }
+    }
+}


### PR DESCRIPTION
We assert because we don't expect an `InlineTypeNode` after a `null_assert`. The fix is to simply replace it with null in the parsing map. Full fix to enable scalarization of null after `null_assert` will be done by [JDK-8284443](https://bugs.openjdk.org/browse/JDK-8284443) (as the ToDo in the code at line 2198 already mentions).

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336779](https://bugs.openjdk.org/browse/JDK-8336779): [lworld] C2 compilations hits "what's left behind is null" assert in do_checkcast (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1199/head:pull/1199` \
`$ git checkout pull/1199`

Update a local copy of the PR: \
`$ git checkout pull/1199` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1199`

View PR using the GUI difftool: \
`$ git pr show -t 1199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1199.diff">https://git.openjdk.org/valhalla/pull/1199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1199#issuecomment-2284151423)