### PR TITLE
8339494: Porting HalfFloatVector classes.

### DIFF
--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -139,6 +139,7 @@ public class VectorSupport {
 
     // BasicType codes, for primitives only:
     public static final int
+        T_FLOAT16 = 5,
         T_FLOAT   = 6,
         T_DOUBLE  = 7,
         T_BYTE    = 8,

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractVector.java
@@ -267,6 +267,15 @@ abstract class AbstractVector<E> extends Vector<E> {
      */
     @Override
     @ForceInline
+    public HalffloatVector reinterpretAsHalffloats() {
+        return (HalffloatVector) asVectorRaw(LaneType.FLOAT16);
+    }
+
+    /**
+     * {@inheritDoc} <!--workaround-->
+     */
+    @Override
+    @ForceInline
     public final <F>
     Vector<F> convert(Conversion<E,F> conv, int part) {
         // Shape invariance is simple to implement.
@@ -533,6 +542,8 @@ abstract class AbstractVector<E> extends Vector<E> {
             return FloatVector.fromMemorySegment(rsp.check(float.class), ms, 0, bo, m.check(float.class)).check0(rsp);
         case LaneType.SK_DOUBLE:
             return DoubleVector.fromMemorySegment(rsp.check(double.class), ms, 0, bo, m.check(double.class)).check0(rsp);
+        case LaneType.SK_FLOAT16:
+            return HalffloatVector.fromMemorySegment(rsp.check(Float16.class), ms, 0, bo, m.check(Float16.class)).check0(rsp);
         default:
             throw new AssertionError(rsp.toString());
         }
@@ -595,6 +606,13 @@ abstract class AbstractVector<E> extends Vector<E> {
                 }
                 return DoubleVector.fromArray(dsp.check(double.class), a, 0).check0(dsp);
             }
+            case LaneType.SK_FLOAT16: {
+                Float16[] a = new Float16[rlength];
+                for (int i = 0; i < limit; i++) {
+                    a[i] = Float16.valueOf(lanes[i]);
+                }
+                return HalffloatVector.fromArray(dsp.check(Float16.class), a, 0).check0(dsp);
+            }
             default: break;
             }
         } else {
@@ -644,6 +662,13 @@ abstract class AbstractVector<E> extends Vector<E> {
                     a[i] = (double) lanes[i];
                 }
                 return DoubleVector.fromArray(dsp.check(double.class), a, 0).check0(dsp);
+            }
+            case LaneType.SK_FLOAT16: {
+                Float16[] a = new Float16[rlength];
+                for (int i = 0; i < limit; i++) {
+                    a[i] = Float16.valueOf(lanes[i]);
+                }
+                return HalffloatVector.fromArray(dsp.check(Float16.class), a, 0).check0(dsp);
             }
             default: break;
             }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Byte128Vector extends ByteVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        byte res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, Byte128Mask.class, (Byte128Mask) m);  // specialized
+        byte res = super.reduceLanesTemplate(op, Byte128Mask.class, (Byte128Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -682,7 +684,7 @@ final class Byte128Vector extends ByteVector {
         /*package-private*/
         Byte128Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Byte128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Byte128Mask.class, byte.class, VLENGTH, offset, limit,
+                Byte128Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Byte128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Byte256Vector extends ByteVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        byte res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, Byte256Mask.class, (Byte256Mask) m);  // specialized
+        byte res = super.reduceLanesTemplate(op, Byte256Mask.class, (Byte256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -714,7 +716,7 @@ final class Byte256Vector extends ByteVector {
         /*package-private*/
         Byte256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Byte256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Byte256Mask.class, byte.class, VLENGTH, offset, limit,
+                Byte256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Byte256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Byte512Vector extends ByteVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        byte res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, Byte512Mask.class, (Byte512Mask) m);  // specialized
+        byte res = super.reduceLanesTemplate(op, Byte512Mask.class, (Byte512Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -778,7 +780,7 @@ final class Byte512Vector extends ByteVector {
         /*package-private*/
         Byte512Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Byte512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Byte512Mask.class, byte.class, VLENGTH, offset, limit,
+                Byte512Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Byte512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Byte64Vector extends ByteVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        byte res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, Byte64Mask.class, (Byte64Mask) m);  // specialized
+        byte res = super.reduceLanesTemplate(op, Byte64Mask.class, (Byte64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -666,7 +668,7 @@ final class Byte64Vector extends ByteVector {
         /*package-private*/
         Byte64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Byte64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Byte64Mask.class, byte.class, VLENGTH, offset, limit,
+                Byte64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Byte64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class ByteMaxVector extends ByteVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        byte res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Byte> m) {
-        return (long) super.reduceLanesTemplate(op, ByteMaxMask.class, (ByteMaxMask) m);  // specialized
+        byte res = super.reduceLanesTemplate(op, ByteMaxMask.class, (ByteMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -652,7 +654,7 @@ final class ByteMaxVector extends ByteVector {
         /*package-private*/
         ByteMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (ByteMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                ByteMaxMask.class, byte.class, VLENGTH, offset, limit,
+                ByteMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (ByteMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -2220,8 +2220,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 ByteVector iota = s.iota();
-                byte sc = (byte) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul((byte)scale_));
             });
     }
 
@@ -2284,7 +2283,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Byte> iota = iotaShuffle();
-        VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(length() - origin))));
+        byte pivotidx = (byte)(length() - origin);
+        VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2314,7 +2314,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
     ByteVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Byte> iota = iotaShuffle();
-        VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(length() - origin))));
+        byte pivotidx = (byte)(length() - origin);
+        VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2376,7 +2377,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Byte> iota = iotaShuffle();
         VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((byte)(origin))));
+                                                                  broadcast((byte)(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2948,7 +2949,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         byte[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = (double) a[i];
+            res[i] = ((double) a[i]);
         }
         return res;
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class Double128Vector extends DoubleVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        double res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Double> m) {
-        return (long) super.reduceLanesTemplate(op, Double128Mask.class, (Double128Mask) m);  // specialized
+        double res = super.reduceLanesTemplate(op, Double128Mask.class, (Double128Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -643,7 +645,7 @@ final class Double128Vector extends DoubleVector {
         /*package-private*/
         Double128Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Double128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Double128Mask.class, double.class, VLENGTH, offset, limit,
+                Double128Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Double128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class Double256Vector extends DoubleVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        double res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Double> m) {
-        return (long) super.reduceLanesTemplate(op, Double256Mask.class, (Double256Mask) m);  // specialized
+        double res = super.reduceLanesTemplate(op, Double256Mask.class, (Double256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -647,7 +649,7 @@ final class Double256Vector extends DoubleVector {
         /*package-private*/
         Double256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Double256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Double256Mask.class, double.class, VLENGTH, offset, limit,
+                Double256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Double256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Double64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class Double64Vector extends DoubleVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        double res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Double> m) {
-        return (long) super.reduceLanesTemplate(op, Double64Mask.class, (Double64Mask) m);  // specialized
+        double res = super.reduceLanesTemplate(op, Double64Mask.class, (Double64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -641,7 +643,7 @@ final class Double64Vector extends DoubleVector {
         /*package-private*/
         Double64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Double64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Double64Mask.class, double.class, VLENGTH, offset, limit,
+                Double64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Double64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class DoubleMaxVector extends DoubleVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        double res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Double> m) {
-        return (long) super.reduceLanesTemplate(op, DoubleMaxMask.class, (DoubleMaxMask) m);  // specialized
+        double res = super.reduceLanesTemplate(op, DoubleMaxMask.class, (DoubleMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -640,7 +642,7 @@ final class DoubleMaxVector extends DoubleVector {
         /*package-private*/
         DoubleMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (DoubleMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                DoubleMaxMask.class, double.class, VLENGTH, offset, limit,
+                DoubleMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (DoubleMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -486,7 +486,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     /*package-private*/
     @ForceInline
     static long toBits(double e) {
-        return  Double.doubleToRawLongBits(e);
+        return Double.doubleToRawLongBits(e);
     }
 
     /*package-private*/
@@ -1027,8 +1027,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
     private static TernaryOperation<DoubleVector, VectorMask<Double>> ternaryOperations(int opc_) {
         switch (opc_) {
-            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) ->
-                    v0.tOp(v1_, v2_, m, (i, a, b, c) -> Math.fma(a, b, c));
+            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) -> v0.tOp(v1_, v2_, m, (i, a, b, c) -> Math.fma(a, b, c));
             default: return null;
         }
     }
@@ -2062,8 +2061,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 DoubleVector iota = s.iota();
-                double sc = (double) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul((double)scale_));
             });
     }
 
@@ -2126,7 +2124,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Double> iota = iotaShuffle();
-        VectorMask<Double> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((double)(length() - origin))));
+        double pivotidx = (double)(length() - origin);
+        VectorMask<Double> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2156,7 +2155,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
     DoubleVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Double> iota = iotaShuffle();
-        VectorMask<Double> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((double)(length() - origin))));
+        double pivotidx = (double)(length() - origin);
+        VectorMask<Double> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2218,7 +2218,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Double> iota = iotaShuffle();
         VectorMask<Double> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((double)(origin))));
+                                                                  broadcast((double)(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class Float256Vector extends FloatVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        float res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Float> m) {
-        return (long) super.reduceLanesTemplate(op, Float256Mask.class, (Float256Mask) m);  // specialized
+        float res = super.reduceLanesTemplate(op, Float256Mask.class, (Float256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -655,7 +657,7 @@ final class Float256Vector extends FloatVector {
         /*package-private*/
         Float256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Float256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float256Mask.class, float.class, VLENGTH, offset, limit,
+                Float256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Float256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class Float64Vector extends FloatVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        float res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Float> m) {
-        return (long) super.reduceLanesTemplate(op, Float64Mask.class, (Float64Mask) m);  // specialized
+        float res = super.reduceLanesTemplate(op, Float64Mask.class, (Float64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -643,7 +645,7 @@ final class Float64Vector extends FloatVector {
         /*package-private*/
         Float64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Float64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float64Mask.class, float.class, VLENGTH, offset, limit,
+                Float64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Float64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -334,14 +334,16 @@ final class FloatMaxVector extends FloatVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        float res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Float> m) {
-        return (long) super.reduceLanesTemplate(op, FloatMaxMask.class, (FloatMaxMask) m);  // specialized
+        float res = super.reduceLanesTemplate(op, FloatMaxMask.class, (FloatMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -640,7 +642,7 @@ final class FloatMaxVector extends FloatVector {
         /*package-private*/
         FloatMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (FloatMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                FloatMaxMask.class, float.class, VLENGTH, offset, limit,
+                FloatMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (FloatMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat128Vector.java
@@ -39,33 +39,33 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-final class Double512Vector extends DoubleVector {
-    static final DoubleSpecies VSPECIES =
-        (DoubleSpecies) DoubleVector.SPECIES_512;
+final class Halffloat128Vector extends HalffloatVector {
+    static final HalffloatSpecies VSPECIES =
+        (HalffloatSpecies) HalffloatVector.SPECIES_128;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Double512Vector> VCLASS = Double512Vector.class;
+    static final Class<Halffloat128Vector> VCLASS = Halffloat128Vector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
     static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
 
-    static final Class<Double> ETYPE = double.class; // used by the JVM
+    static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-    Double512Vector(double[] v) {
+    Halffloat128Vector(Float16[] v) {
         super(v);
     }
 
-    // For compatibility as Double512Vector::new,
+    // For compatibility as Halffloat128Vector::new,
     // stored into species.vectorFactory.
-    Double512Vector(Object v) {
-        this((double[]) v);
+    Halffloat128Vector(Object v) {
+        this((Float16[]) v);
     }
 
-    static final Double512Vector ZERO = new Double512Vector(new double[VLENGTH]);
-    static final Double512Vector IOTA = new Double512Vector(VSPECIES.iotaArray());
+    static final Halffloat128Vector ZERO = new Halffloat128Vector(new Float16[VLENGTH]);
+    static final Halffloat128Vector IOTA = new Halffloat128Vector(VSPECIES.iotaArray());
 
     static {
         // Warm up a few species caches.
@@ -79,7 +79,7 @@ final class Double512Vector extends DoubleVector {
 
     @ForceInline
     final @Override
-    public DoubleSpecies vspecies() {
+    public HalffloatSpecies vspecies() {
         // ISSUE:  This should probably be a @Stable
         // field inside AbstractVector, rather than
         // a megamorphic method.
@@ -88,11 +88,11 @@ final class Double512Vector extends DoubleVector {
 
     @ForceInline
     @Override
-    public final Class<Double> elementType() { return double.class; }
+    public final Class<Float16> elementType() { return Float16.class; }
 
     @ForceInline
     @Override
-    public final int elementSize() { return Double.SIZE; }
+    public final int elementSize() { return Float16.SIZE; }
 
     @ForceInline
     @Override
@@ -113,68 +113,68 @@ final class Double512Vector extends DoubleVector {
     /*package-private*/
     @ForceInline
     final @Override
-    double[] vec() {
-        return (double[])getPayload();
+    Float16[] vec() {
+        return (Float16[])getPayload();
     }
 
     // Virtualized constructors
 
     @Override
     @ForceInline
-    public final Double512Vector broadcast(double e) {
-        return (Double512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat128Vector broadcast(Float16 e) {
+        return (Halffloat128Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double512Vector broadcast(long e) {
-        return (Double512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat128Vector broadcast(long e) {
+        return (Halffloat128Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Double512Mask maskFromArray(boolean[] bits) {
-        return new Double512Mask(bits);
+    Halffloat128Mask maskFromArray(boolean[] bits) {
+        return new Halffloat128Mask(bits);
     }
 
     @Override
     @ForceInline
-    Double512Shuffle iotaShuffle() { return Double512Shuffle.IOTA; }
+    Halffloat128Shuffle iotaShuffle() { return Halffloat128Shuffle.IOTA; }
 
     @ForceInline
-    Double512Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    Halffloat128Shuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Double512Shuffle)VectorSupport.shuffleIota(ETYPE, Double512Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (Halffloat128Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat128Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Double512Shuffle)VectorSupport.shuffleIota(ETYPE, Double512Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (Halffloat128Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat128Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Double512Shuffle shuffleFromBytes(byte[] reorder) { return new Double512Shuffle(reorder); }
+    Halffloat128Shuffle shuffleFromBytes(byte[] reorder) { return new Halffloat128Shuffle(reorder); }
 
     @Override
     @ForceInline
-    Double512Shuffle shuffleFromArray(int[] indexes, int i) { return new Double512Shuffle(indexes, i); }
+    Halffloat128Shuffle shuffleFromArray(int[] indexes, int i) { return new Halffloat128Shuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Double512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Double512Shuffle(fn); }
+    Halffloat128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Halffloat128Shuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Double512Vector vectorFactory(double[] vec) {
-        return new Double512Vector(vec);
+    Halffloat128Vector vectorFactory(Float16[] vec) {
+        return new Halffloat128Vector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte512Vector asByteVectorRaw() {
-        return (Byte512Vector) super.asByteVectorRawTemplate();  // specialize
+    Byte128Vector asByteVectorRaw() {
+        return (Byte128Vector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ final class Double512Vector extends DoubleVector {
 
     @ForceInline
     final @Override
-    Double512Vector uOp(FUnOp f) {
-        return (Double512Vector) super.uOpTemplate(f);  // specialize
+    Halffloat128Vector uOp(FUnOp f) {
+        return (Halffloat128Vector) super.uOpTemplate(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double512Vector uOp(VectorMask<Double> m, FUnOp f) {
-        return (Double512Vector)
-            super.uOpTemplate((Double512Mask)m, f);  // specialize
+    Halffloat128Vector uOp(VectorMask<Float16> m, FUnOp f) {
+        return (Halffloat128Vector)
+            super.uOpTemplate((Halffloat128Mask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Double512Vector bOp(Vector<Double> v, FBinOp f) {
-        return (Double512Vector) super.bOpTemplate((Double512Vector)v, f);  // specialize
+    Halffloat128Vector bOp(Vector<Float16> v, FBinOp f) {
+        return (Halffloat128Vector) super.bOpTemplate((Halffloat128Vector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double512Vector bOp(Vector<Double> v,
-                     VectorMask<Double> m, FBinOp f) {
-        return (Double512Vector)
-            super.bOpTemplate((Double512Vector)v, (Double512Mask)m,
+    Halffloat128Vector bOp(Vector<Float16> v,
+                     VectorMask<Float16> m, FBinOp f) {
+        return (Halffloat128Vector)
+            super.bOpTemplate((Halffloat128Vector)v, (Halffloat128Mask)m,
                               f);  // specialize
     }
 
@@ -219,31 +219,31 @@ final class Double512Vector extends DoubleVector {
 
     @ForceInline
     final @Override
-    Double512Vector tOp(Vector<Double> v1, Vector<Double> v2, FTriOp f) {
-        return (Double512Vector)
-            super.tOpTemplate((Double512Vector)v1, (Double512Vector)v2,
+    Halffloat128Vector tOp(Vector<Float16> v1, Vector<Float16> v2, FTriOp f) {
+        return (Halffloat128Vector)
+            super.tOpTemplate((Halffloat128Vector)v1, (Halffloat128Vector)v2,
                               f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Double512Vector tOp(Vector<Double> v1, Vector<Double> v2,
-                     VectorMask<Double> m, FTriOp f) {
-        return (Double512Vector)
-            super.tOpTemplate((Double512Vector)v1, (Double512Vector)v2,
-                              (Double512Mask)m, f);  // specialize
+    Halffloat128Vector tOp(Vector<Float16> v1, Vector<Float16> v2,
+                     VectorMask<Float16> m, FTriOp f) {
+        return (Halffloat128Vector)
+            super.tOpTemplate((Halffloat128Vector)v1, (Halffloat128Vector)v2,
+                              (Halffloat128Mask)m, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    double rOp(double v, VectorMask<Double> m, FBinOp f) {
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f) {
         return super.rOpTemplate(v, m, f);  // specialize
     }
 
     @Override
     @ForceInline
     public final <F>
-    Vector<F> convertShape(VectorOperators.Conversion<Double,F> conv,
+    Vector<F> convertShape(VectorOperators.Conversion<Float16,F> conv,
                            VectorSpecies<F> rsp, int part) {
         return super.convertShapeTemplate(conv, rsp, part);  // specialize
     }
@@ -269,26 +269,26 @@ final class Double512Vector extends DoubleVector {
 
     @Override
     @ForceInline
-    public Double512Vector lanewise(Unary op) {
-        return (Double512Vector) super.lanewiseTemplate(op);  // specialize
+    public Halffloat128Vector lanewise(Unary op) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector lanewise(Unary op, VectorMask<Double> m) {
-        return (Double512Vector) super.lanewiseTemplate(op, Double512Mask.class, (Double512Mask) m);  // specialize
+    public Halffloat128Vector lanewise(Unary op, VectorMask<Float16> m) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op, Halffloat128Mask.class, (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector lanewise(Binary op, Vector<Double> v) {
-        return (Double512Vector) super.lanewiseTemplate(op, v);  // specialize
+    public Halffloat128Vector lanewise(Binary op, Vector<Float16> v) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector lanewise(Binary op, Vector<Double> v, VectorMask<Double> m) {
-        return (Double512Vector) super.lanewiseTemplate(op, Double512Mask.class, v, (Double512Mask) m);  // specialize
+    public Halffloat128Vector lanewise(Binary op, Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op, Halffloat128Mask.class, v, (Halffloat128Mask) m);  // specialize
     }
 
 
@@ -296,210 +296,210 @@ final class Double512Vector extends DoubleVector {
     @Override
     @ForceInline
     public final
-    Double512Vector
-    lanewise(Ternary op, Vector<Double> v1, Vector<Double> v2) {
-        return (Double512Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+    Halffloat128Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Double512Vector
-    lanewise(Ternary op, Vector<Double> v1, Vector<Double> v2, VectorMask<Double> m) {
-        return (Double512Vector) super.lanewiseTemplate(op, Double512Mask.class, v1, v2, (Double512Mask) m);  // specialize
+    Halffloat128Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2, VectorMask<Float16> m) {
+        return (Halffloat128Vector) super.lanewiseTemplate(op, Halffloat128Mask.class, v1, v2, (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Double512Vector addIndex(int scale) {
-        return (Double512Vector) super.addIndexTemplate(scale);  // specialize
+    Halffloat128Vector addIndex(int scale) {
+        return (Halffloat128Vector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
 
     @Override
     @ForceInline
-    public final double reduceLanes(VectorOperators.Associative op) {
+    public final Float16 reduceLanes(VectorOperators.Associative op) {
         return super.reduceLanesTemplate(op);  // specialized
     }
 
     @Override
     @ForceInline
-    public final double reduceLanes(VectorOperators.Associative op,
-                                    VectorMask<Double> m) {
-        return super.reduceLanesTemplate(op, Double512Mask.class, (Double512Mask) m);  // specialized
+    public final Float16 reduceLanes(VectorOperators.Associative op,
+                                    VectorMask<Float16> m) {
+        return super.reduceLanesTemplate(op, Halffloat128Mask.class, (Halffloat128Mask) m);  // specialized
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        double res = super.reduceLanesTemplate(op);  // specialized
-        return  (long) res;
+        Float16 res = super.reduceLanesTemplate(op);  // specialized
+        return res.longValue();
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
-                                        VectorMask<Double> m) {
-        double res = super.reduceLanesTemplate(op, Double512Mask.class, (Double512Mask) m);  // specialized
-        return  (long) res;
+                                        VectorMask<Float16> m) {
+        Float16 res = super.reduceLanesTemplate(op, Halffloat128Mask.class, (Halffloat128Mask) m);  // specialized
+        return res.longValue();
     }
 
     @ForceInline
-    public VectorShuffle<Double> toShuffle() {
-        return super.toShuffleTemplate(Double512Shuffle.class); // specialize
+    public VectorShuffle<Float16> toShuffle() {
+        return super.toShuffleTemplate(Halffloat128Shuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Double512Mask test(Test op) {
-        return super.testTemplate(Double512Mask.class, op);  // specialize
+    public final Halffloat128Mask test(Test op) {
+        return super.testTemplate(Halffloat128Mask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double512Mask test(Test op, VectorMask<Double> m) {
-        return super.testTemplate(Double512Mask.class, op, (Double512Mask) m);  // specialize
+    public final Halffloat128Mask test(Test op, VectorMask<Float16> m) {
+        return super.testTemplate(Halffloat128Mask.class, op, (Halffloat128Mask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Double512Mask compare(Comparison op, Vector<Double> v) {
-        return super.compareTemplate(Double512Mask.class, op, v);  // specialize
+    public final Halffloat128Mask compare(Comparison op, Vector<Float16> v) {
+        return super.compareTemplate(Halffloat128Mask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double512Mask compare(Comparison op, double s) {
-        return super.compareTemplate(Double512Mask.class, op, s);  // specialize
+    public final Halffloat128Mask compare(Comparison op, Float16 s) {
+        return super.compareTemplate(Halffloat128Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double512Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Double512Mask.class, op, s);  // specialize
+    public final Halffloat128Mask compare(Comparison op, long s) {
+        return super.compareTemplate(Halffloat128Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Double512Mask compare(Comparison op, Vector<Double> v, VectorMask<Double> m) {
-        return super.compareTemplate(Double512Mask.class, op, v, (Double512Mask) m);
+    public final Halffloat128Mask compare(Comparison op, Vector<Float16> v, VectorMask<Float16> m) {
+        return super.compareTemplate(Halffloat128Mask.class, op, v, (Halffloat128Mask) m);
     }
 
 
     @Override
     @ForceInline
-    public Double512Vector blend(Vector<Double> v, VectorMask<Double> m) {
-        return (Double512Vector)
-            super.blendTemplate(Double512Mask.class,
-                                (Double512Vector) v,
-                                (Double512Mask) m);  // specialize
+    public Halffloat128Vector blend(Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.blendTemplate(Halffloat128Mask.class,
+                                (Halffloat128Vector) v,
+                                (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector slice(int origin, Vector<Double> v) {
-        return (Double512Vector) super.sliceTemplate(origin, v);  // specialize
+    public Halffloat128Vector slice(int origin, Vector<Float16> v) {
+        return (Halffloat128Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector slice(int origin) {
-        return (Double512Vector) super.sliceTemplate(origin);  // specialize
+    public Halffloat128Vector slice(int origin) {
+        return (Halffloat128Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector unslice(int origin, Vector<Double> w, int part) {
-        return (Double512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public Halffloat128Vector unslice(int origin, Vector<Float16> w, int part) {
+        return (Halffloat128Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector unslice(int origin, Vector<Double> w, int part, VectorMask<Double> m) {
-        return (Double512Vector)
-            super.unsliceTemplate(Double512Mask.class,
+    public Halffloat128Vector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.unsliceTemplate(Halffloat128Mask.class,
                                   origin, w, part,
-                                  (Double512Mask) m);  // specialize
+                                  (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector unslice(int origin) {
-        return (Double512Vector) super.unsliceTemplate(origin);  // specialize
+    public Halffloat128Vector unslice(int origin) {
+        return (Halffloat128Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector rearrange(VectorShuffle<Double> s) {
-        return (Double512Vector)
-            super.rearrangeTemplate(Double512Shuffle.class,
-                                    (Double512Shuffle) s);  // specialize
+    public Halffloat128Vector rearrange(VectorShuffle<Float16> s) {
+        return (Halffloat128Vector)
+            super.rearrangeTemplate(Halffloat128Shuffle.class,
+                                    (Halffloat128Shuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector rearrange(VectorShuffle<Double> shuffle,
-                                  VectorMask<Double> m) {
-        return (Double512Vector)
-            super.rearrangeTemplate(Double512Shuffle.class,
-                                    Double512Mask.class,
-                                    (Double512Shuffle) shuffle,
-                                    (Double512Mask) m);  // specialize
+    public Halffloat128Vector rearrange(VectorShuffle<Float16> shuffle,
+                                  VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.rearrangeTemplate(Halffloat128Shuffle.class,
+                                    Halffloat128Mask.class,
+                                    (Halffloat128Shuffle) shuffle,
+                                    (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector rearrange(VectorShuffle<Double> s,
-                                  Vector<Double> v) {
-        return (Double512Vector)
-            super.rearrangeTemplate(Double512Shuffle.class,
-                                    (Double512Shuffle) s,
-                                    (Double512Vector) v);  // specialize
+    public Halffloat128Vector rearrange(VectorShuffle<Float16> s,
+                                  Vector<Float16> v) {
+        return (Halffloat128Vector)
+            super.rearrangeTemplate(Halffloat128Shuffle.class,
+                                    (Halffloat128Shuffle) s,
+                                    (Halffloat128Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector compress(VectorMask<Double> m) {
-        return (Double512Vector)
-            super.compressTemplate(Double512Mask.class,
-                                   (Double512Mask) m);  // specialize
+    public Halffloat128Vector compress(VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.compressTemplate(Halffloat128Mask.class,
+                                   (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector expand(VectorMask<Double> m) {
-        return (Double512Vector)
-            super.expandTemplate(Double512Mask.class,
-                                   (Double512Mask) m);  // specialize
+    public Halffloat128Vector expand(VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.expandTemplate(Halffloat128Mask.class,
+                                   (Halffloat128Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector selectFrom(Vector<Double> v) {
-        return (Double512Vector)
-            super.selectFromTemplate((Double512Vector) v);  // specialize
+    public Halffloat128Vector selectFrom(Vector<Float16> v) {
+        return (Halffloat128Vector)
+            super.selectFromTemplate((Halffloat128Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Double512Vector selectFrom(Vector<Double> v,
-                                   VectorMask<Double> m) {
-        return (Double512Vector)
-            super.selectFromTemplate((Double512Vector) v,
-                                     (Double512Mask) m);  // specialize
+    public Halffloat128Vector selectFrom(Vector<Float16> v,
+                                   VectorMask<Float16> m) {
+        return (Halffloat128Vector)
+            super.selectFromTemplate((Halffloat128Vector) v,
+                                     (Halffloat128Mask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
-    public double lane(int i) {
-        long bits;
+    public Float16 lane(int i) {
+        short bits;
         switch(i) {
             case 0: bits = laneHelper(0); break;
             case 1: bits = laneHelper(1); break;
@@ -511,22 +511,22 @@ final class Double512Vector extends DoubleVector {
             case 7: bits = laneHelper(7); break;
             default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
-        return Double.longBitsToDouble(bits);
+        return Float16.shortBitsToFloat16(bits);
     }
 
-    public long laneHelper(int i) {
-        return (long) VectorSupport.extract(
+    public short laneHelper(int i) {
+        return (short) VectorSupport.extract(
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                     double[] vecarr = vec.vec();
-                     return (long)Double.doubleToLongBits(vecarr[ix]);
+                     Float16[] vecarr = vec.vec();
+                     return (long)Float16.float16ToShortBits(vecarr[ix]);
                      });
     }
 
     @ForceInline
     @Override
-    public Double512Vector withLane(int i, double e) {
+    public Halffloat128Vector withLane(int i, Float16 e) {
         switch(i) {
             case 0: return withLaneHelper(0, e);
             case 1: return withLaneHelper(1, e);
@@ -540,32 +540,32 @@ final class Double512Vector extends DoubleVector {
         }
     }
 
-    public Double512Vector withLaneHelper(int i, double e) {
+    public Halffloat128Vector withLaneHelper(int i, Float16 e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
-                                this, i, (long)Double.doubleToLongBits(e),
+                                this, i, (long)Float16.float16ToShortBits(e),
                                 (v, ix, bits) -> {
-                                    double[] res = v.vec().clone();
-                                    res[ix] = Double.longBitsToDouble((long)bits);
+                                    Float16[] res = v.vec().clone();
+                                    res[ix] = Float16.shortBitsToFloat16((short)bits);
                                     return v.vectorFactory(res);
                                 });
     }
 
     // Mask
 
-    static final class Double512Mask extends AbstractMask<Double> {
+    static final class Halffloat128Mask extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Double> ETYPE = double.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Double512Mask(boolean[] bits) {
+        Halffloat128Mask(boolean[] bits) {
             this(bits, 0);
         }
 
-        Double512Mask(boolean[] bits, int offset) {
+        Halffloat128Mask(boolean[] bits, int offset) {
             super(prepare(bits, offset));
         }
 
-        Double512Mask(boolean val) {
+        Halffloat128Mask(boolean val) {
             super(prepare(val));
         }
 
@@ -585,7 +585,7 @@ final class Double512Vector extends DoubleVector {
 
         @ForceInline
         final @Override
-        public DoubleSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             // ISSUE:  This should probably be a @Stable
             // field inside AbstractMask, rather than
             // a megamorphic method.
@@ -598,31 +598,31 @@ final class Double512Vector extends DoubleVector {
         }
 
         @Override
-        Double512Mask uOp(MUnOp f) {
+        Halffloat128Mask uOp(MUnOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i]);
             }
-            return new Double512Mask(res);
+            return new Halffloat128Mask(res);
         }
 
         @Override
-        Double512Mask bOp(VectorMask<Double> m, MBinOp f) {
+        Halffloat128Mask bOp(VectorMask<Float16> m, MBinOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
-            boolean[] mbits = ((Double512Mask)m).getBits();
+            boolean[] mbits = ((Halffloat128Mask)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i], mbits[i]);
             }
-            return new Double512Mask(res);
+            return new Halffloat128Mask(res);
         }
 
         @ForceInline
         @Override
         public final
-        Double512Vector toVector() {
-            return (Double512Vector) super.toVectorTemplate();  // specialize
+        Halffloat128Vector toVector() {
+            return (Halffloat128Vector) super.toVectorTemplate();  // specialize
         }
 
         /**
@@ -655,26 +655,26 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         /*package-private*/
-        Double512Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Double512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Double512Mask.class, ETYPE, VLENGTH, offset, limit,
-                (o, l) -> (Double512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        Halffloat128Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Halffloat128Mask) VectorSupport.indexPartiallyInUpperRange(
+                Halffloat128Mask.class, ETYPE, VLENGTH, offset, limit,
+                (o, l) -> (Halffloat128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Double512Mask not() {
+        public Halffloat128Mask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Double512Mask compress() {
-            return (Double512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Double512Vector.class, Double512Mask.class, ETYPE, VLENGTH, null, this,
-                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
+        public Halffloat128Mask compress() {
+            return (Halffloat128Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                Halffloat128Vector.class, Halffloat128Mask.class, ETYPE, VLENGTH, null, this,
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
         }
 
 
@@ -682,30 +682,30 @@ final class Double512Vector extends DoubleVector {
 
         @Override
         @ForceInline
-        public Double512Mask and(VectorMask<Double> mask) {
+        public Halffloat128Mask and(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Double512Mask m = (Double512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Double512Mask.class, null, long.class, VLENGTH,
+            Halffloat128Mask m = (Halffloat128Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Halffloat128Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Double512Mask or(VectorMask<Double> mask) {
+        public Halffloat128Mask or(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Double512Mask m = (Double512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Double512Mask.class, null, long.class, VLENGTH,
+            Halffloat128Mask m = (Halffloat128Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Halffloat128Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Double512Mask xor(VectorMask<Double> mask) {
+        public Halffloat128Mask xor(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Double512Mask m = (Double512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Double512Mask.class, null, long.class, VLENGTH,
+            Halffloat128Mask m = (Halffloat128Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Halffloat128Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
         }
@@ -715,21 +715,21 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Double512Mask.class, long.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Halffloat128Mask.class, short.class, VLENGTH, this,
                                                       (m) -> trueCountHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Double512Mask.class, long.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Halffloat128Mask.class, short.class, VLENGTH, this,
                                                       (m) -> firstTrueHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Double512Mask.class, long.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Halffloat128Mask.class, short.class, VLENGTH, this,
                                                       (m) -> lastTrueHelper(m.getBits()));
         }
 
@@ -739,7 +739,7 @@ final class Double512Vector extends DoubleVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Double512Mask.class, long.class, VLENGTH, this,
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Halffloat128Mask.class, short.class, VLENGTH, this,
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
@@ -749,7 +749,7 @@ final class Double512Vector extends DoubleVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Double512Mask.class, double.class, VLENGTH,
+            return VectorSupport.extract(Halffloat128Mask.class, Float16.class, VLENGTH,
                                          this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
         }
 
@@ -758,55 +758,55 @@ final class Double512Vector extends DoubleVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Double512Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_ne, Halffloat128Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Double512Mask)m).getBits()));
+                                         (m, __) -> anyTrueHelper(((Halffloat128Mask)m).getBits()));
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Double512Mask.class, long.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, Halffloat128Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Double512Mask)m).getBits()));
+                                         (m, __) -> allTrueHelper(((Halffloat128Mask)m).getBits()));
         }
 
         @ForceInline
         /*package-private*/
-        static Double512Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Double512Mask.class, long.class, VLENGTH,
+        static Halffloat128Mask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(Halffloat128Mask.class, short.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Double512Mask  TRUE_MASK = new Double512Mask(true);
-        private static final Double512Mask FALSE_MASK = new Double512Mask(false);
+        private static final Halffloat128Mask  TRUE_MASK = new Halffloat128Mask(true);
+        private static final Halffloat128Mask FALSE_MASK = new Halffloat128Mask(false);
 
     }
 
     // Shuffle
 
-    static final class Double512Shuffle extends AbstractShuffle<Double> {
+    static final class Halffloat128Shuffle extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Double> ETYPE = double.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Double512Shuffle(byte[] reorder) {
+        Halffloat128Shuffle(byte[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Double512Shuffle(int[] reorder) {
+        public Halffloat128Shuffle(int[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Double512Shuffle(int[] reorder, int i) {
+        public Halffloat128Shuffle(int[] reorder, int i) {
             super(VLENGTH, reorder, i);
         }
 
-        public Double512Shuffle(IntUnaryOperator fn) {
+        public Halffloat128Shuffle(IntUnaryOperator fn) {
             super(VLENGTH, fn);
         }
 
         @Override
-        public DoubleSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             return VSPECIES;
         }
 
@@ -816,13 +816,13 @@ final class Double512Vector extends DoubleVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Double512Shuffle IOTA = new Double512Shuffle(IDENTITY);
+        static final Halffloat128Shuffle IOTA = new Halffloat128Shuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Double512Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Double512Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Double512Vector)(((AbstractShuffle<Double>)(s)).toVectorTemplate())));
+        public Halffloat128Vector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Halffloat128Shuffle.class, this, VLENGTH,
+                                                    (s) -> ((Halffloat128Vector)(((AbstractShuffle<Float16>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -837,8 +837,8 @@ final class Double512Vector extends DoubleVector {
 
         @ForceInline
         @Override
-        public Double512Shuffle rearrange(VectorShuffle<Double> shuffle) {
-            Double512Shuffle s = (Double512Shuffle) shuffle;
+        public Halffloat128Shuffle rearrange(VectorShuffle<Float16> shuffle) {
+            Halffloat128Shuffle s = (Halffloat128Shuffle) shuffle;
             byte[] reorder1 = reorder();
             byte[] reorder2 = s.reorder();
             byte[] r = new byte[reorder1.length];
@@ -846,7 +846,7 @@ final class Double512Vector extends DoubleVector {
                 int ssi = reorder2[i];
                 r[i] = reorder1[ssi];  // throws on exceptional index
             }
-            return new Double512Shuffle(r);
+            return new Halffloat128Shuffle(r);
         }
     }
 
@@ -857,67 +857,55 @@ final class Double512Vector extends DoubleVector {
     @ForceInline
     @Override
     final
-    DoubleVector fromArray0(double[] a, int offset) {
+    HalffloatVector fromArray0(Float16[] a, int offset) {
         return super.fromArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    DoubleVector fromArray0(double[] a, int offset, VectorMask<Double> m, int offsetInRange) {
-        return super.fromArray0Template(Double512Mask.class, a, offset, (Double512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromArray0Template(Halffloat128Mask.class, a, offset, (Halffloat128Mask) m, offsetInRange);  // specialize
     }
 
-    @ForceInline
-    @Override
-    final
-    DoubleVector fromArray0(double[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Double> m) {
-        return super.fromArray0Template(Double512Mask.class, a, offset, indexMap, mapOffset, (Double512Mask) m);
-    }
 
 
 
     @ForceInline
     @Override
     final
-    DoubleVector fromMemorySegment0(MemorySegment ms, long offset) {
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset) {
         return super.fromMemorySegment0Template(ms, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    DoubleVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Double> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Double512Mask.class, ms, offset, (Double512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromMemorySegment0Template(Halffloat128Mask.class, ms, offset, (Halffloat128Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset) {
+    void intoArray0(Float16[] a, int offset) {
         super.intoArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(double[] a, int offset, VectorMask<Double> m) {
-        super.intoArray0Template(Double512Mask.class, a, offset, (Double512Mask) m);
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m) {
+        super.intoArray0Template(Halffloat128Mask.class, a, offset, (Halffloat128Mask) m);
     }
 
-    @ForceInline
-    @Override
-    final
-    void intoArray0(double[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Double> m) {
-        super.intoArray0Template(Double512Mask.class, a, offset, indexMap, mapOffset, (Double512Mask) m);
-    }
 
 
     @ForceInline
     @Override
     final
-    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Double> m) {
-        super.intoMemorySegment0Template(Double512Mask.class, ms, offset, (Double512Mask) m);
+    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m) {
+        super.intoMemorySegment0Template(Halffloat128Mask.class, ms, offset, (Halffloat128Mask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat256Vector.java
@@ -39,33 +39,33 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-final class Float512Vector extends FloatVector {
-    static final FloatSpecies VSPECIES =
-        (FloatSpecies) FloatVector.SPECIES_512;
+final class Halffloat256Vector extends HalffloatVector {
+    static final HalffloatSpecies VSPECIES =
+        (HalffloatSpecies) HalffloatVector.SPECIES_256;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Float512Vector> VCLASS = Float512Vector.class;
+    static final Class<Halffloat256Vector> VCLASS = Halffloat256Vector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
     static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
 
-    static final Class<Float> ETYPE = float.class; // used by the JVM
+    static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-    Float512Vector(float[] v) {
+    Halffloat256Vector(Float16[] v) {
         super(v);
     }
 
-    // For compatibility as Float512Vector::new,
+    // For compatibility as Halffloat256Vector::new,
     // stored into species.vectorFactory.
-    Float512Vector(Object v) {
-        this((float[]) v);
+    Halffloat256Vector(Object v) {
+        this((Float16[]) v);
     }
 
-    static final Float512Vector ZERO = new Float512Vector(new float[VLENGTH]);
-    static final Float512Vector IOTA = new Float512Vector(VSPECIES.iotaArray());
+    static final Halffloat256Vector ZERO = new Halffloat256Vector(new Float16[VLENGTH]);
+    static final Halffloat256Vector IOTA = new Halffloat256Vector(VSPECIES.iotaArray());
 
     static {
         // Warm up a few species caches.
@@ -79,7 +79,7 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    public FloatSpecies vspecies() {
+    public HalffloatSpecies vspecies() {
         // ISSUE:  This should probably be a @Stable
         // field inside AbstractVector, rather than
         // a megamorphic method.
@@ -88,11 +88,11 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     @Override
-    public final Class<Float> elementType() { return float.class; }
+    public final Class<Float16> elementType() { return Float16.class; }
 
     @ForceInline
     @Override
-    public final int elementSize() { return Float.SIZE; }
+    public final int elementSize() { return Float16.SIZE; }
 
     @ForceInline
     @Override
@@ -113,68 +113,68 @@ final class Float512Vector extends FloatVector {
     /*package-private*/
     @ForceInline
     final @Override
-    float[] vec() {
-        return (float[])getPayload();
+    Float16[] vec() {
+        return (Float16[])getPayload();
     }
 
     // Virtualized constructors
 
     @Override
     @ForceInline
-    public final Float512Vector broadcast(float e) {
-        return (Float512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat256Vector broadcast(Float16 e) {
+        return (Halffloat256Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Vector broadcast(long e) {
-        return (Float512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat256Vector broadcast(long e) {
+        return (Halffloat256Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Float512Mask maskFromArray(boolean[] bits) {
-        return new Float512Mask(bits);
+    Halffloat256Mask maskFromArray(boolean[] bits) {
+        return new Halffloat256Mask(bits);
     }
 
     @Override
     @ForceInline
-    Float512Shuffle iotaShuffle() { return Float512Shuffle.IOTA; }
+    Halffloat256Shuffle iotaShuffle() { return Halffloat256Shuffle.IOTA; }
 
     @ForceInline
-    Float512Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    Halffloat256Shuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Float512Shuffle)VectorSupport.shuffleIota(ETYPE, Float512Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (Halffloat256Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat256Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Float512Shuffle)VectorSupport.shuffleIota(ETYPE, Float512Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (Halffloat256Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat256Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromBytes(byte[] reorder) { return new Float512Shuffle(reorder); }
+    Halffloat256Shuffle shuffleFromBytes(byte[] reorder) { return new Halffloat256Shuffle(reorder); }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromArray(int[] indexes, int i) { return new Float512Shuffle(indexes, i); }
+    Halffloat256Shuffle shuffleFromArray(int[] indexes, int i) { return new Halffloat256Shuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float512Shuffle(fn); }
+    Halffloat256Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Halffloat256Shuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Float512Vector vectorFactory(float[] vec) {
-        return new Float512Vector(vec);
+    Halffloat256Vector vectorFactory(Float16[] vec) {
+        return new Halffloat256Vector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte512Vector asByteVectorRaw() {
-        return (Byte512Vector) super.asByteVectorRawTemplate();  // specialize
+    Byte256Vector asByteVectorRaw() {
+        return (Byte256Vector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float512Vector uOp(FUnOp f) {
-        return (Float512Vector) super.uOpTemplate(f);  // specialize
+    Halffloat256Vector uOp(FUnOp f) {
+        return (Halffloat256Vector) super.uOpTemplate(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector uOp(VectorMask<Float> m, FUnOp f) {
-        return (Float512Vector)
-            super.uOpTemplate((Float512Mask)m, f);  // specialize
+    Halffloat256Vector uOp(VectorMask<Float16> m, FUnOp f) {
+        return (Halffloat256Vector)
+            super.uOpTemplate((Halffloat256Mask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Float512Vector bOp(Vector<Float> v, FBinOp f) {
-        return (Float512Vector) super.bOpTemplate((Float512Vector)v, f);  // specialize
+    Halffloat256Vector bOp(Vector<Float16> v, FBinOp f) {
+        return (Halffloat256Vector) super.bOpTemplate((Halffloat256Vector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector bOp(Vector<Float> v,
-                     VectorMask<Float> m, FBinOp f) {
-        return (Float512Vector)
-            super.bOpTemplate((Float512Vector)v, (Float512Mask)m,
+    Halffloat256Vector bOp(Vector<Float16> v,
+                     VectorMask<Float16> m, FBinOp f) {
+        return (Halffloat256Vector)
+            super.bOpTemplate((Halffloat256Vector)v, (Halffloat256Mask)m,
                               f);  // specialize
     }
 
@@ -219,31 +219,31 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float512Vector tOp(Vector<Float> v1, Vector<Float> v2, FTriOp f) {
-        return (Float512Vector)
-            super.tOpTemplate((Float512Vector)v1, (Float512Vector)v2,
+    Halffloat256Vector tOp(Vector<Float16> v1, Vector<Float16> v2, FTriOp f) {
+        return (Halffloat256Vector)
+            super.tOpTemplate((Halffloat256Vector)v1, (Halffloat256Vector)v2,
                               f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector tOp(Vector<Float> v1, Vector<Float> v2,
-                     VectorMask<Float> m, FTriOp f) {
-        return (Float512Vector)
-            super.tOpTemplate((Float512Vector)v1, (Float512Vector)v2,
-                              (Float512Mask)m, f);  // specialize
+    Halffloat256Vector tOp(Vector<Float16> v1, Vector<Float16> v2,
+                     VectorMask<Float16> m, FTriOp f) {
+        return (Halffloat256Vector)
+            super.tOpTemplate((Halffloat256Vector)v1, (Halffloat256Vector)v2,
+                              (Halffloat256Mask)m, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    float rOp(float v, VectorMask<Float> m, FBinOp f) {
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f) {
         return super.rOpTemplate(v, m, f);  // specialize
     }
 
     @Override
     @ForceInline
     public final <F>
-    Vector<F> convertShape(VectorOperators.Conversion<Float,F> conv,
+    Vector<F> convertShape(VectorOperators.Conversion<Float16,F> conv,
                            VectorSpecies<F> rsp, int part) {
         return super.convertShapeTemplate(conv, rsp, part);  // specialize
     }
@@ -269,26 +269,26 @@ final class Float512Vector extends FloatVector {
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Unary op) {
-        return (Float512Vector) super.lanewiseTemplate(op);  // specialize
+    public Halffloat256Vector lanewise(Unary op) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Unary op, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialize
+    public Halffloat256Vector lanewise(Unary op, VectorMask<Float16> m) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op, Halffloat256Mask.class, (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Binary op, Vector<Float> v) {
-        return (Float512Vector) super.lanewiseTemplate(op, v);  // specialize
+    public Halffloat256Vector lanewise(Binary op, Vector<Float16> v) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Binary op, Vector<Float> v, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, v, (Float512Mask) m);  // specialize
+    public Halffloat256Vector lanewise(Binary op, Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op, Halffloat256Mask.class, v, (Halffloat256Mask) m);  // specialize
     }
 
 
@@ -296,210 +296,210 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public final
-    Float512Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2) {
-        return (Float512Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+    Halffloat256Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float512Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, v1, v2, (Float512Mask) m);  // specialize
+    Halffloat256Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2, VectorMask<Float16> m) {
+        return (Halffloat256Vector) super.lanewiseTemplate(op, Halffloat256Mask.class, v1, v2, (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float512Vector addIndex(int scale) {
-        return (Float512Vector) super.addIndexTemplate(scale);  // specialize
+    Halffloat256Vector addIndex(int scale) {
+        return (Halffloat256Vector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op) {
+    public final Float16 reduceLanes(VectorOperators.Associative op) {
         return super.reduceLanesTemplate(op);  // specialized
     }
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op,
-                                    VectorMask<Float> m) {
-        return super.reduceLanesTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialized
+    public final Float16 reduceLanes(VectorOperators.Associative op,
+                                    VectorMask<Float16> m) {
+        return super.reduceLanesTemplate(op, Halffloat256Mask.class, (Halffloat256Mask) m);  // specialized
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        float res = super.reduceLanesTemplate(op);  // specialized
-        return  (long) res;
+        Float16 res = super.reduceLanesTemplate(op);  // specialized
+        return res.longValue();
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
-                                        VectorMask<Float> m) {
-        float res = super.reduceLanesTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialized
-        return  (long) res;
+                                        VectorMask<Float16> m) {
+        Float16 res = super.reduceLanesTemplate(op, Halffloat256Mask.class, (Halffloat256Mask) m);  // specialized
+        return res.longValue();
     }
 
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
-        return super.toShuffleTemplate(Float512Shuffle.class); // specialize
+    public VectorShuffle<Float16> toShuffle() {
+        return super.toShuffleTemplate(Halffloat256Shuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Float512Mask test(Test op) {
-        return super.testTemplate(Float512Mask.class, op);  // specialize
+    public final Halffloat256Mask test(Test op) {
+        return super.testTemplate(Halffloat256Mask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask test(Test op, VectorMask<Float> m) {
-        return super.testTemplate(Float512Mask.class, op, (Float512Mask) m);  // specialize
+    public final Halffloat256Mask test(Test op, VectorMask<Float16> m) {
+        return super.testTemplate(Halffloat256Mask.class, op, (Halffloat256Mask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, Vector<Float> v) {
-        return super.compareTemplate(Float512Mask.class, op, v);  // specialize
+    public final Halffloat256Mask compare(Comparison op, Vector<Float16> v) {
+        return super.compareTemplate(Halffloat256Mask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, float s) {
-        return super.compareTemplate(Float512Mask.class, op, s);  // specialize
+    public final Halffloat256Mask compare(Comparison op, Float16 s) {
+        return super.compareTemplate(Halffloat256Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Float512Mask.class, op, s);  // specialize
+    public final Halffloat256Mask compare(Comparison op, long s) {
+        return super.compareTemplate(Halffloat256Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, Vector<Float> v, VectorMask<Float> m) {
-        return super.compareTemplate(Float512Mask.class, op, v, (Float512Mask) m);
+    public final Halffloat256Mask compare(Comparison op, Vector<Float16> v, VectorMask<Float16> m) {
+        return super.compareTemplate(Halffloat256Mask.class, op, v, (Halffloat256Mask) m);
     }
 
 
     @Override
     @ForceInline
-    public Float512Vector blend(Vector<Float> v, VectorMask<Float> m) {
-        return (Float512Vector)
-            super.blendTemplate(Float512Mask.class,
-                                (Float512Vector) v,
-                                (Float512Mask) m);  // specialize
+    public Halffloat256Vector blend(Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.blendTemplate(Halffloat256Mask.class,
+                                (Halffloat256Vector) v,
+                                (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector slice(int origin, Vector<Float> v) {
-        return (Float512Vector) super.sliceTemplate(origin, v);  // specialize
+    public Halffloat256Vector slice(int origin, Vector<Float16> v) {
+        return (Halffloat256Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector slice(int origin) {
-        return (Float512Vector) super.sliceTemplate(origin);  // specialize
+    public Halffloat256Vector slice(int origin) {
+        return (Halffloat256Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public Halffloat256Vector unslice(int origin, Vector<Float16> w, int part) {
+        return (Halffloat256Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m) {
-        return (Float512Vector)
-            super.unsliceTemplate(Float512Mask.class,
+    public Halffloat256Vector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.unsliceTemplate(Halffloat256Mask.class,
                                   origin, w, part,
-                                  (Float512Mask) m);  // specialize
+                                  (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin) {
-        return (Float512Vector) super.unsliceTemplate(origin);  // specialize
+    public Halffloat256Vector unslice(int origin) {
+        return (Halffloat256Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> s) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    (Float512Shuffle) s);  // specialize
+    public Halffloat256Vector rearrange(VectorShuffle<Float16> s) {
+        return (Halffloat256Vector)
+            super.rearrangeTemplate(Halffloat256Shuffle.class,
+                                    (Halffloat256Shuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> shuffle,
-                                  VectorMask<Float> m) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    Float512Mask.class,
-                                    (Float512Shuffle) shuffle,
-                                    (Float512Mask) m);  // specialize
+    public Halffloat256Vector rearrange(VectorShuffle<Float16> shuffle,
+                                  VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.rearrangeTemplate(Halffloat256Shuffle.class,
+                                    Halffloat256Mask.class,
+                                    (Halffloat256Shuffle) shuffle,
+                                    (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> s,
-                                  Vector<Float> v) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    (Float512Shuffle) s,
-                                    (Float512Vector) v);  // specialize
+    public Halffloat256Vector rearrange(VectorShuffle<Float16> s,
+                                  Vector<Float16> v) {
+        return (Halffloat256Vector)
+            super.rearrangeTemplate(Halffloat256Shuffle.class,
+                                    (Halffloat256Shuffle) s,
+                                    (Halffloat256Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector compress(VectorMask<Float> m) {
-        return (Float512Vector)
-            super.compressTemplate(Float512Mask.class,
-                                   (Float512Mask) m);  // specialize
+    public Halffloat256Vector compress(VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.compressTemplate(Halffloat256Mask.class,
+                                   (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector expand(VectorMask<Float> m) {
-        return (Float512Vector)
-            super.expandTemplate(Float512Mask.class,
-                                   (Float512Mask) m);  // specialize
+    public Halffloat256Vector expand(VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.expandTemplate(Halffloat256Mask.class,
+                                   (Halffloat256Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector selectFrom(Vector<Float> v) {
-        return (Float512Vector)
-            super.selectFromTemplate((Float512Vector) v);  // specialize
+    public Halffloat256Vector selectFrom(Vector<Float16> v) {
+        return (Halffloat256Vector)
+            super.selectFromTemplate((Halffloat256Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector selectFrom(Vector<Float> v,
-                                   VectorMask<Float> m) {
-        return (Float512Vector)
-            super.selectFromTemplate((Float512Vector) v,
-                                     (Float512Mask) m);  // specialize
+    public Halffloat256Vector selectFrom(Vector<Float16> v,
+                                   VectorMask<Float16> m) {
+        return (Halffloat256Vector)
+            super.selectFromTemplate((Halffloat256Vector) v,
+                                     (Halffloat256Mask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
-    public float lane(int i) {
-        int bits;
+    public Float16 lane(int i) {
+        short bits;
         switch(i) {
             case 0: bits = laneHelper(0); break;
             case 1: bits = laneHelper(1); break;
@@ -519,22 +519,22 @@ final class Float512Vector extends FloatVector {
             case 15: bits = laneHelper(15); break;
             default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
-        return Float.intBitsToFloat(bits);
+        return Float16.shortBitsToFloat16(bits);
     }
 
-    public int laneHelper(int i) {
-        return (int) VectorSupport.extract(
+    public short laneHelper(int i) {
+        return (short) VectorSupport.extract(
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                     float[] vecarr = vec.vec();
-                     return (long)Float.floatToIntBits(vecarr[ix]);
+                     Float16[] vecarr = vec.vec();
+                     return (long)Float16.float16ToShortBits(vecarr[ix]);
                      });
     }
 
     @ForceInline
     @Override
-    public Float512Vector withLane(int i, float e) {
+    public Halffloat256Vector withLane(int i, Float16 e) {
         switch(i) {
             case 0: return withLaneHelper(0, e);
             case 1: return withLaneHelper(1, e);
@@ -556,32 +556,32 @@ final class Float512Vector extends FloatVector {
         }
     }
 
-    public Float512Vector withLaneHelper(int i, float e) {
+    public Halffloat256Vector withLaneHelper(int i, Float16 e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
-                                this, i, (long)Float.floatToIntBits(e),
+                                this, i, (long)Float16.float16ToShortBits(e),
                                 (v, ix, bits) -> {
-                                    float[] res = v.vec().clone();
-                                    res[ix] = Float.intBitsToFloat((int)bits);
+                                    Float16[] res = v.vec().clone();
+                                    res[ix] = Float16.shortBitsToFloat16((short)bits);
                                     return v.vectorFactory(res);
                                 });
     }
 
     // Mask
 
-    static final class Float512Mask extends AbstractMask<Float> {
+    static final class Halffloat256Mask extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float512Mask(boolean[] bits) {
+        Halffloat256Mask(boolean[] bits) {
             this(bits, 0);
         }
 
-        Float512Mask(boolean[] bits, int offset) {
+        Halffloat256Mask(boolean[] bits, int offset) {
             super(prepare(bits, offset));
         }
 
-        Float512Mask(boolean val) {
+        Halffloat256Mask(boolean val) {
             super(prepare(val));
         }
 
@@ -601,7 +601,7 @@ final class Float512Vector extends FloatVector {
 
         @ForceInline
         final @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             // ISSUE:  This should probably be a @Stable
             // field inside AbstractMask, rather than
             // a megamorphic method.
@@ -614,31 +614,31 @@ final class Float512Vector extends FloatVector {
         }
 
         @Override
-        Float512Mask uOp(MUnOp f) {
+        Halffloat256Mask uOp(MUnOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i]);
             }
-            return new Float512Mask(res);
+            return new Halffloat256Mask(res);
         }
 
         @Override
-        Float512Mask bOp(VectorMask<Float> m, MBinOp f) {
+        Halffloat256Mask bOp(VectorMask<Float16> m, MBinOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
-            boolean[] mbits = ((Float512Mask)m).getBits();
+            boolean[] mbits = ((Halffloat256Mask)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i], mbits[i]);
             }
-            return new Float512Mask(res);
+            return new Halffloat256Mask(res);
         }
 
         @ForceInline
         @Override
         public final
-        Float512Vector toVector() {
-            return (Float512Vector) super.toVectorTemplate();  // specialize
+        Halffloat256Vector toVector() {
+            return (Halffloat256Vector) super.toVectorTemplate();  // specialize
         }
 
         /**
@@ -671,26 +671,26 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float512Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Float512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float512Mask.class, ETYPE, VLENGTH, offset, limit,
-                (o, l) -> (Float512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        Halffloat256Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Halffloat256Mask) VectorSupport.indexPartiallyInUpperRange(
+                Halffloat256Mask.class, ETYPE, VLENGTH, offset, limit,
+                (o, l) -> (Halffloat256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Float512Mask not() {
+        public Halffloat256Mask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Float512Mask compress() {
-            return (Float512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Float512Vector.class, Float512Mask.class, ETYPE, VLENGTH, null, this,
-                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
+        public Halffloat256Mask compress() {
+            return (Halffloat256Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                Halffloat256Vector.class, Halffloat256Mask.class, ETYPE, VLENGTH, null, this,
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
         }
 
 
@@ -698,30 +698,30 @@ final class Float512Vector extends FloatVector {
 
         @Override
         @ForceInline
-        public Float512Mask and(VectorMask<Float> mask) {
+        public Halffloat256Mask and(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat256Mask m = (Halffloat256Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Halffloat256Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Float512Mask or(VectorMask<Float> mask) {
+        public Halffloat256Mask or(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat256Mask m = (Halffloat256Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Halffloat256Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Float512Mask xor(VectorMask<Float> mask) {
+        public Halffloat256Mask xor(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat256Mask m = (Halffloat256Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Halffloat256Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
         }
@@ -731,21 +731,21 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Halffloat256Mask.class, short.class, VLENGTH, this,
                                                       (m) -> trueCountHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Halffloat256Mask.class, short.class, VLENGTH, this,
                                                       (m) -> firstTrueHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Halffloat256Mask.class, short.class, VLENGTH, this,
                                                       (m) -> lastTrueHelper(m.getBits()));
         }
 
@@ -755,7 +755,7 @@ final class Float512Vector extends FloatVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Float512Mask.class, int.class, VLENGTH, this,
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Halffloat256Mask.class, short.class, VLENGTH, this,
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
@@ -765,7 +765,7 @@ final class Float512Vector extends FloatVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Float512Mask.class, float.class, VLENGTH,
+            return VectorSupport.extract(Halffloat256Mask.class, Float16.class, VLENGTH,
                                          this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
         }
 
@@ -774,55 +774,55 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Float512Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_ne, Halffloat256Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Float512Mask)m).getBits()));
+                                         (m, __) -> anyTrueHelper(((Halffloat256Mask)m).getBits()));
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Float512Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, Halffloat256Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Float512Mask)m).getBits()));
+                                         (m, __) -> allTrueHelper(((Halffloat256Mask)m).getBits()));
         }
 
         @ForceInline
         /*package-private*/
-        static Float512Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Float512Mask.class, int.class, VLENGTH,
+        static Halffloat256Mask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(Halffloat256Mask.class, short.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Float512Mask  TRUE_MASK = new Float512Mask(true);
-        private static final Float512Mask FALSE_MASK = new Float512Mask(false);
+        private static final Halffloat256Mask  TRUE_MASK = new Halffloat256Mask(true);
+        private static final Halffloat256Mask FALSE_MASK = new Halffloat256Mask(false);
 
     }
 
     // Shuffle
 
-    static final class Float512Shuffle extends AbstractShuffle<Float> {
+    static final class Halffloat256Shuffle extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float512Shuffle(byte[] reorder) {
+        Halffloat256Shuffle(byte[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float512Shuffle(int[] reorder) {
+        public Halffloat256Shuffle(int[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float512Shuffle(int[] reorder, int i) {
+        public Halffloat256Shuffle(int[] reorder, int i) {
             super(VLENGTH, reorder, i);
         }
 
-        public Float512Shuffle(IntUnaryOperator fn) {
+        public Halffloat256Shuffle(IntUnaryOperator fn) {
             super(VLENGTH, fn);
         }
 
         @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             return VSPECIES;
         }
 
@@ -832,13 +832,13 @@ final class Float512Vector extends FloatVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Float512Shuffle IOTA = new Float512Shuffle(IDENTITY);
+        static final Halffloat256Shuffle IOTA = new Halffloat256Shuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Float512Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Float512Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Float512Vector)(((AbstractShuffle<Float>)(s)).toVectorTemplate())));
+        public Halffloat256Vector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Halffloat256Shuffle.class, this, VLENGTH,
+                                                    (s) -> ((Halffloat256Vector)(((AbstractShuffle<Float16>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -853,8 +853,8 @@ final class Float512Vector extends FloatVector {
 
         @ForceInline
         @Override
-        public Float512Shuffle rearrange(VectorShuffle<Float> shuffle) {
-            Float512Shuffle s = (Float512Shuffle) shuffle;
+        public Halffloat256Shuffle rearrange(VectorShuffle<Float16> shuffle) {
+            Halffloat256Shuffle s = (Halffloat256Shuffle) shuffle;
             byte[] reorder1 = reorder();
             byte[] reorder2 = s.reorder();
             byte[] r = new byte[reorder1.length];
@@ -862,7 +862,7 @@ final class Float512Vector extends FloatVector {
                 int ssi = reorder2[i];
                 r[i] = reorder1[ssi];  // throws on exceptional index
             }
-            return new Float512Shuffle(r);
+            return new Halffloat256Shuffle(r);
         }
     }
 
@@ -873,67 +873,55 @@ final class Float512Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset) {
+    HalffloatVector fromArray0(Float16[] a, int offset) {
         return super.fromArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromArray0Template(Float512Mask.class, a, offset, (Float512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromArray0Template(Halffloat256Mask.class, a, offset, (Halffloat256Mask) m, offsetInRange);  // specialize
     }
 
-    @ForceInline
-    @Override
-    final
-    FloatVector fromArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        return super.fromArray0Template(Float512Mask.class, a, offset, indexMap, mapOffset, (Float512Mask) m);
-    }
 
 
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset) {
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset) {
         return super.fromMemorySegment0Template(ms, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Float512Mask.class, ms, offset, (Float512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromMemorySegment0Template(Halffloat256Mask.class, ms, offset, (Halffloat256Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset) {
+    void intoArray0(Float16[] a, int offset) {
         super.intoArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float512Mask.class, a, offset, (Float512Mask) m);
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m) {
+        super.intoArray0Template(Halffloat256Mask.class, a, offset, (Halffloat256Mask) m);
     }
 
-    @ForceInline
-    @Override
-    final
-    void intoArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        super.intoArray0Template(Float512Mask.class, a, offset, indexMap, mapOffset, (Float512Mask) m);
-    }
 
 
     @ForceInline
     @Override
     final
-    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m) {
-        super.intoMemorySegment0Template(Float512Mask.class, ms, offset, (Float512Mask) m);
+    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m) {
+        super.intoMemorySegment0Template(Halffloat256Mask.class, ms, offset, (Halffloat256Mask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat512Vector.java
@@ -39,33 +39,33 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-final class Float512Vector extends FloatVector {
-    static final FloatSpecies VSPECIES =
-        (FloatSpecies) FloatVector.SPECIES_512;
+final class Halffloat512Vector extends HalffloatVector {
+    static final HalffloatSpecies VSPECIES =
+        (HalffloatSpecies) HalffloatVector.SPECIES_512;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Float512Vector> VCLASS = Float512Vector.class;
+    static final Class<Halffloat512Vector> VCLASS = Halffloat512Vector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
     static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
 
-    static final Class<Float> ETYPE = float.class; // used by the JVM
+    static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-    Float512Vector(float[] v) {
+    Halffloat512Vector(Float16[] v) {
         super(v);
     }
 
-    // For compatibility as Float512Vector::new,
+    // For compatibility as Halffloat512Vector::new,
     // stored into species.vectorFactory.
-    Float512Vector(Object v) {
-        this((float[]) v);
+    Halffloat512Vector(Object v) {
+        this((Float16[]) v);
     }
 
-    static final Float512Vector ZERO = new Float512Vector(new float[VLENGTH]);
-    static final Float512Vector IOTA = new Float512Vector(VSPECIES.iotaArray());
+    static final Halffloat512Vector ZERO = new Halffloat512Vector(new Float16[VLENGTH]);
+    static final Halffloat512Vector IOTA = new Halffloat512Vector(VSPECIES.iotaArray());
 
     static {
         // Warm up a few species caches.
@@ -79,7 +79,7 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    public FloatSpecies vspecies() {
+    public HalffloatSpecies vspecies() {
         // ISSUE:  This should probably be a @Stable
         // field inside AbstractVector, rather than
         // a megamorphic method.
@@ -88,11 +88,11 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     @Override
-    public final Class<Float> elementType() { return float.class; }
+    public final Class<Float16> elementType() { return Float16.class; }
 
     @ForceInline
     @Override
-    public final int elementSize() { return Float.SIZE; }
+    public final int elementSize() { return Float16.SIZE; }
 
     @ForceInline
     @Override
@@ -113,62 +113,62 @@ final class Float512Vector extends FloatVector {
     /*package-private*/
     @ForceInline
     final @Override
-    float[] vec() {
-        return (float[])getPayload();
+    Float16[] vec() {
+        return (Float16[])getPayload();
     }
 
     // Virtualized constructors
 
     @Override
     @ForceInline
-    public final Float512Vector broadcast(float e) {
-        return (Float512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat512Vector broadcast(Float16 e) {
+        return (Halffloat512Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Vector broadcast(long e) {
-        return (Float512Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat512Vector broadcast(long e) {
+        return (Halffloat512Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Float512Mask maskFromArray(boolean[] bits) {
-        return new Float512Mask(bits);
+    Halffloat512Mask maskFromArray(boolean[] bits) {
+        return new Halffloat512Mask(bits);
     }
 
     @Override
     @ForceInline
-    Float512Shuffle iotaShuffle() { return Float512Shuffle.IOTA; }
+    Halffloat512Shuffle iotaShuffle() { return Halffloat512Shuffle.IOTA; }
 
     @ForceInline
-    Float512Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    Halffloat512Shuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Float512Shuffle)VectorSupport.shuffleIota(ETYPE, Float512Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (Halffloat512Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat512Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Float512Shuffle)VectorSupport.shuffleIota(ETYPE, Float512Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (Halffloat512Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat512Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromBytes(byte[] reorder) { return new Float512Shuffle(reorder); }
+    Halffloat512Shuffle shuffleFromBytes(byte[] reorder) { return new Halffloat512Shuffle(reorder); }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromArray(int[] indexes, int i) { return new Float512Shuffle(indexes, i); }
+    Halffloat512Shuffle shuffleFromArray(int[] indexes, int i) { return new Halffloat512Shuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Float512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float512Shuffle(fn); }
+    Halffloat512Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Halffloat512Shuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Float512Vector vectorFactory(float[] vec) {
-        return new Float512Vector(vec);
+    Halffloat512Vector vectorFactory(Float16[] vec) {
+        return new Halffloat512Vector(vec);
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float512Vector uOp(FUnOp f) {
-        return (Float512Vector) super.uOpTemplate(f);  // specialize
+    Halffloat512Vector uOp(FUnOp f) {
+        return (Halffloat512Vector) super.uOpTemplate(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector uOp(VectorMask<Float> m, FUnOp f) {
-        return (Float512Vector)
-            super.uOpTemplate((Float512Mask)m, f);  // specialize
+    Halffloat512Vector uOp(VectorMask<Float16> m, FUnOp f) {
+        return (Halffloat512Vector)
+            super.uOpTemplate((Halffloat512Mask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Float512Vector bOp(Vector<Float> v, FBinOp f) {
-        return (Float512Vector) super.bOpTemplate((Float512Vector)v, f);  // specialize
+    Halffloat512Vector bOp(Vector<Float16> v, FBinOp f) {
+        return (Halffloat512Vector) super.bOpTemplate((Halffloat512Vector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector bOp(Vector<Float> v,
-                     VectorMask<Float> m, FBinOp f) {
-        return (Float512Vector)
-            super.bOpTemplate((Float512Vector)v, (Float512Mask)m,
+    Halffloat512Vector bOp(Vector<Float16> v,
+                     VectorMask<Float16> m, FBinOp f) {
+        return (Halffloat512Vector)
+            super.bOpTemplate((Halffloat512Vector)v, (Halffloat512Mask)m,
                               f);  // specialize
     }
 
@@ -219,31 +219,31 @@ final class Float512Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float512Vector tOp(Vector<Float> v1, Vector<Float> v2, FTriOp f) {
-        return (Float512Vector)
-            super.tOpTemplate((Float512Vector)v1, (Float512Vector)v2,
+    Halffloat512Vector tOp(Vector<Float16> v1, Vector<Float16> v2, FTriOp f) {
+        return (Halffloat512Vector)
+            super.tOpTemplate((Halffloat512Vector)v1, (Halffloat512Vector)v2,
                               f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float512Vector tOp(Vector<Float> v1, Vector<Float> v2,
-                     VectorMask<Float> m, FTriOp f) {
-        return (Float512Vector)
-            super.tOpTemplate((Float512Vector)v1, (Float512Vector)v2,
-                              (Float512Mask)m, f);  // specialize
+    Halffloat512Vector tOp(Vector<Float16> v1, Vector<Float16> v2,
+                     VectorMask<Float16> m, FTriOp f) {
+        return (Halffloat512Vector)
+            super.tOpTemplate((Halffloat512Vector)v1, (Halffloat512Vector)v2,
+                              (Halffloat512Mask)m, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    float rOp(float v, VectorMask<Float> m, FBinOp f) {
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f) {
         return super.rOpTemplate(v, m, f);  // specialize
     }
 
     @Override
     @ForceInline
     public final <F>
-    Vector<F> convertShape(VectorOperators.Conversion<Float,F> conv,
+    Vector<F> convertShape(VectorOperators.Conversion<Float16,F> conv,
                            VectorSpecies<F> rsp, int part) {
         return super.convertShapeTemplate(conv, rsp, part);  // specialize
     }
@@ -269,26 +269,26 @@ final class Float512Vector extends FloatVector {
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Unary op) {
-        return (Float512Vector) super.lanewiseTemplate(op);  // specialize
+    public Halffloat512Vector lanewise(Unary op) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Unary op, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialize
+    public Halffloat512Vector lanewise(Unary op, VectorMask<Float16> m) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op, Halffloat512Mask.class, (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Binary op, Vector<Float> v) {
-        return (Float512Vector) super.lanewiseTemplate(op, v);  // specialize
+    public Halffloat512Vector lanewise(Binary op, Vector<Float16> v) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector lanewise(Binary op, Vector<Float> v, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, v, (Float512Mask) m);  // specialize
+    public Halffloat512Vector lanewise(Binary op, Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op, Halffloat512Mask.class, v, (Halffloat512Mask) m);  // specialize
     }
 
 
@@ -296,210 +296,210 @@ final class Float512Vector extends FloatVector {
     @Override
     @ForceInline
     public final
-    Float512Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2) {
-        return (Float512Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+    Halffloat512Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float512Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2, VectorMask<Float> m) {
-        return (Float512Vector) super.lanewiseTemplate(op, Float512Mask.class, v1, v2, (Float512Mask) m);  // specialize
+    Halffloat512Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2, VectorMask<Float16> m) {
+        return (Halffloat512Vector) super.lanewiseTemplate(op, Halffloat512Mask.class, v1, v2, (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float512Vector addIndex(int scale) {
-        return (Float512Vector) super.addIndexTemplate(scale);  // specialize
+    Halffloat512Vector addIndex(int scale) {
+        return (Halffloat512Vector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op) {
+    public final Float16 reduceLanes(VectorOperators.Associative op) {
         return super.reduceLanesTemplate(op);  // specialized
     }
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op,
-                                    VectorMask<Float> m) {
-        return super.reduceLanesTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialized
+    public final Float16 reduceLanes(VectorOperators.Associative op,
+                                    VectorMask<Float16> m) {
+        return super.reduceLanesTemplate(op, Halffloat512Mask.class, (Halffloat512Mask) m);  // specialized
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        float res = super.reduceLanesTemplate(op);  // specialized
-        return  (long) res;
+        Float16 res = super.reduceLanesTemplate(op);  // specialized
+        return res.longValue();
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
-                                        VectorMask<Float> m) {
-        float res = super.reduceLanesTemplate(op, Float512Mask.class, (Float512Mask) m);  // specialized
-        return  (long) res;
+                                        VectorMask<Float16> m) {
+        Float16 res = super.reduceLanesTemplate(op, Halffloat512Mask.class, (Halffloat512Mask) m);  // specialized
+        return res.longValue();
     }
 
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
-        return super.toShuffleTemplate(Float512Shuffle.class); // specialize
+    public VectorShuffle<Float16> toShuffle() {
+        return super.toShuffleTemplate(Halffloat512Shuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Float512Mask test(Test op) {
-        return super.testTemplate(Float512Mask.class, op);  // specialize
+    public final Halffloat512Mask test(Test op) {
+        return super.testTemplate(Halffloat512Mask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask test(Test op, VectorMask<Float> m) {
-        return super.testTemplate(Float512Mask.class, op, (Float512Mask) m);  // specialize
+    public final Halffloat512Mask test(Test op, VectorMask<Float16> m) {
+        return super.testTemplate(Halffloat512Mask.class, op, (Halffloat512Mask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, Vector<Float> v) {
-        return super.compareTemplate(Float512Mask.class, op, v);  // specialize
+    public final Halffloat512Mask compare(Comparison op, Vector<Float16> v) {
+        return super.compareTemplate(Halffloat512Mask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, float s) {
-        return super.compareTemplate(Float512Mask.class, op, s);  // specialize
+    public final Halffloat512Mask compare(Comparison op, Float16 s) {
+        return super.compareTemplate(Halffloat512Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Float512Mask.class, op, s);  // specialize
+    public final Halffloat512Mask compare(Comparison op, long s) {
+        return super.compareTemplate(Halffloat512Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float512Mask compare(Comparison op, Vector<Float> v, VectorMask<Float> m) {
-        return super.compareTemplate(Float512Mask.class, op, v, (Float512Mask) m);
+    public final Halffloat512Mask compare(Comparison op, Vector<Float16> v, VectorMask<Float16> m) {
+        return super.compareTemplate(Halffloat512Mask.class, op, v, (Halffloat512Mask) m);
     }
 
 
     @Override
     @ForceInline
-    public Float512Vector blend(Vector<Float> v, VectorMask<Float> m) {
-        return (Float512Vector)
-            super.blendTemplate(Float512Mask.class,
-                                (Float512Vector) v,
-                                (Float512Mask) m);  // specialize
+    public Halffloat512Vector blend(Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.blendTemplate(Halffloat512Mask.class,
+                                (Halffloat512Vector) v,
+                                (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector slice(int origin, Vector<Float> v) {
-        return (Float512Vector) super.sliceTemplate(origin, v);  // specialize
+    public Halffloat512Vector slice(int origin, Vector<Float16> v) {
+        return (Halffloat512Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector slice(int origin) {
-        return (Float512Vector) super.sliceTemplate(origin);  // specialize
+    public Halffloat512Vector slice(int origin) {
+        return (Halffloat512Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float512Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public Halffloat512Vector unslice(int origin, Vector<Float16> w, int part) {
+        return (Halffloat512Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m) {
-        return (Float512Vector)
-            super.unsliceTemplate(Float512Mask.class,
+    public Halffloat512Vector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.unsliceTemplate(Halffloat512Mask.class,
                                   origin, w, part,
-                                  (Float512Mask) m);  // specialize
+                                  (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector unslice(int origin) {
-        return (Float512Vector) super.unsliceTemplate(origin);  // specialize
+    public Halffloat512Vector unslice(int origin) {
+        return (Halffloat512Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> s) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    (Float512Shuffle) s);  // specialize
+    public Halffloat512Vector rearrange(VectorShuffle<Float16> s) {
+        return (Halffloat512Vector)
+            super.rearrangeTemplate(Halffloat512Shuffle.class,
+                                    (Halffloat512Shuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> shuffle,
-                                  VectorMask<Float> m) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    Float512Mask.class,
-                                    (Float512Shuffle) shuffle,
-                                    (Float512Mask) m);  // specialize
+    public Halffloat512Vector rearrange(VectorShuffle<Float16> shuffle,
+                                  VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.rearrangeTemplate(Halffloat512Shuffle.class,
+                                    Halffloat512Mask.class,
+                                    (Halffloat512Shuffle) shuffle,
+                                    (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector rearrange(VectorShuffle<Float> s,
-                                  Vector<Float> v) {
-        return (Float512Vector)
-            super.rearrangeTemplate(Float512Shuffle.class,
-                                    (Float512Shuffle) s,
-                                    (Float512Vector) v);  // specialize
+    public Halffloat512Vector rearrange(VectorShuffle<Float16> s,
+                                  Vector<Float16> v) {
+        return (Halffloat512Vector)
+            super.rearrangeTemplate(Halffloat512Shuffle.class,
+                                    (Halffloat512Shuffle) s,
+                                    (Halffloat512Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector compress(VectorMask<Float> m) {
-        return (Float512Vector)
-            super.compressTemplate(Float512Mask.class,
-                                   (Float512Mask) m);  // specialize
+    public Halffloat512Vector compress(VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.compressTemplate(Halffloat512Mask.class,
+                                   (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector expand(VectorMask<Float> m) {
-        return (Float512Vector)
-            super.expandTemplate(Float512Mask.class,
-                                   (Float512Mask) m);  // specialize
+    public Halffloat512Vector expand(VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.expandTemplate(Halffloat512Mask.class,
+                                   (Halffloat512Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector selectFrom(Vector<Float> v) {
-        return (Float512Vector)
-            super.selectFromTemplate((Float512Vector) v);  // specialize
+    public Halffloat512Vector selectFrom(Vector<Float16> v) {
+        return (Halffloat512Vector)
+            super.selectFromTemplate((Halffloat512Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float512Vector selectFrom(Vector<Float> v,
-                                   VectorMask<Float> m) {
-        return (Float512Vector)
-            super.selectFromTemplate((Float512Vector) v,
-                                     (Float512Mask) m);  // specialize
+    public Halffloat512Vector selectFrom(Vector<Float16> v,
+                                   VectorMask<Float16> m) {
+        return (Halffloat512Vector)
+            super.selectFromTemplate((Halffloat512Vector) v,
+                                     (Halffloat512Mask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
-    public float lane(int i) {
-        int bits;
+    public Float16 lane(int i) {
+        short bits;
         switch(i) {
             case 0: bits = laneHelper(0); break;
             case 1: bits = laneHelper(1); break;
@@ -519,22 +519,22 @@ final class Float512Vector extends FloatVector {
             case 15: bits = laneHelper(15); break;
             default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
-        return Float.intBitsToFloat(bits);
+        return Float16.shortBitsToFloat16(bits);
     }
 
-    public int laneHelper(int i) {
-        return (int) VectorSupport.extract(
+    public short laneHelper(int i) {
+        return (short) VectorSupport.extract(
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                     float[] vecarr = vec.vec();
-                     return (long)Float.floatToIntBits(vecarr[ix]);
+                     Float16[] vecarr = vec.vec();
+                     return (long)Float16.float16ToShortBits(vecarr[ix]);
                      });
     }
 
     @ForceInline
     @Override
-    public Float512Vector withLane(int i, float e) {
+    public Halffloat512Vector withLane(int i, Float16 e) {
         switch(i) {
             case 0: return withLaneHelper(0, e);
             case 1: return withLaneHelper(1, e);
@@ -556,32 +556,32 @@ final class Float512Vector extends FloatVector {
         }
     }
 
-    public Float512Vector withLaneHelper(int i, float e) {
+    public Halffloat512Vector withLaneHelper(int i, Float16 e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
-                                this, i, (long)Float.floatToIntBits(e),
+                                this, i, (long)Float16.float16ToShortBits(e),
                                 (v, ix, bits) -> {
-                                    float[] res = v.vec().clone();
-                                    res[ix] = Float.intBitsToFloat((int)bits);
+                                    Float16[] res = v.vec().clone();
+                                    res[ix] = Float16.shortBitsToFloat16((short)bits);
                                     return v.vectorFactory(res);
                                 });
     }
 
     // Mask
 
-    static final class Float512Mask extends AbstractMask<Float> {
+    static final class Halffloat512Mask extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float512Mask(boolean[] bits) {
+        Halffloat512Mask(boolean[] bits) {
             this(bits, 0);
         }
 
-        Float512Mask(boolean[] bits, int offset) {
+        Halffloat512Mask(boolean[] bits, int offset) {
             super(prepare(bits, offset));
         }
 
-        Float512Mask(boolean val) {
+        Halffloat512Mask(boolean val) {
             super(prepare(val));
         }
 
@@ -601,7 +601,7 @@ final class Float512Vector extends FloatVector {
 
         @ForceInline
         final @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             // ISSUE:  This should probably be a @Stable
             // field inside AbstractMask, rather than
             // a megamorphic method.
@@ -614,31 +614,31 @@ final class Float512Vector extends FloatVector {
         }
 
         @Override
-        Float512Mask uOp(MUnOp f) {
+        Halffloat512Mask uOp(MUnOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i]);
             }
-            return new Float512Mask(res);
+            return new Halffloat512Mask(res);
         }
 
         @Override
-        Float512Mask bOp(VectorMask<Float> m, MBinOp f) {
+        Halffloat512Mask bOp(VectorMask<Float16> m, MBinOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
-            boolean[] mbits = ((Float512Mask)m).getBits();
+            boolean[] mbits = ((Halffloat512Mask)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i], mbits[i]);
             }
-            return new Float512Mask(res);
+            return new Halffloat512Mask(res);
         }
 
         @ForceInline
         @Override
         public final
-        Float512Vector toVector() {
-            return (Float512Vector) super.toVectorTemplate();  // specialize
+        Halffloat512Vector toVector() {
+            return (Halffloat512Vector) super.toVectorTemplate();  // specialize
         }
 
         /**
@@ -671,26 +671,26 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float512Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Float512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float512Mask.class, ETYPE, VLENGTH, offset, limit,
-                (o, l) -> (Float512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        Halffloat512Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Halffloat512Mask) VectorSupport.indexPartiallyInUpperRange(
+                Halffloat512Mask.class, ETYPE, VLENGTH, offset, limit,
+                (o, l) -> (Halffloat512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Float512Mask not() {
+        public Halffloat512Mask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Float512Mask compress() {
-            return (Float512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Float512Vector.class, Float512Mask.class, ETYPE, VLENGTH, null, this,
-                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
+        public Halffloat512Mask compress() {
+            return (Halffloat512Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                Halffloat512Vector.class, Halffloat512Mask.class, ETYPE, VLENGTH, null, this,
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
         }
 
 
@@ -698,30 +698,30 @@ final class Float512Vector extends FloatVector {
 
         @Override
         @ForceInline
-        public Float512Mask and(VectorMask<Float> mask) {
+        public Halffloat512Mask and(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat512Mask m = (Halffloat512Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Halffloat512Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Float512Mask or(VectorMask<Float> mask) {
+        public Halffloat512Mask or(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat512Mask m = (Halffloat512Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Halffloat512Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Float512Mask xor(VectorMask<Float> mask) {
+        public Halffloat512Mask xor(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float512Mask m = (Float512Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float512Mask.class, null, int.class, VLENGTH,
+            Halffloat512Mask m = (Halffloat512Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Halffloat512Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
         }
@@ -731,21 +731,21 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Halffloat512Mask.class, short.class, VLENGTH, this,
                                                       (m) -> trueCountHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Halffloat512Mask.class, short.class, VLENGTH, this,
                                                       (m) -> firstTrueHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Float512Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Halffloat512Mask.class, short.class, VLENGTH, this,
                                                       (m) -> lastTrueHelper(m.getBits()));
         }
 
@@ -755,7 +755,7 @@ final class Float512Vector extends FloatVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Float512Mask.class, int.class, VLENGTH, this,
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Halffloat512Mask.class, short.class, VLENGTH, this,
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
@@ -765,7 +765,7 @@ final class Float512Vector extends FloatVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Float512Mask.class, float.class, VLENGTH,
+            return VectorSupport.extract(Halffloat512Mask.class, Float16.class, VLENGTH,
                                          this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
         }
 
@@ -774,55 +774,55 @@ final class Float512Vector extends FloatVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Float512Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_ne, Halffloat512Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Float512Mask)m).getBits()));
+                                         (m, __) -> anyTrueHelper(((Halffloat512Mask)m).getBits()));
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Float512Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, Halffloat512Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Float512Mask)m).getBits()));
+                                         (m, __) -> allTrueHelper(((Halffloat512Mask)m).getBits()));
         }
 
         @ForceInline
         /*package-private*/
-        static Float512Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Float512Mask.class, int.class, VLENGTH,
+        static Halffloat512Mask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(Halffloat512Mask.class, short.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Float512Mask  TRUE_MASK = new Float512Mask(true);
-        private static final Float512Mask FALSE_MASK = new Float512Mask(false);
+        private static final Halffloat512Mask  TRUE_MASK = new Halffloat512Mask(true);
+        private static final Halffloat512Mask FALSE_MASK = new Halffloat512Mask(false);
 
     }
 
     // Shuffle
 
-    static final class Float512Shuffle extends AbstractShuffle<Float> {
+    static final class Halffloat512Shuffle extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float512Shuffle(byte[] reorder) {
+        Halffloat512Shuffle(byte[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float512Shuffle(int[] reorder) {
+        public Halffloat512Shuffle(int[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float512Shuffle(int[] reorder, int i) {
+        public Halffloat512Shuffle(int[] reorder, int i) {
             super(VLENGTH, reorder, i);
         }
 
-        public Float512Shuffle(IntUnaryOperator fn) {
+        public Halffloat512Shuffle(IntUnaryOperator fn) {
             super(VLENGTH, fn);
         }
 
         @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             return VSPECIES;
         }
 
@@ -832,13 +832,13 @@ final class Float512Vector extends FloatVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Float512Shuffle IOTA = new Float512Shuffle(IDENTITY);
+        static final Halffloat512Shuffle IOTA = new Halffloat512Shuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Float512Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Float512Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Float512Vector)(((AbstractShuffle<Float>)(s)).toVectorTemplate())));
+        public Halffloat512Vector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Halffloat512Shuffle.class, this, VLENGTH,
+                                                    (s) -> ((Halffloat512Vector)(((AbstractShuffle<Float16>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -853,8 +853,8 @@ final class Float512Vector extends FloatVector {
 
         @ForceInline
         @Override
-        public Float512Shuffle rearrange(VectorShuffle<Float> shuffle) {
-            Float512Shuffle s = (Float512Shuffle) shuffle;
+        public Halffloat512Shuffle rearrange(VectorShuffle<Float16> shuffle) {
+            Halffloat512Shuffle s = (Halffloat512Shuffle) shuffle;
             byte[] reorder1 = reorder();
             byte[] reorder2 = s.reorder();
             byte[] r = new byte[reorder1.length];
@@ -862,7 +862,7 @@ final class Float512Vector extends FloatVector {
                 int ssi = reorder2[i];
                 r[i] = reorder1[ssi];  // throws on exceptional index
             }
-            return new Float512Shuffle(r);
+            return new Halffloat512Shuffle(r);
         }
     }
 
@@ -873,67 +873,55 @@ final class Float512Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset) {
+    HalffloatVector fromArray0(Float16[] a, int offset) {
         return super.fromArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromArray0Template(Float512Mask.class, a, offset, (Float512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromArray0Template(Halffloat512Mask.class, a, offset, (Halffloat512Mask) m, offsetInRange);  // specialize
     }
 
-    @ForceInline
-    @Override
-    final
-    FloatVector fromArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        return super.fromArray0Template(Float512Mask.class, a, offset, indexMap, mapOffset, (Float512Mask) m);
-    }
 
 
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset) {
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset) {
         return super.fromMemorySegment0Template(ms, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Float512Mask.class, ms, offset, (Float512Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromMemorySegment0Template(Halffloat512Mask.class, ms, offset, (Halffloat512Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset) {
+    void intoArray0(Float16[] a, int offset) {
         super.intoArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float512Mask.class, a, offset, (Float512Mask) m);
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m) {
+        super.intoArray0Template(Halffloat512Mask.class, a, offset, (Halffloat512Mask) m);
     }
 
-    @ForceInline
-    @Override
-    final
-    void intoArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        super.intoArray0Template(Float512Mask.class, a, offset, indexMap, mapOffset, (Float512Mask) m);
-    }
 
 
     @ForceInline
     @Override
     final
-    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m) {
-        super.intoMemorySegment0Template(Float512Mask.class, ms, offset, (Float512Mask) m);
+    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m) {
+        super.intoMemorySegment0Template(Halffloat512Mask.class, ms, offset, (Halffloat512Mask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Halffloat64Vector.java
@@ -39,33 +39,33 @@ import static jdk.incubator.vector.VectorOperators.*;
 // -- This file was mechanically generated: Do not edit! -- //
 
 @SuppressWarnings("cast")  // warning: redundant cast
-final class Float128Vector extends FloatVector {
-    static final FloatSpecies VSPECIES =
-        (FloatSpecies) FloatVector.SPECIES_128;
+final class Halffloat64Vector extends HalffloatVector {
+    static final HalffloatSpecies VSPECIES =
+        (HalffloatSpecies) HalffloatVector.SPECIES_64;
 
     static final VectorShape VSHAPE =
         VSPECIES.vectorShape();
 
-    static final Class<Float128Vector> VCLASS = Float128Vector.class;
+    static final Class<Halffloat64Vector> VCLASS = Halffloat64Vector.class;
 
     static final int VSIZE = VSPECIES.vectorBitSize();
 
     static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
 
-    static final Class<Float> ETYPE = float.class; // used by the JVM
+    static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-    Float128Vector(float[] v) {
+    Halffloat64Vector(Float16[] v) {
         super(v);
     }
 
-    // For compatibility as Float128Vector::new,
+    // For compatibility as Halffloat64Vector::new,
     // stored into species.vectorFactory.
-    Float128Vector(Object v) {
-        this((float[]) v);
+    Halffloat64Vector(Object v) {
+        this((Float16[]) v);
     }
 
-    static final Float128Vector ZERO = new Float128Vector(new float[VLENGTH]);
-    static final Float128Vector IOTA = new Float128Vector(VSPECIES.iotaArray());
+    static final Halffloat64Vector ZERO = new Halffloat64Vector(new Float16[VLENGTH]);
+    static final Halffloat64Vector IOTA = new Halffloat64Vector(VSPECIES.iotaArray());
 
     static {
         // Warm up a few species caches.
@@ -79,7 +79,7 @@ final class Float128Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    public FloatSpecies vspecies() {
+    public HalffloatSpecies vspecies() {
         // ISSUE:  This should probably be a @Stable
         // field inside AbstractVector, rather than
         // a megamorphic method.
@@ -88,11 +88,11 @@ final class Float128Vector extends FloatVector {
 
     @ForceInline
     @Override
-    public final Class<Float> elementType() { return float.class; }
+    public final Class<Float16> elementType() { return Float16.class; }
 
     @ForceInline
     @Override
-    public final int elementSize() { return Float.SIZE; }
+    public final int elementSize() { return Float16.SIZE; }
 
     @ForceInline
     @Override
@@ -113,68 +113,68 @@ final class Float128Vector extends FloatVector {
     /*package-private*/
     @ForceInline
     final @Override
-    float[] vec() {
-        return (float[])getPayload();
+    Float16[] vec() {
+        return (Float16[])getPayload();
     }
 
     // Virtualized constructors
 
     @Override
     @ForceInline
-    public final Float128Vector broadcast(float e) {
-        return (Float128Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat64Vector broadcast(Float16 e) {
+        return (Halffloat64Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float128Vector broadcast(long e) {
-        return (Float128Vector) super.broadcastTemplate(e);  // specialize
+    public final Halffloat64Vector broadcast(long e) {
+        return (Halffloat64Vector) super.broadcastTemplate(e);  // specialize
     }
 
     @Override
     @ForceInline
-    Float128Mask maskFromArray(boolean[] bits) {
-        return new Float128Mask(bits);
+    Halffloat64Mask maskFromArray(boolean[] bits) {
+        return new Halffloat64Mask(bits);
     }
 
     @Override
     @ForceInline
-    Float128Shuffle iotaShuffle() { return Float128Shuffle.IOTA; }
+    Halffloat64Shuffle iotaShuffle() { return Halffloat64Shuffle.IOTA; }
 
     @ForceInline
-    Float128Shuffle iotaShuffle(int start, int step, boolean wrap) {
+    Halffloat64Shuffle iotaShuffle(int start, int step, boolean wrap) {
       if (wrap) {
-        return (Float128Shuffle)VectorSupport.shuffleIota(ETYPE, Float128Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
+        return (Halffloat64Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat64Shuffle.class, VSPECIES, VLENGTH, start, step, 1,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
       } else {
-        return (Float128Shuffle)VectorSupport.shuffleIota(ETYPE, Float128Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
+        return (Halffloat64Shuffle)VectorSupport.shuffleIota(ETYPE, Halffloat64Shuffle.class, VSPECIES, VLENGTH, start, step, 0,
                 (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
       }
     }
 
     @Override
     @ForceInline
-    Float128Shuffle shuffleFromBytes(byte[] reorder) { return new Float128Shuffle(reorder); }
+    Halffloat64Shuffle shuffleFromBytes(byte[] reorder) { return new Halffloat64Shuffle(reorder); }
 
     @Override
     @ForceInline
-    Float128Shuffle shuffleFromArray(int[] indexes, int i) { return new Float128Shuffle(indexes, i); }
+    Halffloat64Shuffle shuffleFromArray(int[] indexes, int i) { return new Halffloat64Shuffle(indexes, i); }
 
     @Override
     @ForceInline
-    Float128Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Float128Shuffle(fn); }
+    Halffloat64Shuffle shuffleFromOp(IntUnaryOperator fn) { return new Halffloat64Shuffle(fn); }
 
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    Float128Vector vectorFactory(float[] vec) {
-        return new Float128Vector(vec);
+    Halffloat64Vector vectorFactory(Float16[] vec) {
+        return new Halffloat64Vector(vec);
     }
 
     @ForceInline
     final @Override
-    Byte128Vector asByteVectorRaw() {
-        return (Byte128Vector) super.asByteVectorRawTemplate();  // specialize
+    Byte64Vector asByteVectorRaw() {
+        return (Byte64Vector) super.asByteVectorRawTemplate();  // specialize
     }
 
     @ForceInline
@@ -187,31 +187,31 @@ final class Float128Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float128Vector uOp(FUnOp f) {
-        return (Float128Vector) super.uOpTemplate(f);  // specialize
+    Halffloat64Vector uOp(FUnOp f) {
+        return (Halffloat64Vector) super.uOpTemplate(f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float128Vector uOp(VectorMask<Float> m, FUnOp f) {
-        return (Float128Vector)
-            super.uOpTemplate((Float128Mask)m, f);  // specialize
+    Halffloat64Vector uOp(VectorMask<Float16> m, FUnOp f) {
+        return (Halffloat64Vector)
+            super.uOpTemplate((Halffloat64Mask)m, f);  // specialize
     }
 
     // Binary operator
 
     @ForceInline
     final @Override
-    Float128Vector bOp(Vector<Float> v, FBinOp f) {
-        return (Float128Vector) super.bOpTemplate((Float128Vector)v, f);  // specialize
+    Halffloat64Vector bOp(Vector<Float16> v, FBinOp f) {
+        return (Halffloat64Vector) super.bOpTemplate((Halffloat64Vector)v, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float128Vector bOp(Vector<Float> v,
-                     VectorMask<Float> m, FBinOp f) {
-        return (Float128Vector)
-            super.bOpTemplate((Float128Vector)v, (Float128Mask)m,
+    Halffloat64Vector bOp(Vector<Float16> v,
+                     VectorMask<Float16> m, FBinOp f) {
+        return (Halffloat64Vector)
+            super.bOpTemplate((Halffloat64Vector)v, (Halffloat64Mask)m,
                               f);  // specialize
     }
 
@@ -219,31 +219,31 @@ final class Float128Vector extends FloatVector {
 
     @ForceInline
     final @Override
-    Float128Vector tOp(Vector<Float> v1, Vector<Float> v2, FTriOp f) {
-        return (Float128Vector)
-            super.tOpTemplate((Float128Vector)v1, (Float128Vector)v2,
+    Halffloat64Vector tOp(Vector<Float16> v1, Vector<Float16> v2, FTriOp f) {
+        return (Halffloat64Vector)
+            super.tOpTemplate((Halffloat64Vector)v1, (Halffloat64Vector)v2,
                               f);  // specialize
     }
 
     @ForceInline
     final @Override
-    Float128Vector tOp(Vector<Float> v1, Vector<Float> v2,
-                     VectorMask<Float> m, FTriOp f) {
-        return (Float128Vector)
-            super.tOpTemplate((Float128Vector)v1, (Float128Vector)v2,
-                              (Float128Mask)m, f);  // specialize
+    Halffloat64Vector tOp(Vector<Float16> v1, Vector<Float16> v2,
+                     VectorMask<Float16> m, FTriOp f) {
+        return (Halffloat64Vector)
+            super.tOpTemplate((Halffloat64Vector)v1, (Halffloat64Vector)v2,
+                              (Halffloat64Mask)m, f);  // specialize
     }
 
     @ForceInline
     final @Override
-    float rOp(float v, VectorMask<Float> m, FBinOp f) {
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f) {
         return super.rOpTemplate(v, m, f);  // specialize
     }
 
     @Override
     @ForceInline
     public final <F>
-    Vector<F> convertShape(VectorOperators.Conversion<Float,F> conv,
+    Vector<F> convertShape(VectorOperators.Conversion<Float16,F> conv,
                            VectorSpecies<F> rsp, int part) {
         return super.convertShapeTemplate(conv, rsp, part);  // specialize
     }
@@ -269,26 +269,26 @@ final class Float128Vector extends FloatVector {
 
     @Override
     @ForceInline
-    public Float128Vector lanewise(Unary op) {
-        return (Float128Vector) super.lanewiseTemplate(op);  // specialize
+    public Halffloat64Vector lanewise(Unary op) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector lanewise(Unary op, VectorMask<Float> m) {
-        return (Float128Vector) super.lanewiseTemplate(op, Float128Mask.class, (Float128Mask) m);  // specialize
+    public Halffloat64Vector lanewise(Unary op, VectorMask<Float16> m) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op, Halffloat64Mask.class, (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector lanewise(Binary op, Vector<Float> v) {
-        return (Float128Vector) super.lanewiseTemplate(op, v);  // specialize
+    public Halffloat64Vector lanewise(Binary op, Vector<Float16> v) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector lanewise(Binary op, Vector<Float> v, VectorMask<Float> m) {
-        return (Float128Vector) super.lanewiseTemplate(op, Float128Mask.class, v, (Float128Mask) m);  // specialize
+    public Halffloat64Vector lanewise(Binary op, Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op, Halffloat64Mask.class, v, (Halffloat64Mask) m);  // specialize
     }
 
 
@@ -296,210 +296,210 @@ final class Float128Vector extends FloatVector {
     @Override
     @ForceInline
     public final
-    Float128Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2) {
-        return (Float128Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
+    Halffloat64Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op, v1, v2);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float128Vector
-    lanewise(Ternary op, Vector<Float> v1, Vector<Float> v2, VectorMask<Float> m) {
-        return (Float128Vector) super.lanewiseTemplate(op, Float128Mask.class, v1, v2, (Float128Mask) m);  // specialize
+    Halffloat64Vector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2, VectorMask<Float16> m) {
+        return (Halffloat64Vector) super.lanewiseTemplate(op, Halffloat64Mask.class, v1, v2, (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
     public final
-    Float128Vector addIndex(int scale) {
-        return (Float128Vector) super.addIndexTemplate(scale);  // specialize
+    Halffloat64Vector addIndex(int scale) {
+        return (Halffloat64Vector) super.addIndexTemplate(scale);  // specialize
     }
 
     // Type specific horizontal reductions
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op) {
+    public final Float16 reduceLanes(VectorOperators.Associative op) {
         return super.reduceLanesTemplate(op);  // specialized
     }
 
     @Override
     @ForceInline
-    public final float reduceLanes(VectorOperators.Associative op,
-                                    VectorMask<Float> m) {
-        return super.reduceLanesTemplate(op, Float128Mask.class, (Float128Mask) m);  // specialized
+    public final Float16 reduceLanes(VectorOperators.Associative op,
+                                    VectorMask<Float16> m) {
+        return super.reduceLanesTemplate(op, Halffloat64Mask.class, (Halffloat64Mask) m);  // specialized
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        float res = super.reduceLanesTemplate(op);  // specialized
-        return  (long) res;
+        Float16 res = super.reduceLanesTemplate(op);  // specialized
+        return res.longValue();
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
-                                        VectorMask<Float> m) {
-        float res = super.reduceLanesTemplate(op, Float128Mask.class, (Float128Mask) m);  // specialized
-        return  (long) res;
+                                        VectorMask<Float16> m) {
+        Float16 res = super.reduceLanesTemplate(op, Halffloat64Mask.class, (Halffloat64Mask) m);  // specialized
+        return res.longValue();
     }
 
     @ForceInline
-    public VectorShuffle<Float> toShuffle() {
-        return super.toShuffleTemplate(Float128Shuffle.class); // specialize
+    public VectorShuffle<Float16> toShuffle() {
+        return super.toShuffleTemplate(Halffloat64Shuffle.class); // specialize
     }
 
     // Specialized unary testing
 
     @Override
     @ForceInline
-    public final Float128Mask test(Test op) {
-        return super.testTemplate(Float128Mask.class, op);  // specialize
+    public final Halffloat64Mask test(Test op) {
+        return super.testTemplate(Halffloat64Mask.class, op);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float128Mask test(Test op, VectorMask<Float> m) {
-        return super.testTemplate(Float128Mask.class, op, (Float128Mask) m);  // specialize
+    public final Halffloat64Mask test(Test op, VectorMask<Float16> m) {
+        return super.testTemplate(Halffloat64Mask.class, op, (Halffloat64Mask) m);  // specialize
     }
 
     // Specialized comparisons
 
     @Override
     @ForceInline
-    public final Float128Mask compare(Comparison op, Vector<Float> v) {
-        return super.compareTemplate(Float128Mask.class, op, v);  // specialize
+    public final Halffloat64Mask compare(Comparison op, Vector<Float16> v) {
+        return super.compareTemplate(Halffloat64Mask.class, op, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float128Mask compare(Comparison op, float s) {
-        return super.compareTemplate(Float128Mask.class, op, s);  // specialize
+    public final Halffloat64Mask compare(Comparison op, Float16 s) {
+        return super.compareTemplate(Halffloat64Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float128Mask compare(Comparison op, long s) {
-        return super.compareTemplate(Float128Mask.class, op, s);  // specialize
+    public final Halffloat64Mask compare(Comparison op, long s) {
+        return super.compareTemplate(Halffloat64Mask.class, op, s);  // specialize
     }
 
     @Override
     @ForceInline
-    public final Float128Mask compare(Comparison op, Vector<Float> v, VectorMask<Float> m) {
-        return super.compareTemplate(Float128Mask.class, op, v, (Float128Mask) m);
+    public final Halffloat64Mask compare(Comparison op, Vector<Float16> v, VectorMask<Float16> m) {
+        return super.compareTemplate(Halffloat64Mask.class, op, v, (Halffloat64Mask) m);
     }
 
 
     @Override
     @ForceInline
-    public Float128Vector blend(Vector<Float> v, VectorMask<Float> m) {
-        return (Float128Vector)
-            super.blendTemplate(Float128Mask.class,
-                                (Float128Vector) v,
-                                (Float128Mask) m);  // specialize
+    public Halffloat64Vector blend(Vector<Float16> v, VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.blendTemplate(Halffloat64Mask.class,
+                                (Halffloat64Vector) v,
+                                (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector slice(int origin, Vector<Float> v) {
-        return (Float128Vector) super.sliceTemplate(origin, v);  // specialize
+    public Halffloat64Vector slice(int origin, Vector<Float16> v) {
+        return (Halffloat64Vector) super.sliceTemplate(origin, v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector slice(int origin) {
-        return (Float128Vector) super.sliceTemplate(origin);  // specialize
+    public Halffloat64Vector slice(int origin) {
+        return (Halffloat64Vector) super.sliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector unslice(int origin, Vector<Float> w, int part) {
-        return (Float128Vector) super.unsliceTemplate(origin, w, part);  // specialize
+    public Halffloat64Vector unslice(int origin, Vector<Float16> w, int part) {
+        return (Halffloat64Vector) super.unsliceTemplate(origin, w, part);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m) {
-        return (Float128Vector)
-            super.unsliceTemplate(Float128Mask.class,
+    public Halffloat64Vector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.unsliceTemplate(Halffloat64Mask.class,
                                   origin, w, part,
-                                  (Float128Mask) m);  // specialize
+                                  (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector unslice(int origin) {
-        return (Float128Vector) super.unsliceTemplate(origin);  // specialize
+    public Halffloat64Vector unslice(int origin) {
+        return (Halffloat64Vector) super.unsliceTemplate(origin);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector rearrange(VectorShuffle<Float> s) {
-        return (Float128Vector)
-            super.rearrangeTemplate(Float128Shuffle.class,
-                                    (Float128Shuffle) s);  // specialize
+    public Halffloat64Vector rearrange(VectorShuffle<Float16> s) {
+        return (Halffloat64Vector)
+            super.rearrangeTemplate(Halffloat64Shuffle.class,
+                                    (Halffloat64Shuffle) s);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector rearrange(VectorShuffle<Float> shuffle,
-                                  VectorMask<Float> m) {
-        return (Float128Vector)
-            super.rearrangeTemplate(Float128Shuffle.class,
-                                    Float128Mask.class,
-                                    (Float128Shuffle) shuffle,
-                                    (Float128Mask) m);  // specialize
+    public Halffloat64Vector rearrange(VectorShuffle<Float16> shuffle,
+                                  VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.rearrangeTemplate(Halffloat64Shuffle.class,
+                                    Halffloat64Mask.class,
+                                    (Halffloat64Shuffle) shuffle,
+                                    (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector rearrange(VectorShuffle<Float> s,
-                                  Vector<Float> v) {
-        return (Float128Vector)
-            super.rearrangeTemplate(Float128Shuffle.class,
-                                    (Float128Shuffle) s,
-                                    (Float128Vector) v);  // specialize
+    public Halffloat64Vector rearrange(VectorShuffle<Float16> s,
+                                  Vector<Float16> v) {
+        return (Halffloat64Vector)
+            super.rearrangeTemplate(Halffloat64Shuffle.class,
+                                    (Halffloat64Shuffle) s,
+                                    (Halffloat64Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector compress(VectorMask<Float> m) {
-        return (Float128Vector)
-            super.compressTemplate(Float128Mask.class,
-                                   (Float128Mask) m);  // specialize
+    public Halffloat64Vector compress(VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.compressTemplate(Halffloat64Mask.class,
+                                   (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector expand(VectorMask<Float> m) {
-        return (Float128Vector)
-            super.expandTemplate(Float128Mask.class,
-                                   (Float128Mask) m);  // specialize
+    public Halffloat64Vector expand(VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.expandTemplate(Halffloat64Mask.class,
+                                   (Halffloat64Mask) m);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector selectFrom(Vector<Float> v) {
-        return (Float128Vector)
-            super.selectFromTemplate((Float128Vector) v);  // specialize
+    public Halffloat64Vector selectFrom(Vector<Float16> v) {
+        return (Halffloat64Vector)
+            super.selectFromTemplate((Halffloat64Vector) v);  // specialize
     }
 
     @Override
     @ForceInline
-    public Float128Vector selectFrom(Vector<Float> v,
-                                   VectorMask<Float> m) {
-        return (Float128Vector)
-            super.selectFromTemplate((Float128Vector) v,
-                                     (Float128Mask) m);  // specialize
+    public Halffloat64Vector selectFrom(Vector<Float16> v,
+                                   VectorMask<Float16> m) {
+        return (Halffloat64Vector)
+            super.selectFromTemplate((Halffloat64Vector) v,
+                                     (Halffloat64Mask) m);  // specialize
     }
 
 
     @ForceInline
     @Override
-    public float lane(int i) {
-        int bits;
+    public Float16 lane(int i) {
+        short bits;
         switch(i) {
             case 0: bits = laneHelper(0); break;
             case 1: bits = laneHelper(1); break;
@@ -507,22 +507,22 @@ final class Float128Vector extends FloatVector {
             case 3: bits = laneHelper(3); break;
             default: throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
         }
-        return Float.intBitsToFloat(bits);
+        return Float16.shortBitsToFloat16(bits);
     }
 
-    public int laneHelper(int i) {
-        return (int) VectorSupport.extract(
+    public short laneHelper(int i) {
+        return (short) VectorSupport.extract(
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                     float[] vecarr = vec.vec();
-                     return (long)Float.floatToIntBits(vecarr[ix]);
+                     Float16[] vecarr = vec.vec();
+                     return (long)Float16.float16ToShortBits(vecarr[ix]);
                      });
     }
 
     @ForceInline
     @Override
-    public Float128Vector withLane(int i, float e) {
+    public Halffloat64Vector withLane(int i, Float16 e) {
         switch(i) {
             case 0: return withLaneHelper(0, e);
             case 1: return withLaneHelper(1, e);
@@ -532,32 +532,32 @@ final class Float128Vector extends FloatVector {
         }
     }
 
-    public Float128Vector withLaneHelper(int i, float e) {
+    public Halffloat64Vector withLaneHelper(int i, Float16 e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
-                                this, i, (long)Float.floatToIntBits(e),
+                                this, i, (long)Float16.float16ToShortBits(e),
                                 (v, ix, bits) -> {
-                                    float[] res = v.vec().clone();
-                                    res[ix] = Float.intBitsToFloat((int)bits);
+                                    Float16[] res = v.vec().clone();
+                                    res[ix] = Float16.shortBitsToFloat16((short)bits);
                                     return v.vectorFactory(res);
                                 });
     }
 
     // Mask
 
-    static final class Float128Mask extends AbstractMask<Float> {
+    static final class Halffloat64Mask extends AbstractMask<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float128Mask(boolean[] bits) {
+        Halffloat64Mask(boolean[] bits) {
             this(bits, 0);
         }
 
-        Float128Mask(boolean[] bits, int offset) {
+        Halffloat64Mask(boolean[] bits, int offset) {
             super(prepare(bits, offset));
         }
 
-        Float128Mask(boolean val) {
+        Halffloat64Mask(boolean val) {
             super(prepare(val));
         }
 
@@ -577,7 +577,7 @@ final class Float128Vector extends FloatVector {
 
         @ForceInline
         final @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             // ISSUE:  This should probably be a @Stable
             // field inside AbstractMask, rather than
             // a megamorphic method.
@@ -590,31 +590,31 @@ final class Float128Vector extends FloatVector {
         }
 
         @Override
-        Float128Mask uOp(MUnOp f) {
+        Halffloat64Mask uOp(MUnOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i]);
             }
-            return new Float128Mask(res);
+            return new Halffloat64Mask(res);
         }
 
         @Override
-        Float128Mask bOp(VectorMask<Float> m, MBinOp f) {
+        Halffloat64Mask bOp(VectorMask<Float16> m, MBinOp f) {
             boolean[] res = new boolean[vspecies().laneCount()];
             boolean[] bits = getBits();
-            boolean[] mbits = ((Float128Mask)m).getBits();
+            boolean[] mbits = ((Halffloat64Mask)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i, bits[i], mbits[i]);
             }
-            return new Float128Mask(res);
+            return new Halffloat64Mask(res);
         }
 
         @ForceInline
         @Override
         public final
-        Float128Vector toVector() {
-            return (Float128Vector) super.toVectorTemplate();  // specialize
+        Halffloat64Vector toVector() {
+            return (Halffloat64Vector) super.toVectorTemplate();  // specialize
         }
 
         /**
@@ -647,26 +647,26 @@ final class Float128Vector extends FloatVector {
         @Override
         @ForceInline
         /*package-private*/
-        Float128Mask indexPartiallyInUpperRange(long offset, long limit) {
-            return (Float128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Float128Mask.class, ETYPE, VLENGTH, offset, limit,
-                (o, l) -> (Float128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
+        Halffloat64Mask indexPartiallyInUpperRange(long offset, long limit) {
+            return (Halffloat64Mask) VectorSupport.indexPartiallyInUpperRange(
+                Halffloat64Mask.class, ETYPE, VLENGTH, offset, limit,
+                (o, l) -> (Halffloat64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
         // Unary operations
 
         @Override
         @ForceInline
-        public Float128Mask not() {
+        public Halffloat64Mask not() {
             return xor(maskAll(true));
         }
 
         @Override
         @ForceInline
-        public Float128Mask compress() {
-            return (Float128Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
-                Float128Vector.class, Float128Mask.class, ETYPE, VLENGTH, null, this,
-                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
+        public Halffloat64Mask compress() {
+            return (Halffloat64Mask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                Halffloat64Vector.class, Halffloat64Mask.class, ETYPE, VLENGTH, null, this,
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
         }
 
 
@@ -674,30 +674,30 @@ final class Float128Vector extends FloatVector {
 
         @Override
         @ForceInline
-        public Float128Mask and(VectorMask<Float> mask) {
+        public Halffloat64Mask and(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float128Mask m = (Float128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, Float128Mask.class, null, int.class, VLENGTH,
+            Halffloat64Mask m = (Halffloat64Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, Halffloat64Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
         }
 
         @Override
         @ForceInline
-        public Float128Mask or(VectorMask<Float> mask) {
+        public Halffloat64Mask or(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float128Mask m = (Float128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, Float128Mask.class, null, int.class, VLENGTH,
+            Halffloat64Mask m = (Halffloat64Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, Halffloat64Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
         }
 
         @Override
         @ForceInline
-        public Float128Mask xor(VectorMask<Float> mask) {
+        public Halffloat64Mask xor(VectorMask<Float16> mask) {
             Objects.requireNonNull(mask);
-            Float128Mask m = (Float128Mask)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, Float128Mask.class, null, int.class, VLENGTH,
+            Halffloat64Mask m = (Halffloat64Mask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, Halffloat64Mask.class, null, short.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
         }
@@ -707,21 +707,21 @@ final class Float128Vector extends FloatVector {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Float128Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, Halffloat64Mask.class, short.class, VLENGTH, this,
                                                       (m) -> trueCountHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Float128Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, Halffloat64Mask.class, short.class, VLENGTH, this,
                                                       (m) -> firstTrueHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Float128Mask.class, int.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, Halffloat64Mask.class, short.class, VLENGTH, this,
                                                       (m) -> lastTrueHelper(m.getBits()));
         }
 
@@ -731,7 +731,7 @@ final class Float128Vector extends FloatVector {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Float128Mask.class, int.class, VLENGTH, this,
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, Halffloat64Mask.class, short.class, VLENGTH, this,
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
@@ -741,7 +741,7 @@ final class Float128Vector extends FloatVector {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract(Float128Mask.class, float.class, VLENGTH,
+            return VectorSupport.extract(Halffloat64Mask.class, Float16.class, VLENGTH,
                                          this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
         }
 
@@ -750,55 +750,55 @@ final class Float128Vector extends FloatVector {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, Float128Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_ne, Halffloat64Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> anyTrueHelper(((Float128Mask)m).getBits()));
+                                         (m, __) -> anyTrueHelper(((Halffloat64Mask)m).getBits()));
         }
 
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, Float128Mask.class, int.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, Halffloat64Mask.class, short.class, VLENGTH,
                                          this, vspecies().maskAll(true),
-                                         (m, __) -> allTrueHelper(((Float128Mask)m).getBits()));
+                                         (m, __) -> allTrueHelper(((Halffloat64Mask)m).getBits()));
         }
 
         @ForceInline
         /*package-private*/
-        static Float128Mask maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced(Float128Mask.class, int.class, VLENGTH,
+        static Halffloat64Mask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(Halffloat64Mask.class, short.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
-        private static final Float128Mask  TRUE_MASK = new Float128Mask(true);
-        private static final Float128Mask FALSE_MASK = new Float128Mask(false);
+        private static final Halffloat64Mask  TRUE_MASK = new Halffloat64Mask(true);
+        private static final Halffloat64Mask FALSE_MASK = new Halffloat64Mask(false);
 
     }
 
     // Shuffle
 
-    static final class Float128Shuffle extends AbstractShuffle<Float> {
+    static final class Halffloat64Shuffle extends AbstractShuffle<Float16> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<Float> ETYPE = float.class; // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
 
-        Float128Shuffle(byte[] reorder) {
+        Halffloat64Shuffle(byte[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float128Shuffle(int[] reorder) {
+        public Halffloat64Shuffle(int[] reorder) {
             super(VLENGTH, reorder);
         }
 
-        public Float128Shuffle(int[] reorder, int i) {
+        public Halffloat64Shuffle(int[] reorder, int i) {
             super(VLENGTH, reorder, i);
         }
 
-        public Float128Shuffle(IntUnaryOperator fn) {
+        public Halffloat64Shuffle(IntUnaryOperator fn) {
             super(VLENGTH, fn);
         }
 
         @Override
-        public FloatSpecies vspecies() {
+        public HalffloatSpecies vspecies() {
             return VSPECIES;
         }
 
@@ -808,13 +808,13 @@ final class Float128Vector extends FloatVector {
             assert(VLENGTH < Byte.MAX_VALUE);
             assert(Byte.MIN_VALUE <= -VLENGTH);
         }
-        static final Float128Shuffle IOTA = new Float128Shuffle(IDENTITY);
+        static final Halffloat64Shuffle IOTA = new Halffloat64Shuffle(IDENTITY);
 
         @Override
         @ForceInline
-        public Float128Vector toVector() {
-            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Float128Shuffle.class, this, VLENGTH,
-                                                    (s) -> ((Float128Vector)(((AbstractShuffle<Float>)(s)).toVectorTemplate())));
+        public Halffloat64Vector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, Halffloat64Shuffle.class, this, VLENGTH,
+                                                    (s) -> ((Halffloat64Vector)(((AbstractShuffle<Float16>)(s)).toVectorTemplate())));
         }
 
         @Override
@@ -829,8 +829,8 @@ final class Float128Vector extends FloatVector {
 
         @ForceInline
         @Override
-        public Float128Shuffle rearrange(VectorShuffle<Float> shuffle) {
-            Float128Shuffle s = (Float128Shuffle) shuffle;
+        public Halffloat64Shuffle rearrange(VectorShuffle<Float16> shuffle) {
+            Halffloat64Shuffle s = (Halffloat64Shuffle) shuffle;
             byte[] reorder1 = reorder();
             byte[] reorder2 = s.reorder();
             byte[] r = new byte[reorder1.length];
@@ -838,7 +838,7 @@ final class Float128Vector extends FloatVector {
                 int ssi = reorder2[i];
                 r[i] = reorder1[ssi];  // throws on exceptional index
             }
-            return new Float128Shuffle(r);
+            return new Halffloat64Shuffle(r);
         }
     }
 
@@ -849,67 +849,55 @@ final class Float128Vector extends FloatVector {
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset) {
+    HalffloatVector fromArray0(Float16[] a, int offset) {
         return super.fromArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromArray0(float[] a, int offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromArray0Template(Float128Mask.class, a, offset, (Float128Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromArray0Template(Halffloat64Mask.class, a, offset, (Halffloat64Mask) m, offsetInRange);  // specialize
     }
 
-    @ForceInline
-    @Override
-    final
-    FloatVector fromArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        return super.fromArray0Template(Float128Mask.class, a, offset, indexMap, mapOffset, (Float128Mask) m);
-    }
 
 
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset) {
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset) {
         return super.fromMemorySegment0Template(ms, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m, int offsetInRange) {
-        return super.fromMemorySegment0Template(Float128Mask.class, ms, offset, (Float128Mask) m, offsetInRange);  // specialize
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromMemorySegment0Template(Halffloat64Mask.class, ms, offset, (Halffloat64Mask) m, offsetInRange);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset) {
+    void intoArray0(Float16[] a, int offset) {
         super.intoArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0(float[] a, int offset, VectorMask<Float> m) {
-        super.intoArray0Template(Float128Mask.class, a, offset, (Float128Mask) m);
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m) {
+        super.intoArray0Template(Halffloat64Mask.class, a, offset, (Halffloat64Mask) m);
     }
 
-    @ForceInline
-    @Override
-    final
-    void intoArray0(float[] a, int offset, int[] indexMap, int mapOffset, VectorMask<Float> m) {
-        super.intoArray0Template(Float128Mask.class, a, offset, indexMap, mapOffset, (Float128Mask) m);
-    }
 
 
     @ForceInline
     @Override
     final
-    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m) {
-        super.intoMemorySegment0Template(Float128Mask.class, ms, offset, (Float128Mask) m);
+    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m) {
+        super.intoMemorySegment0Template(Halffloat64Mask.class, ms, offset, (Halffloat64Mask) m);
     }
 
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/HalffloatMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/HalffloatMaxVector.java
@@ -1,0 +1,902 @@
+/*
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.incubator.vector;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.IntUnaryOperator;
+
+import jdk.internal.vm.annotation.ForceInline;
+import jdk.internal.vm.vector.VectorSupport;
+
+import static jdk.internal.vm.vector.VectorSupport.*;
+
+import static jdk.incubator.vector.VectorOperators.*;
+
+// -- This file was mechanically generated: Do not edit! -- //
+
+@SuppressWarnings("cast")  // warning: redundant cast
+final class HalffloatMaxVector extends HalffloatVector {
+    static final HalffloatSpecies VSPECIES =
+        (HalffloatSpecies) HalffloatVector.SPECIES_MAX;
+
+    static final VectorShape VSHAPE =
+        VSPECIES.vectorShape();
+
+    static final Class<HalffloatMaxVector> VCLASS = HalffloatMaxVector.class;
+
+    static final int VSIZE = VSPECIES.vectorBitSize();
+
+    static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
+
+    static final Class<Float16> ETYPE = Float16.class; // used by the JVM
+
+    HalffloatMaxVector(Float16[] v) {
+        super(v);
+    }
+
+    // For compatibility as HalffloatMaxVector::new,
+    // stored into species.vectorFactory.
+    HalffloatMaxVector(Object v) {
+        this((Float16[]) v);
+    }
+
+    static final HalffloatMaxVector ZERO = new HalffloatMaxVector(new Float16[VLENGTH]);
+    static final HalffloatMaxVector IOTA = new HalffloatMaxVector(VSPECIES.iotaArray());
+
+    static {
+        // Warm up a few species caches.
+        // If we do this too much we will
+        // get NPEs from bootstrap circularity.
+        VSPECIES.dummyVector();
+        VSPECIES.withLanes(LaneType.BYTE);
+    }
+
+    // Specialized extractors
+
+    @ForceInline
+    final @Override
+    public HalffloatSpecies vspecies() {
+        // ISSUE:  This should probably be a @Stable
+        // field inside AbstractVector, rather than
+        // a megamorphic method.
+        return VSPECIES;
+    }
+
+    @ForceInline
+    @Override
+    public final Class<Float16> elementType() { return Float16.class; }
+
+    @ForceInline
+    @Override
+    public final int elementSize() { return Float16.SIZE; }
+
+    @ForceInline
+    @Override
+    public final VectorShape shape() { return VSHAPE; }
+
+    @ForceInline
+    @Override
+    public final int length() { return VLENGTH; }
+
+    @ForceInline
+    @Override
+    public final int bitSize() { return VSIZE; }
+
+    @ForceInline
+    @Override
+    public final int byteSize() { return VSIZE / Byte.SIZE; }
+
+    /*package-private*/
+    @ForceInline
+    final @Override
+    Float16[] vec() {
+        return (Float16[])getPayload();
+    }
+
+    // Virtualized constructors
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxVector broadcast(Float16 e) {
+        return (HalffloatMaxVector) super.broadcastTemplate(e);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxVector broadcast(long e) {
+        return (HalffloatMaxVector) super.broadcastTemplate(e);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    HalffloatMaxMask maskFromArray(boolean[] bits) {
+        return new HalffloatMaxMask(bits);
+    }
+
+    @Override
+    @ForceInline
+    HalffloatMaxShuffle iotaShuffle() { return HalffloatMaxShuffle.IOTA; }
+
+    @ForceInline
+    HalffloatMaxShuffle iotaShuffle(int start, int step, boolean wrap) {
+      if (wrap) {
+        return (HalffloatMaxShuffle)VectorSupport.shuffleIota(ETYPE, HalffloatMaxShuffle.class, VSPECIES, VLENGTH, start, step, 1,
+                (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (VectorIntrinsics.wrapToRange(i*lstep + lstart, l))));
+      } else {
+        return (HalffloatMaxShuffle)VectorSupport.shuffleIota(ETYPE, HalffloatMaxShuffle.class, VSPECIES, VLENGTH, start, step, 0,
+                (l, lstart, lstep, s) -> s.shuffleFromOp(i -> (i*lstep + lstart)));
+      }
+    }
+
+    @Override
+    @ForceInline
+    HalffloatMaxShuffle shuffleFromBytes(byte[] reorder) { return new HalffloatMaxShuffle(reorder); }
+
+    @Override
+    @ForceInline
+    HalffloatMaxShuffle shuffleFromArray(int[] indexes, int i) { return new HalffloatMaxShuffle(indexes, i); }
+
+    @Override
+    @ForceInline
+    HalffloatMaxShuffle shuffleFromOp(IntUnaryOperator fn) { return new HalffloatMaxShuffle(fn); }
+
+    // Make a vector of the same species but the given elements:
+    @ForceInline
+    final @Override
+    HalffloatMaxVector vectorFactory(Float16[] vec) {
+        return new HalffloatMaxVector(vec);
+    }
+
+    @ForceInline
+    final @Override
+    ByteMaxVector asByteVectorRaw() {
+        return (ByteMaxVector) super.asByteVectorRawTemplate();  // specialize
+    }
+
+    @ForceInline
+    final @Override
+    AbstractVector<?> asVectorRaw(LaneType laneType) {
+        return super.asVectorRawTemplate(laneType);  // specialize
+    }
+
+    // Unary operator
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector uOp(FUnOp f) {
+        return (HalffloatMaxVector) super.uOpTemplate(f);  // specialize
+    }
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector uOp(VectorMask<Float16> m, FUnOp f) {
+        return (HalffloatMaxVector)
+            super.uOpTemplate((HalffloatMaxMask)m, f);  // specialize
+    }
+
+    // Binary operator
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector bOp(Vector<Float16> v, FBinOp f) {
+        return (HalffloatMaxVector) super.bOpTemplate((HalffloatMaxVector)v, f);  // specialize
+    }
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector bOp(Vector<Float16> v,
+                     VectorMask<Float16> m, FBinOp f) {
+        return (HalffloatMaxVector)
+            super.bOpTemplate((HalffloatMaxVector)v, (HalffloatMaxMask)m,
+                              f);  // specialize
+    }
+
+    // Ternary operator
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector tOp(Vector<Float16> v1, Vector<Float16> v2, FTriOp f) {
+        return (HalffloatMaxVector)
+            super.tOpTemplate((HalffloatMaxVector)v1, (HalffloatMaxVector)v2,
+                              f);  // specialize
+    }
+
+    @ForceInline
+    final @Override
+    HalffloatMaxVector tOp(Vector<Float16> v1, Vector<Float16> v2,
+                     VectorMask<Float16> m, FTriOp f) {
+        return (HalffloatMaxVector)
+            super.tOpTemplate((HalffloatMaxVector)v1, (HalffloatMaxVector)v2,
+                              (HalffloatMaxMask)m, f);  // specialize
+    }
+
+    @ForceInline
+    final @Override
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f) {
+        return super.rOpTemplate(v, m, f);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final <F>
+    Vector<F> convertShape(VectorOperators.Conversion<Float16,F> conv,
+                           VectorSpecies<F> rsp, int part) {
+        return super.convertShapeTemplate(conv, rsp, part);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final <F>
+    Vector<F> reinterpretShape(VectorSpecies<F> toSpecies, int part) {
+        return super.reinterpretShapeTemplate(toSpecies, part);  // specialize
+    }
+
+    // Specialized algebraic operations:
+
+    // The following definition forces a specialized version of this
+    // crucial method into the v-table of this class.  A call to add()
+    // will inline to a call to lanewise(ADD,), at which point the JIT
+    // intrinsic will have the opcode of ADD, plus all the metadata
+    // for this particular class, enabling it to generate precise
+    // code.
+    //
+    // There is probably no benefit to the JIT to specialize the
+    // masked or broadcast versions of the lanewise method.
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector lanewise(Unary op) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector lanewise(Unary op, VectorMask<Float16> m) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op, HalffloatMaxMask.class, (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector lanewise(Binary op, Vector<Float16> v) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op, v);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector lanewise(Binary op, Vector<Float16> v, VectorMask<Float16> m) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op, HalffloatMaxMask.class, v, (HalffloatMaxMask) m);  // specialize
+    }
+
+
+    /*package-private*/
+    @Override
+    @ForceInline
+    public final
+    HalffloatMaxVector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op, v1, v2);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final
+    HalffloatMaxVector
+    lanewise(Ternary op, Vector<Float16> v1, Vector<Float16> v2, VectorMask<Float16> m) {
+        return (HalffloatMaxVector) super.lanewiseTemplate(op, HalffloatMaxMask.class, v1, v2, (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final
+    HalffloatMaxVector addIndex(int scale) {
+        return (HalffloatMaxVector) super.addIndexTemplate(scale);  // specialize
+    }
+
+    // Type specific horizontal reductions
+
+    @Override
+    @ForceInline
+    public final Float16 reduceLanes(VectorOperators.Associative op) {
+        return super.reduceLanesTemplate(op);  // specialized
+    }
+
+    @Override
+    @ForceInline
+    public final Float16 reduceLanes(VectorOperators.Associative op,
+                                    VectorMask<Float16> m) {
+        return super.reduceLanesTemplate(op, HalffloatMaxMask.class, (HalffloatMaxMask) m);  // specialized
+    }
+
+    @Override
+    @ForceInline
+    public final long reduceLanesToLong(VectorOperators.Associative op) {
+        Float16 res = super.reduceLanesTemplate(op);  // specialized
+        return res.longValue();
+    }
+
+    @Override
+    @ForceInline
+    public final long reduceLanesToLong(VectorOperators.Associative op,
+                                        VectorMask<Float16> m) {
+        Float16 res = super.reduceLanesTemplate(op, HalffloatMaxMask.class, (HalffloatMaxMask) m);  // specialized
+        return res.longValue();
+    }
+
+    @ForceInline
+    public VectorShuffle<Float16> toShuffle() {
+        return super.toShuffleTemplate(HalffloatMaxShuffle.class); // specialize
+    }
+
+    // Specialized unary testing
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask test(Test op) {
+        return super.testTemplate(HalffloatMaxMask.class, op);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask test(Test op, VectorMask<Float16> m) {
+        return super.testTemplate(HalffloatMaxMask.class, op, (HalffloatMaxMask) m);  // specialize
+    }
+
+    // Specialized comparisons
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask compare(Comparison op, Vector<Float16> v) {
+        return super.compareTemplate(HalffloatMaxMask.class, op, v);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask compare(Comparison op, Float16 s) {
+        return super.compareTemplate(HalffloatMaxMask.class, op, s);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask compare(Comparison op, long s) {
+        return super.compareTemplate(HalffloatMaxMask.class, op, s);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public final HalffloatMaxMask compare(Comparison op, Vector<Float16> v, VectorMask<Float16> m) {
+        return super.compareTemplate(HalffloatMaxMask.class, op, v, (HalffloatMaxMask) m);
+    }
+
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector blend(Vector<Float16> v, VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.blendTemplate(HalffloatMaxMask.class,
+                                (HalffloatMaxVector) v,
+                                (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector slice(int origin, Vector<Float16> v) {
+        return (HalffloatMaxVector) super.sliceTemplate(origin, v);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector slice(int origin) {
+        return (HalffloatMaxVector) super.sliceTemplate(origin);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector unslice(int origin, Vector<Float16> w, int part) {
+        return (HalffloatMaxVector) super.unsliceTemplate(origin, w, part);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.unsliceTemplate(HalffloatMaxMask.class,
+                                  origin, w, part,
+                                  (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector unslice(int origin) {
+        return (HalffloatMaxVector) super.unsliceTemplate(origin);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector rearrange(VectorShuffle<Float16> s) {
+        return (HalffloatMaxVector)
+            super.rearrangeTemplate(HalffloatMaxShuffle.class,
+                                    (HalffloatMaxShuffle) s);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector rearrange(VectorShuffle<Float16> shuffle,
+                                  VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.rearrangeTemplate(HalffloatMaxShuffle.class,
+                                    HalffloatMaxMask.class,
+                                    (HalffloatMaxShuffle) shuffle,
+                                    (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector rearrange(VectorShuffle<Float16> s,
+                                  Vector<Float16> v) {
+        return (HalffloatMaxVector)
+            super.rearrangeTemplate(HalffloatMaxShuffle.class,
+                                    (HalffloatMaxShuffle) s,
+                                    (HalffloatMaxVector) v);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector compress(VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.compressTemplate(HalffloatMaxMask.class,
+                                   (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector expand(VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.expandTemplate(HalffloatMaxMask.class,
+                                   (HalffloatMaxMask) m);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector selectFrom(Vector<Float16> v) {
+        return (HalffloatMaxVector)
+            super.selectFromTemplate((HalffloatMaxVector) v);  // specialize
+    }
+
+    @Override
+    @ForceInline
+    public HalffloatMaxVector selectFrom(Vector<Float16> v,
+                                   VectorMask<Float16> m) {
+        return (HalffloatMaxVector)
+            super.selectFromTemplate((HalffloatMaxVector) v,
+                                     (HalffloatMaxMask) m);  // specialize
+    }
+
+
+    @ForceInline
+    @Override
+    public Float16 lane(int i) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        }
+        short bits = laneHelper(i);
+        return Float16.shortBitsToFloat16(bits);
+    }
+
+    public short laneHelper(int i) {
+        return (short) VectorSupport.extract(
+                     VCLASS, ETYPE, VLENGTH,
+                     this, i,
+                     (vec, ix) -> {
+                     Float16[] vecarr = vec.vec();
+                     return (long)Float16.float16ToShortBits(vecarr[ix]);
+                     });
+    }
+
+    @ForceInline
+    @Override
+    public HalffloatMaxVector withLane(int i, Float16 e) {
+        if (i < 0 || i >= VLENGTH) {
+            throw new IllegalArgumentException("Index " + i + " must be zero or positive, and less than " + VLENGTH);
+        }
+        return withLaneHelper(i, e);
+    }
+
+    public HalffloatMaxVector withLaneHelper(int i, Float16 e) {
+        return VectorSupport.insert(
+                                VCLASS, ETYPE, VLENGTH,
+                                this, i, (long)Float16.float16ToShortBits(e),
+                                (v, ix, bits) -> {
+                                    Float16[] res = v.vec().clone();
+                                    res[ix] = Float16.shortBitsToFloat16((short)bits);
+                                    return v.vectorFactory(res);
+                                });
+    }
+
+    // Mask
+
+    static final class HalffloatMaxMask extends AbstractMask<Float16> {
+        static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
+
+        HalffloatMaxMask(boolean[] bits) {
+            this(bits, 0);
+        }
+
+        HalffloatMaxMask(boolean[] bits, int offset) {
+            super(prepare(bits, offset));
+        }
+
+        HalffloatMaxMask(boolean val) {
+            super(prepare(val));
+        }
+
+        private static boolean[] prepare(boolean[] bits, int offset) {
+            boolean[] newBits = new boolean[VSPECIES.laneCount()];
+            for (int i = 0; i < newBits.length; i++) {
+                newBits[i] = bits[offset + i];
+            }
+            return newBits;
+        }
+
+        private static boolean[] prepare(boolean val) {
+            boolean[] bits = new boolean[VSPECIES.laneCount()];
+            Arrays.fill(bits, val);
+            return bits;
+        }
+
+        @ForceInline
+        final @Override
+        public HalffloatSpecies vspecies() {
+            // ISSUE:  This should probably be a @Stable
+            // field inside AbstractMask, rather than
+            // a megamorphic method.
+            return VSPECIES;
+        }
+
+        @ForceInline
+        boolean[] getBits() {
+            return (boolean[])getPayload();
+        }
+
+        @Override
+        HalffloatMaxMask uOp(MUnOp f) {
+            boolean[] res = new boolean[vspecies().laneCount()];
+            boolean[] bits = getBits();
+            for (int i = 0; i < res.length; i++) {
+                res[i] = f.apply(i, bits[i]);
+            }
+            return new HalffloatMaxMask(res);
+        }
+
+        @Override
+        HalffloatMaxMask bOp(VectorMask<Float16> m, MBinOp f) {
+            boolean[] res = new boolean[vspecies().laneCount()];
+            boolean[] bits = getBits();
+            boolean[] mbits = ((HalffloatMaxMask)m).getBits();
+            for (int i = 0; i < res.length; i++) {
+                res[i] = f.apply(i, bits[i], mbits[i]);
+            }
+            return new HalffloatMaxMask(res);
+        }
+
+        @ForceInline
+        @Override
+        public final
+        HalffloatMaxVector toVector() {
+            return (HalffloatMaxVector) super.toVectorTemplate();  // specialize
+        }
+
+        /**
+         * Helper function for lane-wise mask conversions.
+         * This function kicks in after intrinsic failure.
+         */
+        @ForceInline
+        private final <E>
+        VectorMask<E> defaultMaskCast(AbstractSpecies<E> dsp) {
+            if (length() != dsp.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+            boolean[] maskArray = toArray();
+            return  dsp.maskFactory(maskArray).check(dsp);
+        }
+
+        @Override
+        @ForceInline
+        public <E> VectorMask<E> cast(VectorSpecies<E> dsp) {
+            AbstractSpecies<E> species = (AbstractSpecies<E>) dsp;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorMask length and species length differ");
+
+            return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
+                this.getClass(), ETYPE, VLENGTH,
+                species.maskType(), species.elementType(), VLENGTH,
+                this, species,
+                (m, s) -> s.maskFactory(m.toArray()).check(s));
+        }
+
+        @Override
+        @ForceInline
+        /*package-private*/
+        HalffloatMaxMask indexPartiallyInUpperRange(long offset, long limit) {
+            return (HalffloatMaxMask) VectorSupport.indexPartiallyInUpperRange(
+                HalffloatMaxMask.class, ETYPE, VLENGTH, offset, limit,
+                (o, l) -> (HalffloatMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
+        }
+
+        // Unary operations
+
+        @Override
+        @ForceInline
+        public HalffloatMaxMask not() {
+            return xor(maskAll(true));
+        }
+
+        @Override
+        @ForceInline
+        public HalffloatMaxMask compress() {
+            return (HalffloatMaxMask)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
+                HalffloatMaxVector.class, HalffloatMaxMask.class, ETYPE, VLENGTH, null, this,
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
+        }
+
+
+        // Binary operations
+
+        @Override
+        @ForceInline
+        public HalffloatMaxMask and(VectorMask<Float16> mask) {
+            Objects.requireNonNull(mask);
+            HalffloatMaxMask m = (HalffloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_AND, HalffloatMaxMask.class, null, short.class, VLENGTH,
+                                          this, m, null,
+                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
+        }
+
+        @Override
+        @ForceInline
+        public HalffloatMaxMask or(VectorMask<Float16> mask) {
+            Objects.requireNonNull(mask);
+            HalffloatMaxMask m = (HalffloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_OR, HalffloatMaxMask.class, null, short.class, VLENGTH,
+                                          this, m, null,
+                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
+        }
+
+        @Override
+        @ForceInline
+        public HalffloatMaxMask xor(VectorMask<Float16> mask) {
+            Objects.requireNonNull(mask);
+            HalffloatMaxMask m = (HalffloatMaxMask)mask;
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, HalffloatMaxMask.class, null, short.class, VLENGTH,
+                                          this, m, null,
+                                          (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
+        }
+
+        // Mask Query operations
+
+        @Override
+        @ForceInline
+        public int trueCount() {
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, HalffloatMaxMask.class, short.class, VLENGTH, this,
+                                                      (m) -> trueCountHelper(m.getBits()));
+        }
+
+        @Override
+        @ForceInline
+        public int firstTrue() {
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, HalffloatMaxMask.class, short.class, VLENGTH, this,
+                                                      (m) -> firstTrueHelper(m.getBits()));
+        }
+
+        @Override
+        @ForceInline
+        public int lastTrue() {
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, HalffloatMaxMask.class, short.class, VLENGTH, this,
+                                                      (m) -> lastTrueHelper(m.getBits()));
+        }
+
+        @Override
+        @ForceInline
+        public long toLong() {
+            if (length() > Long.SIZE) {
+                throw new UnsupportedOperationException("too many lanes for one long");
+            }
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, HalffloatMaxMask.class, short.class, VLENGTH, this,
+                                                      (m) -> toLongHelper(m.getBits()));
+        }
+
+        // laneIsSet
+
+        @Override
+        @ForceInline
+        public boolean laneIsSet(int i) {
+            Objects.checkIndex(i, length());
+            return VectorSupport.extract(HalffloatMaxMask.class, Float16.class, VLENGTH,
+                                         this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
+        }
+
+        // Reductions
+
+        @Override
+        @ForceInline
+        public boolean anyTrue() {
+            return VectorSupport.test(BT_ne, HalffloatMaxMask.class, short.class, VLENGTH,
+                                         this, vspecies().maskAll(true),
+                                         (m, __) -> anyTrueHelper(((HalffloatMaxMask)m).getBits()));
+        }
+
+        @Override
+        @ForceInline
+        public boolean allTrue() {
+            return VectorSupport.test(BT_overflow, HalffloatMaxMask.class, short.class, VLENGTH,
+                                         this, vspecies().maskAll(true),
+                                         (m, __) -> allTrueHelper(((HalffloatMaxMask)m).getBits()));
+        }
+
+        @ForceInline
+        /*package-private*/
+        static HalffloatMaxMask maskAll(boolean bit) {
+            return VectorSupport.fromBitsCoerced(HalffloatMaxMask.class, short.class, VLENGTH,
+                                                 (bit ? -1 : 0), MODE_BROADCAST, null,
+                                                 (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
+        }
+        private static final HalffloatMaxMask  TRUE_MASK = new HalffloatMaxMask(true);
+        private static final HalffloatMaxMask FALSE_MASK = new HalffloatMaxMask(false);
+
+    }
+
+    // Shuffle
+
+    static final class HalffloatMaxShuffle extends AbstractShuffle<Float16> {
+        static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
+        static final Class<Float16> ETYPE = Float16.class; // used by the JVM
+
+        HalffloatMaxShuffle(byte[] reorder) {
+            super(VLENGTH, reorder);
+        }
+
+        public HalffloatMaxShuffle(int[] reorder) {
+            super(VLENGTH, reorder);
+        }
+
+        public HalffloatMaxShuffle(int[] reorder, int i) {
+            super(VLENGTH, reorder, i);
+        }
+
+        public HalffloatMaxShuffle(IntUnaryOperator fn) {
+            super(VLENGTH, fn);
+        }
+
+        @Override
+        public HalffloatSpecies vspecies() {
+            return VSPECIES;
+        }
+
+        static {
+            // There must be enough bits in the shuffle lanes to encode
+            // VLENGTH valid indexes and VLENGTH exceptional ones.
+            assert(VLENGTH < Byte.MAX_VALUE);
+            assert(Byte.MIN_VALUE <= -VLENGTH);
+        }
+        static final HalffloatMaxShuffle IOTA = new HalffloatMaxShuffle(IDENTITY);
+
+        @Override
+        @ForceInline
+        public HalffloatMaxVector toVector() {
+            return VectorSupport.shuffleToVector(VCLASS, ETYPE, HalffloatMaxShuffle.class, this, VLENGTH,
+                                                    (s) -> ((HalffloatMaxVector)(((AbstractShuffle<Float16>)(s)).toVectorTemplate())));
+        }
+
+        @Override
+        @ForceInline
+        public <F> VectorShuffle<F> cast(VectorSpecies<F> s) {
+            AbstractSpecies<F> species = (AbstractSpecies<F>) s;
+            if (length() != species.laneCount())
+                throw new IllegalArgumentException("VectorShuffle length and species length differ");
+            int[] shuffleArray = toArray();
+            return s.shuffleFromArray(shuffleArray, 0).check(s);
+        }
+
+        @ForceInline
+        @Override
+        public HalffloatMaxShuffle rearrange(VectorShuffle<Float16> shuffle) {
+            HalffloatMaxShuffle s = (HalffloatMaxShuffle) shuffle;
+            byte[] reorder1 = reorder();
+            byte[] reorder2 = s.reorder();
+            byte[] r = new byte[reorder1.length];
+            for (int i = 0; i < reorder1.length; i++) {
+                int ssi = reorder2[i];
+                r[i] = reorder1[ssi];  // throws on exceptional index
+            }
+            return new HalffloatMaxShuffle(r);
+        }
+    }
+
+    // ================================================
+
+    // Specialized low-level memory operations.
+
+    @ForceInline
+    @Override
+    final
+    HalffloatVector fromArray0(Float16[] a, int offset) {
+        return super.fromArray0Template(a, offset);  // specialize
+    }
+
+    @ForceInline
+    @Override
+    final
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromArray0Template(HalffloatMaxMask.class, a, offset, (HalffloatMaxMask) m, offsetInRange);  // specialize
+    }
+
+
+
+
+    @ForceInline
+    @Override
+    final
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset) {
+        return super.fromMemorySegment0Template(ms, offset);  // specialize
+    }
+
+    @ForceInline
+    @Override
+    final
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange) {
+        return super.fromMemorySegment0Template(HalffloatMaxMask.class, ms, offset, (HalffloatMaxMask) m, offsetInRange);  // specialize
+    }
+
+    @ForceInline
+    @Override
+    final
+    void intoArray0(Float16[] a, int offset) {
+        super.intoArray0Template(a, offset);  // specialize
+    }
+
+    @ForceInline
+    @Override
+    final
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m) {
+        super.intoArray0Template(HalffloatMaxMask.class, a, offset, (HalffloatMaxMask) m);
+    }
+
+
+
+    @ForceInline
+    @Override
+    final
+    void intoMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m) {
+        super.intoMemorySegment0Template(HalffloatMaxMask.class, ms, offset, (HalffloatMaxMask) m);
+    }
+
+
+    // End of specialized low-level memory operations.
+
+    // ================================================
+
+}
+

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/HalffloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/HalffloatVector.java
@@ -46,18 +46,18 @@ import static jdk.incubator.vector.VectorOperators.*;
 
 /**
  * A specialized {@link Vector} representing an ordered immutable sequence of
- * {@code float} values.
+ * {@code Float16} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
-public abstract class FloatVector extends AbstractVector<Float> {
+public abstract class HalffloatVector extends AbstractVector<Float16> {
 
-    FloatVector(float[] vec) {
+    HalffloatVector(Float16[] vec) {
         super(vec);
     }
 
     static final int FORBID_OPCODE_KIND = VO_NOFP;
 
-    static final ValueLayout.OfFloat ELEMENT_LAYOUT = ValueLayout.JAVA_FLOAT.withByteAlignment(1);
+    static final ValueLayout.OfShort ELEMENT_LAYOUT = ValueLayout.JAVA_SHORT.withByteAlignment(1);
 
     @ForceInline
     static int opCode(Operator op) {
@@ -94,7 +94,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // Virtualized getter
 
     /*package-private*/
-    abstract float[] vec();
+    abstract Float16[] vec();
 
     // Virtualized constructors
 
@@ -103,7 +103,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * It is an error if the array is aliased elsewhere.
      */
     /*package-private*/
-    abstract FloatVector vectorFactory(float[] vec);
+    abstract HalffloatVector vectorFactory(Float16[] vec);
 
     /**
      * Build a mask directly using my species.
@@ -112,20 +112,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Float> maskFactory(boolean[] bits) {
+    AbstractMask<Float16> maskFactory(boolean[] bits) {
         return vspecies().maskFactory(bits);
     }
 
     // Constant loader (takes dummy as vector arg)
     interface FVOp {
-        float apply(int i);
+        Float16 apply(int i);
     }
 
     /*package-private*/
     @ForceInline
     final
-    FloatVector vOp(FVOp f) {
-        float[] res = new float[length()];
+    HalffloatVector vOp(FVOp f) {
+        Float16[] res = new Float16[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i);
         }
@@ -134,9 +134,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     @ForceInline
     final
-    FloatVector vOp(VectorMask<Float> m, FVOp f) {
-        float[] res = new float[length()];
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+    HalffloatVector vOp(VectorMask<Float16> m, FVOp f) {
+        Float16[] res = new Float16[length()];
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
                 res[i] = f.apply(i);
@@ -149,17 +149,17 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     interface FUnOp {
-        float apply(int i, float a);
+        Float16 apply(int i, Float16 a);
     }
 
     /*package-private*/
     abstract
-    FloatVector uOp(FUnOp f);
+    HalffloatVector uOp(FUnOp f);
     @ForceInline
     final
-    FloatVector uOpTemplate(FUnOp f) {
-        float[] vec = vec();
-        float[] res = new float[length()];
+    HalffloatVector uOpTemplate(FUnOp f) {
+        Float16[] vec = vec();
+        Float16[] res = new Float16[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec[i]);
         }
@@ -168,18 +168,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    FloatVector uOp(VectorMask<Float> m,
+    HalffloatVector uOp(VectorMask<Float16> m,
                              FUnOp f);
     @ForceInline
     final
-    FloatVector uOpTemplate(VectorMask<Float> m,
+    HalffloatVector uOpTemplate(VectorMask<Float16> m,
                                      FUnOp f) {
         if (m == null) {
             return uOpTemplate(f);
         }
-        float[] vec = vec();
-        float[] res = new float[length()];
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] vec = vec();
+        Float16[] res = new Float16[length()];
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec[i]) : vec[i];
         }
@@ -190,20 +190,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     interface FBinOp {
-        float apply(int i, float a, float b);
+        Float16 apply(int i, Float16 a, Float16 b);
     }
 
     /*package-private*/
     abstract
-    FloatVector bOp(Vector<Float> o,
+    HalffloatVector bOp(Vector<Float16> o,
                              FBinOp f);
     @ForceInline
     final
-    FloatVector bOpTemplate(Vector<Float> o,
+    HalffloatVector bOpTemplate(Vector<Float16> o,
                                      FBinOp f) {
-        float[] res = new float[length()];
-        float[] vec1 = this.vec();
-        float[] vec2 = ((FloatVector)o).vec();
+        Float16[] res = new Float16[length()];
+        Float16[] vec1 = this.vec();
+        Float16[] vec2 = ((HalffloatVector)o).vec();
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec1[i], vec2[i]);
         }
@@ -212,21 +212,21 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    FloatVector bOp(Vector<Float> o,
-                             VectorMask<Float> m,
+    HalffloatVector bOp(Vector<Float16> o,
+                             VectorMask<Float16> m,
                              FBinOp f);
     @ForceInline
     final
-    FloatVector bOpTemplate(Vector<Float> o,
-                                     VectorMask<Float> m,
+    HalffloatVector bOpTemplate(Vector<Float16> o,
+                                     VectorMask<Float16> m,
                                      FBinOp f) {
         if (m == null) {
             return bOpTemplate(o, f);
         }
-        float[] res = new float[length()];
-        float[] vec1 = this.vec();
-        float[] vec2 = ((FloatVector)o).vec();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] res = new Float16[length()];
+        Float16[] vec1 = this.vec();
+        Float16[] vec2 = ((HalffloatVector)o).vec();
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec1[i], vec2[i]) : vec1[i];
         }
@@ -237,23 +237,23 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     interface FTriOp {
-        float apply(int i, float a, float b, float c);
+        Float16 apply(int i, Float16 a, Float16 b, Float16 c);
     }
 
     /*package-private*/
     abstract
-    FloatVector tOp(Vector<Float> o1,
-                             Vector<Float> o2,
+    HalffloatVector tOp(Vector<Float16> o1,
+                             Vector<Float16> o2,
                              FTriOp f);
     @ForceInline
     final
-    FloatVector tOpTemplate(Vector<Float> o1,
-                                     Vector<Float> o2,
+    HalffloatVector tOpTemplate(Vector<Float16> o1,
+                                     Vector<Float16> o2,
                                      FTriOp f) {
-        float[] res = new float[length()];
-        float[] vec1 = this.vec();
-        float[] vec2 = ((FloatVector)o1).vec();
-        float[] vec3 = ((FloatVector)o2).vec();
+        Float16[] res = new Float16[length()];
+        Float16[] vec1 = this.vec();
+        Float16[] vec2 = ((HalffloatVector)o1).vec();
+        Float16[] vec3 = ((HalffloatVector)o2).vec();
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec1[i], vec2[i], vec3[i]);
         }
@@ -262,24 +262,24 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    FloatVector tOp(Vector<Float> o1,
-                             Vector<Float> o2,
-                             VectorMask<Float> m,
+    HalffloatVector tOp(Vector<Float16> o1,
+                             Vector<Float16> o2,
+                             VectorMask<Float16> m,
                              FTriOp f);
     @ForceInline
     final
-    FloatVector tOpTemplate(Vector<Float> o1,
-                                     Vector<Float> o2,
-                                     VectorMask<Float> m,
+    HalffloatVector tOpTemplate(Vector<Float16> o1,
+                                     Vector<Float16> o2,
+                                     VectorMask<Float16> m,
                                      FTriOp f) {
         if (m == null) {
             return tOpTemplate(o1, o2, f);
         }
-        float[] res = new float[length()];
-        float[] vec1 = this.vec();
-        float[] vec2 = ((FloatVector)o1).vec();
-        float[] vec3 = ((FloatVector)o2).vec();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] res = new Float16[length()];
+        Float16[] vec1 = this.vec();
+        Float16[] vec2 = ((HalffloatVector)o1).vec();
+        Float16[] vec3 = ((HalffloatVector)o2).vec();
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec1[i], vec2[i], vec3[i]) : vec1[i];
         }
@@ -290,16 +290,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    float rOp(float v, VectorMask<Float> m, FBinOp f);
+    Float16 rOp(Float16 v, VectorMask<Float16> m, FBinOp f);
 
     @ForceInline
     final
-    float rOpTemplate(float v, VectorMask<Float> m, FBinOp f) {
+    Float16 rOpTemplate(Float16 v, VectorMask<Float16> m, FBinOp f) {
         if (m == null) {
             return rOpTemplate(v, f);
         }
-        float[] vec = vec();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] vec = vec();
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             v = mbits[i] ? f.apply(i, v, vec[i]) : v;
         }
@@ -308,8 +308,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     @ForceInline
     final
-    float rOpTemplate(float v, FBinOp f) {
-        float[] vec = vec();
+    Float16 rOpTemplate(Float16 v, FBinOp f) {
+        Float16[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             v = f.apply(i, v, vec[i]);
         }
@@ -320,16 +320,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     interface FLdOp<M> {
-        float apply(M memory, int offset, int i);
+        Float16 apply(M memory, int offset, int i);
     }
 
     /*package-private*/
     @ForceInline
     final
-    <M> FloatVector ldOp(M memory, int offset,
+    <M> HalffloatVector ldOp(M memory, int offset,
                                   FLdOp<M> f) {
         //dummy; no vec = vec();
-        float[] res = new float[length()];
+        Float16[] res = new Float16[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(memory, offset, i);
         }
@@ -339,12 +339,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    <M> FloatVector ldOp(M memory, int offset,
-                                  VectorMask<Float> m,
+    <M> HalffloatVector ldOp(M memory, int offset,
+                                  VectorMask<Float16> m,
                                   FLdOp<M> f) {
-        //float[] vec = vec();
-        float[] res = new float[length()];
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        //Float16[] vec = vec();
+        Float16[] res = new Float16[length()];
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
                 res[i] = f.apply(memory, offset, i);
@@ -355,16 +355,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     interface FLdLongOp {
-        float apply(MemorySegment memory, long offset, int i);
+        Float16 apply(MemorySegment memory, long offset, int i);
     }
 
     /*package-private*/
     @ForceInline
     final
-    FloatVector ldLongOp(MemorySegment memory, long offset,
+    HalffloatVector ldLongOp(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         //dummy; no vec = vec();
-        float[] res = new float[length()];
+        Float16[] res = new Float16[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(memory, offset, i);
         }
@@ -374,12 +374,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    FloatVector ldLongOp(MemorySegment memory, long offset,
-                                  VectorMask<Float> m,
+    HalffloatVector ldLongOp(MemorySegment memory, long offset,
+                                  VectorMask<Float16> m,
                                   FLdLongOp f) {
-        //float[] vec = vec();
-        float[] res = new float[length()];
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        //Float16[] vec = vec();
+        Float16[] res = new Float16[length()];
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
                 res[i] = f.apply(memory, offset, i);
@@ -388,12 +388,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
         return vectorFactory(res);
     }
 
-    static float memorySegmentGet(MemorySegment ms, long o, int i) {
-        return ms.get(ELEMENT_LAYOUT, o + i * 4L);
+    static Float16 memorySegmentGet(MemorySegment ms, long o, int i) {
+        return Float16.valueOf(ms.get(ELEMENT_LAYOUT, o + i * 2L));
     }
 
     interface FStOp<M> {
-        void apply(M memory, int offset, int i, float a);
+        void apply(M memory, int offset, int i, Float16 a);
     }
 
     /*package-private*/
@@ -401,7 +401,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     <M> void stOp(M memory, int offset,
                   FStOp<M> f) {
-        float[] vec = vec();
+        Float16[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             f.apply(memory, offset, i, vec[i]);
         }
@@ -411,10 +411,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     final
     <M> void stOp(M memory, int offset,
-                  VectorMask<Float> m,
+                  VectorMask<Float16> m,
                   FStOp<M> f) {
-        float[] vec = vec();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] vec = vec();
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             if (mbits[i]) {
                 f.apply(memory, offset, i, vec[i]);
@@ -423,7 +423,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     interface FStLongOp {
-        void apply(MemorySegment memory, long offset, int i, float a);
+        void apply(MemorySegment memory, long offset, int i, Float16 a);
     }
 
     /*package-private*/
@@ -431,7 +431,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     final
     void stLongOp(MemorySegment memory, long offset,
                   FStLongOp f) {
-        float[] vec = vec();
+        Float16[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             f.apply(memory, offset, i, vec[i]);
         }
@@ -441,10 +441,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     final
     void stLongOp(MemorySegment memory, long offset,
-                  VectorMask<Float> m,
+                  VectorMask<Float16> m,
                   FStLongOp f) {
-        float[] vec = vec();
-        boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        Float16[] vec = vec();
+        boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             if (mbits[i]) {
                 f.apply(memory, offset, i, vec[i]);
@@ -452,25 +452,25 @@ public abstract class FloatVector extends AbstractVector<Float> {
         }
     }
 
-    static void memorySegmentSet(MemorySegment ms, long o, int i, float e) {
-        ms.set(ELEMENT_LAYOUT, o + i * 4L, e);
+    static void memorySegmentSet(MemorySegment ms, long o, int i, Float16 e) {
+        ms.set(ELEMENT_LAYOUT, o + i * 2L, e.shortValue());
     }
 
     // Binary test
 
     /*package-private*/
     interface FBinTest {
-        boolean apply(int cond, int i, float a, float b);
+        boolean apply(int cond, int i, Float16 a, Float16 b);
     }
 
     /*package-private*/
     @ForceInline
     final
-    AbstractMask<Float> bTest(int cond,
-                                  Vector<Float> o,
+    AbstractMask<Float16> bTest(int cond,
+                                  Vector<Float16> o,
                                   FBinTest f) {
-        float[] vec1 = vec();
-        float[] vec2 = ((FloatVector)o).vec();
+        Float16[] vec1 = vec();
+        Float16[] vec2 = ((HalffloatVector)o).vec();
         boolean[] bits = new boolean[length()];
         for (int i = 0; i < length(); i++){
             bits[i] = f.apply(cond, i, vec1[i], vec2[i]);
@@ -481,24 +481,24 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     @Override
-    abstract FloatSpecies vspecies();
+    abstract HalffloatSpecies vspecies();
 
     /*package-private*/
     @ForceInline
-    static long toBits(float e) {
-        return Float.floatToRawIntBits(e);
+    static long toBits(Float16 e) {
+        return Float16.float16ToRawShortBits(e);
     }
 
     /*package-private*/
     @ForceInline
-    static float fromBits(long bits) {
-        return Float.intBitsToFloat((int)bits);
+    static Float16 fromBits(long bits) {
+        return Float16.shortBitsToFloat16((short)bits);
     }
 
-    static FloatVector expandHelper(Vector<Float> v, VectorMask<Float> m) {
-        VectorSpecies<Float> vsp = m.vectorSpecies();
-        FloatVector r  = (FloatVector) vsp.zero();
-        FloatVector vi = (FloatVector) v;
+    static HalffloatVector expandHelper(Vector<Float16> v, VectorMask<Float16> m) {
+        VectorSpecies<Float16> vsp = m.vectorSpecies();
+        HalffloatVector r  = (HalffloatVector) vsp.zero();
+        HalffloatVector vi = (HalffloatVector) v;
         if (m.allTrue()) {
             return vi;
         }
@@ -510,10 +510,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
         return r;
     }
 
-    static FloatVector compressHelper(Vector<Float> v, VectorMask<Float> m) {
-        VectorSpecies<Float> vsp = m.vectorSpecies();
-        FloatVector r  = (FloatVector) vsp.zero();
-        FloatVector vi = (FloatVector) v;
+    static HalffloatVector compressHelper(Vector<Float16> v, VectorMask<Float16> m) {
+        VectorSpecies<Float16> vsp = m.vectorSpecies();
+        HalffloatVector r  = (HalffloatVector) vsp.zero();
+        HalffloatVector vi = (HalffloatVector) v;
         if (m.allTrue()) {
             return vi;
         }
@@ -531,7 +531,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // sometimes makes a lone /** {@inheritDoc} */
     // comment drop the method altogether,
     // apparently if the method mentions an
-    // parameter or return type of Vector<Float>
+    // parameter or return type of Vector<Float16>
     // instead of Vector<E> as originally specified.
     // Adding an empty HTML fragment appears to
     // nudge javadoc into providing the desired
@@ -547,10 +547,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @return a zero vector
      */
     @ForceInline
-    public static FloatVector zero(VectorSpecies<Float> species) {
-        FloatSpecies vsp = (FloatSpecies) species;
-        return VectorSupport.fromBitsCoerced(vsp.vectorType(), float.class, species.length(),
-                        toBits(0.0f), MODE_BROADCAST, vsp,
+    public static HalffloatVector zero(VectorSpecies<Float16> species) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
+        return VectorSupport.fromBitsCoerced(vsp.vectorType(), Float16.class, species.length(),
+                        toBits(Float16.valueOf(0.0f)), MODE_BROADCAST, vsp,
                         ((bits_, s_) -> s_.rvOp(i -> bits_)));
     }
 
@@ -563,7 +563,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * only the species is relevant to this operation.
      *
      * <p> This method returns the value of this expression:
-     * {@code FloatVector.broadcast(this.species(), e)}.
+     * {@code HalffloatVector.broadcast(this.species(), e)}.
      *
      * @apiNote
      * Unlike the similar method named {@code broadcast()}
@@ -579,7 +579,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @see Vector#broadcast(long)
      * @see VectorSpecies#broadcast(long)
      */
-    public abstract FloatVector broadcast(float e);
+    public abstract HalffloatVector broadcast(Float16 e);
 
     /**
      * Returns a vector of the given species
@@ -595,29 +595,29 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @see VectorSpecies#broadcast(long)
      */
     @ForceInline
-    public static FloatVector broadcast(VectorSpecies<Float> species, float e) {
-        FloatSpecies vsp = (FloatSpecies) species;
+    public static HalffloatVector broadcast(VectorSpecies<Float16> species, Float16 e) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         return vsp.broadcast(e);
     }
 
     /*package-private*/
     @ForceInline
-    final FloatVector broadcastTemplate(float e) {
-        FloatSpecies vsp = vspecies();
+    final HalffloatVector broadcastTemplate(Float16 e) {
+        HalffloatSpecies vsp = vspecies();
         return vsp.broadcast(e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
      * @apiNote
-     * When working with vector subtypes like {@code FloatVector},
-     * {@linkplain #broadcast(float) the more strongly typed method}
+     * When working with vector subtypes like {@code HalffloatVector},
+     * {@linkplain #broadcast(Float16) the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.broadcast((float)e)}.
+     * using a cast: {@code v.broadcast((Float16)e)}.
      * The two expressions will produce numerically identical results.
      */
     @Override
-    public abstract FloatVector broadcast(long e);
+    public abstract HalffloatVector broadcast(long e);
 
     /**
      * Returns a vector of the given species
@@ -635,18 +635,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws IllegalArgumentException
      *         if the given {@code long} value cannot
      *         be represented by the vector's {@code ETYPE}
-     * @see #broadcast(VectorSpecies,float)
+     * @see #broadcast(VectorSpecies,Float16)
      * @see VectorSpecies#checkValue(long)
      */
     @ForceInline
-    public static FloatVector broadcast(VectorSpecies<Float> species, long e) {
-        FloatSpecies vsp = (FloatSpecies) species;
+    public static HalffloatVector broadcast(VectorSpecies<Float16> species, long e) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         return vsp.broadcast(e);
     }
 
     /*package-private*/
     @ForceInline
-    final FloatVector broadcastTemplate(long e) {
+    final HalffloatVector broadcastTemplate(long e) {
         return vspecies().broadcast(e);
     }
 
@@ -656,11 +656,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * {@inheritDoc} <!--workaround-->
      */
     public abstract
-    FloatVector lanewise(VectorOperators.Unary op);
+    HalffloatVector lanewise(VectorOperators.Unary op);
 
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Unary op) {
+    HalffloatVector lanewiseTemplate(VectorOperators.Unary op) {
         if (opKind(op, VO_SPECIAL)) {
             if (op == ZOMO) {
                 return blend(broadcast(-1), compare(NE, 0));
@@ -668,9 +668,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
         }
         int opc = opCode(op);
         return VectorSupport.unaryOp(
-            opc, getClass(), null, float.class, length(),
+            opc, getClass(), null, Float16.class, length(),
             this, null,
-            UN_IMPL.find(op, opc, FloatVector::unaryOperations));
+            UN_IMPL.find(op, opc, HalffloatVector::unaryOperations));
     }
 
     /**
@@ -678,13 +678,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector lanewise(VectorOperators.Unary op,
-                                  VectorMask<Float> m);
+    HalffloatVector lanewise(VectorOperators.Unary op,
+                                  VectorMask<Float16> m);
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Unary op,
-                                          Class<? extends VectorMask<Float>> maskClass,
-                                          VectorMask<Float> m) {
+    HalffloatVector lanewiseTemplate(VectorOperators.Unary op,
+                                          Class<? extends VectorMask<Float16>> maskClass,
+                                          VectorMask<Float16> m) {
         m.check(maskClass, this);
         if (opKind(op, VO_SPECIAL)) {
             if (op == ZOMO) {
@@ -693,53 +693,53 @@ public abstract class FloatVector extends AbstractVector<Float> {
         }
         int opc = opCode(op);
         return VectorSupport.unaryOp(
-            opc, getClass(), maskClass, float.class, length(),
+            opc, getClass(), maskClass, Float16.class, length(),
             this, m,
-            UN_IMPL.find(op, opc, FloatVector::unaryOperations));
+            UN_IMPL.find(op, opc, HalffloatVector::unaryOperations));
     }
 
     private static final
-    ImplCache<Unary, UnaryOperation<FloatVector, VectorMask<Float>>>
-        UN_IMPL = new ImplCache<>(Unary.class, FloatVector.class);
+    ImplCache<Unary, UnaryOperation<HalffloatVector, VectorMask<Float16>>>
+        UN_IMPL = new ImplCache<>(Unary.class, HalffloatVector.class);
 
-    private static UnaryOperation<FloatVector, VectorMask<Float>> unaryOperations(int opc_) {
+    private static UnaryOperation<HalffloatVector, VectorMask<Float16>> unaryOperations(int opc_) {
         switch (opc_) {
             case VECTOR_OP_NEG: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) -a);
+                    v0.uOp(m, (i, a) -> (Float16) Float16.valueOf(-a.floatValue()));
             case VECTOR_OP_ABS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.abs(a));
+                    v0.uOp(m, (i, a) -> (Float16) Float16.abs(a));
             case VECTOR_OP_SIN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.sin(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sin(a.floatValue())));
             case VECTOR_OP_COS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.cos(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cos(a.floatValue())));
             case VECTOR_OP_TAN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.tan(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.tan(a.floatValue())));
             case VECTOR_OP_ASIN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.asin(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.asin(a.floatValue())));
             case VECTOR_OP_ACOS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.acos(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.acos(a.floatValue())));
             case VECTOR_OP_ATAN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.atan(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.atan(a.floatValue())));
             case VECTOR_OP_EXP: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.exp(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.exp(a.floatValue())));
             case VECTOR_OP_LOG: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.log(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log(a.floatValue())));
             case VECTOR_OP_LOG10: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.log10(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log10(a.floatValue())));
             case VECTOR_OP_SQRT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.sqrt(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sqrt(a.floatValue())));
             case VECTOR_OP_CBRT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.cbrt(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cbrt(a.floatValue())));
             case VECTOR_OP_SINH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.sinh(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sinh(a.floatValue())));
             case VECTOR_OP_COSH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.cosh(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cosh(a.floatValue())));
             case VECTOR_OP_TANH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.tanh(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.tanh(a.floatValue())));
             case VECTOR_OP_EXPM1: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.expm1(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.expm1(a.floatValue())));
             case VECTOR_OP_LOG1P: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> (float) Math.log1p(a));
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log1p(a.floatValue())));
             default: return null;
         }
     }
@@ -748,95 +748,93 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Binary,float)
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      */
     @Override
     public abstract
-    FloatVector lanewise(VectorOperators.Binary op,
-                                  Vector<Float> v);
+    HalffloatVector lanewise(VectorOperators.Binary op,
+                                  Vector<Float16> v);
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Binary op,
-                                          Vector<Float> v) {
-        FloatVector that = (FloatVector) v;
+    HalffloatVector lanewiseTemplate(VectorOperators.Binary op,
+                                          Vector<Float16> v) {
+        HalffloatVector that = (HalffloatVector) v;
         that.check(this);
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                VectorMask<Integer> mask
-                    = this.viewAsIntegralLanes().compare(EQ, (int) 0);
+                VectorMask<Short> mask
+                    = this.viewAsIntegralLanes().compare(EQ, (short) 0);
                 return this.blend(that, mask.cast(vspecies()));
             }
         }
 
         int opc = opCode(op);
         return VectorSupport.binaryOp(
-            opc, getClass(), null, float.class, length(),
+            opc, getClass(), null, Float16.class, length(),
             this, that, null,
-            BIN_IMPL.find(op, opc, FloatVector::binaryOperations));
+            BIN_IMPL.find(op, opc, HalffloatVector::binaryOperations));
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      */
     @Override
     public abstract
-    FloatVector lanewise(VectorOperators.Binary op,
-                                  Vector<Float> v,
-                                  VectorMask<Float> m);
+    HalffloatVector lanewise(VectorOperators.Binary op,
+                                  Vector<Float16> v,
+                                  VectorMask<Float16> m);
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Binary op,
-                                          Class<? extends VectorMask<Float>> maskClass,
-                                          Vector<Float> v, VectorMask<Float> m) {
-        FloatVector that = (FloatVector) v;
+    HalffloatVector lanewiseTemplate(VectorOperators.Binary op,
+                                          Class<? extends VectorMask<Float16>> maskClass,
+                                          Vector<Float16> v, VectorMask<Float16> m) {
+        HalffloatVector that = (HalffloatVector) v;
         that.check(this);
         m.check(maskClass, this);
 
         if (opKind(op, VO_SPECIAL )) {
             if (op == FIRST_NONZERO) {
-                IntVector bits = this.viewAsIntegralLanes();
-                VectorMask<Integer> mask
-                    = bits.compare(EQ, (int) 0, m.cast(bits.vspecies()));
+                ShortVector bits = this.viewAsIntegralLanes();
+                VectorMask<Short> mask
+                    = bits.compare(EQ, (short) 0, m.cast(bits.vspecies()));
                 return this.blend(that, mask.cast(vspecies()));
             }
         }
 
         int opc = opCode(op);
         return VectorSupport.binaryOp(
-            opc, getClass(), maskClass, float.class, length(),
+            opc, getClass(), maskClass, Float16.class, length(),
             this, that, m,
-            BIN_IMPL.find(op, opc, FloatVector::binaryOperations));
+            BIN_IMPL.find(op, opc, HalffloatVector::binaryOperations));
     }
 
     private static final
-    ImplCache<Binary, BinaryOperation<FloatVector, VectorMask<Float>>>
-        BIN_IMPL = new ImplCache<>(Binary.class, FloatVector.class);
+    ImplCache<Binary, BinaryOperation<HalffloatVector, VectorMask<Float16>>>
+        BIN_IMPL = new ImplCache<>(Binary.class, HalffloatVector.class);
 
-    private static BinaryOperation<FloatVector, VectorMask<Float>> binaryOperations(int opc_) {
+    private static BinaryOperation<HalffloatVector, VectorMask<Float16>> binaryOperations(int opc_) {
         switch (opc_) {
             case VECTOR_OP_ADD: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)(a + b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.add(a, b));
             case VECTOR_OP_SUB: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)(a - b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.subtract(a, b));
             case VECTOR_OP_MUL: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)(a * b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.multiply(a, b));
             case VECTOR_OP_DIV: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)(a / b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.divide(a, b));
             case VECTOR_OP_MAX: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)Math.max(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.max(a, b));
             case VECTOR_OP_MIN: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float)Math.min(a, b));
-            case VECTOR_OP_OR: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> fromBits(toBits(a) | toBits(b)));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.min(a, b));
             case VECTOR_OP_ATAN2: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float) Math.atan2(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.atan2(a.floatValue(), b.floatValue())));
             case VECTOR_OP_POW: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float) Math.pow(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.pow(a.floatValue(), b.floatValue())));
             case VECTOR_OP_HYPOT: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> (float) Math.hypot(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.hypot(a.floatValue(), b.floatValue())));
             default: return null;
         }
     }
@@ -863,12 +861,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Binary op,
-                                  float e) {
+    HalffloatVector lanewise(VectorOperators.Binary op,
+                                  Float16 e) {
         return lanewise(op, broadcast(e));
     }
 
@@ -890,32 +888,32 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Binary op,
-                                  float e,
-                                  VectorMask<Float> m) {
+    HalffloatVector lanewise(VectorOperators.Binary op,
+                                  Float16 e,
+                                  VectorMask<Float16> m) {
         return lanewise(op, broadcast(e), m);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
      * @apiNote
-     * When working with vector subtypes like {@code FloatVector},
-     * {@linkplain #lanewise(VectorOperators.Binary,float)
+     * When working with vector subtypes like {@code HalffloatVector},
+     * {@linkplain #lanewise(VectorOperators.Binary,Float16)
      * the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.lanewise(op,(float)e)}.
+     * using a cast: {@code v.lanewise(op,(Float16)e)}.
      * The two expressions will produce numerically identical results.
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Binary op,
+    HalffloatVector lanewise(VectorOperators.Binary op,
                                   long e) {
-        float e1 = (float) e;
-        if ((long)e1 != e) {
+        Float16 e1 = Float16.valueOf(e);
+        if (e1.longValue() != e) {
             vspecies().checkValue(e);  // for exception
         }
         return lanewise(op, e1);
@@ -924,19 +922,19 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /**
      * {@inheritDoc} <!--workaround-->
      * @apiNote
-     * When working with vector subtypes like {@code FloatVector},
-     * {@linkplain #lanewise(VectorOperators.Binary,float,VectorMask)
+     * When working with vector subtypes like {@code HalffloatVector},
+     * {@linkplain #lanewise(VectorOperators.Binary,Float16,VectorMask)
      * the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.lanewise(op,(float)e,m)}.
+     * using a cast: {@code v.lanewise(op,(Float16)e,m)}.
      * The two expressions will produce numerically identical results.
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Binary op,
-                                  long e, VectorMask<Float> m) {
-        float e1 = (float) e;
-        if ((long)e1 != e) {
+    HalffloatVector lanewise(VectorOperators.Binary op,
+                                  long e, VectorMask<Float16> m) {
+        Float16 e1 = Float16.valueOf(e);
+        if (e1.longValue() != e) {
             vspecies().checkValue(e);  // for exception
         }
         return lanewise(op, e1, m);
@@ -955,25 +953,25 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
    /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Ternary,float,float,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,float,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,float,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,float,float)
-     * @see #lanewise(VectorOperators.Ternary,Vector,float)
-     * @see #lanewise(VectorOperators.Ternary,float,Vector)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,Float16,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16)
+     * @see #lanewise(VectorOperators.Ternary,Vector,Float16)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Vector)
      */
     @Override
     public abstract
-    FloatVector lanewise(VectorOperators.Ternary op,
-                                                  Vector<Float> v1,
-                                                  Vector<Float> v2);
+    HalffloatVector lanewise(VectorOperators.Ternary op,
+                                                  Vector<Float16> v1,
+                                                  Vector<Float16> v2);
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Ternary op,
-                                          Vector<Float> v1,
-                                          Vector<Float> v2) {
-        FloatVector that = (FloatVector) v1;
-        FloatVector tother = (FloatVector) v2;
+    HalffloatVector lanewiseTemplate(VectorOperators.Ternary op,
+                                          Vector<Float16> v1,
+                                          Vector<Float16> v2) {
+        HalffloatVector that = (HalffloatVector) v1;
+        HalffloatVector tother = (HalffloatVector) v2;
         // It's a word: https://www.dictionary.com/browse/tother
         // See also Chapter 11 of Dickens, Our Mutual Friend:
         // "Totherest Governor," replied Mr Riderhood...
@@ -981,32 +979,32 @@ public abstract class FloatVector extends AbstractVector<Float> {
         tother.check(this);
         int opc = opCode(op);
         return VectorSupport.ternaryOp(
-            opc, getClass(), null, float.class, length(),
+            opc, getClass(), null, Float16.class, length(),
             this, that, tother, null,
-            TERN_IMPL.find(op, opc, FloatVector::ternaryOperations));
+            TERN_IMPL.find(op, opc, HalffloatVector::ternaryOperations));
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Ternary,float,float,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,float,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,float,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,Float16,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Vector,VectorMask)
      */
     @Override
     public abstract
-    FloatVector lanewise(VectorOperators.Ternary op,
-                                  Vector<Float> v1,
-                                  Vector<Float> v2,
-                                  VectorMask<Float> m);
+    HalffloatVector lanewise(VectorOperators.Ternary op,
+                                  Vector<Float16> v1,
+                                  Vector<Float16> v2,
+                                  VectorMask<Float16> m);
     @ForceInline
     final
-    FloatVector lanewiseTemplate(VectorOperators.Ternary op,
-                                          Class<? extends VectorMask<Float>> maskClass,
-                                          Vector<Float> v1,
-                                          Vector<Float> v2,
-                                          VectorMask<Float> m) {
-        FloatVector that = (FloatVector) v1;
-        FloatVector tother = (FloatVector) v2;
+    HalffloatVector lanewiseTemplate(VectorOperators.Ternary op,
+                                          Class<? extends VectorMask<Float16>> maskClass,
+                                          Vector<Float16> v1,
+                                          Vector<Float16> v2,
+                                          VectorMask<Float16> m) {
+        HalffloatVector that = (HalffloatVector) v1;
+        HalffloatVector tother = (HalffloatVector) v2;
         // It's a word: https://www.dictionary.com/browse/tother
         // See also Chapter 11 of Dickens, Our Mutual Friend:
         // "Totherest Governor," replied Mr Riderhood...
@@ -1016,18 +1014,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         int opc = opCode(op);
         return VectorSupport.ternaryOp(
-            opc, getClass(), maskClass, float.class, length(),
+            opc, getClass(), maskClass, Float16.class, length(),
             this, that, tother, m,
-            TERN_IMPL.find(op, opc, FloatVector::ternaryOperations));
+            TERN_IMPL.find(op, opc, HalffloatVector::ternaryOperations));
     }
 
     private static final
-    ImplCache<Ternary, TernaryOperation<FloatVector, VectorMask<Float>>>
-        TERN_IMPL = new ImplCache<>(Ternary.class, FloatVector.class);
+    ImplCache<Ternary, TernaryOperation<HalffloatVector, VectorMask<Float16>>>
+        TERN_IMPL = new ImplCache<>(Ternary.class, HalffloatVector.class);
 
-    private static TernaryOperation<FloatVector, VectorMask<Float>> ternaryOperations(int opc_) {
+    private static TernaryOperation<HalffloatVector, VectorMask<Float16>> ternaryOperations(int opc_) {
         switch (opc_) {
-            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) -> v0.tOp(v1_, v2_, m, (i, a, b, c) -> Math.fma(a, b, c));
+            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) -> v0.tOp(v1_, v2_, m, (i, a, b, c) -> Float16.fma(a, b, c));
             default: return null;
         }
     }
@@ -1049,13 +1047,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,float,float,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,e1,e2)
-                                  float e1,
-                                  float e2) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,e1,e2)
+                                  Float16 e1,
+                                  Float16 e2) {
         return lanewise(op, broadcast(e1), broadcast(e2));
     }
 
@@ -1078,14 +1076,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,float,float)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,e1,e2,m)
-                                  float e1,
-                                  float e2,
-                                  VectorMask<Float> m) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,e1,e2,m)
+                                  Float16 e1,
+                                  Float16 e2,
+                                  VectorMask<Float16> m) {
         return lanewise(op, broadcast(e1), broadcast(e2), m);
     }
 
@@ -1105,14 +1103,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         to the input vectors and the scalar
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
-     * @see #lanewise(VectorOperators.Ternary,float,float)
-     * @see #lanewise(VectorOperators.Ternary,Vector,float,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16)
+     * @see #lanewise(VectorOperators.Ternary,Vector,Float16,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,v1,e2)
-                                  Vector<Float> v1,
-                                  float e2) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,v1,e2)
+                                  Vector<Float16> v1,
+                                  Float16 e2) {
         return lanewise(op, v1, broadcast(e2));
     }
 
@@ -1135,15 +1133,15 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,float,float,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,float)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,Float16)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,v1,e2,m)
-                                  Vector<Float> v1,
-                                  float e2,
-                                  VectorMask<Float> m) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,v1,e2,m)
+                                  Vector<Float16> v1,
+                                  Float16 e2,
+                                  VectorMask<Float16> m) {
         return lanewise(op, v1, broadcast(e2), m);
     }
 
@@ -1164,13 +1162,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,float,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Vector,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,e1,v2)
-                                  float e1,
-                                  Vector<Float> v2) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,e1,v2)
+                                  Float16 e1,
+                                  Vector<Float16> v2) {
         return lanewise(op, broadcast(e1), v2);
     }
 
@@ -1193,14 +1191,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,float,Vector)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Vector)
      */
     @ForceInline
     public final
-    FloatVector lanewise(VectorOperators.Ternary op, //(op,e1,v2,m)
-                                  float e1,
-                                  Vector<Float> v2,
-                                  VectorMask<Float> m) {
+    HalffloatVector lanewise(VectorOperators.Ternary op, //(op,e1,v2,m)
+                                  Float16 e1,
+                                  Vector<Float16> v2,
+                                  VectorMask<Float16> m) {
         return lanewise(op, broadcast(e1), v2, m);
     }
 
@@ -1214,11 +1212,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #add(float)
+     * @see #add(Float16)
      */
     @Override
     @ForceInline
-    public final FloatVector add(Vector<Float> v) {
+    public final HalffloatVector add(Vector<Float16> v) {
         return lanewise(ADD, v);
     }
 
@@ -1229,33 +1227,33 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive addition operation ({@code +}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#ADD
      *    ADD}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of adding each lane of this vector to the scalar
      * @see #add(Vector)
-     * @see #broadcast(float)
-     * @see #add(float,VectorMask)
+     * @see #broadcast(Float16)
+     * @see #add(Float16,VectorMask)
      * @see VectorOperators#ADD
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
     public final
-    FloatVector add(float e) {
+    HalffloatVector add(Float16 e) {
         return lanewise(ADD, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #add(float,VectorMask)
+     * @see #add(Float16,VectorMask)
      */
     @Override
     @ForceInline
-    public final FloatVector add(Vector<Float> v,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector add(Vector<Float16> v,
+                                          VectorMask<Float16> m) {
         return lanewise(ADD, v, m);
     }
 
@@ -1267,7 +1265,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive addition operation ({@code +}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,Float16,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#ADD
      *    ADD}{@code , s, m)}.
      *
@@ -1275,25 +1273,25 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param m the mask controlling lane selection
      * @return the result of adding each lane of this vector to the scalar
      * @see #add(Vector,VectorMask)
-     * @see #broadcast(float)
-     * @see #add(float)
+     * @see #broadcast(Float16)
+     * @see #add(Float16)
      * @see VectorOperators#ADD
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector add(float e,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector add(Float16 e,
+                                          VectorMask<Float16> m) {
         return lanewise(ADD, e, m);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #sub(float)
+     * @see #sub(Float16)
      */
     @Override
     @ForceInline
-    public final FloatVector sub(Vector<Float> v) {
+    public final HalffloatVector sub(Vector<Float16> v) {
         return lanewise(SUB, v);
     }
 
@@ -1304,32 +1302,32 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive subtraction operation ({@code -}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#SUB
      *    SUB}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of subtracting the scalar from each lane of this vector
      * @see #sub(Vector)
-     * @see #broadcast(float)
-     * @see #sub(float,VectorMask)
+     * @see #broadcast(Float16)
+     * @see #sub(Float16,VectorMask)
      * @see VectorOperators#SUB
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector sub(float e) {
+    public final HalffloatVector sub(Float16 e) {
         return lanewise(SUB, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #sub(float,VectorMask)
+     * @see #sub(Float16,VectorMask)
      */
     @Override
     @ForceInline
-    public final FloatVector sub(Vector<Float> v,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector sub(Vector<Float16> v,
+                                          VectorMask<Float16> m) {
         return lanewise(SUB, v, m);
     }
 
@@ -1341,7 +1339,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive subtraction operation ({@code -}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,Float16,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#SUB
      *    SUB}{@code , s, m)}.
      *
@@ -1349,25 +1347,25 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param m the mask controlling lane selection
      * @return the result of subtracting the scalar from each lane of this vector
      * @see #sub(Vector,VectorMask)
-     * @see #broadcast(float)
-     * @see #sub(float)
+     * @see #broadcast(Float16)
+     * @see #sub(Float16)
      * @see VectorOperators#SUB
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector sub(float e,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector sub(Float16 e,
+                                          VectorMask<Float16> m) {
         return lanewise(SUB, e, m);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #mul(float)
+     * @see #mul(Float16)
      */
     @Override
     @ForceInline
-    public final FloatVector mul(Vector<Float> v) {
+    public final HalffloatVector mul(Vector<Float16> v) {
         return lanewise(MUL, v);
     }
 
@@ -1378,32 +1376,32 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive multiplication operation ({@code *}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#MUL
      *    MUL}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #mul(Vector)
-     * @see #broadcast(float)
-     * @see #mul(float,VectorMask)
+     * @see #broadcast(Float16)
+     * @see #mul(Float16,VectorMask)
      * @see VectorOperators#MUL
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector mul(float e) {
+    public final HalffloatVector mul(Float16 e) {
         return lanewise(MUL, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #mul(float,VectorMask)
+     * @see #mul(Float16,VectorMask)
      */
     @Override
     @ForceInline
-    public final FloatVector mul(Vector<Float> v,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector mul(Vector<Float16> v,
+                                          VectorMask<Float16> m) {
         return lanewise(MUL, v, m);
     }
 
@@ -1415,7 +1413,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive multiplication operation ({@code *}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,Float16,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#MUL
      *    MUL}{@code , s, m)}.
      *
@@ -1423,15 +1421,15 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param m the mask controlling lane selection
      * @return the result of muling each lane of this vector to the scalar
      * @see #mul(Vector,VectorMask)
-     * @see #broadcast(float)
-     * @see #mul(float)
+     * @see #broadcast(Float16)
+     * @see #mul(Float16)
      * @see VectorOperators#MUL
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector mul(float e,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector mul(Float16 e,
+                                          VectorMask<Float16> m) {
         return lanewise(MUL, e, m);
     }
 
@@ -1444,7 +1442,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     @ForceInline
-    public final FloatVector div(Vector<Float> v) {
+    public final HalffloatVector div(Vector<Float16> v) {
         return lanewise(DIV, v);
     }
 
@@ -1455,7 +1453,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive division operation ({@code /}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#DIV
      *    DIV}{@code , e)}.
      *
@@ -1467,20 +1465,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param e the input scalar
      * @return the result of dividing each lane of this vector by the scalar
      * @see #div(Vector)
-     * @see #broadcast(float)
-     * @see #div(float,VectorMask)
+     * @see #broadcast(Float16)
+     * @see #div(Float16,VectorMask)
      * @see VectorOperators#DIV
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector div(float e) {
+    public final HalffloatVector div(Float16 e) {
         return lanewise(DIV, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #div(float,VectorMask)
+     * @see #div(Float16,VectorMask)
      * @apiNote Because the underlying scalar operator is an IEEE
      * floating point number, division by zero in fact will
      * not throw an exception, but will yield a signed
@@ -1488,8 +1486,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     @ForceInline
-    public final FloatVector div(Vector<Float> v,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector div(Vector<Float16> v,
+                                          VectorMask<Float16> m) {
         return lanewise(DIV, v, m);
     }
 
@@ -1501,7 +1499,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * the primitive division operation ({@code /}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,Float16,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#DIV
      *    DIV}{@code , s, m)}.
      *
@@ -1514,15 +1512,15 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param m the mask controlling lane selection
      * @return the result of dividing each lane of this vector by the scalar
      * @see #div(Vector,VectorMask)
-     * @see #broadcast(float)
-     * @see #div(float)
+     * @see #broadcast(Float16)
+     * @see #div(Float16)
      * @see VectorOperators#DIV
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,float)
+     * @see #lanewise(VectorOperators.Binary,Float16)
      */
     @ForceInline
-    public final FloatVector div(float e,
-                                          VectorMask<Float> m) {
+    public final HalffloatVector div(Float16 e,
+                                          VectorMask<Float16> m) {
         return lanewise(DIV, e, m);
     }
 
@@ -1541,7 +1539,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     @ForceInline
-    public final FloatVector min(Vector<Float> v) {
+    public final HalffloatVector min(Vector<Float16> v) {
         return lanewise(MIN, v);
     }
 
@@ -1554,23 +1552,23 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * corresponding lane values.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#MIN
      *    MIN}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #min(Vector)
-     * @see #broadcast(float)
+     * @see #broadcast(Float16)
      * @see VectorOperators#MIN
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      * @apiNote
      * For this method, floating point negative
      * zero {@code -0.0} is treated as a value distinct from, and less
      * than the default value (positive zero).
      */
     @ForceInline
-    public final FloatVector min(float e) {
+    public final HalffloatVector min(Float16 e) {
         return lanewise(MIN, e);
     }
 
@@ -1583,7 +1581,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     @ForceInline
-    public final FloatVector max(Vector<Float> v) {
+    public final HalffloatVector max(Vector<Float16> v) {
         return lanewise(MAX, v);
     }
 
@@ -1595,23 +1593,23 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * corresponding lane values.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,float)
+     * {@link #lanewise(VectorOperators.Binary,Float16)
      *    lanewise}{@code (}{@link VectorOperators#MAX
      *    MAX}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #max(Vector)
-     * @see #broadcast(float)
+     * @see #broadcast(Float16)
      * @see VectorOperators#MAX
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      * @apiNote
      * For this method, floating point negative
      * zero {@code -0.0} is treated as a value distinct from, and less
      * than the default value (positive zero).
      */
     @ForceInline
-    public final FloatVector max(float e) {
+    public final HalffloatVector max(Float16 e) {
         return lanewise(MAX, e);
     }
 
@@ -1624,10 +1622,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * conforming to the specification of
      * {@link Math#pow Math.pow(a,b)}
      * to each pair of corresponding lane values.
-     * The operation is adapted to cast the operands and the result,
-     * specifically widening {@code float} operands to {@code double}
-     * operands and narrowing the {@code double} result to a {@code float}
-     * result.
      *
      * This method is also equivalent to the expression
      * {@link #lanewise(VectorOperators.Binary,Vector)
@@ -1643,12 +1637,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *
      * @param b a vector exponent by which to raise this vector
      * @return the {@code b}-th power of this vector
-     * @see #pow(float)
+     * @see #pow(Float16)
      * @see VectorOperators#POW
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
      */
     @ForceInline
-    public final FloatVector pow(Vector<Float> b) {
+    public final HalffloatVector pow(Vector<Float16> b) {
         return lanewise(POW, b);
     }
 
@@ -1659,10 +1653,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * conforming to the specification of
      * {@link Math#pow Math.pow(a,b)}
      * to each pair of corresponding lane values.
-     * The operation is adapted to cast the operands and the result,
-     * specifically widening {@code float} operands to {@code double}
-     * operands and narrowing the {@code double} result to a {@code float}
-     * result.
      *
      * This method is also equivalent to the expression
      * {@link #lanewise(VectorOperators.Binary,Vector)
@@ -1673,10 +1663,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @return the {@code b}-th power of this vector
      * @see #pow(Vector)
      * @see VectorOperators#POW
-     * @see #lanewise(VectorOperators.Binary,float,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,Float16,VectorMask)
      */
     @ForceInline
-    public final FloatVector pow(float b) {
+    public final HalffloatVector pow(Float16 b) {
         return lanewise(POW, b);
     }
 
@@ -1688,7 +1678,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    FloatVector neg() {
+    HalffloatVector neg() {
         return lanewise(NEG);
     }
 
@@ -1698,7 +1688,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    FloatVector abs() {
+    HalffloatVector abs() {
         return lanewise(ABS);
     }
 
@@ -1712,10 +1702,6 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * conforming to the specification of
      * {@link Math#sqrt Math.sqrt(a)}
      * to each lane value.
-     * The operation is adapted to cast the operand and the result,
-     * specifically widening the {@code float} operand to a {@code double}
-     * operand and narrowing the {@code double} result to a {@code float}
-     * result.
      *
      * This method is also equivalent to the expression
      * {@link #lanewise(VectorOperators.Unary)
@@ -1727,7 +1713,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @see #lanewise(VectorOperators.Unary,VectorMask)
      */
     @ForceInline
-    public final FloatVector sqrt() {
+    public final HalffloatVector sqrt() {
         return lanewise(SQRT);
     }
 
@@ -1739,7 +1725,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    VectorMask<Float> eq(Vector<Float> v) {
+    VectorMask<Float16> eq(Vector<Float16> v) {
         return compare(EQ, v);
     }
 
@@ -1753,11 +1739,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param e the input scalar
      * @return the result mask of testing if this vector
      *         is equal to {@code e}
-     * @see #compare(VectorOperators.Comparison,float)
+     * @see #compare(VectorOperators.Comparison,Float16)
      */
     @ForceInline
     public final
-    VectorMask<Float> eq(float e) {
+    VectorMask<Float16> eq(Float16 e) {
         return compare(EQ, e);
     }
 
@@ -1767,7 +1753,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    VectorMask<Float> lt(Vector<Float> v) {
+    VectorMask<Float16> lt(Vector<Float16> v) {
         return compare(LT, v);
     }
 
@@ -1781,11 +1767,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param e the input scalar
      * @return the mask result of testing if this vector
      *         is less than the input scalar
-     * @see #compare(VectorOperators.Comparison,float)
+     * @see #compare(VectorOperators.Comparison,Float16)
      */
     @ForceInline
     public final
-    VectorMask<Float> lt(float e) {
+    VectorMask<Float16> lt(Float16 e) {
         return compare(LT, e);
     }
 
@@ -1794,29 +1780,29 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    VectorMask<Float> test(VectorOperators.Test op);
+    VectorMask<Float16> test(VectorOperators.Test op);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
+    <M extends VectorMask<Float16>>
     M testTemplate(Class<M> maskType, Test op) {
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         if (opKind(op, VO_SPECIAL)) {
-            IntVector bits = this.viewAsIntegralLanes();
-            VectorMask<Integer> m;
+            ShortVector bits = this.viewAsIntegralLanes();
+            VectorMask<Short> m;
             if (op == IS_DEFAULT) {
-                m = bits.compare(EQ, (int) 0);
+                m = bits.compare(EQ, (short) 0);
             } else if (op == IS_NEGATIVE) {
-                m = bits.compare(LT, (int) 0);
+                m = bits.compare(LT, (short) 0);
             }
             else if (op == IS_FINITE ||
                      op == IS_NAN ||
                      op == IS_INFINITE) {
                 // first kill the sign:
-                bits = bits.and(Integer.MAX_VALUE);
+                bits = bits.and(Short.MAX_VALUE);
                 // next find the bit pattern for infinity:
-                int infbits = (int) toBits(Float.POSITIVE_INFINITY);
+                short infbits = (short) toBits(Float16.POSITIVE_INFINITY);
                 // now compare:
                 if (op == IS_FINITE) {
                     m = bits.compare(LT, infbits);
@@ -1840,31 +1826,31 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    VectorMask<Float> test(VectorOperators.Test op,
-                                  VectorMask<Float> m);
+    VectorMask<Float16> test(VectorOperators.Test op,
+                                  VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
+    <M extends VectorMask<Float16>>
     M testTemplate(Class<M> maskType, Test op, M mask) {
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         mask.check(maskType, this);
         if (opKind(op, VO_SPECIAL)) {
-            IntVector bits = this.viewAsIntegralLanes();
-            VectorMask<Integer> m = mask.cast(IntVector.species(shape()));
+            ShortVector bits = this.viewAsIntegralLanes();
+            VectorMask<Short> m = mask.cast(ShortVector.species(shape()));
             if (op == IS_DEFAULT) {
-                m = bits.compare(EQ, (int) 0, m);
+                m = bits.compare(EQ, (short) 0, m);
             } else if (op == IS_NEGATIVE) {
-                m = bits.compare(LT, (int) 0, m);
+                m = bits.compare(LT, (short) 0, m);
             }
             else if (op == IS_FINITE ||
                      op == IS_NAN ||
                      op == IS_INFINITE) {
                 // first kill the sign:
-                bits = bits.and(Integer.MAX_VALUE);
+                bits = bits.and(Short.MAX_VALUE);
                 // next find the bit pattern for infinity:
-                int infbits = (int) toBits(Float.POSITIVE_INFINITY);
+                short infbits = (short) toBits(Float16.POSITIVE_INFINITY);
                 // now compare:
                 if (op == IS_FINITE) {
                     m = bits.compare(LT, infbits, m);
@@ -1888,21 +1874,21 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    VectorMask<Float> compare(VectorOperators.Comparison op, Vector<Float> v);
+    VectorMask<Float16> compare(VectorOperators.Comparison op, Vector<Float16> v);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    M compareTemplate(Class<M> maskType, Comparison op, Vector<Float> v) {
-        FloatVector that = (FloatVector) v;
+    <M extends VectorMask<Float16>>
+    M compareTemplate(Class<M> maskType, Comparison op, Vector<Float16> v) {
+        HalffloatVector that = (HalffloatVector) v;
         that.check(this);
         int opc = opCode(op);
         return VectorSupport.compare(
-            opc, getClass(), maskType, float.class, length(),
+            opc, getClass(), maskType, Float16.class, length(),
             this, that, null,
             (cond, v0, v1, m1) -> {
-                AbstractMask<Float> m
+                AbstractMask<Float16> m
                     = v0.bTest(cond, v1, (cond_, i, a, b)
                                -> compareWithOp(cond, a, b));
                 @SuppressWarnings("unchecked")
@@ -1914,17 +1900,17 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    M compareTemplate(Class<M> maskType, Comparison op, Vector<Float> v, M m) {
-        FloatVector that = (FloatVector) v;
+    <M extends VectorMask<Float16>>
+    M compareTemplate(Class<M> maskType, Comparison op, Vector<Float16> v, M m) {
+        HalffloatVector that = (HalffloatVector) v;
         that.check(this);
         m.check(maskType, this);
         int opc = opCode(op);
         return VectorSupport.compare(
-            opc, getClass(), maskType, float.class, length(),
+            opc, getClass(), maskType, Float16.class, length(),
             this, that, m,
             (cond, v0, v1, m1) -> {
-                AbstractMask<Float> cmpM
+                AbstractMask<Float16> cmpM
                     = v0.bTest(cond, v1, (cond_, i, a, b)
                                -> compareWithOp(cond, a, b));
                 @SuppressWarnings("unchecked")
@@ -1934,14 +1920,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     @ForceInline
-    private static boolean compareWithOp(int cond, float a, float b) {
+    private static boolean compareWithOp(int cond, Float16 a, Float16 b) {
         return switch (cond) {
             case BT_eq -> a == b;
             case BT_ne -> a != b;
-            case BT_lt -> a < b;
-            case BT_le -> a <= b;
-            case BT_gt -> a > b;
-            case BT_ge -> a >= b;
+            case BT_lt -> a.floatValue() < b.floatValue();
+            case BT_le -> a.floatValue() <= b.floatValue();
+            case BT_gt -> a.floatValue() > b.floatValue();
+            case BT_ge -> a.floatValue() >= b.floatValue();
             default -> throw new AssertionError();
         };
     }
@@ -1965,18 +1951,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @return the mask result of testing lane-wise if this vector
      *         compares to the input, according to the selected
      *         comparison operator
-     * @see FloatVector#compare(VectorOperators.Comparison,Vector)
-     * @see #eq(float)
-     * @see #lt(float)
+     * @see HalffloatVector#compare(VectorOperators.Comparison,Vector)
+     * @see #eq(Float16)
+     * @see #lt(Float16)
      */
     public abstract
-    VectorMask<Float> compare(Comparison op, float e);
+    VectorMask<Float16> compare(Comparison op, Float16 e);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    M compareTemplate(Class<M> maskType, Comparison op, float e) {
+    <M extends VectorMask<Float16>>
+    M compareTemplate(Class<M> maskType, Comparison op, Float16 e) {
         return compareTemplate(maskType, op, broadcast(e));
     }
 
@@ -1998,12 +1984,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         compares to the input, according to the selected
      *         comparison operator,
      *         and only in the lanes selected by the mask
-     * @see FloatVector#compare(VectorOperators.Comparison,Vector,VectorMask)
+     * @see HalffloatVector#compare(VectorOperators.Comparison,Vector,VectorMask)
      */
     @ForceInline
-    public final VectorMask<Float> compare(VectorOperators.Comparison op,
-                                               float e,
-                                               VectorMask<Float> m) {
+    public final VectorMask<Float16> compare(VectorOperators.Comparison op,
+                                               Float16 e,
+                                               VectorMask<Float16> m) {
         return compare(op, broadcast(e), m);
     }
 
@@ -2012,12 +1998,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    VectorMask<Float> compare(Comparison op, long e);
+    VectorMask<Float16> compare(Comparison op, long e);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
+    <M extends VectorMask<Float16>>
     M compareTemplate(Class<M> maskType, Comparison op, long e) {
         return compareTemplate(maskType, op, broadcast(e));
     }
@@ -2028,7 +2014,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    VectorMask<Float> compare(Comparison op, long e, VectorMask<Float> m) {
+    VectorMask<Float16> compare(Comparison op, long e, VectorMask<Float16> m) {
         return compare(op, broadcast(e), m);
     }
 
@@ -2038,17 +2024,17 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * {@inheritDoc} <!--workaround-->
      */
     @Override public abstract
-    FloatVector blend(Vector<Float> v, VectorMask<Float> m);
+    HalffloatVector blend(Vector<Float16> v, VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    FloatVector
-    blendTemplate(Class<M> maskType, FloatVector v, M m) {
+    <M extends VectorMask<Float16>>
+    HalffloatVector
+    blendTemplate(Class<M> maskType, HalffloatVector v, M m) {
         v.check(this);
         return VectorSupport.blend(
-            getClass(), maskType, float.class, length(),
+            getClass(), maskType, Float16.class, length(),
             this, v, m,
             (v0, v1, m_) -> v0.bOp(v1, m_, (i, a, b) -> b));
     }
@@ -2056,24 +2042,24 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /**
      * {@inheritDoc} <!--workaround-->
      */
-    @Override public abstract FloatVector addIndex(int scale);
+    @Override public abstract HalffloatVector addIndex(int scale);
 
     /*package-private*/
     @ForceInline
-    final FloatVector addIndexTemplate(int scale) {
-        FloatSpecies vsp = vspecies();
+    final HalffloatVector addIndexTemplate(int scale) {
+        HalffloatSpecies vsp = vspecies();
         // make sure VLENGTH*scale doesn't overflow:
         vsp.checkScale(scale);
         return VectorSupport.indexVector(
-            getClass(), float.class, length(),
+            getClass(), Float16.class, length(),
             this, scale, vsp,
             (v, scale_, s)
             -> {
                 // If the platform doesn't support an INDEX
                 // instruction directly, load IOTA from memory
                 // and multiply.
-                FloatVector iota = s.iota();
-                return v.add(scale_ == 1 ? iota : iota.mul((float)scale_));
+                HalffloatVector iota = s.iota();
+                return v.add(scale_ == 1 ? iota : iota.mul(Float16.valueOf(scale_)));
             });
     }
 
@@ -2094,8 +2080,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         the scalar value
      */
     @ForceInline
-    public final FloatVector blend(float e,
-                                            VectorMask<Float> m) {
+    public final HalffloatVector blend(Float16 e,
+                                            VectorMask<Float16> m) {
         return blend(broadcast(e), m);
     }
 
@@ -2116,8 +2102,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         the scalar value
      */
     @ForceInline
-    public final FloatVector blend(long e,
-                                            VectorMask<Float> m) {
+    public final HalffloatVector blend(long e,
+                                            VectorMask<Float16> m) {
         return blend(broadcast(e), m);
     }
 
@@ -2126,18 +2112,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector slice(int origin, Vector<Float> v1);
+    HalffloatVector slice(int origin, Vector<Float16> v1);
 
     /*package-private*/
     final
     @ForceInline
-    FloatVector sliceTemplate(int origin, Vector<Float> v1) {
-        FloatVector that = (FloatVector) v1;
+    HalffloatVector sliceTemplate(int origin, Vector<Float16> v1) {
+        HalffloatVector that = (HalffloatVector) v1;
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
-        VectorShuffle<Float> iota = iotaShuffle();
-        float pivotidx = (float)(length() - origin);
-        VectorMask<Float> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
+        VectorShuffle<Float16> iota = iotaShuffle();
+        Float16 pivotidx = Float16.valueOf(length() - origin);
+        VectorMask<Float16> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2148,9 +2134,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     public final
-    FloatVector slice(int origin,
-                               Vector<Float> w,
-                               VectorMask<Float> m) {
+    HalffloatVector slice(int origin,
+                               Vector<Float16> w,
+                               VectorMask<Float16> m) {
         return broadcast(0).blend(slice(origin, w), m);
     }
 
@@ -2159,16 +2145,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector slice(int origin);
+    HalffloatVector slice(int origin);
 
     /*package-private*/
     final
     @ForceInline
-    FloatVector sliceTemplate(int origin) {
+    HalffloatVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
-        VectorShuffle<Float> iota = iotaShuffle();
-        float pivotidx = (float)(length() - origin);
-        VectorMask<Float> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
+        VectorShuffle<Float16> iota = iotaShuffle();
+        Float16 pivotidx = Float16.valueOf(length() - origin);
+        VectorMask<Float16> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2178,19 +2164,19 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector unslice(int origin, Vector<Float> w, int part);
+    HalffloatVector unslice(int origin, Vector<Float16> w, int part);
 
     /*package-private*/
     final
     @ForceInline
-    FloatVector
-    unsliceTemplate(int origin, Vector<Float> w, int part) {
-        FloatVector that = (FloatVector) w;
+    HalffloatVector
+    unsliceTemplate(int origin, Vector<Float16> w, int part) {
+        HalffloatVector that = (HalffloatVector) w;
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
-        VectorShuffle<Float> iota = iotaShuffle();
-        VectorMask<Float> blendMask = iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast((float)(origin))));
+        VectorShuffle<Float16> iota = iotaShuffle();
+        VectorMask<Float16> blendMask = iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
+                                                                  (broadcast(Float16.valueOf(origin))));
         iota = iotaShuffle(-origin, 1, true);
         return that.blend(this.rearrange(iota), blendMask);
     }
@@ -2198,12 +2184,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     final
     @ForceInline
-    <M extends VectorMask<Float>>
-    FloatVector
-    unsliceTemplate(Class<M> maskType, int origin, Vector<Float> w, int part, M m) {
-        FloatVector that = (FloatVector) w;
+    <M extends VectorMask<Float16>>
+    HalffloatVector
+    unsliceTemplate(Class<M> maskType, int origin, Vector<Float16> w, int part, M m) {
+        HalffloatVector that = (HalffloatVector) w;
         that.check(this);
-        FloatVector slice = that.sliceTemplate(origin, that);
+        HalffloatVector slice = that.sliceTemplate(origin, that);
         slice = slice.blendTemplate(maskType, this, m);
         return slice.unsliceTemplate(origin, w, part);
     }
@@ -2213,24 +2199,24 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector unslice(int origin, Vector<Float> w, int part, VectorMask<Float> m);
+    HalffloatVector unslice(int origin, Vector<Float16> w, int part, VectorMask<Float16> m);
 
     /**
      * {@inheritDoc} <!--workaround-->
      */
     @Override
     public abstract
-    FloatVector unslice(int origin);
+    HalffloatVector unslice(int origin);
 
     /*package-private*/
     final
     @ForceInline
-    FloatVector
+    HalffloatVector
     unsliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
-        VectorShuffle<Float> iota = iotaShuffle();
-        VectorMask<Float> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  broadcast((float)(origin)));
+        VectorShuffle<Float16> iota = iotaShuffle();
+        VectorMask<Float16> blendMask = iota.toVector().compare(VectorOperators.GE,
+                                                                  broadcast(Float16.valueOf(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2247,16 +2233,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector rearrange(VectorShuffle<Float> m);
+    HalffloatVector rearrange(VectorShuffle<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <S extends VectorShuffle<Float>>
-    FloatVector rearrangeTemplate(Class<S> shuffletype, S shuffle) {
+    <S extends VectorShuffle<Float16>>
+    HalffloatVector rearrangeTemplate(Class<S> shuffletype, S shuffle) {
         shuffle.checkIndexes();
         return VectorSupport.rearrangeOp(
-            getClass(), shuffletype, null, float.class, length(),
+            getClass(), shuffletype, null, Float16.class, length(),
             this, shuffle, null,
             (v1, s_, m_) -> v1.uOp((i, a) -> {
                 int ei = s_.laneSource(i);
@@ -2269,30 +2255,30 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector rearrange(VectorShuffle<Float> s,
-                                   VectorMask<Float> m);
+    HalffloatVector rearrange(VectorShuffle<Float16> s,
+                                   VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <S extends VectorShuffle<Float>, M extends VectorMask<Float>>
-    FloatVector rearrangeTemplate(Class<S> shuffletype,
+    <S extends VectorShuffle<Float16>, M extends VectorMask<Float16>>
+    HalffloatVector rearrangeTemplate(Class<S> shuffletype,
                                            Class<M> masktype,
                                            S shuffle,
                                            M m) {
 
         m.check(masktype, this);
-        VectorMask<Float> valid = shuffle.laneIsValid();
+        VectorMask<Float16> valid = shuffle.laneIsValid();
         if (m.andNot(valid).anyTrue()) {
             shuffle.checkIndexes();
             throw new AssertionError();
         }
         return VectorSupport.rearrangeOp(
-                   getClass(), shuffletype, masktype, float.class, length(),
+                   getClass(), shuffletype, masktype, Float16.class, length(),
                    this, shuffle, m,
                    (v1, s_, m_) -> v1.uOp((i, a) -> {
                         int ei = s_.laneSource(i);
-                        return ei < 0  || !m_.laneIsSet(i) ? 0 : v1.lane(ei);
+                        return ei < 0  || !m_.laneIsSet(i) ? Float16.valueOf(0) : v1.lane(ei);
                    }));
     }
 
@@ -2301,30 +2287,30 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector rearrange(VectorShuffle<Float> s,
-                                   Vector<Float> v);
+    HalffloatVector rearrange(VectorShuffle<Float16> s,
+                                   Vector<Float16> v);
 
     /*package-private*/
     @ForceInline
     final
-    <S extends VectorShuffle<Float>>
-    FloatVector rearrangeTemplate(Class<S> shuffletype,
+    <S extends VectorShuffle<Float16>>
+    HalffloatVector rearrangeTemplate(Class<S> shuffletype,
                                            S shuffle,
-                                           FloatVector v) {
-        VectorMask<Float> valid = shuffle.laneIsValid();
+                                           HalffloatVector v) {
+        VectorMask<Float16> valid = shuffle.laneIsValid();
         @SuppressWarnings("unchecked")
         S ws = (S) shuffle.wrapIndexes();
-        FloatVector r0 =
+        HalffloatVector r0 =
             VectorSupport.rearrangeOp(
-                getClass(), shuffletype, null, float.class, length(),
+                getClass(), shuffletype, null, Float16.class, length(),
                 this, ws, null,
                 (v0, s_, m_) -> v0.uOp((i, a) -> {
                     int ei = s_.laneSource(i);
                     return v0.lane(ei);
                 }));
-        FloatVector r1 =
+        HalffloatVector r1 =
             VectorSupport.rearrangeOp(
-                getClass(), shuffletype, null, float.class, length(),
+                getClass(), shuffletype, null, Float16.class, length(),
                 v, ws, null,
                 (v1, s_, m_) -> v1.uOp((i, a) -> {
                     int ei = s_.laneSource(i);
@@ -2335,11 +2321,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     @ForceInline
     private final
-    VectorShuffle<Float> toShuffle0(FloatSpecies dsp) {
-        float[] a = toArray();
+    VectorShuffle<Float16> toShuffle0(HalffloatSpecies dsp) {
+        Float16[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
+            sa[i] = a[i].intValue();
         }
         return VectorShuffle.fromArray(dsp, sa, 0);
     }
@@ -2347,13 +2333,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /*package-private*/
     @ForceInline
     final
-    VectorShuffle<Float> toShuffleTemplate(Class<?> shuffleType) {
-        FloatSpecies vsp = vspecies();
+    VectorShuffle<Float16> toShuffleTemplate(Class<?> shuffleType) {
+        HalffloatSpecies vsp = vspecies();
         return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     getClass(), float.class, length(),
+                                     getClass(), Float16.class, length(),
                                      shuffleType, byte.class, length(),
                                      this, vsp,
-                                     FloatVector::toShuffle0);
+                                     HalffloatVector::toShuffle0);
     }
 
     /**
@@ -2362,16 +2348,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector compress(VectorMask<Float> m);
+    HalffloatVector compress(VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends AbstractMask<Float>>
-    FloatVector compressTemplate(Class<M> masktype, M m) {
+    <M extends AbstractMask<Float16>>
+    HalffloatVector compressTemplate(Class<M> masktype, M m) {
       m.check(masktype, this);
-      return (FloatVector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_COMPRESS, getClass(), masktype,
-                                                        float.class, length(), this, m,
+      return (HalffloatVector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_COMPRESS, getClass(), masktype,
+                                                        Float16.class, length(), this, m,
                                                         (v1, m1) -> compressHelper(v1, m1));
     }
 
@@ -2381,16 +2367,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector expand(VectorMask<Float> m);
+    HalffloatVector expand(VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    <M extends AbstractMask<Float>>
-    FloatVector expandTemplate(Class<M> masktype, M m) {
+    <M extends AbstractMask<Float16>>
+    HalffloatVector expandTemplate(Class<M> masktype, M m) {
       m.check(masktype, this);
-      return (FloatVector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_EXPAND, getClass(), masktype,
-                                                        float.class, length(), this, m,
+      return (HalffloatVector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_EXPAND, getClass(), masktype,
+                                                        Float16.class, length(), this, m,
                                                         (v1, m1) -> expandHelper(v1, m1));
     }
 
@@ -2400,11 +2386,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector selectFrom(Vector<Float> v);
+    HalffloatVector selectFrom(Vector<Float16> v);
 
     /*package-private*/
     @ForceInline
-    final FloatVector selectFromTemplate(FloatVector v) {
+    final HalffloatVector selectFromTemplate(HalffloatVector v) {
         return v.rearrange(this.toShuffle());
     }
 
@@ -2413,12 +2399,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @Override
     public abstract
-    FloatVector selectFrom(Vector<Float> s, VectorMask<Float> m);
+    HalffloatVector selectFrom(Vector<Float16> s, VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
-    final FloatVector selectFromTemplate(FloatVector v,
-                                                  AbstractMask<Float> m) {
+    final HalffloatVector selectFromTemplate(HalffloatVector v,
+                                                  AbstractMask<Float16> m) {
         return v.rearrange(this.toShuffle(), m);
     }
 
@@ -2437,12 +2423,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *
      * This is a lane-wise ternary operation which applies an operation
      * conforming to the specification of
-     * {@link Math#fma(float,float,float) Math.fma(a,b,c)}
+     * {@link Float16#fma(Float16,Float16,Float16) Float16.fma(a,b,c)}
      * to each lane.
-     * The operation is adapted to cast the operands and the result,
-     * specifically widening {@code float} operands to {@code double}
-     * operands and narrowing the {@code double} result to a {@code float}
-     * result.
      *
      * This method is also equivalent to the expression
      * {@link #lanewise(VectorOperators.Ternary,Vector,Vector)
@@ -2454,13 +2436,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @return the product of this vector and the second input vector
      *         summed with the third input vector, using extended precision
      *         for the intermediate result
-     * @see #fma(float,float)
+     * @see #fma(Float16,Float16)
      * @see VectorOperators#FMA
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector fma(Vector<Float> b, Vector<Float> c) {
+    HalffloatVector fma(Vector<Float16> b, Vector<Float16> c) {
         return lanewise(FMA, b, c);
     }
 
@@ -2476,12 +2458,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *
      * This is a lane-wise ternary operation which applies an operation
      * conforming to the specification of
-     * {@link Math#fma(float,float,float) Math.fma(a,b,c)}
+     * {@link Float16#fma(Float16,Float16,Float16) Float16.fma(a,b,c)}
      * to each lane.
-     * The operation is adapted to cast the operands and the result,
-     * specifically widening {@code float} operands to {@code double}
-     * operands and narrowing the {@code double} result to a {@code float}
-     * result.
      *
      * This method is also equivalent to the expression
      * {@link #lanewise(VectorOperators.Ternary,Vector,Vector)
@@ -2495,15 +2473,15 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         for the intermediate result
      * @see #fma(Vector,Vector)
      * @see VectorOperators#FMA
-     * @see #lanewise(VectorOperators.Ternary,float,float,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Float16,Float16,VectorMask)
      */
     @ForceInline
     public final
-    FloatVector fma(float b, float c) {
+    HalffloatVector fma(Float16 b, Float16 c) {
         return lanewise(FMA, b, c);
     }
 
-    // Don't bother with (Vector,float) and (float,Vector) overloadings.
+    // Don't bother with (Vector,Float16) and (Float16,Vector) overloadings.
 
     // Type specific horizontal reductions
 
@@ -2548,7 +2526,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @see #max(Vector)
      * @see VectorOperators#FIRST_NONZERO
      */
-    public abstract float reduceLanes(VectorOperators.Associative op);
+    public abstract Float16 reduceLanes(VectorOperators.Associative op);
 
     /**
      * Returns a value accumulated from selected lanes of this vector,
@@ -2564,16 +2542,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * If the operation is
      *  {@code ADD}
      * or {@code FIRST_NONZERO},
-     * then the identity value is positive zero, the default {@code float} value.
+     * then the identity value is positive zero, the default {@code Float16} value.
      * <li>
      * If the operation is {@code MUL},
      * then the identity value is one.
      * <li>
      * If the operation is {@code MAX},
-     * then the identity value is {@code Float.NEGATIVE_INFINITY}.
+     * then the identity value is {@code Float16.NEGATIVE_INFINITY}.
      * <li>
      * If the operation is {@code MIN},
-     * then the identity value is {@code Float.POSITIVE_INFINITY}.
+     * then the identity value is {@code Float16.POSITIVE_INFINITY}.
      * </ul>
      * <p>
      * A few reduction operations do not support arbitrary reordering
@@ -2607,70 +2585,70 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         not support the requested operation
      * @see #reduceLanes(VectorOperators.Associative)
      */
-    public abstract float reduceLanes(VectorOperators.Associative op,
-                                       VectorMask<Float> m);
+    public abstract Float16 reduceLanes(VectorOperators.Associative op,
+                                       VectorMask<Float16> m);
 
     /*package-private*/
     @ForceInline
     final
-    float reduceLanesTemplate(VectorOperators.Associative op,
-                               Class<? extends VectorMask<Float>> maskClass,
-                               VectorMask<Float> m) {
+    Float16 reduceLanesTemplate(VectorOperators.Associative op,
+                               Class<? extends VectorMask<Float16>> maskClass,
+                               VectorMask<Float16> m) {
         m.check(maskClass, this);
         if (op == FIRST_NONZERO) {
             // FIXME:  The JIT should handle this.
-            FloatVector v = broadcast((float) 0).blend(this, m);
+            HalffloatVector v = broadcast(Float16.valueOf(0)).blend(this, m);
             return v.reduceLanesTemplate(op);
         }
         int opc = opCode(op);
         return fromBits(VectorSupport.reductionCoerced(
-            opc, getClass(), maskClass, float.class, length(),
+            opc, getClass(), maskClass, Float16.class, length(),
             this, m,
-            REDUCE_IMPL.find(op, opc, FloatVector::reductionOperations)));
+            REDUCE_IMPL.find(op, opc, HalffloatVector::reductionOperations)));
     }
 
     /*package-private*/
     @ForceInline
     final
-    float reduceLanesTemplate(VectorOperators.Associative op) {
+    Float16 reduceLanesTemplate(VectorOperators.Associative op) {
         if (op == FIRST_NONZERO) {
             // FIXME:  The JIT should handle this.
-            VectorMask<Integer> thisNZ
-                = this.viewAsIntegralLanes().compare(NE, (int) 0);
+            VectorMask<Short> thisNZ
+                = this.viewAsIntegralLanes().compare(NE, (short) 0);
             int ft = thisNZ.firstTrue();
-            return ft < length() ? this.lane(ft) : (float) 0;
+            return ft < length() ? this.lane(ft) : Float16.valueOf(0);
         }
         int opc = opCode(op);
         return fromBits(VectorSupport.reductionCoerced(
-            opc, getClass(), null, float.class, length(),
+            opc, getClass(), null, Float16.class, length(),
             this, null,
-            REDUCE_IMPL.find(op, opc, FloatVector::reductionOperations)));
+            REDUCE_IMPL.find(op, opc, HalffloatVector::reductionOperations)));
     }
 
     private static final
-    ImplCache<Associative, ReductionOperation<FloatVector, VectorMask<Float>>>
-        REDUCE_IMPL = new ImplCache<>(Associative.class, FloatVector.class);
+    ImplCache<Associative, ReductionOperation<HalffloatVector, VectorMask<Float16>>>
+        REDUCE_IMPL = new ImplCache<>(Associative.class, HalffloatVector.class);
 
-    private static ReductionOperation<FloatVector, VectorMask<Float>> reductionOperations(int opc_) {
+    private static ReductionOperation<HalffloatVector, VectorMask<Float16>> reductionOperations(int opc_) {
         switch (opc_) {
             case VECTOR_OP_ADD: return (v, m) ->
-                    toBits(v.rOp((float)0, m, (i, a, b) -> (float)(a + b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.add(a, b)));
             case VECTOR_OP_MUL: return (v, m) ->
-                    toBits(v.rOp((float)1, m, (i, a, b) -> (float)(a * b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.multiply(a, b)));
             case VECTOR_OP_MIN: return (v, m) ->
-                    toBits(v.rOp(MAX_OR_INF, m, (i, a, b) -> (float) Math.min(a, b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.min(a, b)));
             case VECTOR_OP_MAX: return (v, m) ->
-                    toBits(v.rOp(MIN_OR_INF, m, (i, a, b) -> (float) Math.max(a, b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.max(a, b)));
             default: return null;
         }
     }
 
-    private static final float MIN_OR_INF = Float.NEGATIVE_INFINITY;
-    private static final float MAX_OR_INF = Float.POSITIVE_INFINITY;
+    private static final Float16 MIN_OR_INF = Float16.NEGATIVE_INFINITY;
+    private static final Float16 MAX_OR_INF = Float16.POSITIVE_INFINITY;
 
     public @Override abstract long reduceLanesToLong(VectorOperators.Associative op);
     public @Override abstract long reduceLanesToLong(VectorOperators.Associative op,
-                                                     VectorMask<Float> m);
+                                                     VectorMask<Float16> m);
 
     // Type specific accessors
 
@@ -2682,7 +2660,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws IllegalArgumentException if the index is out of range
      * ({@code < 0 || >= length()})
      */
-    public abstract float lane(int i);
+    public abstract Float16 lane(int i);
 
     /**
      * Replaces the lane element of this vector at lane index {@code i} with
@@ -2700,22 +2678,22 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @throws IllegalArgumentException if the index is out of range
      * ({@code < 0 || >= length()})
      */
-    public abstract FloatVector withLane(int i, float e);
+    public abstract HalffloatVector withLane(int i, Float16 e);
 
     // Memory load operations
 
     /**
-     * Returns an array of type {@code float[]}
+     * Returns an array of type {@code Float16[]}
      * containing all the lane values.
      * The array length is the same as the vector length.
      * The array elements are stored in lane order.
      * <p>
      * This method behaves as if it stores
      * this vector into an allocated array
-     * (using {@link #intoArray(float[], int) intoArray})
+     * (using {@link #intoArray(Float16[], int) intoArray})
      * and returns the array as follows:
      * <pre>{@code
-     *   float[] a = new float[this.length()];
+     *   Float16[] a = new Float16[this.length()];
      *   this.intoArray(a, 0);
      *   return a;
      * }</pre>
@@ -2724,8 +2702,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     @Override
-    public final float[] toArray() {
-        float[] a = new float[vspecies().laneCount()];
+    public final Float16[] toArray() {
+        Float16[] a = new Float16[vspecies().laneCount()];
         intoArray(a, 0);
         return a;
     }
@@ -2735,11 +2713,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     @Override
     public final int[] toIntArray() {
-        float[] a = toArray();
+        Float16[] a = toArray();
         int[] res = new int[a.length];
         for (int i = 0; i < a.length; i++) {
-            float e = a[i];
-            res[i] = (int) FloatSpecies.toIntegralChecked(e, true);
+            Float16 e = a[i];
+            res[i] = (int) HalffloatSpecies.toIntegralChecked(e, true);
         }
         return res;
     }
@@ -2749,11 +2727,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @ForceInline
     @Override
     public final long[] toLongArray() {
-        float[] a = toArray();
+        Float16[] a = toArray();
         long[] res = new long[a.length];
         for (int i = 0; i < a.length; i++) {
-            float e = a[i];
-            res[i] = FloatSpecies.toIntegralChecked(e, false);
+            // Value range of integral casted Float16 value is a proper subset of
+            // long value range.
+            res[i] = a[i].longValue();
         }
         return res;
     }
@@ -2761,22 +2740,22 @@ public abstract class FloatVector extends AbstractVector<Float> {
     /** {@inheritDoc} <!--workaround-->
      * @implNote
      * When this method is used on used on vectors
-     * of type {@code FloatVector},
+     * of type {@code HalffloatVector},
      * there will be no loss of precision.
      */
     @ForceInline
     @Override
     public final double[] toDoubleArray() {
-        float[] a = toArray();
+        Float16[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = ((double) a[i]);
+            res[i] = a[i].doubleValue();
         }
         return res;
     }
 
     /**
-     * Loads a vector from an array of type {@code float[]}
+     * Loads a vector from an array of type {@code Float16[]}
      * starting at an offset.
      * For each vector lane, where {@code N} is the vector lane index, the
      * array element at index {@code offset + N} is placed into the
@@ -2792,18 +2771,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public static
-    FloatVector fromArray(VectorSpecies<Float> species,
-                                   float[] a, int offset) {
+    HalffloatVector fromArray(VectorSpecies<Float16> species,
+                                   Float16[] a, int offset) {
         offset = checkFromIndexSize(offset, species.length(), a.length);
-        FloatSpecies vsp = (FloatSpecies) species;
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         return vsp.dummyVector().fromArray0(a, offset);
     }
 
     /**
-     * Loads a vector from an array of type {@code float[]}
+     * Loads a vector from an array of type {@code Float16[]}
      * starting at an offset and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code float} (positive zero).
+     * value of {@code Float16} (positive zero).
      * For each vector lane, where {@code N} is the vector lane index,
      * if the mask lane at index {@code N} is set then the array element at
      * index {@code offset + N} is placed into the resulting vector at lane index
@@ -2822,10 +2801,10 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public static
-    FloatVector fromArray(VectorSpecies<Float> species,
-                                   float[] a, int offset,
-                                   VectorMask<Float> m) {
-        FloatSpecies vsp = (FloatSpecies) species;
+    HalffloatVector fromArray(VectorSpecies<Float16> species,
+                                   Float16[] a, int offset,
+                                   VectorMask<Float16> m) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         if (VectorIntrinsics.indexInRange(offset, vsp.length(), a.length)) {
             return vsp.dummyVector().fromArray0(a, offset, m, OFFSET_IN_RANGE);
         }
@@ -2836,7 +2815,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /**
      * Gathers a new vector composed of elements from an array of type
-     * {@code float[]},
+     * {@code Float16[]},
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
      * The index map is a contiguous sequence of {@code VLENGTH}
@@ -2863,38 +2842,20 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         or if {@code f(N)=offset+indexMap[mapOffset+N]}
      *         is an invalid index into {@code a},
      *         for any lane {@code N} in the vector
-     * @see FloatVector#toIntArray()
+     * @see HalffloatVector#toIntArray()
      */
     @ForceInline
     public static
-    FloatVector fromArray(VectorSpecies<Float> species,
-                                   float[] a, int offset,
+    HalffloatVector fromArray(VectorSpecies<Float16> species,
+                                   Float16[] a, int offset,
                                    int[] indexMap, int mapOffset) {
-        FloatSpecies vsp = (FloatSpecies) species;
-        IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
-        Objects.requireNonNull(a);
-        Objects.requireNonNull(indexMap);
-        Class<? extends FloatVector> vectorType = vsp.vectorType();
-
-        // Index vector: vix[0:n] = k -> offset + indexMap[mapOffset + k]
-        IntVector vix = IntVector
-            .fromArray(isp, indexMap, mapOffset)
-            .add(offset);
-
-        vix = VectorIntrinsics.checkIndex(vix, a.length);
-
-        return VectorSupport.loadWithMap(
-            vectorType, null, float.class, vsp.laneCount(),
-            isp.vectorType(),
-            a, ARRAY_BASE, vix, null,
-            a, offset, indexMap, mapOffset, vsp,
-            (c, idx, iMap, idy, s, vm) ->
-            s.vOp(n -> c[idx + iMap[idy+n]]));
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
+        return vsp.vOp(n -> a[offset + indexMap[mapOffset + n]]);
     }
 
     /**
      * Gathers a new vector composed of elements from an array of type
-     * {@code float[]},
+     * {@code Float16[]},
      * under the control of a mask, and
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
@@ -2926,21 +2887,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         is an invalid index into {@code a},
      *         for any lane {@code N} in the vector
      *         where the mask is set
-     * @see FloatVector#toIntArray()
+     * @see HalffloatVector#toIntArray()
      */
     @ForceInline
     public static
-    FloatVector fromArray(VectorSpecies<Float> species,
-                                   float[] a, int offset,
+    HalffloatVector fromArray(VectorSpecies<Float16> species,
+                                   Float16[] a, int offset,
                                    int[] indexMap, int mapOffset,
-                                   VectorMask<Float> m) {
-        if (m.allTrue()) {
-            return fromArray(species, a, offset, indexMap, mapOffset);
-        }
-        else {
-            FloatSpecies vsp = (FloatSpecies) species;
-            return vsp.dummyVector().fromArray0(a, offset, indexMap, mapOffset, m);
-        }
+                                   VectorMask<Float16> m) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
+        return vsp.vOp(m, n -> a[offset + indexMap[mapOffset + n]]);
     }
 
 
@@ -2967,8 +2923,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param bo the intended byte order
      * @return a vector loaded from the memory segment
      * @throws IndexOutOfBoundsException
-     *         if {@code offset+N*4 < 0}
-     *         or {@code offset+N*4 >= ms.byteSize()}
+     *         if {@code offset+N*2 < 0}
+     *         or {@code offset+N*2 >= ms.byteSize()}
      *         for any lane {@code N} in the vector
      * @throws IllegalStateException if the memory segment's session is not alive,
      *         or if access occurs from a thread other than the thread owning the session.
@@ -2976,11 +2932,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public static
-    FloatVector fromMemorySegment(VectorSpecies<Float> species,
+    HalffloatVector fromMemorySegment(VectorSpecies<Float16> species,
                                            MemorySegment ms, long offset,
                                            ByteOrder bo) {
         offset = checkFromIndexSize(offset, species.vectorByteSize(), ms.byteSize());
-        FloatSpecies vsp = (FloatSpecies) species;
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         return vsp.dummyVector().fromMemorySegment0(ms, offset).maybeSwap(bo);
     }
 
@@ -2989,7 +2945,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * starting at an offset into the memory segment
      * and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code float} (positive zero).
+     * value of {@code Float16} (positive zero).
      * Bytes are composed into primitive lane elements according
      * to the specified byte order.
      * The vector is arranged into lanes according to
@@ -2998,13 +2954,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * The following pseudocode illustrates the behavior:
      * <pre>{@code
      * var slice = ms.asSlice(offset);
-     * float[] ar = new float[species.length()];
+     * Float16[] ar = new Float16[species.length()];
      * for (int n = 0; n < ar.length; n++) {
      *     if (m.laneIsSet(n)) {
-     *         ar[n] = slice.getAtIndex(ValuaLayout.JAVA_FLOAT.withByteAlignment(1), n);
+     *         ar[n] = slice.getAtIndex(ValuaLayout.JAVA_HALFFLOAT.withByteAlignment(1), n);
      *     }
      * }
-     * FloatVector r = FloatVector.fromArray(species, ar, 0);
+     * HalffloatVector r = HalffloatVector.fromArray(species, ar, 0);
      * }</pre>
      * @implNote
      * This operation is likely to be more efficient if
@@ -3021,8 +2977,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * @param m the mask controlling lane selection
      * @return a vector loaded from the memory segment
      * @throws IndexOutOfBoundsException
-     *         if {@code offset+N*4 < 0}
-     *         or {@code offset+N*4 >= ms.byteSize()}
+     *         if {@code offset+N*2 < 0}
+     *         or {@code offset+N*2 >= ms.byteSize()}
      *         for any lane {@code N} in the vector
      *         where the mask is set
      * @throws IllegalStateException if the memory segment's session is not alive,
@@ -3031,30 +2987,30 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public static
-    FloatVector fromMemorySegment(VectorSpecies<Float> species,
+    HalffloatVector fromMemorySegment(VectorSpecies<Float16> species,
                                            MemorySegment ms, long offset,
                                            ByteOrder bo,
-                                           VectorMask<Float> m) {
-        FloatSpecies vsp = (FloatSpecies) species;
+                                           VectorMask<Float16> m) {
+        HalffloatSpecies vsp = (HalffloatSpecies) species;
         if (VectorIntrinsics.indexInRange(offset, vsp.vectorByteSize(), ms.byteSize())) {
             return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_IN_RANGE).maybeSwap(bo);
         }
 
-        checkMaskFromIndexSize(offset, vsp, m, 4, ms.byteSize());
+        checkMaskFromIndexSize(offset, vsp, m, 2, ms.byteSize());
         return vsp.dummyVector().fromMemorySegment0(ms, offset, m, OFFSET_OUT_OF_RANGE).maybeSwap(bo);
     }
 
     // Memory store operations
 
     /**
-     * Stores this vector into an array of type {@code float[]}
+     * Stores this vector into an array of type {@code Float16[]}
      * starting at an offset.
      * <p>
      * For each vector lane, where {@code N} is the vector lane index,
      * the lane element at index {@code N} is stored into the array
      * element {@code a[offset+N]}.
      *
-     * @param a the array, of type {@code float[]}
+     * @param a the array, of type {@code Float16[]}
      * @param offset the offset into the array
      * @throws IndexOutOfBoundsException
      *         if {@code offset+N < 0} or {@code offset+N >= a.length}
@@ -3062,9 +3018,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public final
-    void intoArray(float[] a, int offset) {
+    void intoArray(Float16[] a, int offset) {
         offset = checkFromIndexSize(offset, length(), a.length);
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), false,
@@ -3076,7 +3032,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     /**
-     * Stores this vector into an array of type {@code float[]}
+     * Stores this vector into an array of type {@code Float16[]}
      * starting at offset and using a mask.
      * <p>
      * For each vector lane, where {@code N} is the vector lane index,
@@ -3091,7 +3047,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * That is, unset lanes may correspond to array indexes less than
      * zero or beyond the end of the array.
      *
-     * @param a the array, of type {@code float[]}
+     * @param a the array, of type {@code Float16[]}
      * @param offset the offset into the array
      * @param m the mask controlling lane storage
      * @throws IndexOutOfBoundsException
@@ -3101,12 +3057,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     public final
-    void intoArray(float[] a, int offset,
-                   VectorMask<Float> m) {
+    void intoArray(Float16[] a, int offset,
+                   VectorMask<Float16> m) {
         if (m.allTrue()) {
             intoArray(a, offset);
         } else {
-            FloatSpecies vsp = vspecies();
+            HalffloatSpecies vsp = vspecies();
             if (!VectorIntrinsics.indexInRange(offset, vsp.length(), a.length)) {
                 checkMaskFromIndexSize(offset, vsp, m, 1, a.length);
             }
@@ -3115,7 +3071,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     /**
-     * Scatters this vector into an array of type {@code float[]}
+     * Scatters this vector into an array of type {@code Float16[]}
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
      * The index map is a contiguous sequence of {@code VLENGTH}
@@ -3138,37 +3094,21 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         or if {@code f(N)=offset+indexMap[mapOffset+N]}
      *         is an invalid index into {@code a},
      *         for any lane {@code N} in the vector
-     * @see FloatVector#toIntArray()
+     * @see HalffloatVector#toIntArray()
      */
     @ForceInline
     public final
-    void intoArray(float[] a, int offset,
+    void intoArray(Float16[] a, int offset,
                    int[] indexMap, int mapOffset) {
-        FloatSpecies vsp = vspecies();
-        IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
-        // Index vector: vix[0:n] = i -> offset + indexMap[mo + i]
-        IntVector vix = IntVector
-            .fromArray(isp, indexMap, mapOffset)
-            .add(offset);
-
-        vix = VectorIntrinsics.checkIndex(vix, a.length);
-
-        VectorSupport.storeWithMap(
-            vsp.vectorType(), null, vsp.elementType(), vsp.laneCount(),
-            isp.vectorType(),
-            a, arrayAddress(a, 0), vix,
-            this, null,
-            a, offset, indexMap, mapOffset,
-            (arr, off, v, map, mo, vm)
-            -> v.stOp(arr, off,
-                      (arr_, off_, i, e) -> {
-                          int j = map[mo + i];
-                          arr[off + j] = e;
-                      }));
+        stOp(a, offset,
+             (arr, off, i, e) -> {
+                 int j = indexMap[mapOffset + i];
+                 arr[off + j] = e;
+             });
     }
 
     /**
-     * Scatters this vector into an array of type {@code float[]},
+     * Scatters this vector into an array of type {@code Float16[]},
      * under the control of a mask, and
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
@@ -3195,19 +3135,18 @@ public abstract class FloatVector extends AbstractVector<Float> {
      *         is an invalid index into {@code a},
      *         for any lane {@code N} in the vector
      *         where the mask is set
-     * @see FloatVector#toIntArray()
+     * @see HalffloatVector#toIntArray()
      */
     @ForceInline
     public final
-    void intoArray(float[] a, int offset,
+    void intoArray(Float16[] a, int offset,
                    int[] indexMap, int mapOffset,
-                   VectorMask<Float> m) {
-        if (m.allTrue()) {
-            intoArray(a, offset, indexMap, mapOffset);
-        }
-        else {
-            intoArray0(a, offset, indexMap, mapOffset, m);
-        }
+                   VectorMask<Float16> m) {
+        stOp(a, offset, m,
+             (arr, off, i, e) -> {
+                 int j = indexMap[mapOffset + i];
+                 arr[off + j] = e;
+             });
     }
 
 
@@ -3238,16 +3177,16 @@ public abstract class FloatVector extends AbstractVector<Float> {
     public final
     void intoMemorySegment(MemorySegment ms, long offset,
                            ByteOrder bo,
-                           VectorMask<Float> m) {
+                           VectorMask<Float16> m) {
         if (m.allTrue()) {
             intoMemorySegment(ms, offset, bo);
         } else {
             if (ms.isReadOnly()) {
                 throw new UnsupportedOperationException("Attempt to write a read-only segment");
             }
-            FloatSpecies vsp = vspecies();
+            HalffloatSpecies vsp = vspecies();
             if (!VectorIntrinsics.indexInRange(offset, vsp.vectorByteSize(), ms.byteSize())) {
-                checkMaskFromIndexSize(offset, vsp, m, 4, ms.byteSize());
+                checkMaskFromIndexSize(offset, vsp, m, 2, ms.byteSize());
             }
             maybeSwap(bo).intoMemorySegment0(ms, offset, m);
         }
@@ -3274,11 +3213,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    FloatVector fromArray0(float[] a, int offset);
+    HalffloatVector fromArray0(Float16[] a, int offset);
     @ForceInline
     final
-    FloatVector fromArray0Template(float[] a, int offset) {
-        FloatSpecies vsp = vspecies();
+    HalffloatVector fromArray0Template(Float16[] a, int offset) {
+        HalffloatSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), false,
@@ -3289,13 +3228,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     /*package-private*/
     abstract
-    FloatVector fromArray0(float[] a, int offset, VectorMask<Float> m, int offsetInRange);
+    HalffloatVector fromArray0(Float16[] a, int offset, VectorMask<Float16> m, int offsetInRange);
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    FloatVector fromArray0Template(Class<M> maskClass, float[] a, int offset, M m, int offsetInRange) {
+    <M extends VectorMask<Float16>>
+    HalffloatVector fromArray0Template(Class<M> maskClass, Float16[] a, int offset, M m, int offsetInRange) {
         m.check(species());
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), false, m, offsetInRange,
@@ -3304,69 +3243,36 @@ public abstract class FloatVector extends AbstractVector<Float> {
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
 
-    /*package-private*/
-    abstract
-    FloatVector fromArray0(float[] a, int offset,
-                                    int[] indexMap, int mapOffset,
-                                    VectorMask<Float> m);
-    @ForceInline
-    final
-    <M extends VectorMask<Float>>
-    FloatVector fromArray0Template(Class<M> maskClass, float[] a, int offset,
-                                            int[] indexMap, int mapOffset, M m) {
-        FloatSpecies vsp = vspecies();
-        IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
-        Objects.requireNonNull(a);
-        Objects.requireNonNull(indexMap);
-        m.check(vsp);
-        Class<? extends FloatVector> vectorType = vsp.vectorType();
-
-        // Index vector: vix[0:n] = k -> offset + indexMap[mapOffset + k]
-        IntVector vix = IntVector
-            .fromArray(isp, indexMap, mapOffset)
-            .add(offset);
-
-        // FIXME: Check index under mask controlling.
-        vix = VectorIntrinsics.checkIndex(vix, a.length);
-
-        return VectorSupport.loadWithMap(
-            vectorType, maskClass, float.class, vsp.laneCount(),
-            isp.vectorType(),
-            a, ARRAY_BASE, vix, m,
-            a, offset, indexMap, mapOffset, vsp,
-            (c, idx, iMap, idy, s, vm) ->
-            s.vOp(vm, n -> c[idx + iMap[idy+n]]));
-    }
 
 
 
     abstract
-    FloatVector fromMemorySegment0(MemorySegment bb, long offset);
+    HalffloatVector fromMemorySegment0(MemorySegment bb, long offset);
     @ForceInline
     final
-    FloatVector fromMemorySegment0Template(MemorySegment ms, long offset) {
-        FloatSpecies vsp = vspecies();
+    HalffloatVector fromMemorySegment0Template(MemorySegment ms, long offset) {
+        HalffloatSpecies vsp = vspecies();
         return ScopedMemoryAccess.loadFromMemorySegment(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 (AbstractMemorySegmentImpl) ms, offset, vsp,
                 (msp, off, s) -> {
-                    return s.ldLongOp((MemorySegment) msp, off, FloatVector::memorySegmentGet);
+                    return s.ldLongOp((MemorySegment) msp, off, HalffloatVector::memorySegmentGet);
                 });
     }
 
     abstract
-    FloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float> m, int offsetInRange);
+    HalffloatVector fromMemorySegment0(MemorySegment ms, long offset, VectorMask<Float16> m, int offsetInRange);
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    FloatVector fromMemorySegment0Template(Class<M> maskClass, MemorySegment ms, long offset, M m, int offsetInRange) {
-        FloatSpecies vsp = vspecies();
+    <M extends VectorMask<Float16>>
+    HalffloatVector fromMemorySegment0Template(Class<M> maskClass, MemorySegment ms, long offset, M m, int offsetInRange) {
+        HalffloatSpecies vsp = vspecies();
         m.check(vsp);
         return ScopedMemoryAccess.loadFromMemorySegmentMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
                 (AbstractMemorySegmentImpl) ms, offset, m, vsp, offsetInRange,
                 (msp, off, s, vm) -> {
-                    return s.ldLongOp((MemorySegment) msp, off, vm, FloatVector::memorySegmentGet);
+                    return s.ldLongOp((MemorySegment) msp, off, vm, HalffloatVector::memorySegmentGet);
                 });
     }
 
@@ -3375,11 +3281,11 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // byte swapping.
 
     abstract
-    void intoArray0(float[] a, int offset);
+    void intoArray0(Float16[] a, int offset);
     @ForceInline
     final
-    void intoArray0Template(float[] a, int offset) {
-        FloatSpecies vsp = vspecies();
+    void intoArray0Template(Float16[] a, int offset) {
+        HalffloatSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), false,
@@ -3390,13 +3296,13 @@ public abstract class FloatVector extends AbstractVector<Float> {
     }
 
     abstract
-    void intoArray0(float[] a, int offset, VectorMask<Float> m);
+    void intoArray0(Float16[] a, int offset, VectorMask<Float16> m);
     @ForceInline
     final
-    <M extends VectorMask<Float>>
-    void intoArray0Template(Class<M> maskClass, float[] a, int offset, M m) {
+    <M extends VectorMask<Float16>>
+    void intoArray0Template(Class<M> maskClass, Float16[] a, int offset, M m) {
         m.check(species());
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), false,
@@ -3406,68 +3312,35 @@ public abstract class FloatVector extends AbstractVector<Float> {
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
     }
 
-    abstract
-    void intoArray0(float[] a, int offset,
-                    int[] indexMap, int mapOffset,
-                    VectorMask<Float> m);
-    @ForceInline
-    final
-    <M extends VectorMask<Float>>
-    void intoArray0Template(Class<M> maskClass, float[] a, int offset,
-                            int[] indexMap, int mapOffset, M m) {
-        m.check(species());
-        FloatSpecies vsp = vspecies();
-        IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
-        // Index vector: vix[0:n] = i -> offset + indexMap[mo + i]
-        IntVector vix = IntVector
-            .fromArray(isp, indexMap, mapOffset)
-            .add(offset);
-
-        // FIXME: Check index under mask controlling.
-        vix = VectorIntrinsics.checkIndex(vix, a.length);
-
-        VectorSupport.storeWithMap(
-            vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            isp.vectorType(),
-            a, arrayAddress(a, 0), vix,
-            this, m,
-            a, offset, indexMap, mapOffset,
-            (arr, off, v, map, mo, vm)
-            -> v.stOp(arr, off, vm,
-                      (arr_, off_, i, e) -> {
-                          int j = map[mo + i];
-                          arr[off + j] = e;
-                      }));
-    }
 
 
     @ForceInline
     final
     void intoMemorySegment0(MemorySegment ms, long offset) {
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         ScopedMemoryAccess.storeIntoMemorySegment(
                 vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
                 this,
                 (AbstractMemorySegmentImpl) ms, offset,
                 (msp, off, v) -> {
-                    v.stLongOp((MemorySegment) msp, off, FloatVector::memorySegmentSet);
+                    v.stLongOp((MemorySegment) msp, off, HalffloatVector::memorySegmentSet);
                 });
     }
 
     abstract
-    void intoMemorySegment0(MemorySegment bb, long offset, VectorMask<Float> m);
+    void intoMemorySegment0(MemorySegment bb, long offset, VectorMask<Float16> m);
     @ForceInline
     final
-    <M extends VectorMask<Float>>
+    <M extends VectorMask<Float16>>
     void intoMemorySegment0Template(Class<M> maskClass, MemorySegment ms, long offset, M m) {
-        FloatSpecies vsp = vspecies();
+        HalffloatSpecies vsp = vspecies();
         m.check(vsp);
         ScopedMemoryAccess.storeIntoMemorySegmentMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
                 this, m,
                 (AbstractMemorySegmentImpl) ms, offset,
                 (msp, off, v, vm) -> {
-                    v.stLongOp((MemorySegment) msp, off, vm, FloatVector::memorySegmentSet);
+                    v.stLongOp((MemorySegment) msp, off, vm, HalffloatVector::memorySegmentSet);
                 });
     }
 
@@ -3476,28 +3349,28 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     private static
     void checkMaskFromIndexSize(int offset,
-                                FloatSpecies vsp,
-                                VectorMask<Float> m,
+                                HalffloatSpecies vsp,
+                                VectorMask<Float16> m,
                                 int scale,
                                 int limit) {
-        ((AbstractMask<Float>)m)
+        ((AbstractMask<Float16>)m)
             .checkIndexByLane(offset, limit, vsp.iota(), scale);
     }
 
     private static
     void checkMaskFromIndexSize(long offset,
-                                FloatSpecies vsp,
-                                VectorMask<Float> m,
+                                HalffloatSpecies vsp,
+                                VectorMask<Float16> m,
                                 int scale,
                                 long limit) {
-        ((AbstractMask<Float>)m)
+        ((AbstractMask<Float16>)m)
             .checkIndexByLane(offset, limit, vsp.iota(), scale);
     }
 
     @ForceInline
     private void conditionalStoreNYI(int offset,
-                                     FloatSpecies vsp,
-                                     VectorMask<Float> m,
+                                     HalffloatSpecies vsp,
+                                     VectorMask<Float16> m,
                                      int scale,
                                      int limit) {
         if (offset < 0 || offset + vsp.laneCount() * scale > limit) {
@@ -3512,22 +3385,22 @@ public abstract class FloatVector extends AbstractVector<Float> {
     @Override
     @ForceInline
     final
-    FloatVector maybeSwap(ByteOrder bo) {
+    HalffloatVector maybeSwap(ByteOrder bo) {
         if (bo != NATIVE_ENDIAN) {
             return this.reinterpretAsBytes()
                 .rearrange(swapBytesShuffle())
-                .reinterpretAsFloats();
+                .reinterpretAsHalffloats();
         }
         return this;
     }
 
     static final int ARRAY_SHIFT =
-        31 - Integer.numberOfLeadingZeros(Unsafe.ARRAY_FLOAT_INDEX_SCALE);
+        31 - Integer.numberOfLeadingZeros(Unsafe.ARRAY_OBJECT_INDEX_SCALE);
     static final long ARRAY_BASE =
-        Unsafe.ARRAY_FLOAT_BASE_OFFSET;
+        Unsafe.ARRAY_OBJECT_BASE_OFFSET;
 
     @ForceInline
-    static long arrayAddress(float[] a, int index) {
+    static long arrayAddress(Float16[] a, int index) {
         return ARRAY_BASE + (((long)index) << ARRAY_SHIFT);
     }
 
@@ -3561,18 +3434,25 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     @ForceInline
     @Override
-    public final IntVector viewAsIntegralLanes() {
-        LaneType ilt = LaneType.FLOAT.asIntegral();
-        return (IntVector) asVectorRaw(ilt);
+    public final ShortVector viewAsIntegralLanes() {
+        LaneType ilt = LaneType.FLOAT16.asIntegral();
+        return (ShortVector) asVectorRaw(ilt);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
+     *
+     * @implNote This method always throws
+     * {@code UnsupportedOperationException}, because there is no floating
+     * point type of the same size as {@code Float16}.  The return type
+     * of this method is arbitrarily designated as
+     * {@code Vector<?>}.  Future versions of this API may change the return
+     * type if additional floating point types become available.
      */
     @ForceInline
     @Override
     public final
-    FloatVector
+    HalffloatVector
     viewAsFloatingLanes() {
         return this;
     }
@@ -3591,8 +3471,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
      * in lane order.
      *
      * The string is produced as if by a call to {@link
-     * java.util.Arrays#toString(float[]) Arrays.toString()},
-     * as appropriate to the {@code float} array returned by
+     * java.util.Arrays#toString(Float16[]) Arrays.toString()},
+     * as appropriate to the {@code Float16} array returned by
      * {@link #toArray this.toArray()}.
      *
      * @return a string of the form {@code "[0,1,2...]"}
@@ -3638,39 +3518,39 @@ public abstract class FloatVector extends AbstractVector<Float> {
     // Species
 
     /**
-     * Class representing {@link FloatVector}'s of the same {@link VectorShape VectorShape}.
+     * Class representing {@link HalffloatVector}'s of the same {@link VectorShape VectorShape}.
      */
     /*package-private*/
-    static final class FloatSpecies extends AbstractSpecies<Float> {
-        private FloatSpecies(VectorShape shape,
-                Class<? extends FloatVector> vectorType,
-                Class<? extends AbstractMask<Float>> maskType,
-                Function<Object, FloatVector> vectorFactory) {
-            super(shape, LaneType.of(float.class),
+    static final class HalffloatSpecies extends AbstractSpecies<Float16> {
+        private HalffloatSpecies(VectorShape shape,
+                Class<? extends HalffloatVector> vectorType,
+                Class<? extends AbstractMask<Float16>> maskType,
+                Function<Object, HalffloatVector> vectorFactory) {
+            super(shape, LaneType.of(Float16.class),
                   vectorType, maskType,
                   vectorFactory);
-            assert(this.elementSize() == Float.SIZE);
+            assert(this.elementSize() == Float16.SIZE);
         }
 
         // Specializing overrides:
 
         @Override
         @ForceInline
-        public final Class<Float> elementType() {
-            return float.class;
+        public final Class<Float16> elementType() {
+            return Float16.class;
         }
 
         @Override
         @ForceInline
-        final Class<Float> genericElementType() {
-            return Float.class;
+        final Class<Float16> genericElementType() {
+            return Float16.class;
         }
 
         @SuppressWarnings("unchecked")
         @Override
         @ForceInline
-        public final Class<? extends FloatVector> vectorType() {
-            return (Class<? extends FloatVector>) vectorType;
+        public final Class<? extends HalffloatVector> vectorType() {
+            return (Class<? extends HalffloatVector>) vectorType;
         }
 
         @Override
@@ -3683,23 +3563,23 @@ public abstract class FloatVector extends AbstractVector<Float> {
         /*package-private*/
         @Override
         @ForceInline
-        final FloatVector broadcastBits(long bits) {
-            return (FloatVector)
+        final HalffloatVector broadcastBits(long bits) {
+            return (HalffloatVector)
                 VectorSupport.fromBitsCoerced(
-                    vectorType, float.class, laneCount,
+                    vectorType, Float16.class, laneCount,
                     bits, MODE_BROADCAST, this,
                     (bits_, s_) -> s_.rvOp(i -> bits_));
         }
 
         /*package-private*/
         @ForceInline
-        final FloatVector broadcast(float e) {
+        final HalffloatVector broadcast(Float16 e) {
             return broadcastBits(toBits(e));
         }
 
         @Override
         @ForceInline
-        public final FloatVector broadcast(long e) {
+        public final HalffloatVector broadcast(long e) {
             return broadcastBits(longToElementBits(e));
         }
 
@@ -3708,8 +3588,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         @ForceInline
         long longToElementBits(long value) {
             // Do the conversion, and then test it for failure.
-            float e = (float) value;
-            if ((long) e != value) {
+            Float16 e = Float16.valueOf(value);
+            if (e.longValue() != value) {
                 throw badElementBits(value, e);
             }
             return toBits(e);
@@ -3717,9 +3597,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         /*package-private*/
         @ForceInline
-        static long toIntegralChecked(float e, boolean convertToInt) {
-            long value = convertToInt ? (int) e : (long) e;
-            if ((float) value != e) {
+        static long toIntegralChecked(Float16 e, boolean convertToInt) {
+            long value = convertToInt ? e.intValue() : e.longValue();
+            if (value != e.longValue()) {
                 throw badArrayBits(e, convertToInt, value);
             }
             return value;
@@ -3728,14 +3608,14 @@ public abstract class FloatVector extends AbstractVector<Float> {
         /* this non-public one is for internal conversions */
         @Override
         @ForceInline
-        final FloatVector fromIntValues(int[] values) {
+        final HalffloatVector fromIntValues(int[] values) {
             VectorIntrinsics.requireLength(values.length, laneCount);
-            float[] va = new float[laneCount()];
+            Float16[] va = new Float16[laneCount()];
             for (int i = 0; i < va.length; i++) {
                 int lv = values[i];
-                float v = (float) lv;
+                Float16 v = Float16.valueOf(lv);
                 va[i] = v;
-                if ((int)v != lv) {
+                if ( v.intValue() != lv) {
                     throw badElementBits(lv, v);
                 }
             }
@@ -3746,51 +3626,51 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         @ForceInline
         @Override final
-        public FloatVector fromArray(Object a, int offset) {
+        public HalffloatVector fromArray(Object a, int offset) {
             // User entry point
             // Defer only to the equivalent method on the vector class, using the same inputs
-            return FloatVector
-                .fromArray(this, (float[]) a, offset);
+            return HalffloatVector
+                .fromArray(this, (Float16[]) a, offset);
         }
 
         @ForceInline
         @Override final
-        public FloatVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
+        public HalffloatVector fromMemorySegment(MemorySegment ms, long offset, ByteOrder bo) {
             // User entry point
             // Defer only to the equivalent method on the vector class, using the same inputs
-            return FloatVector
+            return HalffloatVector
                 .fromMemorySegment(this, ms, offset, bo);
         }
 
         @ForceInline
         @Override final
-        FloatVector dummyVector() {
-            return (FloatVector) super.dummyVector();
+        HalffloatVector dummyVector() {
+            return (HalffloatVector) super.dummyVector();
         }
 
         /*package-private*/
         final @Override
         @ForceInline
-        FloatVector rvOp(RVOp f) {
-            float[] res = new float[laneCount()];
+        HalffloatVector rvOp(RVOp f) {
+            Float16[] res = new Float16[laneCount()];
             for (int i = 0; i < res.length; i++) {
-                int bits = (int) f.apply(i);
+                short bits = (short) f.apply(i);
                 res[i] = fromBits(bits);
             }
             return dummyVector().vectorFactory(res);
         }
 
-        FloatVector vOp(FVOp f) {
-            float[] res = new float[laneCount()];
+        HalffloatVector vOp(FVOp f) {
+            Float16[] res = new Float16[laneCount()];
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i);
             }
             return dummyVector().vectorFactory(res);
         }
 
-        FloatVector vOp(VectorMask<Float> m, FVOp f) {
-            float[] res = new float[laneCount()];
-            boolean[] mbits = ((AbstractMask<Float>)m).getBits();
+        HalffloatVector vOp(VectorMask<Float16> m, FVOp f) {
+            Float16[] res = new Float16[laneCount()];
+            boolean[] mbits = ((AbstractMask<Float16>)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 if (mbits[i]) {
                     res[i] = f.apply(i);
@@ -3801,30 +3681,30 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
         /*package-private*/
         @ForceInline
-        <M> FloatVector ldOp(M memory, int offset,
+        <M> HalffloatVector ldOp(M memory, int offset,
                                       FLdOp<M> f) {
             return dummyVector().ldOp(memory, offset, f);
         }
 
         /*package-private*/
         @ForceInline
-        <M> FloatVector ldOp(M memory, int offset,
-                                      VectorMask<Float> m,
+        <M> HalffloatVector ldOp(M memory, int offset,
+                                      VectorMask<Float16> m,
                                       FLdOp<M> f) {
             return dummyVector().ldOp(memory, offset, m, f);
         }
 
         /*package-private*/
         @ForceInline
-        FloatVector ldLongOp(MemorySegment memory, long offset,
+        HalffloatVector ldLongOp(MemorySegment memory, long offset,
                                       FLdLongOp f) {
             return dummyVector().ldLongOp(memory, offset, f);
         }
 
         /*package-private*/
         @ForceInline
-        FloatVector ldLongOp(MemorySegment memory, long offset,
-                                      VectorMask<Float> m,
+        HalffloatVector ldLongOp(MemorySegment memory, long offset,
+                                      VectorMask<Float16> m,
                                       FLdLongOp f) {
             return dummyVector().ldLongOp(memory, offset, m, f);
         }
@@ -3838,7 +3718,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         /*package-private*/
         @ForceInline
         <M> void stOp(M memory, int offset,
-                      AbstractMask<Float> m,
+                      AbstractMask<Float16> m,
                       FStOp<M> f) {
             dummyVector().stOp(memory, offset, m, f);
         }
@@ -3852,7 +3732,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         /*package-private*/
         @ForceInline
         void stLongOp(MemorySegment memory, long offset,
-                      AbstractMask<Float> m,
+                      AbstractMask<Float16> m,
                       FStLongOp f) {
             dummyVector().stLongOp(memory, offset, m, f);
         }
@@ -3867,28 +3747,28 @@ public abstract class FloatVector extends AbstractVector<Float> {
         // Zero and iota vector access
         @Override
         @ForceInline
-        public final FloatVector zero() {
-            if ((Class<?>) vectorType() == FloatMaxVector.class)
-                return FloatMaxVector.ZERO;
+        public final HalffloatVector zero() {
+            if ((Class<?>) vectorType() == HalffloatMaxVector.class)
+                return HalffloatMaxVector.ZERO;
             switch (vectorBitSize()) {
-                case 64: return Float64Vector.ZERO;
-                case 128: return Float128Vector.ZERO;
-                case 256: return Float256Vector.ZERO;
-                case 512: return Float512Vector.ZERO;
+                case 64: return Halffloat64Vector.ZERO;
+                case 128: return Halffloat128Vector.ZERO;
+                case 256: return Halffloat256Vector.ZERO;
+                case 512: return Halffloat512Vector.ZERO;
             }
             throw new AssertionError();
         }
 
         @Override
         @ForceInline
-        public final FloatVector iota() {
-            if ((Class<?>) vectorType() == FloatMaxVector.class)
-                return FloatMaxVector.IOTA;
+        public final HalffloatVector iota() {
+            if ((Class<?>) vectorType() == HalffloatMaxVector.class)
+                return HalffloatMaxVector.IOTA;
             switch (vectorBitSize()) {
-                case 64: return Float64Vector.IOTA;
-                case 128: return Float128Vector.IOTA;
-                case 256: return Float256Vector.IOTA;
-                case 512: return Float512Vector.IOTA;
+                case 64: return Halffloat64Vector.IOTA;
+                case 128: return Halffloat128Vector.IOTA;
+                case 256: return Halffloat256Vector.IOTA;
+                case 512: return Halffloat512Vector.IOTA;
             }
             throw new AssertionError();
         }
@@ -3896,78 +3776,78 @@ public abstract class FloatVector extends AbstractVector<Float> {
         // Mask access
         @Override
         @ForceInline
-        public final VectorMask<Float> maskAll(boolean bit) {
-            if ((Class<?>) vectorType() == FloatMaxVector.class)
-                return FloatMaxVector.FloatMaxMask.maskAll(bit);
+        public final VectorMask<Float16> maskAll(boolean bit) {
+            if ((Class<?>) vectorType() == HalffloatMaxVector.class)
+                return HalffloatMaxVector.HalffloatMaxMask.maskAll(bit);
             switch (vectorBitSize()) {
-                case 64: return Float64Vector.Float64Mask.maskAll(bit);
-                case 128: return Float128Vector.Float128Mask.maskAll(bit);
-                case 256: return Float256Vector.Float256Mask.maskAll(bit);
-                case 512: return Float512Vector.Float512Mask.maskAll(bit);
+                case 64: return Halffloat64Vector.Halffloat64Mask.maskAll(bit);
+                case 128: return Halffloat128Vector.Halffloat128Mask.maskAll(bit);
+                case 256: return Halffloat256Vector.Halffloat256Mask.maskAll(bit);
+                case 512: return Halffloat512Vector.Halffloat512Mask.maskAll(bit);
             }
             throw new AssertionError();
         }
     }
 
     /**
-     * Finds a species for an element type of {@code float} and shape.
+     * Finds a species for an element type of {@code Float16} and shape.
      *
      * @param s the shape
-     * @return a species for an element type of {@code float} and shape
+     * @return a species for an element type of {@code Float16} and shape
      * @throws IllegalArgumentException if no such species exists for the shape
      */
-    static FloatSpecies species(VectorShape s) {
+    static HalffloatSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
         switch (s.switchKey) {
-            case VectorShape.SK_64_BIT: return (FloatSpecies) SPECIES_64;
-            case VectorShape.SK_128_BIT: return (FloatSpecies) SPECIES_128;
-            case VectorShape.SK_256_BIT: return (FloatSpecies) SPECIES_256;
-            case VectorShape.SK_512_BIT: return (FloatSpecies) SPECIES_512;
-            case VectorShape.SK_Max_BIT: return (FloatSpecies) SPECIES_MAX;
+            case VectorShape.SK_64_BIT: return (HalffloatSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (HalffloatSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (HalffloatSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (HalffloatSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (HalffloatSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }
 
-    /** Species representing {@link FloatVector}s of {@link VectorShape#S_64_BIT VectorShape.S_64_BIT}. */
-    public static final VectorSpecies<Float> SPECIES_64
-        = new FloatSpecies(VectorShape.S_64_BIT,
-                            Float64Vector.class,
-                            Float64Vector.Float64Mask.class,
-                            Float64Vector::new);
+    /** Species representing {@link HalffloatVector}s of {@link VectorShape#S_64_BIT VectorShape.S_64_BIT}. */
+    public static final VectorSpecies<Float16> SPECIES_64
+        = new HalffloatSpecies(VectorShape.S_64_BIT,
+                            Halffloat64Vector.class,
+                            Halffloat64Vector.Halffloat64Mask.class,
+                            Halffloat64Vector::new);
 
-    /** Species representing {@link FloatVector}s of {@link VectorShape#S_128_BIT VectorShape.S_128_BIT}. */
-    public static final VectorSpecies<Float> SPECIES_128
-        = new FloatSpecies(VectorShape.S_128_BIT,
-                            Float128Vector.class,
-                            Float128Vector.Float128Mask.class,
-                            Float128Vector::new);
+    /** Species representing {@link HalffloatVector}s of {@link VectorShape#S_128_BIT VectorShape.S_128_BIT}. */
+    public static final VectorSpecies<Float16> SPECIES_128
+        = new HalffloatSpecies(VectorShape.S_128_BIT,
+                            Halffloat128Vector.class,
+                            Halffloat128Vector.Halffloat128Mask.class,
+                            Halffloat128Vector::new);
 
-    /** Species representing {@link FloatVector}s of {@link VectorShape#S_256_BIT VectorShape.S_256_BIT}. */
-    public static final VectorSpecies<Float> SPECIES_256
-        = new FloatSpecies(VectorShape.S_256_BIT,
-                            Float256Vector.class,
-                            Float256Vector.Float256Mask.class,
-                            Float256Vector::new);
+    /** Species representing {@link HalffloatVector}s of {@link VectorShape#S_256_BIT VectorShape.S_256_BIT}. */
+    public static final VectorSpecies<Float16> SPECIES_256
+        = new HalffloatSpecies(VectorShape.S_256_BIT,
+                            Halffloat256Vector.class,
+                            Halffloat256Vector.Halffloat256Mask.class,
+                            Halffloat256Vector::new);
 
-    /** Species representing {@link FloatVector}s of {@link VectorShape#S_512_BIT VectorShape.S_512_BIT}. */
-    public static final VectorSpecies<Float> SPECIES_512
-        = new FloatSpecies(VectorShape.S_512_BIT,
-                            Float512Vector.class,
-                            Float512Vector.Float512Mask.class,
-                            Float512Vector::new);
+    /** Species representing {@link HalffloatVector}s of {@link VectorShape#S_512_BIT VectorShape.S_512_BIT}. */
+    public static final VectorSpecies<Float16> SPECIES_512
+        = new HalffloatSpecies(VectorShape.S_512_BIT,
+                            Halffloat512Vector.class,
+                            Halffloat512Vector.Halffloat512Mask.class,
+                            Halffloat512Vector::new);
 
-    /** Species representing {@link FloatVector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
-    public static final VectorSpecies<Float> SPECIES_MAX
-        = new FloatSpecies(VectorShape.S_Max_BIT,
-                            FloatMaxVector.class,
-                            FloatMaxVector.FloatMaxMask.class,
-                            FloatMaxVector::new);
+    /** Species representing {@link HalffloatVector}s of {@link VectorShape#S_Max_BIT VectorShape.S_Max_BIT}. */
+    public static final VectorSpecies<Float16> SPECIES_MAX
+        = new HalffloatSpecies(VectorShape.S_Max_BIT,
+                            HalffloatMaxVector.class,
+                            HalffloatMaxVector.HalffloatMaxMask.class,
+                            HalffloatMaxVector::new);
 
     /**
-     * Preferred species for {@link FloatVector}s.
+     * Preferred species for {@link HalffloatVector}s.
      * A preferred species is a species of maximal bit-size for the platform.
      */
-    public static final VectorSpecies<Float> SPECIES_PREFERRED
-        = (FloatSpecies) VectorSpecies.ofPreferred(float.class);
+    public static final VectorSpecies<Float16> SPECIES_PREFERRED
+        = (HalffloatSpecies) VectorSpecies.ofPreferred(Float16.class);
 }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Int128Vector extends IntVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        int res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, Int128Mask.class, (Int128Mask) m);  // specialized
+        int res = super.reduceLanesTemplate(op, Int128Mask.class, (Int128Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -658,7 +660,7 @@ final class Int128Vector extends IntVector {
         /*package-private*/
         Int128Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Int128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Int128Mask.class, int.class, VLENGTH, offset, limit,
+                Int128Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Int128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Int256Vector extends IntVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        int res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, Int256Mask.class, (Int256Mask) m);  // specialized
+        int res = super.reduceLanesTemplate(op, Int256Mask.class, (Int256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -666,7 +668,7 @@ final class Int256Vector extends IntVector {
         /*package-private*/
         Int256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Int256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Int256Mask.class, int.class, VLENGTH, offset, limit,
+                Int256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Int256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Int512Vector extends IntVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        int res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, Int512Mask.class, (Int512Mask) m);  // specialized
+        int res = super.reduceLanesTemplate(op, Int512Mask.class, (Int512Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -682,7 +684,7 @@ final class Int512Vector extends IntVector {
         /*package-private*/
         Int512Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Int512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Int512Mask.class, int.class, VLENGTH, offset, limit,
+                Int512Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Int512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Int64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Int64Vector extends IntVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        int res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, Int64Mask.class, (Int64Mask) m);  // specialized
+        int res = super.reduceLanesTemplate(op, Int64Mask.class, (Int64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -654,7 +656,7 @@ final class Int64Vector extends IntVector {
         /*package-private*/
         Int64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Int64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Int64Mask.class, int.class, VLENGTH, offset, limit,
+                Int64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Int64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class IntMaxVector extends IntVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        int res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Integer> m) {
-        return (long) super.reduceLanesTemplate(op, IntMaxMask.class, (IntMaxMask) m);  // specialized
+        int res = super.reduceLanesTemplate(op, IntMaxMask.class, (IntMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -652,7 +654,7 @@ final class IntMaxVector extends IntVector {
         /*package-private*/
         IntMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (IntMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                IntMaxMask.class, int.class, VLENGTH, offset, limit,
+                IntMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (IntMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -2205,8 +2205,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 IntVector iota = s.iota();
-                int sc = (int) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul((int)scale_));
             });
     }
 
@@ -2269,7 +2268,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Integer> iota = iotaShuffle();
-        VectorMask<Integer> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((int)(length() - origin))));
+        int pivotidx = (int)(length() - origin);
+        VectorMask<Integer> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2299,7 +2299,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
     IntVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Integer> iota = iotaShuffle();
-        VectorMask<Integer> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((int)(length() - origin))));
+        int pivotidx = (int)(length() - origin);
+        VectorMask<Integer> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2361,7 +2362,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Integer> iota = iotaShuffle();
         VectorMask<Integer> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((int)(origin))));
+                                                                  broadcast((int)(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2926,7 +2927,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         int[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = (double) a[i];
+            res[i] = ((double) a[i]);
         }
         return res;
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,14 +342,16 @@ final class Long128Vector extends LongVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        long res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, Long128Mask.class, (Long128Mask) m);  // specialized
+        long res = super.reduceLanesTemplate(op, Long128Mask.class, (Long128Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -644,7 +646,7 @@ final class Long128Vector extends LongVector {
         /*package-private*/
         Long128Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Long128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Long128Mask.class, long.class, VLENGTH, offset, limit,
+                Long128Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Long128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,14 +342,16 @@ final class Long256Vector extends LongVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        long res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, Long256Mask.class, (Long256Mask) m);  // specialized
+        long res = super.reduceLanesTemplate(op, Long256Mask.class, (Long256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -648,7 +650,7 @@ final class Long256Vector extends LongVector {
         /*package-private*/
         Long256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Long256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Long256Mask.class, long.class, VLENGTH, offset, limit,
+                Long256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Long256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,14 +342,16 @@ final class Long512Vector extends LongVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        long res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, Long512Mask.class, (Long512Mask) m);  // specialized
+        long res = super.reduceLanesTemplate(op, Long512Mask.class, (Long512Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -656,7 +658,7 @@ final class Long512Vector extends LongVector {
         /*package-private*/
         Long512Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Long512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Long512Mask.class, long.class, VLENGTH, offset, limit,
+                Long512Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Long512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Long64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,14 +342,16 @@ final class Long64Vector extends LongVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        long res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, Long64Mask.class, (Long64Mask) m);  // specialized
+        long res = super.reduceLanesTemplate(op, Long64Mask.class, (Long64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -642,7 +644,7 @@ final class Long64Vector extends LongVector {
         /*package-private*/
         Long64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Long64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Long64Mask.class, long.class, VLENGTH, offset, limit,
+                Long64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Long64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -342,14 +342,16 @@ final class LongMaxVector extends LongVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        long res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Long> m) {
-        return (long) super.reduceLanesTemplate(op, LongMaxMask.class, (LongMaxMask) m);  // specialized
+        long res = super.reduceLanesTemplate(op, LongMaxMask.class, (LongMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -642,7 +644,7 @@ final class LongMaxVector extends LongVector {
         /*package-private*/
         LongMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (LongMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                LongMaxMask.class, long.class, VLENGTH, offset, limit,
+                LongMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (LongMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -2092,8 +2092,7 @@ public abstract class LongVector extends AbstractVector<Long> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 LongVector iota = s.iota();
-                long sc = (long) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul((long)scale_));
             });
     }
 
@@ -2135,7 +2134,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Long> iota = iotaShuffle();
-        VectorMask<Long> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
+        long pivotidx = (long)(length() - origin);
+        VectorMask<Long> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2165,7 +2165,8 @@ public abstract class LongVector extends AbstractVector<Long> {
     LongVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Long> iota = iotaShuffle();
-        VectorMask<Long> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((long)(length() - origin))));
+        long pivotidx = (long)(length() - origin);
+        VectorMask<Long> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2227,7 +2228,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Long> iota = iotaShuffle();
         VectorMask<Long> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((long)(origin))));
+                                                                  broadcast((long)(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2787,7 +2788,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         long[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = (double) a[i];
+            res[i] = ((double) a[i]);
         }
         return res;
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short128Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Short128Vector extends ShortVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        short res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, Short128Mask.class, (Short128Mask) m);  // specialized
+        short res = super.reduceLanesTemplate(op, Short128Mask.class, (Short128Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -666,7 +668,7 @@ final class Short128Vector extends ShortVector {
         /*package-private*/
         Short128Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Short128Mask) VectorSupport.indexPartiallyInUpperRange(
-                Short128Mask.class, short.class, VLENGTH, offset, limit,
+                Short128Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Short128Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short256Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Short256Vector extends ShortVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        short res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, Short256Mask.class, (Short256Mask) m);  // specialized
+        short res = super.reduceLanesTemplate(op, Short256Mask.class, (Short256Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -682,7 +684,7 @@ final class Short256Vector extends ShortVector {
         /*package-private*/
         Short256Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Short256Mask) VectorSupport.indexPartiallyInUpperRange(
-                Short256Mask.class, short.class, VLENGTH, offset, limit,
+                Short256Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Short256Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short512Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Short512Vector extends ShortVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        short res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, Short512Mask.class, (Short512Mask) m);  // specialized
+        short res = super.reduceLanesTemplate(op, Short512Mask.class, (Short512Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -714,7 +716,7 @@ final class Short512Vector extends ShortVector {
         /*package-private*/
         Short512Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Short512Mask) VectorSupport.indexPartiallyInUpperRange(
-                Short512Mask.class, short.class, VLENGTH, offset, limit,
+                Short512Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Short512Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Short64Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class Short64Vector extends ShortVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        short res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, Short64Mask.class, (Short64Mask) m);  // specialized
+        short res = super.reduceLanesTemplate(op, Short64Mask.class, (Short64Mask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -658,7 +660,7 @@ final class Short64Vector extends ShortVector {
         /*package-private*/
         Short64Mask indexPartiallyInUpperRange(long offset, long limit) {
             return (Short64Mask) VectorSupport.indexPartiallyInUpperRange(
-                Short64Mask.class, short.class, VLENGTH, offset, limit,
+                Short64Mask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (Short64Mask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortMaxVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,14 +347,16 @@ final class ShortMaxVector extends ShortVector {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        short res = super.reduceLanesTemplate(op);  // specialized
+        return  (long) res;
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<Short> m) {
-        return (long) super.reduceLanesTemplate(op, ShortMaxMask.class, (ShortMaxMask) m);  // specialized
+        short res = super.reduceLanesTemplate(op, ShortMaxMask.class, (ShortMaxMask) m);  // specialized
+        return  (long) res;
     }
 
     @ForceInline
@@ -652,7 +654,7 @@ final class ShortMaxVector extends ShortVector {
         /*package-private*/
         ShortMaxMask indexPartiallyInUpperRange(long offset, long limit) {
             return (ShortMaxMask) VectorSupport.indexPartiallyInUpperRange(
-                ShortMaxMask.class, short.class, VLENGTH, offset, limit,
+                ShortMaxMask.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> (ShortMaxMask) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -2221,8 +2221,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 ShortVector iota = s.iota();
-                short sc = (short) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul((short)scale_));
             });
     }
 
@@ -2285,7 +2284,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Short> iota = iotaShuffle();
-        VectorMask<Short> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
+        short pivotidx = (short)(length() - origin);
+        VectorMask<Short> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2315,7 +2315,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
     ShortVector sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Short> iota = iotaShuffle();
-        VectorMask<Short> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((short)(length() - origin))));
+        short pivotidx = (short)(length() - origin);
+        VectorMask<Short> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2377,7 +2378,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<Short> iota = iotaShuffle();
         VectorMask<Short> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast((short)(origin))));
+                                                                  broadcast((short)(origin)));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2949,7 +2950,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         short[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = (double) a[i];
+            res[i] = ((double) a[i]);
         }
         return res;
     }
@@ -4011,11 +4012,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
     @ForceInline
     @Override
     public final
-    Vector<?>
+    HalffloatVector
     viewAsFloatingLanes() {
-        LaneType flt = LaneType.SHORT.asFloating();
-        // asFloating() will throw UnsupportedOperationException for the unsupported type short
-        throw new AssertionError("Cannot reach here");
+        LaneType flt = LaneType.FLOAT16.asFloating();
+        return (HalffloatVector) asVectorRaw(flt);
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Vector.java
@@ -3028,6 +3028,19 @@ public abstract class Vector<E> extends jdk.internal.vm.vector.VectorSupport.Vec
     public abstract DoubleVector reinterpretAsDoubles();
 
     /**
+     * Reinterprets this vector as a vector of the same shape
+     * and contents but a lane type of {@code Float16},
+     * where the lanes are assembled from successive bytes
+     * according to little-endian order.
+     * It is a convenience method for the expression
+     * {@code reinterpretShape(species().withLanes(Float16.class))}.
+     * It may be considered an inverse to {@link Vector#reinterpretAsBytes()}.
+     *
+     * @return a {@code HalffloatVector} with the same shape and information content
+     */
+    public abstract HalffloatVector reinterpretAsHalffloats();
+
+    /**
      * Views this vector as a vector of the same shape, length, and
      * contents, but a lane type that is not a floating-point type.
      *

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorShape.java
@@ -237,10 +237,18 @@ public enum VectorShape {
         return computePreferredShape();
     }
 
+    private static Class<?> getEffectiveLaneType(Class<?> elementType) {
+        if (elementType == Float16.class) {
+            return short.class;
+        } else {
+            return elementType;
+        }
+    }
+
     private static VectorShape computePreferredShape() {
         int prefBitSize = Integer.MAX_VALUE;
         for (LaneType type : LaneType.values()) {
-            Class<?> etype = type.elementType;
+            Class<?> etype = getEffectiveLaneType(type.elementType);
             prefBitSize = Math.min(prefBitSize, getMaxVectorBitSize(etype));
         }
         // If these assertions fail, we must reconsider our API portability assumptions.

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -46,12 +46,12 @@ import static jdk.incubator.vector.VectorOperators.*;
 
 /**
  * A specialized {@link Vector} representing an ordered immutable sequence of
- * {@code $type$} values.
+ * {@code $elemtype$} values.
  */
 @SuppressWarnings("cast")  // warning: redundant cast
 public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
-    $abstractvectortype$($type$[] vec) {
+    $abstractvectortype$($elemtype$[] vec) {
         super(vec);
     }
 
@@ -61,7 +61,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     static final int FORBID_OPCODE_KIND = VO_ONLYFP;
 #end[FP]
 
-    static final ValueLayout.Of$Type$ ELEMENT_LAYOUT = ValueLayout.JAVA_$TYPE$.withByteAlignment(1);
+    static final ValueLayout.Of{#if[FP16]?Short:$Elemtype$} ELEMENT_LAYOUT = ValueLayout.JAVA_{#if[FP16]?SHORT:$TYPE$}.withByteAlignment(1);
 
     @ForceInline
     static int opCode(Operator op) {
@@ -98,7 +98,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // Virtualized getter
 
     /*package-private*/
-    abstract $type$[] vec();
+    abstract $elemtype$[] vec();
 
     // Virtualized constructors
 
@@ -107,7 +107,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * It is an error if the array is aliased elsewhere.
      */
     /*package-private*/
-    abstract $abstractvectortype$ vectorFactory($type$[] vec);
+    abstract $abstractvectortype$ vectorFactory($elemtype$[] vec);
 
     /**
      * Build a mask directly using my species.
@@ -122,14 +122,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     // Constant loader (takes dummy as vector arg)
     interface FVOp {
-        $type$ apply(int i);
+        $elemtype$ apply(int i);
     }
 
     /*package-private*/
     @ForceInline
     final
     $abstractvectortype$ vOp(FVOp f) {
-        $type$[] res = new $type$[length()];
+        $elemtype$[] res = new $elemtype$[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i);
         }
@@ -139,7 +139,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     $abstractvectortype$ vOp(VectorMask<$Boxtype$> m, FVOp f) {
-        $type$[] res = new $type$[length()];
+        $elemtype$[] res = new $elemtype$[length()];
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
@@ -153,7 +153,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     interface FUnOp {
-        $type$ apply(int i, $type$ a);
+        $elemtype$ apply(int i, $elemtype$ a);
     }
 
     /*package-private*/
@@ -162,8 +162,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     final
     $abstractvectortype$ uOpTemplate(FUnOp f) {
-        $type$[] vec = vec();
-        $type$[] res = new $type$[length()];
+        $elemtype$[] vec = vec();
+        $elemtype$[] res = new $elemtype$[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec[i]);
         }
@@ -181,8 +181,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return uOpTemplate(f);
         }
-        $type$[] vec = vec();
-        $type$[] res = new $type$[length()];
+        $elemtype$[] vec = vec();
+        $elemtype$[] res = new $elemtype$[length()];
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec[i]) : vec[i];
@@ -194,7 +194,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     interface FBinOp {
-        $type$ apply(int i, $type$ a, $type$ b);
+        $elemtype$ apply(int i, $elemtype$ a, $elemtype$ b);
     }
 
     /*package-private*/
@@ -205,9 +205,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     $abstractvectortype$ bOpTemplate(Vector<$Boxtype$> o,
                                      FBinOp f) {
-        $type$[] res = new $type$[length()];
-        $type$[] vec1 = this.vec();
-        $type$[] vec2 = (($abstractvectortype$)o).vec();
+        $elemtype$[] res = new $elemtype$[length()];
+        $elemtype$[] vec1 = this.vec();
+        $elemtype$[] vec2 = (($abstractvectortype$)o).vec();
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec1[i], vec2[i]);
         }
@@ -227,9 +227,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return bOpTemplate(o, f);
         }
-        $type$[] res = new $type$[length()];
-        $type$[] vec1 = this.vec();
-        $type$[] vec2 = (($abstractvectortype$)o).vec();
+        $elemtype$[] res = new $elemtype$[length()];
+        $elemtype$[] vec1 = this.vec();
+        $elemtype$[] vec2 = (($abstractvectortype$)o).vec();
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec1[i], vec2[i]) : vec1[i];
@@ -241,7 +241,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     interface FTriOp {
-        $type$ apply(int i, $type$ a, $type$ b, $type$ c);
+        $elemtype$ apply(int i, $elemtype$ a, $elemtype$ b, $elemtype$ c);
     }
 
     /*package-private*/
@@ -254,10 +254,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ tOpTemplate(Vector<$Boxtype$> o1,
                                      Vector<$Boxtype$> o2,
                                      FTriOp f) {
-        $type$[] res = new $type$[length()];
-        $type$[] vec1 = this.vec();
-        $type$[] vec2 = (($abstractvectortype$)o1).vec();
-        $type$[] vec3 = (($abstractvectortype$)o2).vec();
+        $elemtype$[] res = new $elemtype$[length()];
+        $elemtype$[] vec1 = this.vec();
+        $elemtype$[] vec2 = (($abstractvectortype$)o1).vec();
+        $elemtype$[] vec3 = (($abstractvectortype$)o2).vec();
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(i, vec1[i], vec2[i], vec3[i]);
         }
@@ -279,10 +279,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         if (m == null) {
             return tOpTemplate(o1, o2, f);
         }
-        $type$[] res = new $type$[length()];
-        $type$[] vec1 = this.vec();
-        $type$[] vec2 = (($abstractvectortype$)o1).vec();
-        $type$[] vec3 = (($abstractvectortype$)o2).vec();
+        $elemtype$[] res = new $elemtype$[length()];
+        $elemtype$[] vec1 = this.vec();
+        $elemtype$[] vec2 = (($abstractvectortype$)o1).vec();
+        $elemtype$[] vec3 = (($abstractvectortype$)o2).vec();
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             res[i] = mbits[i] ? f.apply(i, vec1[i], vec2[i], vec3[i]) : vec1[i];
@@ -294,15 +294,15 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     abstract
-    $type$ rOp($type$ v, VectorMask<$Boxtype$> m, FBinOp f);
+    $elemtype$ rOp($elemtype$ v, VectorMask<$Boxtype$> m, FBinOp f);
 
     @ForceInline
     final
-    $type$ rOpTemplate($type$ v, VectorMask<$Boxtype$> m, FBinOp f) {
+    $elemtype$ rOpTemplate($elemtype$ v, VectorMask<$Boxtype$> m, FBinOp f) {
         if (m == null) {
             return rOpTemplate(v, f);
         }
-        $type$[] vec = vec();
+        $elemtype$[] vec = vec();
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             v = mbits[i] ? f.apply(i, v, vec[i]) : v;
@@ -312,8 +312,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     @ForceInline
     final
-    $type$ rOpTemplate($type$ v, FBinOp f) {
-        $type$[] vec = vec();
+    $elemtype$ rOpTemplate($elemtype$ v, FBinOp f) {
+        $elemtype$[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             v = f.apply(i, v, vec[i]);
         }
@@ -324,7 +324,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     interface FLdOp<M> {
-        $type$ apply(M memory, int offset, int i);
+        $elemtype$ apply(M memory, int offset, int i);
     }
 
     /*package-private*/
@@ -333,7 +333,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> $abstractvectortype$ ldOp(M memory, int offset,
                                   FLdOp<M> f) {
         //dummy; no vec = vec();
-        $type$[] res = new $type$[length()];
+        $elemtype$[] res = new $elemtype$[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(memory, offset, i);
         }
@@ -346,8 +346,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> $abstractvectortype$ ldOp(M memory, int offset,
                                   VectorMask<$Boxtype$> m,
                                   FLdOp<M> f) {
-        //$type$[] vec = vec();
-        $type$[] res = new $type$[length()];
+        //$elemtype$[] vec = vec();
+        $elemtype$[] res = new $elemtype$[length()];
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
@@ -359,7 +359,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     interface FLdLongOp {
-        $type$ apply(MemorySegment memory, long offset, int i);
+        $elemtype$ apply(MemorySegment memory, long offset, int i);
     }
 
     /*package-private*/
@@ -368,7 +368,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ ldLongOp(MemorySegment memory, long offset,
                                   FLdLongOp f) {
         //dummy; no vec = vec();
-        $type$[] res = new $type$[length()];
+        $elemtype$[] res = new $elemtype$[length()];
         for (int i = 0; i < res.length; i++) {
             res[i] = f.apply(memory, offset, i);
         }
@@ -381,8 +381,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ ldLongOp(MemorySegment memory, long offset,
                                   VectorMask<$Boxtype$> m,
                                   FLdLongOp f) {
-        //$type$[] vec = vec();
-        $type$[] res = new $type$[length()];
+        //$elemtype$[] vec = vec();
+        $elemtype$[] res = new $elemtype$[length()];
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < res.length; i++) {
             if (mbits[i]) {
@@ -392,12 +392,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return vectorFactory(res);
     }
 
-    static $type$ memorySegmentGet(MemorySegment ms, long o, int i) {
-        return ms.get(ELEMENT_LAYOUT, o + i * $sizeInBytes$L);
+    static $elemtype$ memorySegmentGet(MemorySegment ms, long o, int i) {
+        return {#if[FP16]?Float16.valueOf(ms.get(ELEMENT_LAYOUT, o + i * $sizeInBytes$L)):ms.get(ELEMENT_LAYOUT, o + i * $sizeInBytes$L)};
     }
 
     interface FStOp<M> {
-        void apply(M memory, int offset, int i, $type$ a);
+        void apply(M memory, int offset, int i, $elemtype$ a);
     }
 
     /*package-private*/
@@ -405,7 +405,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     <M> void stOp(M memory, int offset,
                   FStOp<M> f) {
-        $type$[] vec = vec();
+        $elemtype$[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             f.apply(memory, offset, i, vec[i]);
         }
@@ -417,7 +417,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     <M> void stOp(M memory, int offset,
                   VectorMask<$Boxtype$> m,
                   FStOp<M> f) {
-        $type$[] vec = vec();
+        $elemtype$[] vec = vec();
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             if (mbits[i]) {
@@ -427,7 +427,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     interface FStLongOp {
-        void apply(MemorySegment memory, long offset, int i, $type$ a);
+        void apply(MemorySegment memory, long offset, int i, $elemtype$ a);
     }
 
     /*package-private*/
@@ -435,7 +435,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     final
     void stLongOp(MemorySegment memory, long offset,
                   FStLongOp f) {
-        $type$[] vec = vec();
+        $elemtype$[] vec = vec();
         for (int i = 0; i < vec.length; i++) {
             f.apply(memory, offset, i, vec[i]);
         }
@@ -447,7 +447,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     void stLongOp(MemorySegment memory, long offset,
                   VectorMask<$Boxtype$> m,
                   FStLongOp f) {
-        $type$[] vec = vec();
+        $elemtype$[] vec = vec();
         boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
         for (int i = 0; i < vec.length; i++) {
             if (mbits[i]) {
@@ -456,15 +456,15 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
     }
 
-    static void memorySegmentSet(MemorySegment ms, long o, int i, $type$ e) {
-        ms.set(ELEMENT_LAYOUT, o + i * $sizeInBytes$L, e);
+    static void memorySegmentSet(MemorySegment ms, long o, int i, $elemtype$ e) {
+        ms.set(ELEMENT_LAYOUT, o + i * $sizeInBytes$L, {#if[FP16]?e.shortValue():e});
     }
 
     // Binary test
 
     /*package-private*/
     interface FBinTest {
-        boolean apply(int cond, int i, $type$ a, $type$ b);
+        boolean apply(int cond, int i, $elemtype$ a, $elemtype$ b);
     }
 
     /*package-private*/
@@ -473,8 +473,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     AbstractMask<$Boxtype$> bTest(int cond,
                                   Vector<$Boxtype$> o,
                                   FBinTest f) {
-        $type$[] vec1 = vec();
-        $type$[] vec2 = (($abstractvectortype$)o).vec();
+        $elemtype$[] vec1 = vec();
+        $elemtype$[] vec2 = (($abstractvectortype$)o).vec();
         boolean[] bits = new boolean[length()];
         for (int i = 0; i < length(); i++){
             bits[i] = f.apply(cond, i, vec1[i], vec2[i]);
@@ -485,21 +485,21 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[BITWISE]
     /*package-private*/
     @ForceInline
-    static $type$ rotateLeft($type$ a, int n) {
+    static $elemtype$ rotateLeft($elemtype$ a, int n) {
 #if[intOrLong]
         return $Boxtype$.rotateLeft(a, n);
 #else[intOrLong]
-        return ($type$)((((($type$)a) & $Boxtype$.toUnsignedInt(($type$)-1)) << (n & $Boxtype$.SIZE-1)) | (((($type$)a) & $Boxtype$.toUnsignedInt(($type$)-1)) >>> ($Boxtype$.SIZE - (n & $Boxtype$.SIZE-1))));
+        return ($elemtype$)((((($elemtype$)a) & $Boxtype$.toUnsignedInt(($elemtype$)-1)) << (n & $Boxtype$.SIZE-1)) | (((($elemtype$)a) & $Boxtype$.toUnsignedInt(($elemtype$)-1)) >>> ($Boxtype$.SIZE - (n & $Boxtype$.SIZE-1))));
 #end[intOrLong]
     }
 
     /*package-private*/
     @ForceInline
-    static $type$ rotateRight($type$ a, int n) {
+    static $elemtype$ rotateRight($elemtype$ a, int n) {
 #if[intOrLong]
         return $Boxtype$.rotateRight(a, n);
 #else[intOrLong]
-        return ($type$)((((($type$)a) & $Boxtype$.toUnsignedInt(($type$)-1)) >>> (n & $Boxtype$.SIZE-1)) | (((($type$)a) & $Boxtype$.toUnsignedInt(($type$)-1)) << ($Boxtype$.SIZE - (n & $Boxtype$.SIZE-1))));
+        return ($elemtype$)((((($elemtype$)a) & $Boxtype$.toUnsignedInt(($elemtype$)-1)) >>> (n & $Boxtype$.SIZE-1)) | (((($elemtype$)a) & $Boxtype$.toUnsignedInt(($elemtype$)-1)) << ($Boxtype$.SIZE - (n & $Boxtype$.SIZE-1))));
 #end[intOrLong]
     }
 #end[BITWISE]
@@ -510,14 +510,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     @ForceInline
-    static long toBits($type$ e) {
-        return {#if[FP]? $Type$.$type$ToRaw$Bitstype$Bits(e): e};
+    static long toBits($elemtype$ e) {
+        return {#if[FP]?$Elemtype$.$fptype$ToRaw$Bitstype$Bits(e): e};
     }
 
     /*package-private*/
     @ForceInline
-    static $type$ fromBits(long bits) {
-        return {#if[FP]?$Type$.$bitstype$BitsTo$Type$}(($bitstype$)bits);
+    static $elemtype$ fromBits(long bits) {
+        return {#if[FP]?$Elemtype$.$bitstype$BitsTo$Fptype$}(($bitstype$)bits);
     }
 
     static $abstractvectortype$ expandHelper(Vector<$Boxtype$> v, VectorMask<$Boxtype$> m) {
@@ -575,11 +575,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     public static $abstractvectortype$ zero(VectorSpecies<$Boxtype$> species) {
         $Type$Species vsp = ($Type$Species) species;
 #if[FP]
-        return VectorSupport.fromBitsCoerced(vsp.vectorType(), $type$.class, species.length(),
-                        toBits(0.0f), MODE_BROADCAST, vsp,
+        return VectorSupport.fromBitsCoerced(vsp.vectorType(), $elemtype$.class, species.length(),
+                        toBits({#if[FP16]?Float16.valueOf(0.0f):0.0f}), MODE_BROADCAST, vsp,
                         ((bits_, s_) -> s_.rvOp(i -> bits_)));
 #else[FP]
-        return VectorSupport.fromBitsCoerced(vsp.vectorType(), $type$.class, species.length(),
+        return VectorSupport.fromBitsCoerced(vsp.vectorType(), $elemtype$.class, species.length(),
                                 0, MODE_BROADCAST, vsp,
                                 ((bits_, s_) -> s_.rvOp(i -> bits_)));
 #end[FP]
@@ -610,7 +610,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @see Vector#broadcast(long)
      * @see VectorSpecies#broadcast(long)
      */
-    public abstract $abstractvectortype$ broadcast($type$ e);
+    public abstract $abstractvectortype$ broadcast($elemtype$ e);
 
     /**
      * Returns a vector of the given species
@@ -626,14 +626,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @see VectorSpecies#broadcast(long)
      */
     @ForceInline
-    public static $abstractvectortype$ broadcast(VectorSpecies<$Boxtype$> species, $type$ e) {
+    public static $abstractvectortype$ broadcast(VectorSpecies<$Boxtype$> species, $elemtype$ e) {
         $Type$Species vsp = ($Type$Species) species;
         return vsp.broadcast(e);
     }
 
     /*package-private*/
     @ForceInline
-    final $abstractvectortype$ broadcastTemplate($type$ e) {
+    final $abstractvectortype$ broadcastTemplate($elemtype$ e) {
         $Type$Species vsp = vspecies();
         return vsp.broadcast(e);
     }
@@ -643,9 +643,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * {@inheritDoc} <!--workaround-->
      * @apiNote
      * When working with vector subtypes like {@code $abstractvectortype$},
-     * {@linkplain #broadcast($type$) the more strongly typed method}
+     * {@linkplain #broadcast($elemtype$) the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.broadcast(($type$)e)}.
+     * using a cast: {@code v.broadcast(($elemtype$)e)}.
      * The two expressions will produce numerically identical results.
      */
     @Override
@@ -667,7 +667,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws IllegalArgumentException
      *         if the given {@code long} value cannot
      *         be represented by the vector's {@code ETYPE}
-     * @see #broadcast(VectorSpecies,$type$)
+     * @see #broadcast(VectorSpecies,$elemtype$)
      * @see VectorSpecies#checkValue(long)
      */
     @ForceInline
@@ -706,7 +706,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
         int opc = opCode(op);
         return VectorSupport.unaryOp(
-            opc, getClass(), null, $type$.class, length(),
+            opc, getClass(), null, $elemtype$.class, length(),
             this, null,
             UN_IMPL.find(op, opc, $abstractvectortype$::unaryOperations));
     }
@@ -736,7 +736,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
         int opc = opCode(op);
         return VectorSupport.unaryOp(
-            opc, getClass(), maskClass, $type$.class, length(),
+            opc, getClass(), maskClass, $elemtype$.class, length(),
             this, m,
             UN_IMPL.find(op, opc, $abstractvectortype$::unaryOperations));
     }
@@ -748,26 +748,26 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     private static UnaryOperation<$abstractvectortype$, VectorMask<$Boxtype$>> unaryOperations(int opc_) {
         switch (opc_) {
             case VECTOR_OP_NEG: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) -a);
+                    v0.uOp(m, (i, a) -> ($elemtype$) {#if[FP16]?Float16.valueOf(-a.floatValue()):-a});
             case VECTOR_OP_ABS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.abs(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) {#if[FP16]?Float16.abs(a):Math.abs(a)});
 #if[!FP]
 #if[intOrLong]
             case VECTOR_OP_BIT_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) $Boxtype$.bitCount(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) $Boxtype$.bitCount(a));
             case VECTOR_OP_TZ_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) $Boxtype$.numberOfTrailingZeros(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) $Boxtype$.numberOfTrailingZeros(a));
             case VECTOR_OP_LZ_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) $Boxtype$.numberOfLeadingZeros(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) $Boxtype$.numberOfLeadingZeros(a));
             case VECTOR_OP_REVERSE: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) $Boxtype$.reverse(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) $Boxtype$.reverse(a));
 #else[intOrLong]
             case VECTOR_OP_BIT_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) bitCount(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) bitCount(a));
             case VECTOR_OP_TZ_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) numberOfTrailingZeros(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) numberOfTrailingZeros(a));
             case VECTOR_OP_LZ_COUNT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) numberOfLeadingZeros(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) numberOfLeadingZeros(a));
             case VECTOR_OP_REVERSE: return (v0, m) ->
                     v0.uOp(m, (i, a) -> reverse(a));
 #end[intOrLong]
@@ -777,43 +777,78 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                     v0.uOp(m, (i, a) -> a);
 #else[byte]
             case VECTOR_OP_REVERSE_BYTES: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) $Boxtype$.reverseBytes(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) $Boxtype$.reverseBytes(a));
 #end[byte]
 #end[BITWISE]
 #end[!FP]
 #if[FP]
+#if[!FP16]
             case VECTOR_OP_SIN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.sin(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.sin(a));
             case VECTOR_OP_COS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.cos(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.cos(a));
             case VECTOR_OP_TAN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.tan(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.tan(a));
             case VECTOR_OP_ASIN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.asin(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.asin(a));
             case VECTOR_OP_ACOS: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.acos(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.acos(a));
             case VECTOR_OP_ATAN: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.atan(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.atan(a));
             case VECTOR_OP_EXP: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.exp(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.exp(a));
             case VECTOR_OP_LOG: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.log(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.log(a));
             case VECTOR_OP_LOG10: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.log10(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.log10(a));
             case VECTOR_OP_SQRT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.sqrt(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.sqrt(a));
             case VECTOR_OP_CBRT: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.cbrt(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.cbrt(a));
             case VECTOR_OP_SINH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.sinh(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.sinh(a));
             case VECTOR_OP_COSH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.cosh(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.cosh(a));
             case VECTOR_OP_TANH: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.tanh(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.tanh(a));
             case VECTOR_OP_EXPM1: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.expm1(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.expm1(a));
             case VECTOR_OP_LOG1P: return (v0, m) ->
-                    v0.uOp(m, (i, a) -> ($type$) Math.log1p(a));
+                    v0.uOp(m, (i, a) -> ($elemtype$) Math.log1p(a));
+#else[!FP16]
+            case VECTOR_OP_SIN: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sin(a.floatValue())));
+            case VECTOR_OP_COS: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cos(a.floatValue())));
+            case VECTOR_OP_TAN: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.tan(a.floatValue())));
+            case VECTOR_OP_ASIN: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.asin(a.floatValue())));
+            case VECTOR_OP_ACOS: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.acos(a.floatValue())));
+            case VECTOR_OP_ATAN: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.atan(a.floatValue())));
+            case VECTOR_OP_EXP: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.exp(a.floatValue())));
+            case VECTOR_OP_LOG: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log(a.floatValue())));
+            case VECTOR_OP_LOG10: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log10(a.floatValue())));
+            case VECTOR_OP_SQRT: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sqrt(a.floatValue())));
+            case VECTOR_OP_CBRT: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cbrt(a.floatValue())));
+            case VECTOR_OP_SINH: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.sinh(a.floatValue())));
+            case VECTOR_OP_COSH: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.cosh(a.floatValue())));
+            case VECTOR_OP_TANH: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.tanh(a.floatValue())));
+            case VECTOR_OP_EXPM1: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.expm1(a.floatValue())));
+            case VECTOR_OP_LOG1P: return (v0, m) ->
+                    v0.uOp(m, (i, a) -> Float16.valueOf(Math.log1p(a.floatValue())));
+#end[!FP16]
 #end[FP]
             default: return null;
         }
@@ -823,8 +858,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Binary,$type$)
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      */
     @Override
     public abstract
@@ -856,7 +891,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 that = that.lanewise(NOT);
                 op = AND;
             } else if (op == DIV) {
-                VectorMask<$Boxtype$> eqz = that.eq(($type$) 0);
+                VectorMask<$Boxtype$> eqz = that.eq(($elemtype$) 0);
                 if (eqz.anyTrue()) {
                     throw that.divZeroException();
                 }
@@ -866,14 +901,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         int opc = opCode(op);
         return VectorSupport.binaryOp(
-            opc, getClass(), null, $type$.class, length(),
+            opc, getClass(), null, $elemtype$.class, length(),
             this, that, null,
             BIN_IMPL.find(op, opc, $abstractvectortype$::binaryOperations));
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      */
     @Override
     public abstract
@@ -898,7 +933,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 return this.blend(that, mask.cast(vspecies()));
 #else[FP]
                 VectorMask<$Boxtype$> mask
-                    = this.compare(EQ, ($type$) 0, m);
+                    = this.compare(EQ, ($elemtype$) 0, m);
                 return this.blend(that, mask);
 #end[FP]
             }
@@ -915,7 +950,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 that = that.lanewise(NOT);
                 op = AND;
             } else if (op == DIV) {
-                VectorMask<$Boxtype$> eqz = that.eq(($type$)0);
+                VectorMask<$Boxtype$> eqz = that.eq(($elemtype$)0);
                 if (eqz.and(m).anyTrue()) {
                     throw that.divZeroException();
                 }
@@ -927,7 +962,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         int opc = opCode(op);
         return VectorSupport.binaryOp(
-            opc, getClass(), maskClass, $type$.class, length(),
+            opc, getClass(), maskClass, $elemtype$.class, length(),
             this, that, m,
             BIN_IMPL.find(op, opc, $abstractvectortype$::binaryOperations));
     }
@@ -938,31 +973,46 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     private static BinaryOperation<$abstractvectortype$, VectorMask<$Boxtype$>> binaryOperations(int opc_) {
         switch (opc_) {
+#if[FP16]
             case VECTOR_OP_ADD: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a + b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.add(a, b));
             case VECTOR_OP_SUB: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a - b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.subtract(a, b));
             case VECTOR_OP_MUL: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a * b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.multiply(a, b));
             case VECTOR_OP_DIV: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a / b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.divide(a, b));
             case VECTOR_OP_MAX: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)Math.max(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.max(a, b));
             case VECTOR_OP_MIN: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)Math.min(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.min(a, b));
+#else[FP16]
+            case VECTOR_OP_ADD: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a + b));
+            case VECTOR_OP_SUB: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a - b));
+            case VECTOR_OP_MUL: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a * b));
+            case VECTOR_OP_DIV: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a / b));
+            case VECTOR_OP_MAX: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)Math.max(a, b));
+            case VECTOR_OP_MIN: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)Math.min(a, b));
+#end[FP16]
 #if[BITWISE]
             case VECTOR_OP_AND: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a & b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a & b));
             case VECTOR_OP_OR: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a | b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a | b));
             case VECTOR_OP_XOR: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$)(a ^ b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$)(a ^ b));
             case VECTOR_OP_LSHIFT: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, n) -> ($type$)(a << n));
+                    v0.bOp(v1, vm, (i, a, n) -> ($elemtype$)(a << n));
             case VECTOR_OP_RSHIFT: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, n) -> ($type$)(a >> n));
+                    v0.bOp(v1, vm, (i, a, n) -> ($elemtype$)(a >> n));
             case VECTOR_OP_URSHIFT: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, n) -> ($type$)((a & LSHR_SETUP_MASK) >>> n));
+                    v0.bOp(v1, vm, (i, a, n) -> ($elemtype$)((a & LSHR_SETUP_MASK) >>> n));
             case VECTOR_OP_LROTATE: return (v0, v1, vm) ->
                     v0.bOp(v1, vm, (i, a, n) -> rotateLeft(a, (int)n));
             case VECTOR_OP_RROTATE: return (v0, v1, vm) ->
@@ -975,14 +1025,23 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[intOrLong]
 #end[BITWISE]
 #if[FP]
+#if[!FP16]
             case VECTOR_OP_OR: return (v0, v1, vm) ->
                     v0.bOp(v1, vm, (i, a, b) -> fromBits(toBits(a) | toBits(b)));
             case VECTOR_OP_ATAN2: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$) Math.atan2(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$) Math.atan2(a, b));
             case VECTOR_OP_POW: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$) Math.pow(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$) Math.pow(a, b));
             case VECTOR_OP_HYPOT: return (v0, v1, vm) ->
-                    v0.bOp(v1, vm, (i, a, b) -> ($type$) Math.hypot(a, b));
+                    v0.bOp(v1, vm, (i, a, b) -> ($elemtype$) Math.hypot(a, b));
+#else[!FP16]
+            case VECTOR_OP_ATAN2: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.atan2(a.floatValue(), b.floatValue())));
+            case VECTOR_OP_POW: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.pow(a.floatValue(), b.floatValue())));
+            case VECTOR_OP_HYPOT: return (v0, v1, vm) ->
+                    v0.bOp(v1, vm, (i, a, b) -> Float16.valueOf(Math.hypot(a.floatValue(), b.floatValue())));
+#end[!FP16]
 #end[FP]
             default: return null;
         }
@@ -1010,18 +1069,18 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Binary op,
-                                  $type$ e) {
+                                  $elemtype$ e) {
 #if[BITWISE]
-        if (opKind(op, VO_SHIFT) && ($type$)(int)e == e) {
+        if (opKind(op, VO_SHIFT) && ($elemtype$)(int)e == e) {
             return lanewiseShift(op, (int) e);
         }
         if (op == AND_NOT) {
-            op = AND; e = ($type$) ~e;
+            op = AND; e = ($elemtype$) ~e;
         }
 #end[BITWISE]
         return lanewise(op, broadcast(e));
@@ -1045,19 +1104,19 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Binary op,
-                                  $type$ e,
+                                  $elemtype$ e,
                                   VectorMask<$Boxtype$> m) {
 #if[BITWISE]
-        if (opKind(op, VO_SHIFT) && ($type$)(int)e == e) {
+        if (opKind(op, VO_SHIFT) && ($elemtype$)(int)e == e) {
             return lanewiseShift(op, (int) e, m);
         }
         if (op == AND_NOT) {
-            op = AND; e = ($type$) ~e;
+            op = AND; e = ($elemtype$) ~e;
         }
 #end[BITWISE]
         return lanewise(op, broadcast(e), m);
@@ -1068,23 +1127,23 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * {@inheritDoc} <!--workaround-->
      * @apiNote
      * When working with vector subtypes like {@code $abstractvectortype$},
-     * {@linkplain #lanewise(VectorOperators.Binary,$type$)
+     * {@linkplain #lanewise(VectorOperators.Binary,$elemtype$)
      * the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.lanewise(op,($type$)e)}.
+     * using a cast: {@code v.lanewise(op,($elemtype$)e)}.
      * The two expressions will produce numerically identical results.
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Binary op,
                                   long e) {
-        $type$ e1 = ($type$) e;
+        $elemtype$ e1 = {#if[FP16]?Float16.valueOf(e):($elemtype$) e};
 #if[BITWISE]
         if ((long)e1 != e
             // allow shift ops to clip down their int parameters
             && !(opKind(op, VO_SHIFT) && (int)e1 == e)) {
 #else[BITWISE]
-        if ((long)e1 != e) {
+        if ({#if[FP16]?e1.longValue():(long)e1} != e) {
 #end[BITWISE]
             vspecies().checkValue(e);  // for exception
         }
@@ -1095,23 +1154,23 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * {@inheritDoc} <!--workaround-->
      * @apiNote
      * When working with vector subtypes like {@code $abstractvectortype$},
-     * {@linkplain #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * {@linkplain #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      * the more strongly typed method}
      * is typically selected.  It can be explicitly selected
-     * using a cast: {@code v.lanewise(op,($type$)e,m)}.
+     * using a cast: {@code v.lanewise(op,($elemtype$)e,m)}.
      * The two expressions will produce numerically identical results.
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Binary op,
                                   long e, VectorMask<$Boxtype$> m) {
-        $type$ e1 = ($type$) e;
+        $elemtype$ e1 = {#if[FP16]?Float16.valueOf(e):($elemtype$) e};
 #if[BITWISE]
         if ((long)e1 != e
             // allow shift ops to clip down their int parameters
             && !(opKind(op, VO_SHIFT) && (int)e1 == e)) {
 #else[BITWISE]
-        if ((long)e1 != e) {
+        if ({#if[FP16]?e1.longValue():(long)e1} != e) {
 #end[BITWISE]
             vspecies().checkValue(e);  // for exception
         }
@@ -1134,7 +1193,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         e &= SHIFT_MASK;
         int opc = opCode(op);
         return VectorSupport.broadcastInt(
-            opc, getClass(), null, $type$.class, length(),
+            opc, getClass(), null, $elemtype$.class, length(),
             this, e, null,
             BIN_INT_IMPL.find(op, opc, $abstractvectortype$::broadcastIntOperations));
     }
@@ -1155,7 +1214,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         e &= SHIFT_MASK;
         int opc = opCode(op);
         return VectorSupport.broadcastInt(
-            opc, getClass(), maskClass, $type$.class, length(),
+            opc, getClass(), maskClass, $elemtype$.class, length(),
             this, e, m,
             BIN_INT_IMPL.find(op, opc, $abstractvectortype$::broadcastIntOperations));
     }
@@ -1167,11 +1226,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     private static VectorBroadcastIntOp<$abstractvectortype$, VectorMask<$Boxtype$>> broadcastIntOperations(int opc_) {
         switch (opc_) {
             case VECTOR_OP_LSHIFT: return (v, n, m) ->
-                    v.uOp(m, (i, a) -> ($type$)(a << n));
+                    v.uOp(m, (i, a) -> ($elemtype$)(a << n));
             case VECTOR_OP_RSHIFT: return (v, n, m) ->
-                    v.uOp(m, (i, a) -> ($type$)(a >> n));
+                    v.uOp(m, (i, a) -> ($elemtype$)(a >> n));
             case VECTOR_OP_URSHIFT: return (v, n, m) ->
-                    v.uOp(m, (i, a) -> ($type$)((a & LSHR_SETUP_MASK) >>> n));
+                    v.uOp(m, (i, a) -> ($elemtype$)((a & LSHR_SETUP_MASK) >>> n));
             case VECTOR_OP_LROTATE: return (v, n, m) ->
                     v.uOp(m, (i, a) -> rotateLeft(a, (int)n));
             case VECTOR_OP_RROTATE: return (v, n, m) ->
@@ -1190,7 +1249,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // Also simulate >>> on sub-word variables with a mask.
     private static final int LSHR_SETUP_MASK = ((1 << $Boxtype$.SIZE) - 1);
 #else[byteOrShort]
-    private static final $type$ LSHR_SETUP_MASK = -1;
+    private static final $elemtype$ LSHR_SETUP_MASK = -1;
 #end[byteOrShort]
 #end[BITWISE]
 
@@ -1206,12 +1265,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
    /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$)
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$)
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector)
      */
     @Override
     public abstract
@@ -1239,16 +1298,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[BITWISE]
         int opc = opCode(op);
         return VectorSupport.ternaryOp(
-            opc, getClass(), null, $type$.class, length(),
+            opc, getClass(), null, $elemtype$.class, length(),
             this, that, tother, null,
             TERN_IMPL.find(op, opc, $abstractvectortype$::ternaryOperations));
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector,VectorMask)
      */
     @Override
     public abstract
@@ -1281,7 +1340,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[BITWISE]
         int opc = opCode(op);
         return VectorSupport.ternaryOp(
-            opc, getClass(), maskClass, $type$.class, length(),
+            opc, getClass(), maskClass, $elemtype$.class, length(),
             this, that, tother, m,
             TERN_IMPL.find(op, opc, $abstractvectortype$::ternaryOperations));
     }
@@ -1293,8 +1352,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     private static TernaryOperation<$abstractvectortype$, VectorMask<$Boxtype$>> ternaryOperations(int opc_) {
         switch (opc_) {
 #if[FP]
-            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) ->
-                    v0.tOp(v1_, v2_, m, (i, a, b, c) -> Math.fma(a, b, c));
+            case VECTOR_OP_FMA: return (v0, v1_, v2_, m) -> v0.tOp(v1_, v2_, m, (i, a, b, c) -> {#if[FP16]?Float16.fma(a, b, c):Math.fma(a, b, c)});
 #end[FP]
             default: return null;
         }
@@ -1317,13 +1375,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,e1,e2)
-                                  $type$ e1,
-                                  $type$ e2) {
+                                  $elemtype$ e1,
+                                  $elemtype$ e2) {
         return lanewise(op, broadcast(e1), broadcast(e2));
     }
 
@@ -1346,13 +1404,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,e1,e2,m)
-                                  $type$ e1,
-                                  $type$ e2,
+                                  $elemtype$ e1,
+                                  $elemtype$ e2,
                                   VectorMask<$Boxtype$> m) {
         return lanewise(op, broadcast(e1), broadcast(e2), m);
     }
@@ -1373,14 +1431,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         to the input vectors and the scalar
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$)
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,v1,e2)
                                   Vector<$Boxtype$> v1,
-                                  $type$ e2) {
+                                  $elemtype$ e2) {
         return lanewise(op, v1, broadcast(e2));
     }
 
@@ -1403,14 +1461,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,v1,e2,m)
                                   Vector<$Boxtype$> v1,
-                                  $type$ e2,
+                                  $elemtype$ e2,
                                   VectorMask<$Boxtype$> m) {
         return lanewise(op, v1, broadcast(e2), m);
     }
@@ -1432,12 +1490,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector)
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector,VectorMask)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,e1,v2)
-                                  $type$ e1,
+                                  $elemtype$ e1,
                                   Vector<$Boxtype$> v2) {
         return lanewise(op, broadcast(e1), v2);
     }
@@ -1461,12 +1519,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws UnsupportedOperationException if this vector does
      *         not support the requested operation
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector)
      */
     @ForceInline
     public final
     $abstractvectortype$ lanewise(VectorOperators.Ternary op, //(op,e1,v2,m)
-                                  $type$ e1,
+                                  $elemtype$ e1,
                                   Vector<$Boxtype$> v2,
                                   VectorMask<$Boxtype$> m) {
         return lanewise(op, broadcast(e1), v2, m);
@@ -1482,7 +1540,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #add($type$)
+     * @see #add($elemtype$)
      */
     @Override
     @ForceInline
@@ -1497,28 +1555,28 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive addition operation ({@code +}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#ADD
      *    ADD}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of adding each lane of this vector to the scalar
      * @see #add(Vector)
-     * @see #broadcast($type$)
-     * @see #add($type$,VectorMask)
+     * @see #broadcast($elemtype$)
+     * @see #add($elemtype$,VectorMask)
      * @see VectorOperators#ADD
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
     public final
-    $abstractvectortype$ add($type$ e) {
+    $abstractvectortype$ add($elemtype$ e) {
         return lanewise(ADD, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #add($type$,VectorMask)
+     * @see #add($elemtype$,VectorMask)
      */
     @Override
     @ForceInline
@@ -1535,7 +1593,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive addition operation ({@code +}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#ADD
      *    ADD}{@code , s, m)}.
      *
@@ -1543,21 +1601,21 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param m the mask controlling lane selection
      * @return the result of adding each lane of this vector to the scalar
      * @see #add(Vector,VectorMask)
-     * @see #broadcast($type$)
-     * @see #add($type$)
+     * @see #broadcast($elemtype$)
+     * @see #add($elemtype$)
      * @see VectorOperators#ADD
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ add($type$ e,
+    public final $abstractvectortype$ add($elemtype$ e,
                                           VectorMask<$Boxtype$> m) {
         return lanewise(ADD, e, m);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #sub($type$)
+     * @see #sub($elemtype$)
      */
     @Override
     @ForceInline
@@ -1572,27 +1630,27 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive subtraction operation ({@code -}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#SUB
      *    SUB}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of subtracting the scalar from each lane of this vector
      * @see #sub(Vector)
-     * @see #broadcast($type$)
-     * @see #sub($type$,VectorMask)
+     * @see #broadcast($elemtype$)
+     * @see #sub($elemtype$,VectorMask)
      * @see VectorOperators#SUB
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ sub($type$ e) {
+    public final $abstractvectortype$ sub($elemtype$ e) {
         return lanewise(SUB, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #sub($type$,VectorMask)
+     * @see #sub($elemtype$,VectorMask)
      */
     @Override
     @ForceInline
@@ -1609,7 +1667,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive subtraction operation ({@code -}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#SUB
      *    SUB}{@code , s, m)}.
      *
@@ -1617,21 +1675,21 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param m the mask controlling lane selection
      * @return the result of subtracting the scalar from each lane of this vector
      * @see #sub(Vector,VectorMask)
-     * @see #broadcast($type$)
-     * @see #sub($type$)
+     * @see #broadcast($elemtype$)
+     * @see #sub($elemtype$)
      * @see VectorOperators#SUB
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ sub($type$ e,
+    public final $abstractvectortype$ sub($elemtype$ e,
                                           VectorMask<$Boxtype$> m) {
         return lanewise(SUB, e, m);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #mul($type$)
+     * @see #mul($elemtype$)
      */
     @Override
     @ForceInline
@@ -1646,27 +1704,27 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive multiplication operation ({@code *}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#MUL
      *    MUL}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #mul(Vector)
-     * @see #broadcast($type$)
-     * @see #mul($type$,VectorMask)
+     * @see #broadcast($elemtype$)
+     * @see #mul($elemtype$,VectorMask)
      * @see VectorOperators#MUL
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ mul($type$ e) {
+    public final $abstractvectortype$ mul($elemtype$ e) {
         return lanewise(MUL, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #mul($type$,VectorMask)
+     * @see #mul($elemtype$,VectorMask)
      */
     @Override
     @ForceInline
@@ -1683,7 +1741,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive multiplication operation ({@code *}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#MUL
      *    MUL}{@code , s, m)}.
      *
@@ -1691,14 +1749,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param m the mask controlling lane selection
      * @return the result of muling each lane of this vector to the scalar
      * @see #mul(Vector,VectorMask)
-     * @see #broadcast($type$)
-     * @see #mul($type$)
+     * @see #broadcast($elemtype$)
+     * @see #mul($elemtype$)
      * @see VectorOperators#MUL
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ mul($type$ e,
+    public final $abstractvectortype$ mul($elemtype$ e,
                                           VectorMask<$Boxtype$> m) {
         return lanewise(MUL, e, m);
     }
@@ -1728,7 +1786,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive division operation ({@code /}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#DIV
      *    DIV}{@code , e)}.
      *
@@ -1745,20 +1803,20 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param e the input scalar
      * @return the result of dividing each lane of this vector by the scalar
      * @see #div(Vector)
-     * @see #broadcast($type$)
-     * @see #div($type$,VectorMask)
+     * @see #broadcast($elemtype$)
+     * @see #div($elemtype$,VectorMask)
      * @see VectorOperators#DIV
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ div($type$ e) {
+    public final $abstractvectortype$ div($elemtype$ e) {
         return lanewise(DIV, e);
     }
 
     /**
      * {@inheritDoc} <!--workaround-->
-     * @see #div($type$,VectorMask)
+     * @see #div($elemtype$,VectorMask)
 #if[FP]
      * @apiNote Because the underlying scalar operator is an IEEE
      * floating point number, division by zero in fact will
@@ -1784,7 +1842,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * the primitive division operation ({@code /}) to each lane.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      *    lanewise}{@code (}{@link VectorOperators#DIV
      *    DIV}{@code , s, m)}.
      *
@@ -1802,14 +1860,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param m the mask controlling lane selection
      * @return the result of dividing each lane of this vector by the scalar
      * @see #div(Vector,VectorMask)
-     * @see #broadcast($type$)
-     * @see #div($type$)
+     * @see #broadcast($elemtype$)
+     * @see #div($elemtype$)
      * @see VectorOperators#DIV
      * @see #lanewise(VectorOperators.Binary,Vector)
-     * @see #lanewise(VectorOperators.Binary,$type$)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$)
      */
     @ForceInline
-    public final $abstractvectortype$ div($type$ e,
+    public final $abstractvectortype$ div($elemtype$ e,
                                           VectorMask<$Boxtype$> m) {
         return lanewise(DIV, e, m);
     }
@@ -1844,16 +1902,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * corresponding lane values.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#MIN
      *    MIN}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #min(Vector)
-     * @see #broadcast($type$)
+     * @see #broadcast($elemtype$)
      * @see VectorOperators#MIN
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
 #if[FP]
      * @apiNote
      * For this method, floating point negative
@@ -1862,7 +1920,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[FP]
      */
     @ForceInline
-    public final $abstractvectortype$ min($type$ e) {
+    public final $abstractvectortype$ min($elemtype$ e) {
         return lanewise(MIN, e);
     }
 
@@ -1889,16 +1947,16 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * corresponding lane values.
      *
      * This method is also equivalent to the expression
-     * {@link #lanewise(VectorOperators.Binary,$type$)
+     * {@link #lanewise(VectorOperators.Binary,$elemtype$)
      *    lanewise}{@code (}{@link VectorOperators#MAX
      *    MAX}{@code , e)}.
      *
      * @param e the input scalar
      * @return the result of multiplying this vector by the given scalar
      * @see #max(Vector)
-     * @see #broadcast($type$)
+     * @see #broadcast($elemtype$)
      * @see VectorOperators#MAX
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
 #if[FP]
      * @apiNote
      * For this method, floating point negative
@@ -1907,7 +1965,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[FP]
      */
     @ForceInline
-    public final $abstractvectortype$ max($type$ e) {
+    public final $abstractvectortype$ max($elemtype$ e) {
         return lanewise(MAX, e);
     }
 
@@ -1935,7 +1993,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * @param v a second input vector
      * @return the bitwise {@code &} of this vector and the second input vector
-     * @see #and($type$)
+     * @see #and($elemtype$)
      * @see #or(Vector)
      * @see #not()
      * @see VectorOperators#AND
@@ -1966,7 +2024,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
      */
     @ForceInline
-    public final $abstractvectortype$ and($type$ e) {
+    public final $abstractvectortype$ and($elemtype$ e) {
         return lanewise(AND, e);
     }
 
@@ -1992,7 +2050,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * @param v a second input vector
      * @return the bitwise {@code |} of this vector and the second input vector
-     * @see #or($type$)
+     * @see #or($elemtype$)
      * @see #and(Vector)
      * @see #not()
      * @see VectorOperators#OR
@@ -2023,7 +2081,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
      */
     @ForceInline
-    public final $abstractvectortype$ or($type$ e) {
+    public final $abstractvectortype$ or($elemtype$ e) {
         return lanewise(OR, e);
     }
 
@@ -2059,7 +2117,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * @param b a vector exponent by which to raise this vector
      * @return the {@code b}-th power of this vector
-     * @see #pow($type$)
+     * @see #pow($elemtype$)
      * @see VectorOperators#POW
      * @see #lanewise(VectorOperators.Binary,Vector,VectorMask)
      */
@@ -2091,10 +2149,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @return the {@code b}-th power of this vector
      * @see #pow(Vector)
      * @see VectorOperators#POW
-     * @see #lanewise(VectorOperators.Binary,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Binary,$elemtype$,VectorMask)
      */
     @ForceInline
-    public final $abstractvectortype$ pow($type$ b) {
+    public final $abstractvectortype$ pow($elemtype$ b) {
         return lanewise(POW, b);
     }
 #end[FP]
@@ -2123,7 +2181,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
 #if[!FP]
 #if[!intOrLong]
-    static int bitCount($type$ a) {
+    static int bitCount($elemtype$ a) {
 #if[short]
         return Integer.bitCount((int)a & 0xFFFF);
 #else[short]
@@ -2134,7 +2192,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[!FP]
 #if[!FP]
 #if[!intOrLong]
-    static int numberOfTrailingZeros($type$ a) {
+    static int numberOfTrailingZeros($elemtype$ a) {
 #if[short]
         return a != 0 ? Integer.numberOfTrailingZeros(a) : 16;
 #else[short]
@@ -2145,7 +2203,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[!FP]
 #if[!FP]
 #if[!intOrLong]
-    static int numberOfLeadingZeros($type$ a) {
+    static int numberOfLeadingZeros($elemtype$ a) {
 #if[short]
         return a >= 0 ? Integer.numberOfLeadingZeros(a) - 16 : 0;
 #else[short]
@@ -2153,18 +2211,18 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[short]
     }
 
-    static $type$ reverse($type$ a) {
+    static $elemtype$ reverse($elemtype$ a) {
         if (a == 0 || a == -1) return a;
 
 #if[short]
-        $type$ b = rotateLeft(a, 8);
-        b = ($type$) (((b & 0x5555) << 1) | ((b & 0xAAAA) >>> 1));
-        b = ($type$) (((b & 0x3333) << 2) | ((b & 0xCCCC) >>> 2));
-        b = ($type$) (((b & 0x0F0F) << 4) | ((b & 0xF0F0) >>> 4));
+        $elemtype$ b = rotateLeft(a, 8);
+        b = ($elemtype$) (((b & 0x5555) << 1) | ((b & 0xAAAA) >>> 1));
+        b = ($elemtype$) (((b & 0x3333) << 2) | ((b & 0xCCCC) >>> 2));
+        b = ($elemtype$) (((b & 0x0F0F) << 4) | ((b & 0xF0F0) >>> 4));
 #else[short]
-        $type$ b = rotateLeft(a, 4);
-        b = ($type$) (((b & 0x55) << 1) | ((b & 0xAA) >>> 1));
-        b = ($type$) (((b & 0x33) << 2) | ((b & 0xCC) >>> 2));
+        $elemtype$ b = rotateLeft(a, 4);
+        b = ($elemtype$) (((b & 0x55) << 1) | ((b & 0xAA) >>> 1));
+        b = ($elemtype$) (((b & 0x33) << 2) | ((b & 0xCC) >>> 2));
 #end[short]
         return b;
     }
@@ -2257,11 +2315,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param e the input scalar
      * @return the result mask of testing if this vector
      *         is equal to {@code e}
-     * @see #compare(VectorOperators.Comparison,$type$)
+     * @see #compare(VectorOperators.Comparison,$elemtype$)
      */
     @ForceInline
     public final
-    VectorMask<$Boxtype$> eq($type$ e) {
+    VectorMask<$Boxtype$> eq($elemtype$ e) {
         return compare(EQ, e);
     }
 
@@ -2285,11 +2343,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param e the input scalar
      * @return the mask result of testing if this vector
      *         is less than the input scalar
-     * @see #compare(VectorOperators.Comparison,$type$)
+     * @see #compare(VectorOperators.Comparison,$elemtype$)
      */
     @ForceInline
     public final
-    VectorMask<$Boxtype$> lt($type$ e) {
+    VectorMask<$Boxtype$> lt($elemtype$ e) {
         return compare(LT, e);
     }
 
@@ -2413,7 +2471,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         that.check(this);
         int opc = opCode(op);
         return VectorSupport.compare(
-            opc, getClass(), maskType, $type$.class, length(),
+            opc, getClass(), maskType, $elemtype$.class, length(),
             this, that, null,
             (cond, v0, v1, m1) -> {
                 AbstractMask<$Boxtype$> m
@@ -2435,7 +2493,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         m.check(maskType, this);
         int opc = opCode(op);
         return VectorSupport.compare(
-            opc, getClass(), maskType, $type$.class, length(),
+            opc, getClass(), maskType, $elemtype$.class, length(),
             this, that, m,
             (cond, v0, v1, m1) -> {
                 AbstractMask<$Boxtype$> cmpM
@@ -2448,14 +2506,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     @ForceInline
-    private static boolean compareWithOp(int cond, $type$ a, $type$ b) {
+    private static boolean compareWithOp(int cond, $elemtype$ a, $elemtype$ b) {
         return switch (cond) {
             case BT_eq -> a == b;
             case BT_ne -> a != b;
-            case BT_lt -> a < b;
-            case BT_le -> a <= b;
-            case BT_gt -> a > b;
-            case BT_ge -> a >= b;
+            case BT_lt -> {#if[FP16]?a.floatValue() < b.floatValue():a < b};
+            case BT_le -> {#if[FP16]?a.floatValue() <= b.floatValue():a <= b};
+            case BT_gt -> {#if[FP16]?a.floatValue() > b.floatValue():a > b};
+            case BT_ge -> {#if[FP16]?a.floatValue() >= b.floatValue():a >= b};
 #if[!FP]
             case BT_ult -> $Boxtype$.compareUnsigned(a, b) < 0;
             case BT_ule -> $Boxtype$.compareUnsigned(a, b) <= 0;
@@ -2486,17 +2544,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         compares to the input, according to the selected
      *         comparison operator
      * @see $abstractvectortype$#compare(VectorOperators.Comparison,Vector)
-     * @see #eq($type$)
-     * @see #lt($type$)
+     * @see #eq($elemtype$)
+     * @see #lt($elemtype$)
      */
     public abstract
-    VectorMask<$Boxtype$> compare(Comparison op, $type$ e);
+    VectorMask<$Boxtype$> compare(Comparison op, $elemtype$ e);
 
     /*package-private*/
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    M compareTemplate(Class<M> maskType, Comparison op, $type$ e) {
+    M compareTemplate(Class<M> maskType, Comparison op, $elemtype$ e) {
         return compareTemplate(maskType, op, broadcast(e));
     }
 
@@ -2522,7 +2580,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     @ForceInline
     public final VectorMask<$Boxtype$> compare(VectorOperators.Comparison op,
-                                               $type$ e,
+                                               $elemtype$ e,
                                                VectorMask<$Boxtype$> m) {
         return compare(op, broadcast(e), m);
     }
@@ -2570,7 +2628,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     blendTemplate(Class<M> maskType, $abstractvectortype$ v, M m) {
         v.check(this);
         return VectorSupport.blend(
-            getClass(), maskType, $type$.class, length(),
+            getClass(), maskType, $elemtype$.class, length(),
             this, v, m,
             (v0, v1, m_) -> v0.bOp(v1, m_, (i, a, b) -> b));
     }
@@ -2587,7 +2645,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         // make sure VLENGTH*scale doesn't overflow:
         vsp.checkScale(scale);
         return VectorSupport.indexVector(
-            getClass(), $type$.class, length(),
+            getClass(), $elemtype$.class, length(),
             this, scale, vsp,
             (v, scale_, s)
             -> {
@@ -2595,8 +2653,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 // instruction directly, load IOTA from memory
                 // and multiply.
                 $abstractvectortype$ iota = s.iota();
-                $type$ sc = ($type$) scale_;
-                return v.add(sc == 1 ? iota : iota.mul(sc));
+                return v.add(scale_ == 1 ? iota : iota.mul({#if[FP16]?Float16.valueOf(scale_):($elemtype$)scale_}));
             });
     }
 
@@ -2617,7 +2674,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         the scalar value
      */
     @ForceInline
-    public final $abstractvectortype$ blend($type$ e,
+    public final $abstractvectortype$ blend($elemtype$ e,
                                             VectorMask<$Boxtype$> m) {
         return blend(broadcast(e), m);
     }
@@ -2661,7 +2718,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         that.check(this);
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<$Boxtype$> iota = iotaShuffle();
-        VectorMask<$Boxtype$> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
+        $elemtype$ pivotidx = {#if[FP16]?Float16.valueOf(length() - origin):($elemtype$)(length() - origin)};
+        VectorMask<$Boxtype$> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return that.rearrange(iota).blend(this.rearrange(iota), blendMask);
     }
@@ -2691,7 +2749,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ sliceTemplate(int origin) {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<$Boxtype$> iota = iotaShuffle();
-        VectorMask<$Boxtype$> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast(($type$)(length() - origin))));
+        $elemtype$ pivotidx = {#if[FP16]?Float16.valueOf(length() - origin):($elemtype$)(length() - origin)};
+        VectorMask<$Boxtype$> blendMask = iota.toVector().compare(VectorOperators.LT, broadcast(pivotidx));
         iota = iotaShuffle(origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2713,7 +2772,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<$Boxtype$> iota = iotaShuffle();
         VectorMask<$Boxtype$> blendMask = iota.toVector().compare((part == 0) ? VectorOperators.GE : VectorOperators.LT,
-                                                                  (broadcast(($type$)(origin))));
+                                                                  (broadcast({#if[FP16]?Float16.valueOf(origin):($elemtype$)(origin)})));
         iota = iotaShuffle(-origin, 1, true);
         return that.blend(this.rearrange(iota), blendMask);
     }
@@ -2753,7 +2812,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         Objects.checkIndex(origin, length() + 1);
         VectorShuffle<$Boxtype$> iota = iotaShuffle();
         VectorMask<$Boxtype$> blendMask = iota.toVector().compare(VectorOperators.GE,
-                                                                  (broadcast(($type$)(origin))));
+                                                                  broadcast({#if[FP16]?Float16.valueOf(origin):($elemtype$)(origin)}));
         iota = iotaShuffle(-origin, 1, true);
         return vspecies().zero().blend(this.rearrange(iota), blendMask);
     }
@@ -2779,7 +2838,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $abstractvectortype$ rearrangeTemplate(Class<S> shuffletype, S shuffle) {
         shuffle.checkIndexes();
         return VectorSupport.rearrangeOp(
-            getClass(), shuffletype, null, $type$.class, length(),
+            getClass(), shuffletype, null, $elemtype$.class, length(),
             this, shuffle, null,
             (v1, s_, m_) -> v1.uOp((i, a) -> {
                 int ei = s_.laneSource(i);
@@ -2811,11 +2870,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             throw new AssertionError();
         }
         return VectorSupport.rearrangeOp(
-                   getClass(), shuffletype, masktype, $type$.class, length(),
+                   getClass(), shuffletype, masktype, $elemtype$.class, length(),
                    this, shuffle, m,
                    (v1, s_, m_) -> v1.uOp((i, a) -> {
                         int ei = s_.laneSource(i);
-                        return ei < 0  || !m_.laneIsSet(i) ? 0 : v1.lane(ei);
+                        return ei < 0  || !m_.laneIsSet(i) ? {#if[FP16]?Float16.valueOf(0):0} : v1.lane(ei);
                    }));
     }
 
@@ -2839,7 +2898,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         S ws = (S) shuffle.wrapIndexes();
         $abstractvectortype$ r0 =
             VectorSupport.rearrangeOp(
-                getClass(), shuffletype, null, $type$.class, length(),
+                getClass(), shuffletype, null, $elemtype$.class, length(),
                 this, ws, null,
                 (v0, s_, m_) -> v0.uOp((i, a) -> {
                     int ei = s_.laneSource(i);
@@ -2847,7 +2906,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 }));
         $abstractvectortype$ r1 =
             VectorSupport.rearrangeOp(
-                getClass(), shuffletype, null, $type$.class, length(),
+                getClass(), shuffletype, null, $elemtype$.class, length(),
                 v, ws, null,
                 (v1, s_, m_) -> v1.uOp((i, a) -> {
                     int ei = s_.laneSource(i);
@@ -2859,10 +2918,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     private final
     VectorShuffle<$Boxtype$> toShuffle0($Type$Species dsp) {
-        $type$[] a = toArray();
+        $elemtype$[] a = toArray();
         int[] sa = new int[a.length];
         for (int i = 0; i < a.length; i++) {
-            sa[i] = (int) a[i];
+            sa[i] = {#if[FP16]?a[i].intValue():(int) a[i]};
         }
         return VectorShuffle.fromArray(dsp, sa, 0);
     }
@@ -2873,7 +2932,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     VectorShuffle<$Boxtype$> toShuffleTemplate(Class<?> shuffleType) {
         $Type$Species vsp = vspecies();
         return VectorSupport.convert(VectorSupport.VECTOR_OP_CAST,
-                                     getClass(), $type$.class, length(),
+                                     getClass(), $elemtype$.class, length(),
                                      shuffleType, byte.class, length(),
                                      this, vsp,
                                      $Type$Vector::toShuffle0);
@@ -2894,7 +2953,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $Type$Vector compressTemplate(Class<M> masktype, M m) {
       m.check(masktype, this);
       return ($Type$Vector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_COMPRESS, getClass(), masktype,
-                                                        $type$.class, length(), this, m,
+                                                        $elemtype$.class, length(), this, m,
                                                         (v1, m1) -> compressHelper(v1, m1));
     }
 
@@ -2913,7 +2972,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     $Type$Vector expandTemplate(Class<M> masktype, M m) {
       m.check(masktype, this);
       return ($Type$Vector) VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_EXPAND, getClass(), masktype,
-                                                        $type$.class, length(), this, m,
+                                                        $elemtype$.class, length(), this, m,
                                                         (v1, m1) -> expandHelper(v1, m1));
     }
 
@@ -2965,9 +3024,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @param mask a bitwise mask to enable blending of the input bits
      * @return the bitwise blend of the given bits into the current vector,
      *         under control of the bitwise mask
-     * @see #bitwiseBlend($type$,$type$)
-     * @see #bitwiseBlend($type$,Vector)
-     * @see #bitwiseBlend(Vector,$type$)
+     * @see #bitwiseBlend($elemtype$,$elemtype$)
+     * @see #bitwiseBlend($elemtype$,Vector)
+     * @see #bitwiseBlend(Vector,$elemtype$)
      * @see VectorOperators#BITWISE_BLEND
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
      */
@@ -2996,11 +3055,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         under control of the bitwise mask
      * @see #bitwiseBlend(Vector,Vector)
      * @see VectorOperators#BITWISE_BLEND
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
-    $abstractvectortype$ bitwiseBlend($type$ bits, $type$ mask) {
+    $abstractvectortype$ bitwiseBlend($elemtype$ bits, $elemtype$ mask) {
         return lanewise(BITWISE_BLEND, bits, mask);
     }
 
@@ -3023,11 +3082,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         under control of the bitwise mask
      * @see #bitwiseBlend(Vector,Vector)
      * @see VectorOperators#BITWISE_BLEND
-     * @see #lanewise(VectorOperators.Ternary,$type$,Vector,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,Vector,VectorMask)
      */
     @ForceInline
     public final
-    $abstractvectortype$ bitwiseBlend($type$ bits, Vector<$Boxtype$> mask) {
+    $abstractvectortype$ bitwiseBlend($elemtype$ bits, Vector<$Boxtype$> mask) {
         return lanewise(BITWISE_BLEND, bits, mask);
     }
 
@@ -3050,11 +3109,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         under control of the bitwise mask
      * @see #bitwiseBlend(Vector,Vector)
      * @see VectorOperators#BITWISE_BLEND
-     * @see #lanewise(VectorOperators.Ternary,Vector,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,Vector,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
-    $abstractvectortype$ bitwiseBlend(Vector<$Boxtype$> bits, $type$ mask) {
+    $abstractvectortype$ bitwiseBlend(Vector<$Boxtype$> bits, $elemtype$ mask) {
         return lanewise(BITWISE_BLEND, bits, mask);
     }
 #end[BITWISE]
@@ -3072,7 +3131,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * This is a lane-wise ternary operation which applies an operation
      * conforming to the specification of
-     * {@link Math#fma($type$,$type$,$type$) Math.fma(a,b,c)}
+     * {@link {#if[FP16]?Float16:Math}#fma($elemtype$,$elemtype$,$elemtype$) {#if[FP16]?Float16:Math}.fma(a,b,c)}
      * to each lane.
 #if[intOrFloat]
      * The operation is adapted to cast the operands and the result,
@@ -3091,7 +3150,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @return the product of this vector and the second input vector
      *         summed with the third input vector, using extended precision
      *         for the intermediate result
-     * @see #fma($type$,$type$)
+     * @see #fma($elemtype$,$elemtype$)
      * @see VectorOperators#FMA
      * @see #lanewise(VectorOperators.Ternary,Vector,Vector,VectorMask)
      */
@@ -3113,7 +3172,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * This is a lane-wise ternary operation which applies an operation
      * conforming to the specification of
-     * {@link Math#fma($type$,$type$,$type$) Math.fma(a,b,c)}
+     * {@link {#if[FP16]?Float16:Math}#fma($elemtype$,$elemtype$,$elemtype$) {#if[FP16]?Float16:Math}.fma(a,b,c)}
      * to each lane.
 #if[intOrFloat]
      * The operation is adapted to cast the operands and the result,
@@ -3134,15 +3193,15 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         for the intermediate result
      * @see #fma(Vector,Vector)
      * @see VectorOperators#FMA
-     * @see #lanewise(VectorOperators.Ternary,$type$,$type$,VectorMask)
+     * @see #lanewise(VectorOperators.Ternary,$elemtype$,$elemtype$,VectorMask)
      */
     @ForceInline
     public final
-    $abstractvectortype$ fma($type$ b, $type$ c) {
+    $abstractvectortype$ fma($elemtype$ b, $elemtype$ c) {
         return lanewise(FMA, b, c);
     }
 
-    // Don't bother with (Vector,$type$) and ($type$,Vector) overloadings.
+    // Don't bother with (Vector,$elemtype$) and ($elemtype$,Vector) overloadings.
 #end[FP]
 
     // Type specific horizontal reductions
@@ -3195,7 +3254,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[BITWISE]
      * @see VectorOperators#FIRST_NONZERO
      */
-    public abstract $type$ reduceLanes(VectorOperators.Associative op);
+    public abstract $elemtype$ reduceLanes(VectorOperators.Associative op);
 
     /**
      * Returns a value accumulated from selected lanes of this vector,
@@ -3215,7 +3274,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *  {@code ADD}
 #end[BITWISE]
      * or {@code FIRST_NONZERO},
-     * then the identity value is {#if[FP]?positive }zero, the default {@code $type$} value.
+     * then the identity value is {#if[FP]?positive }zero, the default {@code $elemtype$} value.
      * <li>
      * If the operation is {@code MUL},
      * then the identity value is one.
@@ -3273,24 +3332,24 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *         not support the requested operation
      * @see #reduceLanes(VectorOperators.Associative)
      */
-    public abstract $type$ reduceLanes(VectorOperators.Associative op,
+    public abstract $elemtype$ reduceLanes(VectorOperators.Associative op,
                                        VectorMask<$Boxtype$> m);
 
     /*package-private*/
     @ForceInline
     final
-    $type$ reduceLanesTemplate(VectorOperators.Associative op,
+    $elemtype$ reduceLanesTemplate(VectorOperators.Associative op,
                                Class<? extends VectorMask<$Boxtype$>> maskClass,
                                VectorMask<$Boxtype$> m) {
         m.check(maskClass, this);
         if (op == FIRST_NONZERO) {
             // FIXME:  The JIT should handle this.
-            $abstractvectortype$ v = broadcast(($type$) 0).blend(this, m);
+            $abstractvectortype$ v = broadcast({#if[FP16]?Float16.valueOf(0):($elemtype$) 0}).blend(this, m);
             return v.reduceLanesTemplate(op);
         }
         int opc = opCode(op);
         return fromBits(VectorSupport.reductionCoerced(
-            opc, getClass(), maskClass, $type$.class, length(),
+            opc, getClass(), maskClass, $elemtype$.class, length(),
             this, m,
             REDUCE_IMPL.find(op, opc, $abstractvectortype$::reductionOperations)));
     }
@@ -3298,17 +3357,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     /*package-private*/
     @ForceInline
     final
-    $type$ reduceLanesTemplate(VectorOperators.Associative op) {
+    $elemtype$ reduceLanesTemplate(VectorOperators.Associative op) {
         if (op == FIRST_NONZERO) {
             // FIXME:  The JIT should handle this.
             VectorMask<$Boxbitstype$> thisNZ
                 = this.viewAsIntegralLanes().compare(NE, ($bitstype$) 0);
             int ft = thisNZ.firstTrue();
-            return ft < length() ? this.lane(ft) : ($type$) 0;
+            return ft < length() ? this.lane(ft) : {#if[FP16]?Float16.valueOf(0):($elemtype$) 0};
         }
         int opc = opCode(op);
         return fromBits(VectorSupport.reductionCoerced(
-            opc, getClass(), null, $type$.class, length(),
+            opc, getClass(), null, $elemtype$.class, length(),
             this, null,
             REDUCE_IMPL.find(op, opc, $abstractvectortype$::reductionOperations)));
     }
@@ -3319,32 +3378,43 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     private static ReductionOperation<$abstractvectortype$, VectorMask<$Boxtype$>> reductionOperations(int opc_) {
         switch (opc_) {
+#if[FP16]
             case VECTOR_OP_ADD: return (v, m) ->
-                    toBits(v.rOp(($type$)0, m, (i, a, b) -> ($type$)(a + b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.add(a, b)));
             case VECTOR_OP_MUL: return (v, m) ->
-                    toBits(v.rOp(($type$)1, m, (i, a, b) -> ($type$)(a * b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.multiply(a, b)));
             case VECTOR_OP_MIN: return (v, m) ->
-                    toBits(v.rOp(MAX_OR_INF, m, (i, a, b) -> ($type$) Math.min(a, b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.min(a, b)));
             case VECTOR_OP_MAX: return (v, m) ->
-                    toBits(v.rOp(MIN_OR_INF, m, (i, a, b) -> ($type$) Math.max(a, b)));
+                    toBits(v.rOp(Float16.valueOf(0), m, (i, a, b) -> Float16.max(a, b)));
+#else[FP16]
+            case VECTOR_OP_ADD: return (v, m) ->
+                    toBits(v.rOp(($elemtype$)0, m, (i, a, b) -> ($elemtype$)(a + b)));
+            case VECTOR_OP_MUL: return (v, m) ->
+                    toBits(v.rOp(($elemtype$)1, m, (i, a, b) -> ($elemtype$)(a * b)));
+            case VECTOR_OP_MIN: return (v, m) ->
+                    toBits(v.rOp(MAX_OR_INF, m, (i, a, b) -> ($elemtype$) Math.min(a, b)));
+            case VECTOR_OP_MAX: return (v, m) ->
+                    toBits(v.rOp(MIN_OR_INF, m, (i, a, b) -> ($elemtype$) Math.max(a, b)));
+#end[FP16]
 #if[BITWISE]
             case VECTOR_OP_AND: return (v, m) ->
-                    toBits(v.rOp(($type$)-1, m, (i, a, b) -> ($type$)(a & b)));
+                    toBits(v.rOp(($elemtype$)-1, m, (i, a, b) -> ($elemtype$)(a & b)));
             case VECTOR_OP_OR: return (v, m) ->
-                    toBits(v.rOp(($type$)0, m, (i, a, b) -> ($type$)(a | b)));
+                    toBits(v.rOp(($elemtype$)0, m, (i, a, b) -> ($elemtype$)(a | b)));
             case VECTOR_OP_XOR: return (v, m) ->
-                    toBits(v.rOp(($type$)0, m, (i, a, b) -> ($type$)(a ^ b)));
+                    toBits(v.rOp(($elemtype$)0, m, (i, a, b) -> ($elemtype$)(a ^ b)));
 #end[BITWISE]
             default: return null;
         }
     }
 
 #if[FP]
-    private static final $type$ MIN_OR_INF = $Boxtype$.NEGATIVE_INFINITY;
-    private static final $type$ MAX_OR_INF = $Boxtype$.POSITIVE_INFINITY;
+    private static final $elemtype$ MIN_OR_INF = $Boxtype$.NEGATIVE_INFINITY;
+    private static final $elemtype$ MAX_OR_INF = $Boxtype$.POSITIVE_INFINITY;
 #else[FP]
-    private static final $type$ MIN_OR_INF = $Boxtype$.MIN_VALUE;
-    private static final $type$ MAX_OR_INF = $Boxtype$.MAX_VALUE;
+    private static final $elemtype$ MIN_OR_INF = $Boxtype$.MIN_VALUE;
+    private static final $elemtype$ MAX_OR_INF = $Boxtype$.MAX_VALUE;
 #end[FP]
 
     public @Override abstract long reduceLanesToLong(VectorOperators.Associative op);
@@ -3361,7 +3431,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws IllegalArgumentException if the index is out of range
      * ({@code < 0 || >= length()})
      */
-    public abstract $type$ lane(int i);
+    public abstract $elemtype$ lane(int i);
 
     /**
      * Replaces the lane element of this vector at lane index {@code i} with
@@ -3379,22 +3449,22 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * @throws IllegalArgumentException if the index is out of range
      * ({@code < 0 || >= length()})
      */
-    public abstract $abstractvectortype$ withLane(int i, $type$ e);
+    public abstract $abstractvectortype$ withLane(int i, $elemtype$ e);
 
     // Memory load operations
 
     /**
-     * Returns an array of type {@code $type$[]}
+     * Returns an array of type {@code $elemtype$[]}
      * containing all the lane values.
      * The array length is the same as the vector length.
      * The array elements are stored in lane order.
      * <p>
      * This method behaves as if it stores
      * this vector into an allocated array
-     * (using {@link #intoArray($type$[], int) intoArray})
+     * (using {@link #intoArray($elemtype$[], int) intoArray})
      * and returns the array as follows:
      * <pre>{@code
-     *   $type$[] a = new $type$[this.length()];
+     *   $elemtype$[] a = new $elemtype$[this.length()];
      *   this.intoArray(a, 0);
      *   return a;
      * }</pre>
@@ -3403,8 +3473,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     @ForceInline
     @Override
-    public final $type$[] toArray() {
-        $type$[] a = new $type$[vspecies().laneCount()];
+    public final $elemtype$[] toArray() {
+        $elemtype$[] a = new $elemtype$[vspecies().laneCount()];
         intoArray(a, 0);
         return a;
     }
@@ -3438,10 +3508,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     @Override
     public final int[] toIntArray() {
-        $type$[] a = toArray();
+        $elemtype$[] a = toArray();
         int[] res = new int[a.length];
         for (int i = 0; i < a.length; i++) {
-            $type$ e = a[i];
+            $elemtype$ e = a[i];
             res[i] = (int) $Type$Species.toIntegralChecked(e, true);
         }
         return res;
@@ -3475,11 +3545,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     @Override
     public final long[] toLongArray() {
-        $type$[] a = toArray();
+        $elemtype$[] a = toArray();
         long[] res = new long[a.length];
         for (int i = 0; i < a.length; i++) {
-            $type$ e = a[i];
+#if[FP16]
+            // Value range of integral casted Float16 value is a proper subset of
+            // long value range.
+            res[i] = a[i].longValue();
+#else[FP16]
+            $elemtype$ e = a[i];
             res[i] = $Type$Species.toIntegralChecked(e, false);
+#end[FP16]
         }
         return res;
     }
@@ -3516,17 +3592,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     @Override
     public final double[] toDoubleArray() {
-        $type$[] a = toArray();
+        $elemtype$[] a = toArray();
         double[] res = new double[a.length];
         for (int i = 0; i < a.length; i++) {
-            res[i] = (double) a[i];
+            res[i] = {#if[FP16]?a[i].doubleValue():((double) a[i])};
         }
         return res;
     }
 #end[double]
 
     /**
-     * Loads a vector from an array of type {@code $type$[]}
+     * Loads a vector from an array of type {@code $elemtype$[]}
      * starting at an offset.
      * For each vector lane, where {@code N} is the vector lane index, the
      * array element at index {@code offset + N} is placed into the
@@ -3543,17 +3619,17 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset) {
+                                   $elemtype$[] a, int offset) {
         offset = checkFromIndexSize(offset, species.length(), a.length);
         $Type$Species vsp = ($Type$Species) species;
         return vsp.dummyVector().fromArray0(a, offset);
     }
 
     /**
-     * Loads a vector from an array of type {@code $type$[]}
+     * Loads a vector from an array of type {@code $elemtype$[]}
      * starting at an offset and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code $type$} ({#if[FP]?positive }zero).
+     * value of {@code $elemtype$} ({#if[FP]?positive }zero).
      * For each vector lane, where {@code N} is the vector lane index,
      * if the mask lane at index {@code N} is set then the array element at
      * index {@code offset + N} is placed into the resulting vector at lane index
@@ -3573,7 +3649,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset,
+                                   $elemtype$[] a, int offset,
                                    VectorMask<$Boxtype$> m) {
         $Type$Species vsp = ($Type$Species) species;
         if (VectorIntrinsics.indexInRange(offset, vsp.length(), a.length)) {
@@ -3586,7 +3662,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /**
      * Gathers a new vector composed of elements from an array of type
-     * {@code $type$[]},
+     * {@code $elemtype$[]},
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
      * The index map is a contiguous sequence of {@code VLENGTH}
@@ -3619,7 +3695,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset,
+                                   $elemtype$[] a, int offset,
                                    int[] indexMap, int mapOffset) {
         $Type$Species vsp = ($Type$Species) species;
         return vsp.vOp(n -> a[offset + indexMap[mapOffset + n]]);
@@ -3628,7 +3704,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset,
+                                   $elemtype$[] a, int offset,
                                    int[] indexMap, int mapOffset) {
         $Type$Species vsp = ($Type$Species) species;
         IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
@@ -3669,7 +3745,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         vix = VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
-            vectorType, null, $type$.class, vsp.laneCount(),
+            vectorType, null, $elemtype$.class, vsp.laneCount(),
             isp.vectorType(),
             a, ARRAY_BASE, vix, null,
             a, offset, indexMap, mapOffset, vsp,
@@ -3680,7 +3756,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /**
      * Gathers a new vector composed of elements from an array of type
-     * {@code $type$[]},
+     * {@code $elemtype$[]},
      * under the control of a mask, and
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
@@ -3718,7 +3794,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset,
+                                   $elemtype$[] a, int offset,
                                    int[] indexMap, int mapOffset,
                                    VectorMask<$Boxtype$> m) {
         $Type$Species vsp = ($Type$Species) species;
@@ -3728,7 +3804,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     public static
     $abstractvectortype$ fromArray(VectorSpecies<$Boxtype$> species,
-                                   $type$[] a, int offset,
+                                   $elemtype$[] a, int offset,
                                    int[] indexMap, int mapOffset,
                                    VectorMask<$Boxtype$> m) {
         if (m.allTrue()) {
@@ -3771,7 +3847,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Loads a vector from an array of type {@code char[]}
      * starting at an offset and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code $type$} ({#if[FP]?positive }zero).
+     * value of {@code $elemtype$} ({#if[FP]?positive }zero).
      * For each vector lane, where {@code N} is the vector lane index,
      * if the mask lane at index {@code N} is set then the array element at
      * index {@code offset + N}
@@ -3926,7 +4002,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * Loads a vector from an array of type {@code boolean[]}
      * starting at an offset and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code $type$} ({#if[FP]?positive }zero).
+     * value of {@code $elemtype$} ({#if[FP]?positive }zero).
      * For each vector lane, where {@code N} is the vector lane index,
      * if the mask lane at index {@code N} is set then the array element at
      * index {@code offset + N}
@@ -4096,7 +4172,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * starting at an offset into the memory segment
      * and using a mask.
      * Lanes where the mask is unset are filled with the default
-     * value of {@code $type$} ({#if[FP]?positive }zero).
+     * value of {@code $elemtype$} ({#if[FP]?positive }zero).
      * Bytes are composed into primitive lane elements according
      * to the specified byte order.
      * The vector is arranged into lanes according to
@@ -4105,7 +4181,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * The following pseudocode illustrates the behavior:
      * <pre>{@code
      * var slice = ms.asSlice(offset);
-     * $type$[] ar = new $type$[species.length()];
+     * $elemtype$[] ar = new $elemtype$[species.length()];
      * for (int n = 0; n < ar.length; n++) {
      *     if (m.laneIsSet(n)) {
      *         ar[n] = slice.getAtIndex(ValuaLayout.JAVA_$TYPE$.withByteAlignment(1), n);
@@ -4158,14 +4234,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // Memory store operations
 
     /**
-     * Stores this vector into an array of type {@code $type$[]}
+     * Stores this vector into an array of type {@code $elemtype$[]}
      * starting at an offset.
      * <p>
      * For each vector lane, where {@code N} is the vector lane index,
      * the lane element at index {@code N} is stored into the array
      * element {@code a[offset+N]}.
      *
-     * @param a the array, of type {@code $type$[]}
+     * @param a the array, of type {@code $elemtype$[]}
      * @param offset the offset into the array
      * @throws IndexOutOfBoundsException
      *         if {@code offset+N < 0} or {@code offset+N >= a.length}
@@ -4173,7 +4249,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset) {
+    void intoArray($elemtype$[] a, int offset) {
         offset = checkFromIndexSize(offset, length(), a.length);
         $Type$Species vsp = vspecies();
         VectorSupport.store(
@@ -4187,7 +4263,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     /**
-     * Stores this vector into an array of type {@code $type$[]}
+     * Stores this vector into an array of type {@code $elemtype$[]}
      * starting at offset and using a mask.
      * <p>
      * For each vector lane, where {@code N} is the vector lane index,
@@ -4202,7 +4278,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * That is, unset lanes may correspond to array indexes less than
      * zero or beyond the end of the array.
      *
-     * @param a the array, of type {@code $type$[]}
+     * @param a the array, of type {@code $elemtype$[]}
      * @param offset the offset into the array
      * @param m the mask controlling lane storage
      * @throws IndexOutOfBoundsException
@@ -4212,7 +4288,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset,
+    void intoArray($elemtype$[] a, int offset,
                    VectorMask<$Boxtype$> m) {
         if (m.allTrue()) {
             intoArray(a, offset);
@@ -4226,7 +4302,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     /**
-     * Scatters this vector into an array of type {@code $type$[]}
+     * Scatters this vector into an array of type {@code $elemtype$[]}
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
      * The index map is a contiguous sequence of {@code VLENGTH}
@@ -4254,7 +4330,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[byteOrShort]
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset,
+    void intoArray($elemtype$[] a, int offset,
                    int[] indexMap, int mapOffset) {
         stOp(a, offset,
              (arr, off, i, e) -> {
@@ -4265,7 +4341,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #else[byteOrShort]
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset,
+    void intoArray($elemtype$[] a, int offset,
                    int[] indexMap, int mapOffset) {
         $Type$Species vsp = vspecies();
         IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
@@ -4318,7 +4394,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #end[byteOrShort]
 
     /**
-     * Scatters this vector into an array of type {@code $type$[]},
+     * Scatters this vector into an array of type {@code $elemtype$[]},
      * under the control of a mask, and
      * using indexes obtained by adding a fixed {@code offset} to a
      * series of secondary offsets from an <em>index map</em>.
@@ -4350,7 +4426,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[byteOrShort]
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset,
+    void intoArray($elemtype$[] a, int offset,
                    int[] indexMap, int mapOffset,
                    VectorMask<$Boxtype$> m) {
         stOp(a, offset, m,
@@ -4362,7 +4438,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #else[byteOrShort]
     @ForceInline
     public final
-    void intoArray($type$[] a, int offset,
+    void intoArray($elemtype$[] a, int offset,
                    int[] indexMap, int mapOffset,
                    VectorMask<$Boxtype$> m) {
         if (m.allTrue()) {
@@ -4763,10 +4839,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     abstract
-    $abstractvectortype$ fromArray0($type$[] a, int offset);
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset);
     @ForceInline
     final
-    $abstractvectortype$ fromArray0Template($type$[] a, int offset) {
+    $abstractvectortype$ fromArray0Template($elemtype$[] a, int offset) {
         $Type$Species vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -4778,11 +4854,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     /*package-private*/
     abstract
-    $abstractvectortype$ fromArray0($type$[] a, int offset, VectorMask<$Boxtype$> m, int offsetInRange);
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset, VectorMask<$Boxtype$> m, int offsetInRange);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    $abstractvectortype$ fromArray0Template(Class<M> maskClass, $type$[] a, int offset, M m, int offsetInRange) {
+    $abstractvectortype$ fromArray0Template(Class<M> maskClass, $elemtype$[] a, int offset, M m, int offsetInRange) {
         m.check(species());
         $Type$Species vsp = vspecies();
         return VectorSupport.loadMasked(
@@ -4796,13 +4872,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[!byteOrShort]
     /*package-private*/
     abstract
-    $abstractvectortype$ fromArray0($type$[] a, int offset,
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset,
                                     int[] indexMap, int mapOffset,
                                     VectorMask<$Boxtype$> m);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    $abstractvectortype$ fromArray0Template(Class<M> maskClass, $type$[] a, int offset,
+    $abstractvectortype$ fromArray0Template(Class<M> maskClass, $elemtype$[] a, int offset,
                                             int[] indexMap, int mapOffset, M m) {
         $Type$Species vsp = vspecies();
         IntVector.IntSpecies isp = IntVector.species(vsp.indexShape());
@@ -4845,7 +4921,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         vix = VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
-            vectorType, maskClass, $type$.class, vsp.laneCount(),
+            vectorType, maskClass, $elemtype$.class, vsp.laneCount(),
             isp.vectorType(),
             a, ARRAY_BASE, vix, m,
             a, offset, indexMap, mapOffset, vsp,
@@ -4957,10 +5033,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     // byte swapping.
 
     abstract
-    void intoArray0($type$[] a, int offset);
+    void intoArray0($elemtype$[] a, int offset);
     @ForceInline
     final
-    void intoArray0Template($type$[] a, int offset) {
+    void intoArray0Template($elemtype$[] a, int offset) {
         $Type$Species vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
@@ -4972,11 +5048,11 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     abstract
-    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m);
+    void intoArray0($elemtype$[] a, int offset, VectorMask<$Boxtype$> m);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoArray0Template(Class<M> maskClass, $type$[] a, int offset, M m) {
+    void intoArray0Template(Class<M> maskClass, $elemtype$[] a, int offset, M m) {
         m.check(species());
         $Type$Species vsp = vspecies();
         VectorSupport.storeMasked(
@@ -4990,13 +5066,13 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
 #if[!byteOrShort]
     abstract
-    void intoArray0($type$[] a, int offset,
+    void intoArray0($elemtype$[] a, int offset,
                     int[] indexMap, int mapOffset,
                     VectorMask<$Boxtype$> m);
     @ForceInline
     final
     <M extends VectorMask<$Boxtype$>>
-    void intoArray0Template(Class<M> maskClass, $type$[] a, int offset,
+    void intoArray0Template(Class<M> maskClass, $elemtype$[] a, int offset,
                             int[] indexMap, int mapOffset, M m) {
         m.check(species());
         $Type$Species vsp = vspecies();
@@ -5172,12 +5248,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     static final int ARRAY_SHIFT =
-        31 - Integer.numberOfLeadingZeros(Unsafe.ARRAY_$TYPE$_INDEX_SCALE);
+        31 - Integer.numberOfLeadingZeros(Unsafe.ARRAY_{#if[FP16]?OBJECT:$TYPE$}_INDEX_SCALE);
     static final long ARRAY_BASE =
-        Unsafe.ARRAY_$TYPE$_BASE_OFFSET;
+        Unsafe.ARRAY_{#if[FP16]?OBJECT:$TYPE$}_BASE_OFFSET;
 
     @ForceInline
-    static long arrayAddress($type$[] a, int index) {
+    static long arrayAddress($elemtype$[] a, int index) {
         return ARRAY_BASE + (((long)index) << ARRAY_SHIFT);
     }
 
@@ -5241,7 +5317,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 #if[BITWISE]
         return this;
 #else[BITWISE]
-        LaneType ilt = LaneType.$TYPE$.asIntegral();
+        LaneType ilt = LaneType.{#if[FP16]?FLOAT16:$TYPE$}.asIntegral();
         return ($Bitstype$Vector) asVectorRaw(ilt);
 #end[BITWISE]
     }
@@ -5252,7 +5328,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      *
      * @implNote This method always throws
      * {@code UnsupportedOperationException}, because there is no floating
-     * point type of the same size as {@code $type$}.  The return type
+     * point type of the same size as {@code $elemtype$}.  The return type
      * of this method is arbitrarily designated as
      * {@code Vector<?>}.  Future versions of this API may change the return
      * type if additional floating point types become available.
@@ -5261,18 +5337,22 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     @ForceInline
     @Override
     public final
-    {#if[byteOrShort]?Vector<?>:$Fptype$Vector}
+#if[FP]
+    $Type$Vector
+#else[FP]
+    {#if[byte]?Vector<?>:$Boxfptype$Vector}
+#end[FP]
     viewAsFloatingLanes() {
 #if[FP]
         return this;
 #else[FP]
-        LaneType flt = LaneType.$TYPE$.asFloating();
-#if[!byteOrShort]
-        return ($Fptype$Vector) asVectorRaw(flt);
-#else[!byteOrShort]
-        // asFloating() will throw UnsupportedOperationException for the unsupported type $type$
+        LaneType flt = {#if[short]?LaneType.FLOAT16.asFloating():LaneType.$TYPE$.asFloating()};
+#if[!byte]
+        return ($Boxfptype$Vector) asVectorRaw(flt);
+#else[!byte]
+        // asFloating() will throw UnsupportedOperationException for the unsupported type $elemtype$
         throw new AssertionError("Cannot reach here");
-#end[!byteOrShort]
+#end[!byte]
 #end[FP]
     }
 
@@ -5290,8 +5370,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * in lane order.
      *
      * The string is produced as if by a call to {@link
-     * java.util.Arrays#toString($type$[]) Arrays.toString()},
-     * as appropriate to the {@code $type$} array returned by
+     * java.util.Arrays#toString($elemtype$[]) Arrays.toString()},
+     * as appropriate to the {@code $elemtype$} array returned by
      * {@link #toArray this.toArray()}.
      *
      * @return a string of the form {@code "[0,1,2...]"}
@@ -5345,7 +5425,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
                 Class<? extends $abstractvectortype$> vectorType,
                 Class<? extends AbstractMask<$Boxtype$>> maskType,
                 Function<Object, $abstractvectortype$> vectorFactory) {
-            super(shape, LaneType.of($type$.class),
+            super(shape, LaneType.of($elemtype$.class),
                   vectorType, maskType,
                   vectorFactory);
             assert(this.elementSize() == $Boxtype$.SIZE);
@@ -5356,7 +5436,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @Override
         @ForceInline
         public final Class<$Boxtype$> elementType() {
-            return $type$.class;
+            return $elemtype$.class;
         }
 
         @Override
@@ -5385,14 +5465,14 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         final $abstractvectortype$ broadcastBits(long bits) {
             return ($abstractvectortype$)
                 VectorSupport.fromBitsCoerced(
-                    vectorType, $type$.class, laneCount,
+                    vectorType, $elemtype$.class, laneCount,
                     bits, MODE_BROADCAST, this,
                     (bits_, s_) -> s_.rvOp(i -> bits_));
         }
 
         /*package-private*/
         @ForceInline
-        {#if[long]?public }final $abstractvectortype$ broadcast($type$ e) {
+        {#if[long]?public }final $abstractvectortype$ broadcast($elemtype$ e) {
             return broadcastBits(toBits(e));
         }
 
@@ -5413,8 +5493,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             return value;
 #else[long]
             // Do the conversion, and then test it for failure.
-            $type$ e = ($type$) value;
-            if ((long) e != value) {
+            $elemtype$ e = {#if[FP16]?Float16.valueOf(value):($elemtype$) value};
+            if ({#if[FP16]?e.longValue():(long) e} != value) {
                 throw badElementBits(value, e);
             }
             return toBits(e);
@@ -5423,11 +5503,18 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         /*package-private*/
         @ForceInline
-        static long toIntegralChecked($type$ e, boolean convertToInt) {
-            long value = convertToInt ? (int) e : (long) e;
-            if (($type$) value != e) {
+        static long toIntegralChecked($elemtype$ e, boolean convertToInt) {
+#if[FP16]
+            long value = convertToInt ? e.intValue() : e.longValue();
+            if (value != e.longValue()) {
                 throw badArrayBits(e, convertToInt, value);
             }
+#else[FP16]
+            long value = convertToInt ? (int) e : (long) e;
+            if (($elemtype$) value != e) {
+                throw badArrayBits(e, convertToInt, value);
+            }
+#end[FP16]
             return value;
         }
 
@@ -5436,14 +5523,22 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         @ForceInline
         final $abstractvectortype$ fromIntValues(int[] values) {
             VectorIntrinsics.requireLength(values.length, laneCount);
-            $type$[] va = new $type$[laneCount()];
+            $elemtype$[] va = new $elemtype$[laneCount()];
             for (int i = 0; i < va.length; i++) {
                 int lv = values[i];
-                $type$ v = ($type$) lv;
+#if[FP16]
+                $elemtype$ v = Float16.valueOf(lv);
+                va[i] = v;
+                if ( v.intValue() != lv) {
+                    throw badElementBits(lv, v);
+                }
+#else[FP16]
+                $elemtype$ v = ($elemtype$) lv;
                 va[i] = v;
                 if ((int)v != lv) {
                     throw badElementBits(lv, v);
                 }
+#end[FP16]
             }
             return dummyVector().fromArray0(va, 0);
         }
@@ -5456,7 +5551,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             // User entry point
             // Defer only to the equivalent method on the vector class, using the same inputs
             return $abstractvectortype$
-                .fromArray(this, ($type$[]) a, offset);
+                .fromArray(this, ($elemtype$[]) a, offset);
         }
 
         @ForceInline
@@ -5478,7 +5573,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         final @Override
         @ForceInline
         $abstractvectortype$ rvOp(RVOp f) {
-            $type$[] res = new $type$[laneCount()];
+            $elemtype$[] res = new $elemtype$[laneCount()];
             for (int i = 0; i < res.length; i++) {
                 $bitstype$ bits = {#if[!long]?($bitstype$)} f.apply(i);
                 res[i] = fromBits(bits);
@@ -5487,7 +5582,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
 
         $Type$Vector vOp(FVOp f) {
-            $type$[] res = new $type$[laneCount()];
+            $elemtype$[] res = new $elemtype$[laneCount()];
             for (int i = 0; i < res.length; i++) {
                 res[i] = f.apply(i);
             }
@@ -5495,7 +5590,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
 
         $Type$Vector vOp(VectorMask<$Boxtype$> m, FVOp f) {
-            $type$[] res = new $type$[laneCount()];
+            $elemtype$[] res = new $elemtype$[laneCount()];
             boolean[] mbits = ((AbstractMask<$Boxtype$>)m).getBits();
             for (int i = 0; i < res.length; i++) {
                 if (mbits[i]) {
@@ -5616,10 +5711,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
     }
 
     /**
-     * Finds a species for an element type of {@code $type$} and shape.
+     * Finds a species for an element type of {@code $elemtype$} and shape.
      *
      * @param s the shape
-     * @return a species for an element type of {@code $type$} and shape
+     * @return a species for an element type of {@code $elemtype$} and shape
      * @throws IllegalArgumentException if no such species exists for the shape
      */
     static $Type$Species species(VectorShape s) {
@@ -5674,6 +5769,6 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      * A preferred species is a species of maximal bit-size for the platform.
      */
     public static final VectorSpecies<$Boxtype$> SPECIES_PREFERRED
-        = ($Type$Species) VectorSpecies.ofPreferred($type$.class);
+        = ($Type$Species) VectorSpecies.ofPreferred($elemtype$.class);
 }
 

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-VectorBits.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,19 +52,19 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     static final int VLENGTH = VSPECIES.laneCount(); // used by the JVM
 
-    static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
+    static final Class<$Boxtype$> ETYPE = $elemtype$.class; // used by the JVM
 
-    $vectortype$($type$[] v) {
+    $vectortype$($elemtype$[] v) {
         super(v);
     }
 
     // For compatibility as $vectortype$::new,
     // stored into species.vectorFactory.
     $vectortype$(Object v) {
-        this(($type$[]) v);
+        this(($elemtype$[]) v);
     }
 
-    static final $vectortype$ ZERO = new $vectortype$(new $type$[VLENGTH]);
+    static final $vectortype$ ZERO = new $vectortype$(new $elemtype$[VLENGTH]);
     static final $vectortype$ IOTA = new $vectortype$(VSPECIES.iotaArray());
 
     static {
@@ -88,7 +88,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     @ForceInline
     @Override
-    public final Class<$Boxtype$> elementType() { return $type$.class; }
+    public final Class<$Boxtype$> elementType() { return $elemtype$.class; }
 
     @ForceInline
     @Override
@@ -113,15 +113,15 @@ final class $vectortype$ extends $abstractvectortype$ {
     /*package-private*/
     @ForceInline
     final @Override
-    $type$[] vec() {
-        return ($type$[])getPayload();
+    $elemtype$[] vec() {
+        return ($elemtype$[])getPayload();
     }
 
     // Virtualized constructors
 
     @Override
     @ForceInline
-    public final $vectortype$ broadcast($type$ e) {
+    public final $vectortype$ broadcast($elemtype$ e) {
         return ($vectortype$) super.broadcastTemplate(e);  // specialize
     }
 
@@ -169,7 +169,7 @@ final class $vectortype$ extends $abstractvectortype$ {
     // Make a vector of the same species but the given elements:
     @ForceInline
     final @Override
-    $vectortype$ vectorFactory($type$[] vec) {
+    $vectortype$ vectorFactory($elemtype$[] vec) {
         return new $vectortype$(vec);
     }
 
@@ -238,7 +238,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     @ForceInline
     final @Override
-    $type$ rOp($type$ v, VectorMask<$Boxtype$> m, FBinOp f) {
+    $elemtype$ rOp($elemtype$ v, VectorMask<$Boxtype$> m, FBinOp f) {
         return super.rOpTemplate(v, m, f);  // specialize
     }
 
@@ -337,13 +337,13 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     @Override
     @ForceInline
-    public final $type$ reduceLanes(VectorOperators.Associative op) {
+    public final $elemtype$ reduceLanes(VectorOperators.Associative op) {
         return super.reduceLanesTemplate(op);  // specialized
     }
 
     @Override
     @ForceInline
-    public final $type$ reduceLanes(VectorOperators.Associative op,
+    public final $elemtype$ reduceLanes(VectorOperators.Associative op,
                                     VectorMask<$Boxtype$> m) {
         return super.reduceLanesTemplate(op, $masktype$.class, ($masktype$) m);  // specialized
     }
@@ -351,14 +351,16 @@ final class $vectortype$ extends $abstractvectortype$ {
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op) {
-        return (long) super.reduceLanesTemplate(op);  // specialized
+        $elemtype$ res = super.reduceLanesTemplate(op);  // specialized
+        return {#if[FP16]?res.longValue(): (long) res};
     }
 
     @Override
     @ForceInline
     public final long reduceLanesToLong(VectorOperators.Associative op,
                                         VectorMask<$Boxtype$> m) {
-        return (long) super.reduceLanesTemplate(op, $masktype$.class, ($masktype$) m);  // specialized
+        $elemtype$ res = super.reduceLanesTemplate(op, $masktype$.class, ($masktype$) m);  // specialized
+        return {#if[FP16]?res.longValue(): (long) res};
     }
 
     @ForceInline
@@ -390,7 +392,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     @Override
     @ForceInline
-    public final $masktype$ compare(Comparison op, $type$ s) {
+    public final $masktype$ compare(Comparison op, $elemtype$ s) {
         return super.compareTemplate($masktype$.class, op, s);  // specialize
     }
 
@@ -516,7 +518,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 #if[FP]
     @ForceInline
     @Override
-    public $type$ lane(int i) {
+    public $elemtype$ lane(int i) {
 #if[!Max]
         $bitstype$ bits;
         switch(i) {
@@ -552,7 +554,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         }
         $bitstype$ bits = laneHelper(i);
 #end[!Max]
-        return $Type$.$bitstype$BitsTo$Fptype$(bits);
+        return $Elemtype$.$bitstype$BitsTo{#if[FP16]?Float16:$Fptype$}(bits);
     }
 
     public $bitstype$ laneHelper(int i) {
@@ -560,14 +562,14 @@ final class $vectortype$ extends $abstractvectortype$ {
                      VCLASS, ETYPE, VLENGTH,
                      this, i,
                      (vec, ix) -> {
-                     $type$[] vecarr = vec.vec();
-                     return (long)$Type$.$type$To$Bitstype$Bits(vecarr[ix]);
+                     $elemtype$[] vecarr = vec.vec();
+                     return (long)$Elemtype$.{#if[FP16]?float16:$elemtype$}To$Bitstype$Bits(vecarr[ix]);
                      });
     }
 
     @ForceInline
     @Override
-    public $vectortype$ withLane(int i, $type$ e) {
+    public $vectortype$ withLane(int i, $elemtype$ e) {
 #if[!Max]
         switch(i) {
             case 0: return withLaneHelper(0, e);
@@ -604,20 +606,20 @@ final class $vectortype$ extends $abstractvectortype$ {
 #end[!Max]
     }
 
-    public $vectortype$ withLaneHelper(int i, $type$ e) {
+    public $vectortype$ withLaneHelper(int i, $elemtype$ e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
-                                this, i, (long)$Type$.$type$To$Bitstype$Bits(e),
+                                this, i, (long)$Elemtype$.{#if[FP16]?float16:$elemtype$}To$Bitstype$Bits(e),
                                 (v, ix, bits) -> {
-                                    $type$[] res = v.vec().clone();
-                                    res[ix] = $Type$.$bitstype$BitsTo$Type$(($bitstype$)bits);
+                                    $elemtype$[] res = v.vec().clone();
+                                    res[ix] = $Elemtype$.$bitstype$BitsTo$Elemtype$(($bitstype$)bits);
                                     return v.vectorFactory(res);
                                 });
     }
 #else[FP]
     @ForceInline
     @Override
-    public $type$ lane(int i) {
+    public $elemtype$ lane(int i) {
 #if[!Max]
         switch(i) {
             case 0: return laneHelper(0);
@@ -706,19 +708,19 @@ final class $vectortype$ extends $abstractvectortype$ {
 #end[!Max]
     }
 
-    public $type$ laneHelper(int i) {
-        return ($type$) VectorSupport.extract(
+    public $elemtype$ laneHelper(int i) {
+        return ($elemtype$) VectorSupport.extract(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i,
                                 (vec, ix) -> {
-                                    $type$[] vecarr = vec.vec();
+                                    $elemtype$[] vecarr = vec.vec();
                                     return (long)vecarr[ix];
                                 });
     }
 
     @ForceInline
     @Override
-    public $vectortype$ withLane(int i, $type$ e) {
+    public $vectortype$ withLane(int i, $elemtype$ e) {
 #if[!Max]
         switch (i) {
             case 0: return withLaneHelper(0, e);
@@ -807,13 +809,13 @@ final class $vectortype$ extends $abstractvectortype$ {
 #end[!Max]
     }
 
-    public $vectortype$ withLaneHelper(int i, $type$ e) {
+    public $vectortype$ withLaneHelper(int i, $elemtype$ e) {
         return VectorSupport.insert(
                                 VCLASS, ETYPE, VLENGTH,
                                 this, i, (long)e,
                                 (v, ix, bits) -> {
-                                    $type$[] res = v.vec().clone();
-                                    res[ix] = ($type$)bits;
+                                    $elemtype$[] res = v.vec().clone();
+                                    res[ix] = ($elemtype$)bits;
                                     return v.vectorFactory(res);
                                 });
     }
@@ -823,7 +825,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     static final class $masktype$ extends AbstractMask<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
+        static final Class<$Boxtype$> ETYPE = $elemtype$.class; // used by the JVM
 
         $masktype$(boolean[] bits) {
             this(bits, 0);
@@ -925,7 +927,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         /*package-private*/
         $masktype$ indexPartiallyInUpperRange(long offset, long limit) {
             return ($masktype$) VectorSupport.indexPartiallyInUpperRange(
-                $masktype$.class, $type$.class, VLENGTH, offset, limit,
+                $masktype$.class, ETYPE, VLENGTH, offset, limit,
                 (o, l) -> ($masktype$) TRUE_MASK.indexPartiallyInRange(o, l));
         }
 
@@ -942,7 +944,11 @@ final class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ compress() {
             return ($masktype$)VectorSupport.compressExpandOp(VectorSupport.VECTOR_OP_MASK_COMPRESS,
                 $vectortype$.class, $masktype$.class, ETYPE, VLENGTH, null, this,
+#if[FP16]
+                (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, Float.floatToFloat16(m1.trueCount())));
+#else[FP16]
                 (v1, m1) -> VSPECIES.iota().compare(VectorOperators.LT, m1.trueCount()));
+#end[FP16]
         }
 
 
@@ -953,7 +959,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ and(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_AND, $masktype$.class, null, $bitstype$.class, VLENGTH,
+            return VectorSupport.binaryOp(VECTOR_OP_AND, $masktype$.class, null, $maskbitstype$.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a & b));
         }
@@ -963,7 +969,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ or(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_OR, $masktype$.class, null, $bitstype$.class, VLENGTH,
+            return VectorSupport.binaryOp(VECTOR_OP_OR, $masktype$.class, null, $maskbitstype$.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a | b));
         }
@@ -973,7 +979,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         public $masktype$ xor(VectorMask<$Boxtype$> mask) {
             Objects.requireNonNull(mask);
             $masktype$ m = ($masktype$)mask;
-            return VectorSupport.binaryOp(VECTOR_OP_XOR, $masktype$.class, null, $bitstype$.class, VLENGTH,
+            return VectorSupport.binaryOp(VECTOR_OP_XOR, $masktype$.class, null, $maskbitstype$.class, VLENGTH,
                                           this, m, null,
                                           (m1, m2, vm) -> m1.bOp(m2, (i, a, b) -> a ^ b));
         }
@@ -983,21 +989,21 @@ final class $vectortype$ extends $abstractvectortype$ {
         @Override
         @ForceInline
         public int trueCount() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, $masktype$.class, $bitstype$.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TRUECOUNT, $masktype$.class, $maskbitstype$.class, VLENGTH, this,
                                                       (m) -> trueCountHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int firstTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, $masktype$.class, $bitstype$.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_FIRSTTRUE, $masktype$.class, $maskbitstype$.class, VLENGTH, this,
                                                       (m) -> firstTrueHelper(m.getBits()));
         }
 
         @Override
         @ForceInline
         public int lastTrue() {
-            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, $masktype$.class, $bitstype$.class, VLENGTH, this,
+            return (int) VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_LASTTRUE, $masktype$.class, $maskbitstype$.class, VLENGTH, this,
                                                       (m) -> lastTrueHelper(m.getBits()));
         }
 
@@ -1007,7 +1013,7 @@ final class $vectortype$ extends $abstractvectortype$ {
             if (length() > Long.SIZE) {
                 throw new UnsupportedOperationException("too many lanes for one long");
             }
-            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, $masktype$.class, $bitstype$.class, VLENGTH, this,
+            return VectorSupport.maskReductionCoerced(VECTOR_OP_MASK_TOLONG, $masktype$.class, $maskbitstype$.class, VLENGTH, this,
                                                       (m) -> toLongHelper(m.getBits()));
         }
 
@@ -1017,7 +1023,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         @ForceInline
         public boolean laneIsSet(int i) {
             Objects.checkIndex(i, length());
-            return VectorSupport.extract($masktype$.class, $type$.class, VLENGTH,
+            return VectorSupport.extract($masktype$.class, $elemtype$.class, VLENGTH,
                                          this, i, (m, idx) -> (m.getBits()[idx] ? 1L : 0L)) == 1L;
         }
 
@@ -1026,7 +1032,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         @Override
         @ForceInline
         public boolean anyTrue() {
-            return VectorSupport.test(BT_ne, $masktype$.class, $bitstype$.class, VLENGTH,
+            return VectorSupport.test(BT_ne, $masktype$.class, $maskbitstype$.class, VLENGTH,
                                          this, vspecies().maskAll(true),
                                          (m, __) -> anyTrueHelper((($masktype$)m).getBits()));
         }
@@ -1034,7 +1040,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         @Override
         @ForceInline
         public boolean allTrue() {
-            return VectorSupport.test(BT_overflow, $masktype$.class, $bitstype$.class, VLENGTH,
+            return VectorSupport.test(BT_overflow, $masktype$.class, $maskbitstype$.class, VLENGTH,
                                          this, vspecies().maskAll(true),
                                          (m, __) -> allTrueHelper((($masktype$)m).getBits()));
         }
@@ -1042,7 +1048,7 @@ final class $vectortype$ extends $abstractvectortype$ {
         @ForceInline
         /*package-private*/
         static $masktype$ maskAll(boolean bit) {
-            return VectorSupport.fromBitsCoerced($masktype$.class, $bitstype$.class, VLENGTH,
+            return VectorSupport.fromBitsCoerced($masktype$.class, $maskbitstype$.class, VLENGTH,
                                                  (bit ? -1 : 0), MODE_BROADCAST, null,
                                                  (v, __) -> (v != 0 ? TRUE_MASK : FALSE_MASK));
         }
@@ -1070,7 +1076,7 @@ final class $vectortype$ extends $abstractvectortype$ {
 
     static final class $shuffletype$ extends AbstractShuffle<$Boxtype$> {
         static final int VLENGTH = VSPECIES.laneCount();    // used by the JVM
-        static final Class<$Boxtype$> ETYPE = $type$.class; // used by the JVM
+        static final Class<$Boxtype$> ETYPE = $elemtype$.class; // used by the JVM
 
         $shuffletype$(byte[] reorder) {
             super(VLENGTH, reorder);
@@ -1140,14 +1146,14 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    $abstractvectortype$ fromArray0($type$[] a, int offset) {
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset) {
         return super.fromArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    $abstractvectortype$ fromArray0($type$[] a, int offset, VectorMask<$Boxtype$> m, int offsetInRange) {
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset, VectorMask<$Boxtype$> m, int offsetInRange) {
         return super.fromArray0Template($masktype$.class, a, offset, ($masktype$) m, offsetInRange);  // specialize
     }
 
@@ -1155,7 +1161,7 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    $abstractvectortype$ fromArray0($type$[] a, int offset, int[] indexMap, int mapOffset, VectorMask<$Boxtype$> m) {
+    $abstractvectortype$ fromArray0($elemtype$[] a, int offset, int[] indexMap, int mapOffset, VectorMask<$Boxtype$> m) {
         return super.fromArray0Template($masktype$.class, a, offset, indexMap, mapOffset, ($masktype$) m);
     }
 #end[!byteOrShort]
@@ -1209,14 +1215,14 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    void intoArray0($type$[] a, int offset) {
+    void intoArray0($elemtype$[] a, int offset) {
         super.intoArray0Template(a, offset);  // specialize
     }
 
     @ForceInline
     @Override
     final
-    void intoArray0($type$[] a, int offset, VectorMask<$Boxtype$> m) {
+    void intoArray0($elemtype$[] a, int offset, VectorMask<$Boxtype$> m) {
         super.intoArray0Template($masktype$.class, a, offset, ($masktype$) m);
     }
 
@@ -1224,7 +1230,7 @@ final class $vectortype$ extends $abstractvectortype$ {
     @ForceInline
     @Override
     final
-    void intoArray0($type$[] a, int offset, int[] indexMap, int mapOffset, VectorMask<$Boxtype$> m) {
+    void intoArray0($elemtype$[] a, int offset, int[] indexMap, int mapOffset, VectorMask<$Boxtype$> m) {
         super.intoArray0Template($masktype$.class, a, offset, indexMap, mapOffset, ($masktype$) m);
     }
 #end[!byteOrShort]

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/gen-src.sh
@@ -53,10 +53,12 @@ typeprefix=
 globalArgs=""
 #globalArgs="$globalArgs -KextraOverrides"
 
-for type in byte short int long float double
+for type in byte short int long float double Halffloat
 do
+
   Type="$(tr '[:lower:]' '[:upper:]' <<< ${type:0:1})${type:1}"
   TYPE="$(tr '[:lower:]' '[:upper:]' <<< ${type})"
+
   args=$globalArgs
   args="$args -K$type -Dtype=$type -DType=$Type -DTYPE=$TYPE"
 
@@ -66,25 +68,33 @@ do
   kind=BITWISE
 
   bitstype=$type
+  maskbitstype=$type
   Bitstype=$Type
   Boxbitstype=$Boxtype
 
   fptype=$type
   Fptype=$Type
   Boxfptype=$Boxtype
+  elemtype=$type
+  Elemtype=$Type
+  FPtype=$type
 
-  case $type in
-    byte)
+
+  case $Type in
+    Byte)
       Wideboxtype=Integer
       sizeInBytes=1
       args="$args -KbyteOrShort"
       ;;
-    short)
+    Short)
+      fptype=float16
+      Fptype=Float16
+      Boxfptype=Halffloat
       Wideboxtype=Integer
       sizeInBytes=2
       args="$args -KbyteOrShort"
       ;;
-    int)
+    Int)
       Boxtype=Integer
       Wideboxtype=Integer
       Boxbitstype=Integer
@@ -94,35 +104,55 @@ do
       sizeInBytes=4
       args="$args -KintOrLong -KintOrFP -KintOrFloat"
       ;;
-    long)
+    Long)
       fptype=double
       Fptype=Double
       Boxfptype=Double
       sizeInBytes=8
       args="$args -KintOrLong -KlongOrDouble"
       ;;
-    float)
+    Float)
       kind=FP
       bitstype=int
+      maskbitstype=int
       Bitstype=Int
       Boxbitstype=Integer
       sizeInBytes=4
       args="$args -KintOrFP -KintOrFloat"
+      FPtype=FP32
       ;;
-    double)
+    Double)
       kind=FP
       bitstype=long
+      maskbitstype=long
       Bitstype=Long
       Boxbitstype=Long
       sizeInBytes=8
       args="$args -KintOrFP -KlongOrDouble"
+      FPtype=FP64
+      ;;
+    Halffloat)
+      kind=FP
+      bitstype=short
+      maskbitstype=short
+      Bitstype=Short
+      Boxbitstype=Short
+      sizeInBytes=2
+      Boxtype=Float16
+      elemtype=Float16
+      Elemtype=Float16
+      FPtype=FP16
+      fptype=float16
+      Fptype=Float16
+      args="$args -KbyteOrShort -KshortOrFP -KshortOrHalffloat"
       ;;
   esac
 
-  args="$args -K$kind -DBoxtype=$Boxtype -DWideboxtype=$Wideboxtype"
-  args="$args -Dbitstype=$bitstype -DBitstype=$Bitstype -DBoxbitstype=$Boxbitstype"
+  args="$args -K$FPtype -K$kind -DBoxtype=$Boxtype -DWideboxtype=$Wideboxtype"
+  args="$args -Dbitstype=$bitstype -Dmaskbitstype=$maskbitstype -DBitstype=$Bitstype -DBoxbitstype=$Boxbitstype"
   args="$args -Dfptype=$fptype -DFptype=$Fptype -DBoxfptype=$Boxfptype"
   args="$args -DsizeInBytes=$sizeInBytes"
+  args="$args -Delemtype=$elemtype -DElemtype=$Elemtype"
 
   abstractvectortype=${typeprefix}${Type}Vector
   abstractbitsvectortype=${typeprefix}${Bitstype}Vector

--- a/test/jdk/jdk/incubator/vector/Short128VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short128VectorTests.java
@@ -1382,9 +1382,14 @@ public class Short128VectorTests extends AbstractVectorTest {
         Assert.assertEquals(asIntegral.species(), SPECIES);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     void viewAsFloatingLanesTest() {
-        SPECIES.zero().viewAsFloatingLanes();
+        Vector<?> asFloating = SPECIES.zero().viewAsFloatingLanes();
+        VectorSpecies<?> asFloatingSpecies = asFloating.species();
+        Assert.assertNotEquals(asFloatingSpecies.elementType(), SPECIES.elementType());
+        Assert.assertEquals(asFloatingSpecies.vectorShape(), SPECIES.vectorShape());
+        Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
+        Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
 
     @Test

--- a/test/jdk/jdk/incubator/vector/Short256VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short256VectorTests.java
@@ -1382,9 +1382,14 @@ public class Short256VectorTests extends AbstractVectorTest {
         Assert.assertEquals(asIntegral.species(), SPECIES);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     void viewAsFloatingLanesTest() {
-        SPECIES.zero().viewAsFloatingLanes();
+        Vector<?> asFloating = SPECIES.zero().viewAsFloatingLanes();
+        VectorSpecies<?> asFloatingSpecies = asFloating.species();
+        Assert.assertNotEquals(asFloatingSpecies.elementType(), SPECIES.elementType());
+        Assert.assertEquals(asFloatingSpecies.vectorShape(), SPECIES.vectorShape());
+        Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
+        Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
 
     @Test

--- a/test/jdk/jdk/incubator/vector/Short512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short512VectorTests.java
@@ -1382,9 +1382,14 @@ public class Short512VectorTests extends AbstractVectorTest {
         Assert.assertEquals(asIntegral.species(), SPECIES);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     void viewAsFloatingLanesTest() {
-        SPECIES.zero().viewAsFloatingLanes();
+        Vector<?> asFloating = SPECIES.zero().viewAsFloatingLanes();
+        VectorSpecies<?> asFloatingSpecies = asFloating.species();
+        Assert.assertNotEquals(asFloatingSpecies.elementType(), SPECIES.elementType());
+        Assert.assertEquals(asFloatingSpecies.vectorShape(), SPECIES.vectorShape());
+        Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
+        Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
 
     @Test

--- a/test/jdk/jdk/incubator/vector/Short64VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Short64VectorTests.java
@@ -1382,9 +1382,14 @@ public class Short64VectorTests extends AbstractVectorTest {
         Assert.assertEquals(asIntegral.species(), SPECIES);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     void viewAsFloatingLanesTest() {
-        SPECIES.zero().viewAsFloatingLanes();
+        Vector<?> asFloating = SPECIES.zero().viewAsFloatingLanes();
+        VectorSpecies<?> asFloatingSpecies = asFloating.species();
+        Assert.assertNotEquals(asFloatingSpecies.elementType(), SPECIES.elementType());
+        Assert.assertEquals(asFloatingSpecies.vectorShape(), SPECIES.vectorShape());
+        Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
+        Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
 
     @Test

--- a/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ShortMaxVectorTests.java
@@ -1387,9 +1387,14 @@ public class ShortMaxVectorTests extends AbstractVectorTest {
         Assert.assertEquals(asIntegral.species(), SPECIES);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     void viewAsFloatingLanesTest() {
-        SPECIES.zero().viewAsFloatingLanes();
+        Vector<?> asFloating = SPECIES.zero().viewAsFloatingLanes();
+        VectorSpecies<?> asFloatingSpecies = asFloating.species();
+        Assert.assertNotEquals(asFloatingSpecies.elementType(), SPECIES.elementType());
+        Assert.assertEquals(asFloatingSpecies.vectorShape(), SPECIES.vectorShape());
+        Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
+        Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
 
     @Test

--- a/test/jdk/jdk/incubator/vector/templates/Unit-header.template
+++ b/test/jdk/jdk/incubator/vector/templates/Unit-header.template
@@ -1750,13 +1750,13 @@ relativeError));
         Assert.assertEquals(asFloating.species(), SPECIES);
     }
 #else[FP]
-#if[byteOrShort]
+#if[byte]
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     void viewAsFloatingLanesTest() {
         SPECIES.zero().viewAsFloatingLanes();
     }
-#else[byteOrShort]
+#else[byte]
 
     @Test
     void viewAsFloatingLanesTest() {
@@ -1767,7 +1767,7 @@ relativeError));
         Assert.assertEquals(asFloatingSpecies.length(), SPECIES.length());
         Assert.assertEquals(asFloating.viewAsIntegralLanes().species(), SPECIES);
     }
-#end[byteOrShort]
+#end[byte]
 #end[FP]
 #if[BITWISE]
 


### PR DESCRIPTION
- Port existing HalfFloatVector and its concrete vector classes from vectorIntrinsics+fp16 to lworld+fp16.
- These new vector classes uses Float16 array as their backing storage.
- Idea is to enable intrinsificaiton of new HalfFloatVector operations and leverage existing Float16 auto-vectorization and backend support.

All existing VectorAPI tests are passing with the patch.

Best Regards,
Jatin

Follow up work:-
a) Jtreg suite extensions to cover HalfFloatVector operations.
b) Handle Float16 lane type in vector API inline expansion layer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8339494: Porting HalfFloatVector classes.`

### Issue
 * [JDK-8339494](https://bugs.openjdk.org/browse/JDK-8339494): Porting HalfFloatVector classes. (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1233/head:pull/1233` \
`$ git checkout pull/1233`

Update a local copy of the PR: \
`$ git checkout pull/1233` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1233`

View PR using the GUI difftool: \
`$ git pr show -t 1233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1233.diff">https://git.openjdk.org/valhalla/pull/1233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1233#issuecomment-2327074519)