### PR TITLE
8339076: Float16.valueOf(long) incorrectly returns infinities in some cases

### DIFF
--- a/src/java.base/share/classes/java/lang/Float16.java
+++ b/src/java.base/share/classes/java/lang/Float16.java
@@ -282,11 +282,11 @@ public final class Float16
     * @param  value a {@code long} value.
     */
     public static Float16 valueOf(long value) {
-        if (value < -65_504L) {
+        if (value <= -65_520L) {  // -(Float16.MAX_VALUE + Float16.ulp(Float16.MAX_VALUE) / 2)
             return NEGATIVE_INFINITY;
         } else {
-            if (value > 65_504L) {
-                return NEGATIVE_INFINITY;
+            if (value >= 65_520L) {  // Float16.MAX_VALUE + Float16.ulp(Float16.MAX_VALUE) / 2
+                return POSITIVE_INFINITY;
             }
             // Remaining range of long, the integers in approx. +/-
             // 2^16, all fit in a float so the correct conversion can
@@ -856,7 +856,6 @@ public final class Float16
      *
      * @param radicand the argument to have its square root taken
      *
-     * @see Math#sqrt(float)
      * @see Math#sqrt(double)
      */
     // @IntrinsicCandidate

--- a/test/jdk/java/lang/Float16/BasicFloat16ArithTests.java
+++ b/test/jdk/java/lang/Float16/BasicFloat16ArithTests.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8329817 8334432
+ * @bug 8329817 8334432 8339076
  * @summary Basic tests of Float16 arithmetic and similar operations
  */
 
@@ -47,6 +47,7 @@ public class BasicFloat16ArithTests {
         checkGetExponent();
         checkUlp();
         checkValueOfDouble();
+        checkValueOfLong();
         FusedMultiplyAddTests.main();
     }
 
@@ -424,6 +425,15 @@ public class BasicFloat16ArithTests {
             checkFloat16(add(f16, ulp),         valueOf( halfWayNextUp).floatValue(), roundUpMsg);
             checkFloat16(subtract(f16Neg, ulp), valueOf(-halfWayNextUp).floatValue(), roundUpMsg);
         }
+    }
+
+    private static void checkValueOfLong() {
+        checkFloat16(valueOf(-65_521), Float.NEGATIVE_INFINITY, "-infinity");
+        checkFloat16(valueOf(-65_520), Float.NEGATIVE_INFINITY, "-infinity");
+        checkFloat16(valueOf(-65_519), -MAX_VALUE.floatValue(), "-MAX_VALUE");
+        checkFloat16(valueOf(65_519), MAX_VALUE.floatValue(), "MAX_VALUE");
+        checkFloat16(valueOf(65_520), Float.POSITIVE_INFINITY, "+infinity");
+        checkFloat16(valueOf(65_521), Float.POSITIVE_INFINITY, "+infinity");
     }
 
     class FusedMultiplyAddTests {


### PR DESCRIPTION
Corrects a bug whereby Float16.valueOf(long) could erroneously return an infinity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339076](https://bugs.openjdk.org/browse/JDK-8339076): Float16.valueOf(long) incorrectly returns infinities in some cases (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - no project role)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1225.diff">https://git.openjdk.org/valhalla/pull/1225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1225#issuecomment-2312929233)