### PR TITLE
8336673: [lworld] TestIdentityWithEliminateBoxInDebugInfo.java fails with migrated classes

### DIFF
--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,7 +26,7 @@
  * @test
  * @bug 8261137
  * @requires vm.flavor == "server"
- * @summary Verify that box object identity matches after deoptimization when it is eliminated.
+ * @summary Verify that box object content matches after deoptimization when it is eliminated.
  * @library /test/lib
  *
  * @run main/othervm -Xbatch compiler.eliminateAutobox.TestIdentityWithEliminateBoxInDebugInfo
@@ -67,7 +68,7 @@ public class TestIdentityWithEliminateBoxInDebugInfo {
             if (!c) {
                 Asserts.assertTrue(a == Long.valueOf(42L));
                 Asserts.assertTrue(b == Long.valueOf(-42L));
-                Asserts.assertFalse(h == Long.valueOf(highBitsOnly));
+                Asserts.assertTrue(h == Long.valueOf(highBitsOnly));
             }
         });
 

--- a/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
+++ b/test/hotspot/jtreg/compiler/eliminateAutobox/TestIdentityWithEliminateBoxInDebugInfo.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8261137
  * @requires vm.flavor == "server"
+ * @enablePreview
  * @summary Verify that box object content matches after deoptimization when it is eliminated.
  * @library /test/lib
  *


### PR DESCRIPTION
Test fails because it does not expect `==` to be a susbtitutability test for `Long` arguments with `--enable-preview`. Let's just make it the default.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336673](https://bugs.openjdk.org/browse/JDK-8336673): [lworld] TestIdentityWithEliminateBoxInDebugInfo.java fails with migrated classes (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1204/head:pull/1204` \
`$ git checkout pull/1204`

Update a local copy of the PR: \
`$ git checkout pull/1204` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1204`

View PR using the GUI difftool: \
`$ git pr show -t 1204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1204.diff">https://git.openjdk.org/valhalla/pull/1204.diff</a>

</details>
