### PR TITLE
8339357: [lw5] make non-nullable instance fields strict

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -319,7 +319,7 @@ public class Attr extends JCTree.Visitor {
         }
 
         if (!env.info.ctorPrologue &&
-                // it is OK instance initializer blocks will go after super() anyways
+                // it is OK, in value classes, instance initializer blocks will go after super() anyways
                 ((v.owner.isValueClass() && !env.info.instanceInitializerBlock) ||
                         types.isNonNullable(v.type)) &&
                 v.owner.kind == TYP &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -319,8 +319,9 @@ public class Attr extends JCTree.Visitor {
         }
 
         if (!env.info.ctorPrologue &&
-                v.owner.isValueClass() &&
-                !env.info.instanceInitializerBlock && // it is OK instance initializer blocks will go after super() anyways
+                // it is OK instance initializer blocks will go after super() anyways
+                ((v.owner.isValueClass() && !env.info.instanceInitializerBlock) ||
+                        types.isNonNullable(v.type)) &&
                 v.owner.kind == TYP &&
                 v.owner == env.enclClass.sym &&
                 (v.flags() & STATIC) == 0 &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1319,10 +1319,15 @@ public class Check {
             else if ((sym.owner.flags_field & INTERFACE) != 0)
                 mask = implicit = InterfaceVarFlags;
             else {
-                boolean isInstanceFieldOfValueClass = sym.owner.type.isValueClass() && (flags & STATIC) == 0;
-                mask = !isInstanceFieldOfValueClass ? VarFlags : ExtendedVarFlags;
+                boolean isInstanceFieldOfValueClass =
+                        (sym.owner.type.isValueClass() && (flags & STATIC) == 0);
+                boolean isNonNullableInstanceFieldOfNonValueClass =
+                        (!sym.owner.type.isValueClass() && (flags & STATIC) == 0) && types.isNonNullable(sym.type);
+                mask = isInstanceFieldOfValueClass || isNonNullableInstanceFieldOfNonValueClass ? ExtendedVarFlags : VarFlags;
                 if (isInstanceFieldOfValueClass) {
                     implicit |= FINAL | STRICT;
+                } else if (isNonNullableInstanceFieldOfNonValueClass) {
+                    implicit |= STRICT;
                 }
             }
             break;


### PR DESCRIPTION
syncing javac with [[1](https://bugs.openjdk.org/browse/JDK-8303099)], in particular section: `Field and array initialization`:

- A null-restricted instance field without an initializer must be definitely assigned before the (explicit or implicit) super(...) call in each of the class's constructors. The [Flexible Constructor Bodies JEP](https://openjdk.org/jeps/8325803) allows the necessary initialization code to be written at the start of a constructor. In this early construction context, the initialization logic is not allowed to refer to this or risk any attempts to read the uninitialized field.
- If a null-restricted instance field has an initializer, the initializer is executed at the start of each constructor, before the super(...) call. (Constructors that call this(...) are a special case and, as usual, do not execute initializers at all.) Again, this means that the initialization logic of the field occurs in an early construction context and may not refer to this or risk any reads of the uninitialized field.

TIA

[1] https://bugs.openjdk.org/browse/JDK-8303099

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339357](https://bugs.openjdk.org/browse/JDK-8339357): [lw5] make non-nullable instance fields strict (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1234/head:pull/1234` \
`$ git checkout pull/1234`

Update a local copy of the PR: \
`$ git checkout pull/1234` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1234`

View PR using the GUI difftool: \
`$ git pr show -t 1234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1234.diff">https://git.openjdk.org/valhalla/pull/1234.diff</a>

</details>
