### PR TITLE
8336313: [lworld] C2 compilation hits asserts with -XX:VerifyIterativeGVN=11

### DIFF
--- a/src/hotspot/share/opto/inlinetypenode.cpp
+++ b/src/hotspot/share/opto/inlinetypenode.cpp
@@ -1148,6 +1148,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
     if (is_init == nullptr) {
       // Will only be initialized below, use dummy node for now
       is_init = new Node(1);
+      is_init->init_req(0, kit->control()); // Add an input to prevent dummy from being dead
       gvn.set_type_bottom(is_init);
     }
     Node* null_ctrl = kit->top();
@@ -1215,6 +1216,7 @@ void InlineTypeNode::initialize_fields(GraphKit* kit, MultiNode* multi, uint& ba
     gvn.hash_delete(cmp);
     cmp->set_req(1, is_init);
     gvn.hash_find_insert(cmp);
+    gvn.record_for_igvn(cmp);
     base_input++;
   }
 }


### PR DESCRIPTION
Verification code does not like that the hook node we use in `InlineTypeNode::initialize_fields` is dead and that the CmpNode it's attached to is not enqueued for IGVN after replacement. Fixes are straight forward. I'll add `-XX:VerifyIterativeGVN=11` to our (internal) stress job.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336313](https://bugs.openjdk.org/browse/JDK-8336313): [lworld] C2 compilation hits asserts with -XX:VerifyIterativeGVN=11 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1200/head:pull/1200` \
`$ git checkout pull/1200`

Update a local copy of the PR: \
`$ git checkout pull/1200` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1200`

View PR using the GUI difftool: \
`$ git pr show -t 1200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1200.diff">https://git.openjdk.org/valhalla/pull/1200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1200#issuecomment-2284244976)