### PR TITLE
8339456: [lworld] Adjust UnsafeTest.java for JDK-8327729

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -121,7 +121,7 @@ public class UnsafeTest {
         try {
             v = U.makePrivateBuffer(v);
             // patch v3.o
-            U.putObject(v, off_o, list);
+            U.putReference(v, off_o, list);
             // patch v3.v.i;
             U.putInt(v, off_v + off_i - U.valueHeaderSize(Value2.class), 999);
             // patch v3.v.v.point


### PR DESCRIPTION
putObject -> putReference

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339456](https://bugs.openjdk.org/browse/JDK-8339456): [lworld] Adjust UnsafeTest.java for JDK-8327729 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1230/head:pull/1230` \
`$ git checkout pull/1230`

Update a local copy of the PR: \
`$ git checkout pull/1230` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1230`

View PR using the GUI difftool: \
`$ git pr show -t 1230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1230.diff">https://git.openjdk.org/valhalla/pull/1230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1230#issuecomment-2325847405)