### PR TITLE
8339599: Add nextUp(), nextDown(), scalb() to Float16

### DIFF
--- a/src/java.base/share/classes/java/lang/Float16.java
+++ b/src/java.base/share/classes/java/lang/Float16.java
@@ -25,15 +25,9 @@
 
 package java.lang;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.constant.Constable;
-import java.lang.constant.ConstantDesc;
 import java.math.BigDecimal;
-import java.util.Optional;
 
-import jdk.internal.math.FloatConsts;
-import jdk.internal.math.FloatingDecimal;
-import jdk.internal.math.FloatToDecimal;
+import jdk.internal.math.*;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.Float.float16ToFloat;
@@ -1201,4 +1195,126 @@ public final class Float16
         }
         };
     }
+
+    /**
+     * Returns the floating-point value adjacent to {@code v} in
+     * the direction of positive infinity.
+     *
+     * <p>Special Cases:
+     * <ul>
+     * <li> If the argument is NaN, the result is NaN.
+     *
+     * <li> If the argument is positive infinity, the result is
+     * positive infinity.
+     *
+     * <li> If the argument is zero, the result is
+     * {@link #MIN_VALUE}
+     *
+     * </ul>
+     *
+     * @apiNote This method corresponds to the nextUp
+     * operation defined in IEEE 754.
+     *
+     * @param v starting floating-point value
+     * @return The adjacent floating-point value closer to positive
+     * infinity.
+     */
+    public static Float16 nextUp(Float16 v) {
+        float f = v.floatValue();
+        if (f < Float.POSITIVE_INFINITY) {
+            if (f != 0) {
+                int bits = float16ToRawShortBits(v);
+                return shortBitsToFloat16((short) (bits + ((bits >= 0) ? 1 : -1)));
+            }
+            return MIN_VALUE;
+        }
+        return v; // v is NaN or +Infinity
+    }
+
+    /**
+     * Returns the floating-point value adjacent to {@code v} in
+     * the direction of negative infinity.
+     *
+     * <p>Special Cases:
+     * <ul>
+     * <li> If the argument is NaN, the result is NaN.
+     *
+     * <li> If the argument is negative infinity, the result is
+     * negative infinity.
+     *
+     * <li> If the argument is zero, the result is
+     * -{@link #MIN_VALUE}
+     *
+     * </ul>
+     *
+     * @apiNote This method corresponds to the nextDown
+     * operation defined in IEEE 754.
+     *
+     * @param v  starting floating-point value
+     * @return The adjacent floating-point value closer to negative
+     * infinity.
+     */
+    public static Float16 nextDown(Float16 v) {
+        float f = v.floatValue();
+        if (f > Float.NEGATIVE_INFINITY) {
+            if (f != 0) {
+                int bits = float16ToRawShortBits(v);
+                return shortBitsToFloat16((short) (bits - ((bits >= 0) ? 1 : -1)));
+            }
+            return negate(MIN_VALUE);
+        }
+        return v; // v is NaN or -Infinity
+    }
+
+    /**
+     * Returns {@code v} &times; 2<sup>{@code scaleFactor}</sup>
+     * rounded as if performed by a single correctly rounded
+     * floating-point multiply.  If the exponent of the result is
+     * between {@link Float16#MIN_EXPONENT} and {@link
+     * Float16#MAX_EXPONENT}, the answer is calculated exactly.  If the
+     * exponent of the result would be larger than {@code
+     * Float16.MAX_EXPONENT}, an infinity is returned.  Note that if the
+     * result is subnormal, precision may be lost; that is, when
+     * {@code scalb(x, n)} is subnormal, {@code scalb(scalb(x, n),
+     * -n)} may not equal <i>x</i>.  When the result is non-NaN, the
+     * result has the same sign as {@code v}.
+     *
+     * <p>Special cases:
+     * <ul>
+     * <li> If the first argument is NaN, NaN is returned.
+     * <li> If the first argument is infinite, then an infinity of the
+     * same sign is returned.
+     * <li> If the first argument is zero, then a zero of the same
+     * sign is returned.
+     * </ul>
+     *
+     * @apiNote This method corresponds to the scaleB operation
+     * defined in IEEE 754.
+     *
+     * @param v number to be scaled by a power of two.
+     * @param scaleFactor power of 2 used to scale {@code v}
+     * @return {@code v} &times; 2<sup>{@code scaleFactor}</sup>
+     */
+    public static Float16 scalb(Float16 v, int scaleFactor) {
+        // magnitude of a power of two so large that scaling a finite
+        // nonzero value by it would be guaranteed to over or
+        // underflow; due to rounding, scaling down takes an
+        // additional power of two which is reflected here
+        final int MAX_SCALE = Float16.MAX_EXPONENT + -Float16.MIN_EXPONENT +
+                Float16Consts.SIGNIFICAND_WIDTH + 1;
+
+        // Make sure scaling factor is in a reasonable range
+        scaleFactor = Math.max(Math.min(scaleFactor, MAX_SCALE), -MAX_SCALE);
+
+        /*
+         * Since + MAX_SCALE for Float16 fits well within the double
+         * exponent range and + Float16 -> double conversion is exact
+         * the multiplication below will be exact. Therefore, the
+         * rounding that occurs when the double product is cast to
+         * Float16 will be the correctly rounded Float16 result.
+         */
+        return valueOf(v.doubleValue()
+                * Double.longBitsToDouble((long) (scaleFactor + DoubleConsts.EXP_BIAS) << Double.PRECISION - 1));
+    }
+
 }

