### PR TITLE
Improve support for nullable types and arrays

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -1444,8 +1444,8 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             t = this;
             do {
                 t.appendAnnotationsString(sb, true);
-                sb.append(t.getNullMarker().typeSuffix());
                 sb.append("[]");
+                sb.append(t.getNullMarker().typeSuffix());
                 t = ((ArrayType) t).getComponentType();
             } while (t.getKind() == TypeKind.ARRAY);
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1034,11 +1034,16 @@ public class Types {
     //where
         private boolean isSubtypeUncheckedInternal(Type t, Type s, boolean capture, Warner warn) {
             if (t.hasTag(ARRAY) && s.hasTag(ARRAY)) {
+                boolean result;
                 if (((ArrayType)t).elemtype.isPrimitive()) {
-                    return isSameType(elemtype(t), elemtype(s));
+                    result = isSameType(elemtype(t), elemtype(s));
                 } else {
-                    return isSubtypeUncheckedInternal(elemtype(t), elemtype(s), false, warn);
+                    result = isSubtypeUncheckedInternal(elemtype(t), elemtype(s), false, warn);
                 }
+                if (result && allowNullRestrictedTypes && hasNarrowerNullability(s, t)) {
+                    warn.warn(LintCategory.NULL);
+                }
+                return result;
             } else if (isSubtype(t, s, capture, warn)) {
                 return true;
             } else if (t.hasTag(TYPEVAR)) {
@@ -1229,21 +1234,26 @@ public class Types {
 
             @Override
             public Boolean visitArrayType(ArrayType t, Type s) {
+                boolean result = false;
                 if (s.hasTag(ARRAY)) {
                     if (t.elemtype.isPrimitive())
-                        return isSameType(t.elemtype, elemtype(s));
+                        result = isSameType(t.elemtype, elemtype(s));
                     else
-                        return isSubtypeNoCapture(t.elemtype, elemtype(s));
+                        result = isSubtypeNoCapture(t.elemtype, elemtype(s));
                 }
 
-                if (s.hasTag(CLASS)) {
+                if (!result && s.hasTag(CLASS)) {
                     Name sname = s.tsym.getQualifiedName();
-                    return sname == names.java_lang_Object
+                    result = sname == names.java_lang_Object
                         || sname == names.java_lang_Cloneable
                         || sname == names.java_io_Serializable;
                 }
 
-                return false;
+                if (result && allowNullRestrictedTypes && warnStack.nonEmpty() && hasNarrowerNullability(s, t)) {
+                    warnStack.head.warn(LintCategory.NULL);
+                }
+
+                return result;
             }
 
             @Override
@@ -1384,32 +1394,44 @@ public class Types {
         TypeRelation isSameTypeVisitor = new TypeRelation() {
 
             public Boolean visitType(Type t, Type s) {
-                if (t.equalsIgnoreMetadata(s))
+                if (t.equalsIgnoreMetadata(s)) {
+                    if (allowNullRestrictedTypes && warnStack.nonEmpty() && !hasSameNullability(s, t)) {
+                        warnStack.head.warn(LintCategory.NULL);
+                    }
                     return true;
+                }
 
                 if (s.isPartial())
                     return visit(s, t);
 
                 switch (t.getTag()) {
-                case BYTE: case CHAR: case SHORT: case INT: case LONG: case FLOAT:
-                case DOUBLE: case BOOLEAN: case VOID: case BOT: case NONE:
-                    return t.hasTag(s.getTag());
-                case TYPEVAR: {
-                    if (s.hasTag(TYPEVAR)) {
-                        //type-substitution does not preserve type-var types
-                        //check that type var symbols and bounds are indeed the same
-                        return t == s;
+                    case BYTE:
+                    case CHAR:
+                    case SHORT:
+                    case INT:
+                    case LONG:
+                    case FLOAT:
+                    case DOUBLE:
+                    case BOOLEAN:
+                    case VOID:
+                    case BOT:
+                    case NONE:
+                        return t.hasTag(s.getTag());
+                    case TYPEVAR: {
+                        if (s.hasTag(TYPEVAR)) {
+                            //type-substitution does not preserve type-var types
+                            //check that type var symbols and bounds are indeed the same
+                            return t == s;
+                        } else {
+                            //special case for s == ? super X, where upper(s) = u
+                            //check that u == t, where u has been set by Type.withTypeVar
+                            return s.isSuperBound() &&
+                                    !s.isExtendsBound() &&
+                                    visit(t, wildUpperBound(s));
+                        }
                     }
-                    else {
-                        //special case for s == ? super X, where upper(s) = u
-                        //check that u == t, where u has been set by Type.withTypeVar
-                        return s.isSuperBound() &&
-                                !s.isExtendsBound() &&
-                                visit(t, wildUpperBound(s));
-                    }
-                }
-                default:
-                    throw new AssertionError("isSameType " + t.getTag());
+                    default:
+                        throw new AssertionError("isSameType " + t.getTag());
                 }
             }
 
@@ -1439,7 +1461,7 @@ public class Types {
                     if (!visit(supertype(t), supertype(s)))
                         return false;
 
-                    Map<Symbol,Type> tMap = new HashMap<>();
+                    Map<Symbol, Type> tMap = new HashMap<>();
                     for (Type ti : interfaces(t)) {
                         tMap.put(ti.tsym, ti);
                     }
@@ -1463,14 +1485,19 @@ public class Types {
 
             @Override
             public Boolean visitArrayType(ArrayType t, Type s) {
-                if (t == s)
-                    return true;
-
-                if (s.isPartial())
-                    return visit(s, t);
-
-                return s.hasTag(ARRAY)
-                    && containsTypeEquivalent(t.elemtype, elemtype(s));
+                boolean result;
+                if (t == s) {
+                    result = true;
+                } else if (s.isPartial()) {
+                    result = visit(s, t);
+                } else {
+                    result = s.hasTag(ARRAY) &&
+                            containsTypeEquivalent(t.elemtype, elemtype(s));
+                }
+                if (result && allowNullRestrictedTypes && warnStack.nonEmpty() && !hasSameNullability(s, t)) {
+                    warnStack.head.warn(LintCategory.NULL);
+                }
+                return result;
             }
 
             @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1405,33 +1405,25 @@ public class Types {
                     return visit(s, t);
 
                 switch (t.getTag()) {
-                    case BYTE:
-                    case CHAR:
-                    case SHORT:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                    case BOOLEAN:
-                    case VOID:
-                    case BOT:
-                    case NONE:
-                        return t.hasTag(s.getTag());
-                    case TYPEVAR: {
-                        if (s.hasTag(TYPEVAR)) {
-                            //type-substitution does not preserve type-var types
-                            //check that type var symbols and bounds are indeed the same
-                            return t == s;
-                        } else {
-                            //special case for s == ? super X, where upper(s) = u
-                            //check that u == t, where u has been set by Type.withTypeVar
-                            return s.isSuperBound() &&
-                                    !s.isExtendsBound() &&
-                                    visit(t, wildUpperBound(s));
-                        }
+                case BYTE: case CHAR: case SHORT: case INT: case LONG: case FLOAT:
+                case DOUBLE: case BOOLEAN: case VOID: case BOT: case NONE:
+                    return t.hasTag(s.getTag());
+                case TYPEVAR: {
+                    if (s.hasTag(TYPEVAR)) {
+                        //type-substitution does not preserve type-var types
+                        //check that type var symbols and bounds are indeed the same
+                        return t == s;
                     }
-                    default:
-                        throw new AssertionError("isSameType " + t.getTag());
+                    else {
+                        //special case for s == ? super X, where upper(s) = u
+                        //check that u == t, where u has been set by Type.withTypeVar
+                        return s.isSuperBound() &&
+                                !s.isExtendsBound() &&
+                                visit(t, wildUpperBound(s));
+                    }
+                }
+                default:
+                    throw new AssertionError("isSameType " + t.getTag());
                 }
             }
 
@@ -1461,7 +1453,7 @@ public class Types {
                     if (!visit(supertype(t), supertype(s)))
                         return false;
 
-                    Map<Symbol, Type> tMap = new HashMap<>();
+                    Map<Symbol,Type> tMap = new HashMap<>();
                     for (Type ti : interfaces(t)) {
                         tMap.put(ti.tsym, ti);
                     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3152,9 +3152,12 @@ public class Attr extends JCTree.Visitor {
             elemtype = attribType(tree.elemtype, localEnv);
             chk.validate(tree.elemtype, localEnv);
             owntype = elemtype;
+            List<NullMarker> nullMarkers = tree.nullMarkers; // maybe reverse?
             for (List<JCExpression> l = tree.dims; l.nonEmpty(); l = l.tail) {
                 attribExpr(l.head, localEnv, syms.intType);
-                owntype = new ArrayType(owntype, syms.arrayClass);
+                owntype = new ArrayType(owntype, syms.arrayClass)
+                        .asNullMarked(nullMarkers.head);
+                nullMarkers = nullMarkers.tail;
             }
         } else {
             // we are seeing an untyped aggregate { ... }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -3152,7 +3152,7 @@ public class Attr extends JCTree.Visitor {
             elemtype = attribType(tree.elemtype, localEnv);
             chk.validate(tree.elemtype, localEnv);
             owntype = elemtype;
-            List<NullMarker> nullMarkers = tree.nullMarkers; // maybe reverse?
+            List<NullMarker> nullMarkers = tree.nullMarkers.reverse();
             for (List<JCExpression> l = tree.dims; l.nonEmpty(); l = l.tail) {
                 attribExpr(l.head, localEnv, syms.intType);
                 owntype = new ArrayType(owntype, syms.arrayClass)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -38,6 +38,7 @@ import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Directive.RequiresDirective;
 import com.sun.tools.javac.code.Scope.*;
 import com.sun.tools.javac.code.Symbol.*;
+import com.sun.tools.javac.tree.JCTree.JCNullableTypeExpression.NullMarker;
 import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -1912,15 +1913,18 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public List<JCAnnotation> annotations;
         // type annotations on dimensions
         public List<List<JCAnnotation>> dimAnnotations;
+        public List<NullMarker> nullMarkers;
         public List<JCExpression> elems;
         protected JCNewArray(JCExpression elemtype,
-                           List<JCExpression> dims,
-                           List<JCExpression> elems)
+                             List<JCExpression> dims,
+                             List<JCExpression> elems,
+                             List<NullMarker> nullMarkers)
         {
             this.elemtype = elemtype;
             this.dims = dims;
             this.annotations = List.nil();
             this.dimAnnotations = List.nil();
+            this.nullMarkers = nullMarkers;
             this.elems = elems;
         }
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/Pretty.java
@@ -191,7 +191,8 @@ public class Pretty extends JCTree.Visitor {
             if (tree == null) print("/*missing*/");
             else {
                 tree.accept(this);
-                if (tree instanceof JCNullableTypeExpression nullableType) {
+                if (!(tree instanceof JCArrayTypeTree) &&
+                        tree instanceof JCNullableTypeExpression nullableType) {
                     print(nullableType.getNullMarker().typeSuffix());
                 }
             }
@@ -1562,6 +1563,7 @@ public class Pretty extends JCTree.Visitor {
             }
             if (elem.hasTag(TYPEARRAY)) {
                 print("[]");
+                print(((JCArrayTypeTree)elem).getNullMarker().typeSuffix());
                 elem = ((JCArrayTypeTree)elem).elemtype;
             } else {
                 break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
@@ -327,7 +327,8 @@ public class TreeCopier<P> implements TreeVisitor<JCTree,P> {
         JCExpression elemtype = copy(t.elemtype, p);
         List<JCExpression> dims = copy(t.dims, p);
         List<JCExpression> elems = copy(t.elems, p);
-        return M.at(t.pos).NewArray(elemtype, dims, elems);
+        return M.at(t.pos).NewArray(elemtype, dims, elems,
+                ((JCNewArray)node).nullMarkers);
     }
 
     @DefinedBy(Api.COMPILER_TREE)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -33,6 +33,7 @@ import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Attribute.UnresolvedClass;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
+import com.sun.tools.javac.tree.JCTree.JCNullableTypeExpression.NullMarker;
 import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 
@@ -427,10 +428,20 @@ public class TreeMaker implements JCTree.Factory {
     }
 
     public JCNewArray NewArray(JCExpression elemtype,
-                             List<JCExpression> dims,
-                             List<JCExpression> elems)
+                               List<JCExpression> dims,
+                               List<JCExpression> elems)
     {
-        JCNewArray tree = new JCNewArray(elemtype, dims, elems);
+        JCNewArray tree = new JCNewArray(elemtype, dims, elems, List.nil());
+        tree.pos = pos;
+        return tree;
+    }
+
+    public JCNewArray NewArray(JCExpression elemtype,
+                             List<JCExpression> dims,
+                             List<JCExpression> elems,
+                             List<NullMarker> nullMarkers)
+    {
+        JCNewArray tree = new JCNewArray(elemtype, dims, elems, nullMarkers);
         tree.pos = pos;
         return tree;
     }

--- a/test/langtools/tools/javac/nullability/TestArrays.java
+++ b/test/langtools/tools/javac/nullability/TestArrays.java
@@ -1,0 +1,72 @@
+/*
+ * @test /nodynamiccopyright/
+ * @enablePreview
+ * @summary Smoke test for nullable types in array types and array creation expressions
+ * @compile/fail/ref=TestArrays.out -Xlint:null -Werror -XDrawDiagnostics TestArrays.java
+ */
+
+public class TestArrays {
+    void test1() {
+        String! []?[]? arr_local = null;
+        arr_local = new String! [3]? [4]?;
+        arr_local = new String! [3]! [4]?;
+        arr_local = new String! [3]? [4]!;
+        arr_local = new String! [3]! [4]!;
+    }
+
+    void test2() {
+        String! []?[]! arr_local = null;
+        arr_local = new String! [3]? [4]?; // warn
+        arr_local = new String! [3]! [4]?; // warn
+        arr_local = new String! [3]? [4]!;
+        arr_local = new String! [3]! [4]!;
+    }
+
+    void test3() {
+        String! []![]? arr_local = new String! [0]![]?;
+        arr_local = new String! [3]? [4]?; // warn
+        arr_local = new String! [3]! [4]?;
+        arr_local = new String! [3]? [4]!; // warn
+        arr_local = new String! [3]! [4]!;
+    }
+
+    void test4() {
+        String! []![]! arr_local = new String! [0]![]!;
+        arr_local = new String! [3]? [4]?; // warn
+        arr_local = new String! [3]! [4]?; // warn
+        arr_local = new String! [3]? [4]!; // warn
+        arr_local = new String! [3]! [4]!;
+    }
+
+    void test5() {
+        String! []?[]? arr_local = null;
+        arr_local = new String! [3]? []?;
+        arr_local = new String! [3]! []?;
+        arr_local = new String! [3]? []!;
+        arr_local = new String! [3]! []!;
+    }
+
+    void test6() {
+        String! []?[]! arr_local = null;
+        arr_local = new String! [3]? []?; // warn
+        arr_local = new String! [3]! []?; // warn
+        arr_local = new String! [3]? []!;
+        arr_local = new String! [3]! []!;
+    }
+
+    void test7() {
+        String! []![]? arr_local = new String! [0]![]?;
+        arr_local = new String! [3]? []?; // warn
+        arr_local = new String! [3]! []?;
+        arr_local = new String! [3]? []!; // warn
+        arr_local = new String! [3]! []!;
+    }
+
+    void test8() {
+        String! []![]! arr_local = new String! [0]![]!;
+        arr_local = new String! [3]? []?; // warn
+        arr_local = new String! [3]! []?; // warn
+        arr_local = new String! [3]? []!; // warn
+        arr_local = new String! [3]! []!;
+    }
+}

--- a/test/langtools/tools/javac/nullability/TestArrays.out
+++ b/test/langtools/tools/javac/nullability/TestArrays.out
@@ -1,0 +1,19 @@
+TestArrays.java:19:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:20:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:27:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:29:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:35:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:36:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:37:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:51:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:52:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:59:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:61:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:67:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:68:21: compiler.warn.unchecked.nullness.conversion
+TestArrays.java:69:21: compiler.warn.unchecked.nullness.conversion
+- compiler.err.warnings.and.werror
+- compiler.note.preview.filename: TestArrays.java, DEFAULT
+- compiler.note.preview.recompile
+1 error
+14 warnings

--- a/test/langtools/tools/javac/tree/JavacTreeScannerTest.java
+++ b/test/langtools/tools/javac/tree/JavacTreeScannerTest.java
@@ -52,6 +52,7 @@ import javax.tools.*;
 import com.sun.source.util.JavacTask;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.tree.JCTree.JCNullableTypeExpression.NullMarker;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Pair;
@@ -165,8 +166,11 @@ public class JavacTreeScannerTest extends AbstractTreeScannerTest {
                     reflectiveScan(item);
             } else if (o instanceof Pair) {
                 return;
-            } else
+            } else if (o instanceof NullMarker) {
+                return;
+            } else {
                 error("unexpected item: " + o);
+            }
         }
 
         JavaFileObject sourcefile;

--- a/test/langtools/tools/javac/tree/SourceTreeScannerTest.java
+++ b/test/langtools/tools/javac/tree/SourceTreeScannerTest.java
@@ -58,6 +58,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
+import com.sun.tools.javac.tree.JCTree.JCNullableTypeExpression.NullMarker;
 import com.sun.tools.javac.tree.JCTree.TypeBoundKind;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Pair;
@@ -172,6 +173,8 @@ public class SourceTreeScannerTest extends AbstractTreeScannerTest {
                 for (Object item: list)
                     reflectiveScan(item);
             } else if (o instanceof Pair) {
+                return;
+            } else if (o instanceof NullMarker) {
                 return;
             } else
                 error("unexpected item: " + o);


### PR DESCRIPTION
This PR improves general support for arrays with `!` and `?` nullness markers.

The parser was parsing nullness markers associated to array brackets "backwards" - that is, when we have a type like this:

```
String* []? []!
```

* `*` should refer to `String`
* `?` should refer to the outermost array type
* `!` should refer to the innermost array type

The same is true with an array creation expression, like:

```
new String*[3]?[]!
```

(in this case, one might even wonder what sense does it make to say `?` for an array dimension that is going to be filled with `null` elements, but that's for another day).

Most of the `toString` implementation for array types and array trees were also wrong and they either dropped markers, or they displayed them in the "wrong order". So I've fixed that too (which helps when debugging).

Finally, I realized that there were no nullness warnings generated when going from nullable arrays to non-nullable arrays, so I've added some more code in `Types` for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1227/head:pull/1227` \
`$ git checkout pull/1227`

Update a local copy of the PR: \
`$ git checkout pull/1227` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1227`

View PR using the GUI difftool: \
`$ git pr show -t 1227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1227.diff">https://git.openjdk.org/valhalla/pull/1227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1227#issuecomment-2315142109)