### PR TITLE
8338263: [lworld] Make more tests require flagless until JDK-8338261 is fixed

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
@@ -23,7 +23,7 @@
 
  /*
  * @test id=NullMarker32
- * @requires vm.bits == 32
+ * @requires vm.bits == 32 & vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
@@ -33,7 +33,7 @@
 
 /*
  * @test id=NullMarker64CompressedOops
- * @requires vm.bits == 64
+ * @requires vm.bits == 64 & vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
@@ -43,7 +43,7 @@
 
 /*
  * @test id=NullMarker64NoCompressedOops
- * @requires vm.bits == 64
+ * @requires vm.bits == 64 & vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
@@ -53,7 +53,7 @@
 
 /*
  * @test id=NullMarker64NoCompressedOopsNoCompressedKlassPointers
- * @requires vm.bits == 64
+ * @requires vm.bits == 64 & vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview


### PR DESCRIPTION
Another workaround for [JDK-8338261 [lworld] FieldLayoutAnalyzer::checkSubClasses fails with NullPointerException: Cannot read field](https://bugs.openjdk.org/browse/JDK-8338261).

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338263](https://bugs.openjdk.org/browse/JDK-8338263): [lworld] Make more tests require flagless until JDK-8338261 is fixed (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1203/head:pull/1203` \
`$ git checkout pull/1203`

Update a local copy of the PR: \
`$ git checkout pull/1203` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1203`

View PR using the GUI difftool: \
`$ git pr show -t 1203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1203.diff">https://git.openjdk.org/valhalla/pull/1203.diff</a>

</details>
