### PR TITLE
8338261: [lworld] FieldLayoutAnalyzer::checkSubClasses fails with NullPointerException: Cannot read field

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/FieldAlignmentTest.java
@@ -147,6 +147,7 @@
     Collections.addAll(argsList, "--enable-preview");
     Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
     Collections.addAll(argsList, "-XX:+PrintFieldLayout");
+    Collections.addAll(argsList, "-Xshare:off");
     if (compressedOopsArg != null) {
       Collections.addAll(argsList, compressedOopsArg);
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/NullMarkersTest.java
@@ -291,6 +291,7 @@ public class NullMarkersTest {
     Collections.addAll(argsList, "-Xint");
     Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
     Collections.addAll(argsList, "-XX:+PrintFieldLayout");
+    Collections.addAll(argsList, "-Xshare:off");
     if (compressedOopsArg != null) {
       Collections.addAll(argsList, compressedOopsArg);
     }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueFieldInheritanceTest.java
@@ -176,6 +176,7 @@ public class ValueFieldInheritanceTest {
     Collections.addAll(argsList, "--enable-preview");
     Collections.addAll(argsList, "-XX:+UnlockDiagnosticVMOptions");
     Collections.addAll(argsList, "-XX:+PrintFieldLayout");
+    Collections.addAll(argsList, "-Xshare:off");
     if (compressedOopsArg != null) {
       Collections.addAll(argsList, compressedOopsArg);
     }


### PR DESCRIPTION
Disable use of CDS in field layout tests in order to get a complete log of class layouts.

Tested with Mach5, tier 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338261](https://bugs.openjdk.org/browse/JDK-8338261): [lworld] FieldLayoutAnalyzer::checkSubClasses fails with NullPointerException: Cannot read field (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1214/head:pull/1214` \
`$ git checkout pull/1214`

Update a local copy of the PR: \
`$ git checkout pull/1214` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1214`

View PR using the GUI difftool: \
`$ git pr show -t 1214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1214.diff">https://git.openjdk.org/valhalla/pull/1214.diff</a>

</details>
