### PR TITLE
8338260: [lworld] assert(elements_end <= obj_end) failed: payload must fit in object

### DIFF
--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -26,6 +26,7 @@
 #define SHARE_OOPS_ARRAYOOP_HPP
 
 #include "oops/oop.hpp"
+#include "runtime/globals.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
@@ -55,12 +56,15 @@ private:
 
   // Given a type, return true if elements of that type must be aligned to 64-bit.
   static bool element_type_should_be_aligned(BasicType type) {
+    if (EnableValhalla && type == T_PRIMITIVE_OBJECT) {
+      return true; //CMH: tighten the alignment when removing T_PRIMITIVE_OBJECT
+    }
 #ifdef _LP64
-    if (type == T_OBJECT || type == T_ARRAY || type == T_PRIMITIVE_OBJECT) {
+    if (type == T_OBJECT || type == T_ARRAY) {
       return !UseCompressedOops;
     }
 #endif
-    return type == T_DOUBLE || type == T_LONG || type == T_PRIMITIVE_OBJECT;
+    return type == T_DOUBLE || type == T_LONG;
   }
 
  public:

--- a/src/hotspot/share/oops/flatArrayOop.hpp
+++ b/src/hotspot/share/oops/flatArrayOop.hpp
@@ -50,7 +50,8 @@ class flatArrayOopDesc : public arrayOopDesc {
   }
 
   static int object_size(int lh, int length) {
-    julong size_in_bytes = header_size_in_bytes() + element_size(lh, length);
+    julong size_in_bytes = base_offset_in_bytes(Klass::layout_helper_element_type(lh));
+    size_in_bytes += element_size(lh, length);
     julong size_in_words = ((size_in_bytes + (HeapWordSize-1)) >> LogHeapWordSize);
     assert(size_in_words <= (julong)max_jint, "no overflow");
     return align_object_size((intptr_t)size_in_words);


### PR DESCRIPTION
Adjust flatArrayKlass oop creation for 8139457

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338260](https://bugs.openjdk.org/browse/JDK-8338260): [lworld] assert(elements_end &lt;= obj_end) failed: payload must fit in object (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1217/head:pull/1217` \
`$ git checkout pull/1217`

Update a local copy of the PR: \
`$ git checkout pull/1217` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1217`

View PR using the GUI difftool: \
`$ git pr show -t 1217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1217.diff">https://git.openjdk.org/valhalla/pull/1217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1217#issuecomment-2303956593)