### PR TITLE
8339339: [lw5] javac should issue an error if a null-restricted field is left uninitialized, fix override related warnings

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -2010,16 +2010,21 @@ public class Check {
         Type otres = types.subst(ot.getReturnType(), otvars, mtvars);
 
         overrideWarner.clear();
-        boolean resultTypesOK =
-            types.returnTypeSubstitutable(mt, ot, otres, overrideWarner);
-        if (overrideWarner.hasNonSilentLint(LintCategory.NULL)) {
-            warnNullableTypes(TreeInfo.diagnosticPositionFor(m, tree), Warnings.OverridesWithDifferentNullness1);
-        }
-        overrideWarner.remove(LintCategory.NULL);
-        // at this point we know this will be true but to gather the warnings
-        types.isSubSignature(mt, ot, overrideWarner);
-        if (overrideWarner.hasNonSilentLint(LintCategory.NULL)) {
-            warnNullableTypes(TreeInfo.diagnosticPositionFor(m, tree), Warnings.OverridesWithDifferentNullness2);
+        boolean resultTypesOK = false;
+        try {
+            types.pushWarner(overrideWarner);
+            resultTypesOK = types.returnTypeSubstitutable(mt, ot, otres, overrideWarner);
+            if (overrideWarner.hasNonSilentLint(LintCategory.NULL)) {
+                warnNullableTypes(TreeInfo.diagnosticPositionFor(m, tree), Warnings.OverridesWithDifferentNullness1);
+            }
+            overrideWarner.remove(LintCategory.NULL);
+            // at this point we know this will be true but to gather the warnings
+            types.isSubSignature(mt, ot, overrideWarner);
+            if (overrideWarner.hasNonSilentLint(LintCategory.NULL)) {
+                warnNullableTypes(TreeInfo.diagnosticPositionFor(m, tree), Warnings.OverridesWithDifferentNullness2);
+            }
+        } finally {
+            types.popWarner();
         }
         if (!resultTypesOK) {
             if ((m.flags() & STATIC) != 0 && (other.flags() & STATIC) != 0) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4175,6 +4175,9 @@ compiler.err.type.cant.be.null.restricted.2=\
     type: {0}, cannot be a null restricted type\n\
     its element type must be a value class with an implicit constructor
 
+compiler.err.non.nullable.should.be.initialized=\
+    field of non-nullable type should be initialized
+
 # 0: name
 compiler.misc.attribute.must.be.unique=\
     attribute {0} must be unique
@@ -4192,9 +4195,6 @@ compiler.warn.narrowing.nullness.conversion=\
 
 compiler.warn.unchecked.nullness.conversion=\
     unchecked nullness conversion
-
-compiler.warn.non.nullable.should.be.initialized=\
-    field of non-nullable type should be initialized
 
 compiler.warn.parametric.should.be.initialized=\
     field of parametric type should be initialized

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -227,12 +227,8 @@ compiler.misc.feature.value.classes
 compiler.misc.feature.null.restricted.types
 compiler.warn.accessing.member.of.nullable
 compiler.warn.narrowing.nullness.conversion
-compiler.warn.non.nullable.should.be.initialized
 compiler.warn.accessing.member.of.parametric
 compiler.warn.parametric.should.be.initialized
-compiler.warn.unchecked.nullness.conversion
-compiler.warn.overrides.with.different.nullness.1
-compiler.warn.overrides.with.different.nullness.2
 compiler.misc.attribute.must.be.unique                                   # bad class file
 compiler.misc.attribute.not.applicable.to.field.type                     # bad class file
 compiler.misc.attribute.only.applicable.to.fields                        # bad class file

--- a/test/langtools/tools/javac/diags/examples/NonNullableShouldBeInitialized.java
+++ b/test/langtools/tools/javac/diags/examples/NonNullableShouldBeInitialized.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.non.nullable.should.be.initialized
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version}
+
+class NonNullableShouldBeInitialized {
+    NonNullableShouldBeInitialized! field;
+}

--- a/test/langtools/tools/javac/diags/examples/OverrideWithDifferentNullness.java
+++ b/test/langtools/tools/javac/diags/examples/OverrideWithDifferentNullness.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.overrides.with.different.nullness.1
+// key: compiler.warn.overrides.with.different.nullness.2
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version} -Xlint:null
+
+class OverrideWithDifferentNullness {
+    abstract class A {
+        abstract String! lookup(String! arg);
+    }
+
+    abstract class B extends A {
+        abstract String? lookup(String? arg);
+    }
+}

--- a/test/langtools/tools/javac/diags/examples/UncheckedNullnessConversion.java
+++ b/test/langtools/tools/javac/diags/examples/UncheckedNullnessConversion.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.warn.unchecked.nullness.conversion
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version} -Xlint:null
+
+class UncheckedNullnessConversion {
+    void m(UncheckedNullnessConversion! s1, UncheckedNullnessConversion? s3) {
+        s1 = s3;
+    }
+}

