### PR TITLE
Add simple test for nullability warnings

### DIFF
--- a/test/langtools/tools/javac/nullability/NullabilityWarningsTest.java
+++ b/test/langtools/tools/javac/nullability/NullabilityWarningsTest.java
@@ -1,0 +1,53 @@
+/*
+ * @test /nodynamiccopyright/
+ * @summary Smoke test for nullability warnings
+ * @enablePreview
+ * @compile/fail/ref=NullabilityWarningsTest.out -XDrawDiagnostics -Werror -Xlint:null NullabilityWarningsTest.java
+ */
+
+public class NullabilityWarningsTest {
+    static class Box<T> {
+        T t;
+        Box(T t) {
+            this.t = t;
+        }
+        T get() { return t; }
+        void set(T t) { this.t = t; }
+    }
+
+    void test() {
+        String? s_null = null;
+        String! s_nonnull = "";
+        String s_unknown = null;
+        s_null = s_nonnull;
+        s_nonnull = s_null; //warn
+        s_unknown = s_null;
+        s_unknown = s_nonnull;
+
+        Box<String?> bs_null = null;
+        Box<String!> bs_nonnull = null;
+        Box<String> bs_unknown = null;
+        bs_null = bs_nonnull; //warn
+        bs_nonnull = bs_null; //warn
+        bs_unknown = bs_null;
+        bs_unknown = bs_nonnull;
+
+        Box<? super String?> bss_null = null;
+        Box<? super String!> bss_nonnull = null;
+        Box<? super String!> bss_unknown = null;
+
+        bss_nonnull = bss_null;
+        bss_null = bss_nonnull; //warn
+        bss_unknown = bss_null;
+        bss_unknown = bss_nonnull;
+
+        Box<? extends String?> bes_null = null;
+        Box<? extends String!> bes_nonnull = null;
+        Box<? extends String> bes_unknown = null;
+
+        bes_nonnull = bes_null; //warn
+        bes_null = bes_nonnull;
+        bes_unknown = bes_null;
+        bes_unknown = bes_nonnull;
+    }
+}

--- a/test/langtools/tools/javac/nullability/NullabilityWarningsTest.out
+++ b/test/langtools/tools/javac/nullability/NullabilityWarningsTest.out
@@ -1,0 +1,10 @@
+NullabilityWarningsTest.java:23:21: compiler.warn.unchecked.nullness.conversion
+NullabilityWarningsTest.java:30:19: compiler.warn.unchecked.nullness.conversion
+NullabilityWarningsTest.java:31:22: compiler.warn.unchecked.nullness.conversion
+NullabilityWarningsTest.java:40:20: compiler.warn.unchecked.nullness.conversion
+NullabilityWarningsTest.java:48:23: compiler.warn.unchecked.nullness.conversion
+- compiler.err.warnings.and.werror
+- compiler.note.preview.filename: NullabilityWarningsTest.java, DEFAULT
+- compiler.note.preview.recompile
+1 error
+5 warnings


### PR DESCRIPTION
This PR adds a simple test to validate the code in `Types` that generates the various nullability warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1220/head:pull/1220` \
`$ git checkout pull/1220`

Update a local copy of the PR: \
`$ git checkout pull/1220` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1220`

View PR using the GUI difftool: \
`$ git pr show -t 1220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1220.diff">https://git.openjdk.org/valhalla/pull/1220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1220#issuecomment-2306798200)