### PR TITLE
8340027: [lw5] the ACC_STRICT flag is not being set for non-nullable static fields

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1321,12 +1321,11 @@ public class Check {
             else {
                 boolean isInstanceFieldOfValueClass =
                         (sym.owner.type.isValueClass() && (flags & STATIC) == 0);
-                boolean isNonNullableInstanceFieldOfNonValueClass =
-                        (!sym.owner.type.isValueClass() && (flags & STATIC) == 0) && types.isNonNullable(sym.type);
-                mask = isInstanceFieldOfValueClass || isNonNullableInstanceFieldOfNonValueClass ? ExtendedVarFlags : VarFlags;
+                boolean isNonNullableFieldOfNonValueClass = !sym.owner.type.isValueClass() && types.isNonNullable(sym.type);
+                mask = isInstanceFieldOfValueClass || isNonNullableFieldOfNonValueClass ? ExtendedVarFlags : VarFlags;
                 if (isInstanceFieldOfValueClass) {
                     implicit |= FINAL | STRICT;
-                } else if (isNonNullableInstanceFieldOfNonValueClass) {
+                } else if (isNonNullableFieldOfNonValueClass) {
                     implicit |= STRICT;
                 }
             }

--- a/test/langtools/tools/javac/nullability/NullabilityCompilationTests.java
+++ b/test/langtools/tools/javac/nullability/NullabilityCompilationTests.java
@@ -25,6 +25,7 @@
  * NullabilityCompilationTests
  *
  * @test
+ * @bug 8339357 8340027
  * @enablePreview
  * @summary compilation tests for bang types
  * @library /lib/combo /tools/lib /tools/javac/lib
@@ -879,6 +880,14 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 """
                                 class Test {
                                     Object! o;
+                                }
+                                """,
+                                Result.Error,
+                                "compiler.err.non.nullable.should.be.initialized"),
+                        new DiagAndCode(
+                                """
+                                class Test {
+                                    Object! o;
                                     Test() {
                                         o = new Object();
                                         super();
@@ -903,6 +912,34 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                                 }
                                 """,
                                 Result.Clean,
+                                ""),
+                        // static fields
+                        new DiagAndCode(
+                                """
+                                class Test {
+                                    static Object! o;
+                                }
+                                """,
+                                Result.Error,
+                                "compiler.err.non.nullable.should.be.initialized"),
+                        new DiagAndCode(
+                                """
+                                class Test {
+                                    static Object! o = new Object();
+                                }
+                                """,
+                                Result.Clean,
+                                ""),
+                        new DiagAndCode(
+                                """
+                                class Test {
+                                    static Object! o;
+                                    static {
+                                        o = new Object();
+                                    }
+                                }
+                                """,
+                                Result.Clean,
                                 "")
                 )
         );
@@ -911,6 +948,11 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                 """
                 class Test {
                     Object! o = new Object();
+                }
+                """,
+                """
+                class Test {
+                    static Object! o = new Object();
                 }
                 """
         )) {
@@ -921,6 +963,9 @@ public class NullabilityCompilationTests extends CompilationTestCase {
                     if (!field.access_flags.is(Flags.STATIC)) {
                         Set<String> fieldFlags = field.access_flags.getFieldFlags();
                         Assert.check(fieldFlags.size() == 1 && fieldFlags.contains("ACC_STRICT"));
+                    } else {
+                        Set<String> fieldFlags = field.access_flags.getFieldFlags();
+                        Assert.check(fieldFlags.size() == 2 && fieldFlags.contains("ACC_STRICT") && fieldFlags.contains("ACC_STATIC"));
                     }
                 }
             }


### PR DESCRIPTION
the ACC_STRICT flag is not being added to static fields

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8340027](https://bugs.openjdk.org/browse/JDK-8340027): [lw5] the ACC_STRICT flag is not being set for non-nullable static fields (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1244/head:pull/1244` \
`$ git checkout pull/1244`

Update a local copy of the PR: \
`$ git checkout pull/1244` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1244`

View PR using the GUI difftool: \
`$ git pr show -t 1244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1244.diff">https://git.openjdk.org/valhalla/pull/1244.diff</a>

</details>
