### PR TITLE
8338698: [lworld] ObjectStreamClass should throw InstantiationException for abstract value class

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -28,6 +28,7 @@ package java.io;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
@@ -1974,7 +1975,11 @@ public final class ObjectStreamClass implements Serializable {
          * @return a buffered default value
          */
         static Object newValueInstance(Class<?> clazz) throws InstantiationException{
-            assert clazz.isValue() : "Should be a value class";
+            var accessFlags = clazz.accessFlags();
+            if (accessFlags.contains(AccessFlag.ABSTRACT) ||
+                    accessFlags.contains(AccessFlag.IDENTITY)) {
+                throw new InstantiationException("Value class not instantiable: " + clazz.getName());
+            }
             // may not be implicitly constructible; so allocate with Unsafe
             Object obj = UNSAFE.uninitializedDefaultValue(clazz);
             return UNSAFE.makePrivateBuffer(obj);


### PR DESCRIPTION
Updated ObjectStreamClass creation of newValueInstance to throw InstantiationException if the class is abstract or identity class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338698](https://bugs.openjdk.org/browse/JDK-8338698): [lworld] ObjectStreamClass should throw InstantiationException for abstract value class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1215/head:pull/1215` \
`$ git checkout pull/1215`

Update a local copy of the PR: \
`$ git checkout pull/1215` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1215`

View PR using the GUI difftool: \
`$ git pr show -t 1215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1215.diff">https://git.openjdk.org/valhalla/pull/1215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1215#issuecomment-2299979208)