### PR TITLE
8326605: [lworld] SplitIfSharedFastLockBehindCastPP performs synchronization on a value class

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/SplitIfSharedFastLockBehindCastPP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/SplitIfSharedFastLockBehindCastPP.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -70,6 +71,14 @@ public class SplitIfSharedFastLockBehindCastPP {
         }
     }
 
+    static class MyBox {
+        int val;
+
+        public MyBox(int val) {
+            this.val = val;
+        }
+    }
+
     private static Object test2(boolean flag) {
         int integer;
         if (flag) {
@@ -80,7 +89,7 @@ public class SplitIfSharedFastLockBehindCastPP {
             integer = 2;
         }
 
-        Object obj = integer;
+        Object obj = new MyBox(integer);
 
         // This loop will be unswitched. The condition becomes candidate for split if
         for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
I fixed the test to not synchronize on a value class and verified that the test still triggers the original bug.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8326605](https://bugs.openjdk.org/browse/JDK-8326605): [lworld] SplitIfSharedFastLockBehindCastPP performs synchronization on a value class (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1208/head:pull/1208` \
`$ git checkout pull/1208`

Update a local copy of the PR: \
`$ git checkout pull/1208` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1208`

View PR using the GUI difftool: \
`$ git pr show -t 1208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1208.diff">https://git.openjdk.org/valhalla/pull/1208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1208#issuecomment-2288714068)