### PR TITLE
8339302: [lworld] C2: "assert(safepoints.length() == 0 || !res_type->is_inlinetypeptr()) failed: Inline type allocations should not have safepoint uses" with circular inline types

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -865,7 +865,7 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
       // InlineTypeNode::make_scalar_in_safepoint()). When having circular inline types, we stop scalarizing at depth 1
       // to avoid an endless recursion. Therefore, we do not have a SafePointScalarObjectNode node here, yet.
       // We are about to create a SafePointScalarObjectNode as if this is a normal object. Add an additional int input
-      // with value 1 to indicate that the buffer is always initialized (i.e. IsInit is true). This input is checked
+      // with value 1 which sets IsInit to true to indicate that the object is always non-null. This input is checked
       // later in PhaseOutput::filLocArray() for inline types.
       sfpt->add_req(_igvn.intcon(1));
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java
@@ -3287,4 +3287,62 @@ public class TestNullableInlineTypes {
             // Expected
         }
     }
+
+    static value class CircularValue7 {
+        CircularValue7 v;
+        int i;
+
+        public CircularValue7(int i) {
+            this.v = new CircularValue7(); // When <init> is incrementally inlined: StoreN into object
+            dontInline(); // Not inlined -> safepoint which also saves StoreN.
+            this.i = i;
+        }
+
+        public CircularValue7(boolean ignored) {
+            this.v = new CircularValue7();
+            this.i = 23;
+        }
+
+        public CircularValue7() {
+            this.v = null;
+            this.i = 34;
+        }
+
+        @DontInline
+        static void dontInline() {}
+    }
+
+    @Test
+    @IR(failOn = ALLOC_G)
+    int testCircularSafepointUse() {
+        CircularValue7 v = new CircularValue7(true);  // v is non escaping -> EA can remove allocation
+        dontInline(); // Not inlined -> safepoint
+        return v.i; // Use v such that it is still required in the safepoint at dontInline()
+    }
+
+    @DontInline
+    void dontInline() {}
+
+    @Run(test = "testCircularSafepointUse")
+    public void testCircularSafepointUse_verifier() {
+        Asserts.assertEQ(testCircularSafepointUse(), new CircularValue7(true).i);
+    }
+
+
+    @Test
+    @IR(failOn = ALLOC_G)
+    int testCircularSafepointUse2(int i) {
+        // With AlwaysIncrementalInline:
+        // We allocate here because <init> is not inlined at parsing.
+        // At late inline: The store of v.v is done with a StoreN into the allocation to make the effect visible.
+        CircularValue7 v = new CircularValue7(i);
+        return v.i;
+    }
+
+    @Run(test = "testCircularSafepointUse2")
+    public void testCircularSafepointUse2_verifier() {
+        int rand = rI;
+        Asserts.assertEQ(testCircularSafepointUse2(rand), new CircularValue7(rand).i);
+    }
+
 }


### PR DESCRIPTION
The circular inline type test cases show that two asserts are too strong: They assume that we can always replace inline types with `SafePointScalarObject` nodes before doing EA with its scalar replacement phase. If we fail to do so, then there must be a missed optimization opportunity. However, this only holds for non-circular inline types. When having circular inline types, we stop the (eager) scalarization at depth 1 because we could possibly do it endlessly in a recursion. Therefore, we could have a non-scalarized `CheckCastPP` inline type oop in a safepoint which triggers the asserts.

I propose to relax the assert by excluding circular inline types.

#### Additional Required Fix

I also had to adjust the code which creates a `SafePointScalarObject` in the scalar replacement after EA for such a circular inline type represented by a non-`InlineTypeNode` as follows.

Normally, we would call `InlineTypeNode::make_scalar_in_safepoint()` to scalarize an inline type. This adds an additional input to the safepoint for the `IsInit` input to check:

https://github.com/openjdk/valhalla/blob/884078f06a2bf15e4be768dd09d0790b63d8e015/src/hotspot/share/opto/inlinetypenode.cpp#L280-L287

For example, in `testCircularSafepointUse()`, `IsInit` is false for the inline type created for `v` at L3318 and we add a top input when creating `260 SafePointScalarObject`:

https://github.com/openjdk/valhalla/blob/d719d86c33f87bbdb37c5a4055fbbb5f81d7937f/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestNullableInlineTypes.java#L3315-L3321

![image](https://github.com/user-attachments/assets/6defb530-9a37-4701-a704-591ab391a3da)

The first field `v` is the `166 CheckCastPP` oop and the second field `i` has the value `188 ConI #23`. 

But when scalarizing the inline type field `v` later (i.e. `166 CheckCastPP`) after EA, without an `InlineTypeNode`, we miss to account for `IsInit`. We create a new `264 SafePointScalarObject` and directly append the fields after the last input (i.e. `188 ConI`) without `IsInit`:

![image](https://github.com/user-attachments/assets/d5c26975-5847-4bb3-b53e-102af1471acd)

The first field `v` is a `21 ConP #null` and the second field `i` is the value `74 ConI #34`.

Later, when processing the `264 SafePointScalarObject` at code generation, we try to read the `IsInit` input which was never added:

https://github.com/openjdk/valhalla/blob/884078f06a2bf15e4be768dd09d0790b63d8e015/src/hotspot/share/opto/output.cpp#L809-L816

The first input is `21 ConP #null` which is neither `top` nor an `int` and we crash at L816 when trying to convert the type to a `TypeInt`. 

The fix I propose for that is to add an int input with value 1 for circular inline type nodes when scalarizing them after EA to indicate that the buffer is always initialized (i.e. `IsInit` is true).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339302](https://bugs.openjdk.org/browse/JDK-8339302): [lworld] C2: "assert(safepoints.length() == 0 || !res_type-&gt;is_inlinetypeptr()) failed: Inline type allocations should not have safepoint uses" with circular inline types (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1231/head:pull/1231` \
`$ git checkout pull/1231`

Update a local copy of the PR: \
`$ git checkout pull/1231` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1231`

View PR using the GUI difftool: \
`$ git pr show -t 1231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1231.diff">https://git.openjdk.org/valhalla/pull/1231.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1231#issuecomment-2326042611)