### PR TITLE
8338766: [lw5] remove option enableNullRestrictedTypes and make null-restricted types a preview feature

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -212,6 +212,7 @@ public class Preview {
             case SUPER_INIT -> true;
             case PRIMITIVE_PATTERNS -> true;
             case VALUE_CLASSES -> true;
+            case NULL_RESTRICTED_TYPES -> true;
             //Note: this is a backdoor which allows to optionally treat all features as 'preview' (for testing).
             //When real preview features will be added, this method can be implemented to return 'true'
             //for those selected features, and 'false' for all the others.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -270,6 +270,7 @@ public enum Source {
         PRIMITIVE_PATTERNS(JDK23, Fragments.FeaturePrimitivePatterns, DiagKind.PLURAL),
         SUPER_INIT(JDK22, Fragments.FeatureSuperInit, DiagKind.NORMAL),
         VALUE_CLASSES(JDK22, Fragments.FeatureValueClasses, DiagKind.PLURAL),
+        NULL_RESTRICTED_TYPES(JDK23, Fragments.FeatureNullRestrictedTypes, DiagKind.PLURAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -183,7 +183,8 @@ public class Check {
         allowSealed = Feature.SEALED_CLASSES.allowedInSource(source);
         allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
                 Feature.VALUE_CLASSES.allowedInSource(source);
-        enableNullRestrictedTypes = options.isSet("enableNullRestrictedTypes");
+        allowNullRestrictedTypes = (!preview.isPreview(Source.Feature.NULL_RESTRICTED_TYPES) || preview.isEnabled()) &&
+                Source.Feature.NULL_RESTRICTED_TYPES.allowedInSource(source);
     }
 
     /** Character for synthetic names
@@ -231,9 +232,10 @@ public class Check {
      */
     private final boolean allowValueClasses;
 
-    /** Are null-restricted types allowed
+    /** Are null restricted types allowed
      */
-    private final boolean enableNullRestrictedTypes;
+    private final boolean allowNullRestrictedTypes;
+
 /* *************************************************************************
  * Errors and Warnings
  **************************************************************************/
@@ -313,7 +315,7 @@ public class Check {
      *  @param warnKey    A warning key.
      */
     public void warnNullableTypes(DiagnosticPosition pos, Warning warnKey) {
-        if (enableNullRestrictedTypes && lint.isEnabled(LintCategory.NULL)) {
+        if (allowNullRestrictedTypes && lint.isEnabled(LintCategory.NULL)) {
             log.warning(LintCategory.NULL, pos, warnKey);
         }
     }
@@ -816,7 +818,7 @@ public class Check {
     }
 
     void checkConstraintsOfValueClassesWithImplicitConst(JCClassDecl classDecl, ClassSymbol c) {
-        if (enableNullRestrictedTypes) {
+        if (allowNullRestrictedTypes) {
             JCMethodDecl implicitConstructor = TreeInfo.getImplicitConstructor(classDecl.defs);
             if (implicitConstructor != null) {
                 Type encl = c.type.getEnclosingType();
@@ -2794,7 +2796,7 @@ public class Check {
 
         boolean implementsLooselyConsistentValue = false;
         try {
-            implementsLooselyConsistentValue = allowValueClasses && enableNullRestrictedTypes ? types.asSuper(c, syms.looselyConsistentValueType.tsym) != null : false;
+            implementsLooselyConsistentValue = allowValueClasses && allowNullRestrictedTypes ? types.asSuper(c, syms.looselyConsistentValueType.tsym) != null : false;
         } catch (CompletionFailure cf) {
             // ignore
         }
@@ -4571,7 +4573,7 @@ public class Check {
 
         @Override
         public void warn(LintCategory lint) {
-            if (enableNullRestrictedTypes) {
+            if (allowNullRestrictedTypes) {
                 boolean warned = this.warned;
                 super.warn(lint);
                 if (warned) return; // suppress redundant diagnostics

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -104,7 +104,7 @@ public class Lower extends TreeTranslator {
     private final boolean useMatchException;
     private final HashMap<TypePairs, String> typePairToName;
     private final boolean allowValueClasses;
-    private final boolean enableNullRestrictedTypes;
+    private final boolean allowNullRestrictedTypes;
 
     @SuppressWarnings("this-escape")
     protected Lower(Context context) {
@@ -139,7 +139,8 @@ public class Lower extends TreeTranslator {
         typePairToName = TypePairs.initialize(syms);
         this.allowValueClasses = (!preview.isPreview(Feature.VALUE_CLASSES) || preview.isEnabled()) &&
                 Feature.VALUE_CLASSES.allowedInSource(source);
-        enableNullRestrictedTypes = options.isSet("enableNullRestrictedTypes");
+        this.allowNullRestrictedTypes = (!preview.isPreview(Source.Feature.NULL_RESTRICTED_TYPES) || preview.isEnabled()) &&
+                Source.Feature.NULL_RESTRICTED_TYPES.allowedInSource(source);
     }
 
     /** The currently enclosing class.
@@ -4401,7 +4402,7 @@ public class Lower extends TreeTranslator {
             noOfDims++;
         }
         tree.elems = translate(tree.elems, types.elemtype(tree.type));
-        if (!enableNullRestrictedTypes || tree.elemtype == null || !originalElemType.type.isNonNullable()) {
+        if (!allowNullRestrictedTypes || tree.elemtype == null || !originalElemType.type.isNonNullable()) {
             result = tree;
         } else {
             Symbol elemClass = syms.getClassField(tree.elemtype.type, types);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3240,8 +3240,8 @@ compiler.misc.feature.implicit.classes=\
 compiler.misc.feature.super.init=\
     statements before super()
 
-compiler.misc.feature.bang.types=\
-    bang types
+compiler.misc.feature.null.restricted.types=\
+    nullable and null restricted types
 
 compiler.warn.underscore.as.identifier=\
     as of release 9, ''_'' is a keyword, and may not be used as an identifier

--- a/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueClasses/TestValueClasses.java
@@ -115,7 +115,6 @@ public class TestValueClasses extends JavadocTester {
         javadoc("-d", base.resolve("out").toString(),
                 "--enable-preview", "-source", String.valueOf(Runtime.version().feature()),
                 "-sourcepath", src.toString(),
-                "-XDenableNullRestrictedTypes",
                 "p");
         checkExit(Exit.OK);
 

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -224,7 +224,7 @@ compiler.warn.restricted.method
 compiler.misc.feature.value.classes
 
 #nullable types
-compiler.misc.feature.bang.types
+compiler.misc.feature.null.restricted.types
 compiler.warn.accessing.member.of.nullable
 compiler.warn.narrowing.nullness.conversion
 compiler.warn.non.nullable.should.be.initialized

--- a/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
+++ b/test/langtools/tools/javac/diags/examples/CantBeNonNullableType.java
@@ -23,7 +23,9 @@
 
 // key: compiler.err.type.cant.be.null.restricted
 // key: compiler.err.type.cant.be.null.restricted.2
-// options: -XDenableNullRestrictedTypes
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version}
 
 public class CantBeNonNullableType {
     String! s;

--- a/test/langtools/tools/javac/diags/examples/CantImplementInterface.java
+++ b/test/langtools/tools/javac/diags/examples/CantImplementInterface.java
@@ -22,7 +22,7 @@
  */
 
 // key: compiler.err.cant.implement.interface
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 class CantImplementInterface implements LooselyConsistentValue {
 }

--- a/test/langtools/tools/javac/diags/examples/ImplicitConstructorWithBody.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitConstructorWithBody.java
@@ -24,7 +24,7 @@
 // key: compiler.err.implicit.const.cant.have.body
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 value class ImplicitConstructorWithBody {
     public implicit ImplicitConstructorWithBody() {}

--- a/test/langtools/tools/javac/diags/examples/ImplicitMustBeInValueClass.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitMustBeInValueClass.java
@@ -24,7 +24,7 @@
 // key: compiler.err.implicit.const.must.be.declared.in.value.class
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 class ImplicitMustBeInValueClass {
     public implicit ImplicitMustBeInValueClass();

--- a/test/langtools/tools/javac/diags/examples/ImplicitMustBePublic.java
+++ b/test/langtools/tools/javac/diags/examples/ImplicitMustBePublic.java
@@ -24,7 +24,7 @@
 // key: compiler.err.implicit.const.must.be.public
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 value class ImplicitMustBePublic {
     implicit ImplicitMustBePublic();

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCannotBeInner.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCannotBeInner.java
@@ -24,7 +24,7 @@
 // key: compiler.err.value.class.with.implicit.cannot.be.inner
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 class ValueClassWithImplicitCannotBeInner {
     value class V {

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantDeclareInitBlock.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantDeclareInitBlock.java
@@ -24,7 +24,7 @@
 // key: compiler.err.value.class.with.implicit.declares.init.block
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 value class ValueClassWithImplicitCantDeclareInitBlock {
     int i;

--- a/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantHaveFieldInit.java
+++ b/test/langtools/tools/javac/diags/examples/ValueClassWithImplicitCantHaveFieldInit.java
@@ -24,7 +24,7 @@
 // key: compiler.err.value.class.with.implicit.instance.field.initializer
 // key: compiler.note.preview.filename
 // key: compiler.note.preview.recompile
-// options: --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDenableNullRestrictedTypes
+// options: --enable-preview -source ${jdk.version}
 
 value class ValueClassWithImplicitCantHaveFieldInit {
     int i = 0;

--- a/test/langtools/tools/javac/nullability/NullRestrictedAttrTest.java
+++ b/test/langtools/tools/javac/nullability/NullRestrictedAttrTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8338766
+ * @summary [lw5] remove option enableNullRestrictedTypes and make null-restricted types a preview feature
+ * @library /tools/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.code
+ *      jdk.compiler/com.sun.tools.javac.util
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main NullRestrictedAttrTest
+ * @ignore support for the NullRestricted attribute is missing in javap, class library etc
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.util.Assert;
+import com.sun.tools.classfile.ClassFile;
+
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.Task;
+
+public class NullRestrictedAttrTest extends TestRunner {
+    ToolBox tb = new ToolBox();
+
+    public NullRestrictedAttrTest() {
+        super(System.err);
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    Path[] findJavaFiles(Path... paths) throws Exception {
+        return tb.findJavaFiles(paths);
+    }
+
+    public static void main(String... args) throws Exception {
+        new NullRestrictedAttrTest().runTests();
+    }
+
+    @Test
+    public void testLoadableDescField(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                value class V {
+                    public implicit V();
+                }
+                class Test {
+                    V! v1;
+                    void m(V! v) {
+                        v1 = v;
+                    }
+                }
+                """);
+        Path classes = base.resolve("classes");
+        tb.createDirectories(classes);
+
+        new toolbox.JavacTask(tb)
+                .options("--enable-preview", "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src))
+                .run()
+                .writeAll();
+        Path classFilePath = classes.resolve("Test.class");
+        ClassFile classFile = ClassFile.read(classFilePath.toFile());
+        Assert.check(classFile.minor_version == 65535);
+        Assert.check(classFile.attributes.get("NullRestricted") != null);
+    }
+}

--- a/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
+++ b/test/langtools/tools/javac/nullability/NullabilityParsingTest.java
@@ -27,7 +27,7 @@
  * @test
  * @enablePreview
  * @summary Smoke test for parsing of bang types
- * @compile -XDenableNullRestrictedTypes NullabilityParsingTest.java
+ * @compile NullabilityParsingTest.java
  */
 
 import java.util.function.*;

--- a/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
+++ b/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
@@ -32,7 +32,6 @@
  *          jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.ToolBox toolbox.JavacTask
  * @run main RuntimeNullChecks
- * @ignore 8316628
  */
 
 import java.util.*;

--- a/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
+++ b/test/langtools/tools/javac/nullability/RuntimeNullChecks.java
@@ -32,6 +32,7 @@
  *          jdk.jdeps/com.sun.tools.classfile
  * @build toolbox.ToolBox toolbox.JavacTask
  * @run main RuntimeNullChecks
+ * @ignore
  */
 
 import java.util.*;

--- a/test/langtools/tools/javac/valhalla/value-objects/CanonicalCtorTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/CanonicalCtorTest.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8208067
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes CanonicalCtorTest.java
+ * @compile --enable-preview -source ${jdk.version} CanonicalCtorTest.java
  * @summary Verify that instance methods are callable from ctor after all instance fields are DA.
  */
 

--- a/test/langtools/tools/javac/valhalla/value-objects/classfile/implicit_creation_attr/CheckImplicitCreationAttrIsUnique.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/classfile/implicit_creation_attr/CheckImplicitCreationAttrIsUnique.java
@@ -5,7 +5,7 @@
  *          jdk.compiler/com.sun.tools.javac.util
  * @library /tools/lib
  * @compile DuplicateImplicitCreationAttr.jcod
- * @compile/fail/ref=CheckImplicitCreationAttrIsUnique.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics CheckImplicitCreationAttrIsUnique.java
+ * @compile/fail/ref=CheckImplicitCreationAttrIsUnique.out --enable-preview -source ${jdk.version} -XDrawDiagnostics CheckImplicitCreationAttrIsUnique.java
  */
 
 public class CheckImplicitCreationAttrIsUnique {

--- a/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/attr_is_unique/CheckNullRestrictedAttrIsUnique.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/attr_is_unique/CheckNullRestrictedAttrIsUnique.java
@@ -4,8 +4,8 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @library /tools/lib
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes ValueClass.jcod DuplicateNullRestrictedAttr.jcod
- * @compile/fail/ref=CheckNullRestrictedAttrIsUnique.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics CheckNullRestrictedAttrIsUnique.java
+ * @compile --enable-preview -source ${jdk.version} ValueClass.jcod DuplicateNullRestrictedAttr.jcod
+ * @compile/fail/ref=CheckNullRestrictedAttrIsUnique.out --enable-preview -source ${jdk.version} -XDrawDiagnostics CheckNullRestrictedAttrIsUnique.java
  */
 
 public class CheckNullRestrictedAttrIsUnique {

--- a/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/check_field_type/CheckFieldTypeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/check_field_type/CheckFieldTypeTest.java
@@ -4,8 +4,8 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @library /tools/lib
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes NullRestrictedOnPrimitive.jcod
- * @compile/fail/ref=CheckFieldTypeTest.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics CheckFieldTypeTest.java
+ * @compile --enable-preview -source ${jdk.version} NullRestrictedOnPrimitive.jcod
+ * @compile/fail/ref=CheckFieldTypeTest.out --enable-preview -source ${jdk.version} -XDrawDiagnostics CheckFieldTypeTest.java
  */
 
 public class CheckFieldTypeTest {

--- a/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/check_field_type/CheckFieldTypeTest2.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/check_field_type/CheckFieldTypeTest2.java
@@ -4,8 +4,8 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @library /tools/lib
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes NullRestrictedOnArray.jcod
- * @compile/fail/ref=CheckFieldTypeTest2.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics CheckFieldTypeTest2.java
+ * @compile --enable-preview -source ${jdk.version} NullRestrictedOnArray.jcod
+ * @compile/fail/ref=CheckFieldTypeTest2.out --enable-preview -source ${jdk.version} -XDrawDiagnostics CheckFieldTypeTest2.java
  */
 
 public class CheckFieldTypeTest2 {

--- a/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/only_on_fields/NullRestrictedAttrOnlyOnFields.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/classfile/null_restricted_attr/only_on_fields/NullRestrictedAttrOnlyOnFields.java
@@ -4,8 +4,8 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @library /tools/lib
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes NullRestrictedOnMethod.jcod
- * @compile/fail/ref=NullRestrictedAttrOnlyOnFields.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics NullRestrictedAttrOnlyOnFields.java
+ * @compile --enable-preview -source ${jdk.version} NullRestrictedOnMethod.jcod
+ * @compile/fail/ref=NullRestrictedAttrOnlyOnFields.out --enable-preview -source ${jdk.version} -XDrawDiagnostics NullRestrictedAttrOnlyOnFields.java
  */
 
 public class NullRestrictedAttrOnlyOnFields {

--- a/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/cycles/CheckForCyclesAtClassLoadingTimeTest.java
@@ -2,8 +2,8 @@
  * @test /nodynamiccopyright/
  * @bug 8314165
  * @summary check for illegal circularity at class loading time
- * @compile --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes CyclicValueClass.jcod
- * @compile/fail/ref=CheckForCyclesAtClassLoadingTimeTest.out --enable-preview -source ${jdk.version} -XDenableNullRestrictedTypes -XDrawDiagnostics CheckForCyclesAtClassLoadingTimeTest.java
+ * @compile --enable-preview -source ${jdk.version} CyclicValueClass.jcod
+ * @compile/fail/ref=CheckForCyclesAtClassLoadingTimeTest.out --enable-preview -source ${jdk.version} -XDrawDiagnostics CheckForCyclesAtClassLoadingTimeTest.java
  * @ignore
  */
 class CheckForCyclesAtClassLoadingTimeTest {


### PR DESCRIPTION
this fix is removing internal option `enableNullRestrictedTypes` and making null restricted types for value classes a preview feature

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8338766](https://bugs.openjdk.org/browse/JDK-8338766): [lw5] remove option enableNullRestrictedTypes and make null-restricted types a preview feature (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1218/head:pull/1218` \
`$ git checkout pull/1218`

Update a local copy of the PR: \
`$ git checkout pull/1218` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1218`

View PR using the GUI difftool: \
`$ git pr show -t 1218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1218.diff">https://git.openjdk.org/valhalla/pull/1218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1218#issuecomment-2305326317)