### PR TITLE
8339087: [lw5] remove parametric types related warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4470,6 +4470,7 @@ public class Attr extends JCTree.Visitor {
         }
 
         if (types.isParametric(site)) {
+            // see JDK-8339087
             //chk.warnNullableTypes(tree.selected, Warnings.AccessingMemberOfParametric);
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2312,6 +2312,7 @@ public class Flow {
                         if (types.isNonNullable(sym.type)) {
                             log.warning(pos, Warnings.NonNullableShouldBeInitialized);
                         } else {
+                            // see JDK-8339087
                             //log.warning(pos, Warnings.ParametricShouldBeInitialized);
                         }
                     }


### PR DESCRIPTION
removing (commenting) a couple of warnings for now

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339087](https://bugs.openjdk.org/browse/JDK-8339087): [lw5] remove parametric types related warnings (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1224/head:pull/1224` \
`$ git checkout pull/1224`

Update a local copy of the PR: \
`$ git checkout pull/1224` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1224`

View PR using the GUI difftool: \
`$ git pr show -t 1224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1224.diff">https://git.openjdk.org/valhalla/pull/1224.diff</a>

</details>
