### PR TITLE
8336837: [lworld] Invalid monitor information in JVMState when buffering at return

### DIFF
--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4400,6 +4400,7 @@ public class TestLWorld {
         int x = 0;
     }
 
+    // Test merging value classes with Object fields
     @Test
     public MyValueContainer test161(boolean b) {
         MyValueContainer res = b ? new MyValueContainer(new MyValue161()) : null;
@@ -4482,5 +4483,16 @@ public class TestLWorld {
     public void test166_verifier() {
         Asserts.assertEquals(test166(true), new MyValueContainer(42));
         Asserts.assertEquals(test166(false), new MyValueContainer(new MyValue161()));
+    }
+
+    // Verify that monitor information in JVMState is correct at method exit
+    @Test
+    public synchronized Object test167() {
+        return MyValue1.createWithFieldsInline(rI, rL); // Might trigger buffering which requires JVMState
+    }
+
+    @Run(test = "test167")
+    public void test167_verifier() {
+        Asserts.assertEquals(((MyValue1)test167()).hash(), hash());
     }
 }


### PR DESCRIPTION
Similar to [JDK-8244519](https://bugs.openjdk.java.net/browse/JDK-8244519) / https://github.com/openjdk/valhalla/pull/36, while processing the JVMState of a buffer allocation at method return, we assert because there is no monitor information although the method is synchronized. The problem is that we call `shared_unlock` before buffering the return value (when returning a scalarized value object in non-scalarized form). The fix is to do that only afterwards. I also removed some stale code / comments and added corresponding tests.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8336837](https://bugs.openjdk.org/browse/JDK-8336837): [lworld] Invalid monitor information in JVMState when buffering at return (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1206/head:pull/1206` \
`$ git checkout pull/1206`

Update a local copy of the PR: \
`$ git checkout pull/1206` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1206`

View PR using the GUI difftool: \
`$ git pr show -t 1206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1206.diff">https://git.openjdk.org/valhalla/pull/1206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1206#issuecomment-2286434836)