--- a/test/langtools/tools/javac/nullability/NullabilityParsingBangTest.java
+++ b/test/langtools/tools/javac/nullability/NullabilityParsingBangTest.java
@@ -36,7 +36,7 @@ class NullabilityParsingBangTest {
     static value class Point { public implicit Point(); }
     static value class Shape { public implicit Shape(); }
     // fields
-    Point! o2;
+    Point! o2 = new Point();
 
     // method parameters
     void m2(Point! o) { }
@@ -161,7 +161,7 @@ class NullabilityParsingBangTest {
 
     // arrays
 
-    Point![]![]![]! oarr;
+    Point![]![]![]! oarr = {{{new Point()}}};
     Function<Point![]![]!, Function<Point![]![]!, Point![]![]!>>[][] garr;
 
     void mBad1(Object o) {

--- a/test/langtools/tools/javac/nullability/NullabilitySignatureAttrTests.java
+++ b/test/langtools/tools/javac/nullability/NullabilitySignatureAttrTests.java
@@ -85,7 +85,7 @@ public class NullabilitySignatureAttrTests extends CompilationTestCase {
             new SignatureData(
                     """
                     class Test {
-                        Test! t;
+                        Test! t = new Test();
                     }
                     """,
                     "!LTest;"
@@ -120,7 +120,7 @@ public class NullabilitySignatureAttrTests extends CompilationTestCase {
                     """
                     import java.util.*;
                     class Test {
-                        List!<Test!> t;
+                        List!<Test!> t = new ArrayList<>();
                     }
                     """,
                     "!Ljava/util/List<!LTest;>;"
@@ -137,7 +137,7 @@ public class NullabilitySignatureAttrTests extends CompilationTestCase {
             new SignatureData(
                     """
                     class Test<T> {
-                        T! t;
+                        T! t = (T)new Object();
                     }
                     """,
                     "!TT;"
@@ -161,7 +161,7 @@ public class NullabilitySignatureAttrTests extends CompilationTestCase {
             new SignatureData(
                     """
                     class Test {
-                        String[]! t;
+                        String[]! t = {""};
                     }
                     """,
                     "![Ljava/lang/String;"
@@ -177,7 +177,7 @@ public class NullabilitySignatureAttrTests extends CompilationTestCase {
             new SignatureData(
                     """
                     class Test {
-                        String?[]![]? t;
+                        String?[]![]? t = {{""}};
                     }
                     """,
                     "![?[?Ljava/lang/String;"


### PR DESCRIPTION
syncing with the spec, javac was issuing a warning if a null-restricted field was left uninitialized, this should be an error. Also warnings related to method overriding were not being issued.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339339](https://bugs.openjdk.org/browse/JDK-8339339): [lw5] javac should issue an error if a null-restricted field is left uninitialized, fix override related warnings (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1229/head:pull/1229` \
`$ git checkout pull/1229`

Update a local copy of the PR: \
`$ git checkout pull/1229` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1229`

View PR using the GUI difftool: \
`$ git pr show -t 1229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1229.diff">https://git.openjdk.org/valhalla/pull/1229.diff</a>

</details>