--- a/test/jdk/java/lang/Math/Float16Consts.java
+++ b/test/jdk/java/lang/Math/Float16Consts.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import static java.lang.Float16.MIN_EXPONENT;
+import static java.lang.Float16.PRECISION;
+import static java.lang.Float16.SIZE;
+
+/**
+ * This class contains additional constants documenting limits of the
+ * {@code Float16} type.
+ */
+
+public class Float16Consts {
+    /**
+     * Don't let anyone instantiate this class.
+     */
+    private Float16Consts() {}
+
+    /**
+     * The number of logical bits in the significand of a
+     * {@code Float16} number, including the implicit bit.
+     */
+    public static final int SIGNIFICAND_WIDTH = PRECISION;
+
+    /**
+     * The exponent the smallest positive {@code Float16}
+     * subnormal value would have if it could be normalized.
+     */
+    public static final int MIN_SUB_EXPONENT =
+            MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1); // -24
+
+    /**
+     * Bias used in representing a {@code Float16} exponent.
+     */
+    public static final int EXP_BIAS =
+            (1 << (SIZE - SIGNIFICAND_WIDTH - 1)) - 1; // 15
+
+    /**
+     * Bit mask to isolate the sign bit of a {@code Float16}.
+     */
+    public static final int SIGN_BIT_MASK = 1 << (SIZE - 1);
+
+    /**
+     * Bit mask to isolate the exponent field of a {@code Float16}.
+     */
+    public static final int EXP_BIT_MASK =
+            ((1 << (SIZE - SIGNIFICAND_WIDTH)) - 1) << (SIGNIFICAND_WIDTH - 1);
+
+    /**
+     * Bit mask to isolate the significand field of a {@code Float16}.
+     */
+    public static final int SIGNIF_BIT_MASK = (1 << (SIGNIFICAND_WIDTH - 1)) - 1;
+
+    /**
+     * Bit mask to isolate the magnitude bits (combined exponent and
+     * significand fields) of a {@code Float16}.
+     */
+    public static final int MAG_BIT_MASK = EXP_BIT_MASK | SIGNIF_BIT_MASK;
+
+    static {
+        // verify bit masks cover all bit positions and that the bit
+        // masks are non-overlapping
+        assert(((SIGN_BIT_MASK | EXP_BIT_MASK | SIGNIF_BIT_MASK) == 0xFFFF) &&
+               (((SIGN_BIT_MASK & EXP_BIT_MASK) == 0) &&
+                ((SIGN_BIT_MASK & SIGNIF_BIT_MASK) == 0) &&
+                ((EXP_BIT_MASK & SIGNIF_BIT_MASK) == 0)) &&
+                ((SIGN_BIT_MASK | MAG_BIT_MASK) == 0xFFFF));
+    }
+}


### PR DESCRIPTION
Adding these to Float16 rather than Math|StrictMath.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8339599](https://bugs.openjdk.org/browse/JDK-8339599): Add nextUp(), nextDown(), scalb() to Float16 (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1238/head:pull/1238` \
`$ git checkout pull/1238`

Update a local copy of the PR: \
`$ git checkout pull/1238` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1238`

View PR using the GUI difftool: \
`$ git pr show -t 1238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1238.diff">https://git.openjdk.org/valhalla/pull/1238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1238#issuecomment-2341846399)