### PR TITLE
8340190: [lworld] Fix test group after JDK-8328461

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -66,7 +66,7 @@ hotspot_serviceability = \
 hotspot_valhalla = \
   runtime/valhalla \
   compiler/valhalla \
-  serviceability/jvmti/Valhalla
+  serviceability/jvmti/valhalla
 
 hotspot_valhalla_runtime = \
   runtime/valhalla


### PR DESCRIPTION
[JDK-8328461](https://bugs.openjdk.org/browse/JDK-8328461) renamed the folder `serviceability/jvmti/Valhalla` -> `serviceability/jvmti/valhalla` and forgot to update the corresponding jtreg test group. This lets various tasks fail in our CI.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8340190](https://bugs.openjdk.org/browse/JDK-8340190): [lworld] Fix test group after JDK-8328461 (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1245/head:pull/1245` \
`$ git checkout pull/1245`

Update a local copy of the PR: \
`$ git checkout pull/1245` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1245`

View PR using the GUI difftool: \
`$ git pr show -t 1245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1245.diff">https://git.openjdk.org/valhalla/pull/1245.diff</a>

</details>
