### PR TITLE
8325583: [lworld] Develop a test for value class redefinition

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -132,7 +132,8 @@ jdk_lang = \
 # valhalla lworld tests
 jdk_valhalla = \
     java/lang/invoke \
-    valhalla
+    valhalla \
+    java/lang/instrument/valhalla
 
 
 # All of the java.util package

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/Host/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/Host/Host.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    public static String getID() { return "Host/Host.java";}
+    public int m() {
+        return 1; // original class
+    }
+    public Host(int A, long B, char C) {
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/Host/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/Host/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    public static String getID() { return "Host/redef/Host.java";}
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+    }
+
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostA/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostA/Host.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    public static String getID() { return "HostA/Host.java";}
+    public int m() {
+        return 1; // original class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostA/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostA/redef/Host.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    public static String getID() { return "HostA/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAB/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAB/Host.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    long B;
+    public static String getID() { return "HostAB/Host.java";}
+    public int m() {
+        return 1; // original class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+        this.B = B;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAB/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAB/redef/Host.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    long B;
+    public static String getID() { return "HostAB/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+        this.B = B;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostABC/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostABC/redef/Host.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    long B;
+    char C;
+    public static String getID() { return "HostABC/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+        this.B = B;
+        this.C = C;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAC/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostAC/redef/Host.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    int A;
+    char C;
+    public static String getID() { return "HostAC/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.A = A;
+        this.C = C;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostB/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostB/redef/Host.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    long B;
+    public static String getID() { return "HostB/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.B = B;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostBA/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostBA/redef/Host.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public value class Host {
+    long B;
+    int A;
+    public static String getID() { return "HostBA/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this.B = B;
+        this.A = A;
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostI/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostI/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class Host { // this is instance (not value) class
+    public static String getID() { return "HostI/Host.java";}
+    public int m() {
+        return 1; // original class
+    }
+    public Host(int A, long B, char C) {
+    }
+
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostI/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/HostI/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class Host { // this is instance (not value) class
+    public static String getID() { return "Host/redef/Host.java";}
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+    }
+
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/RedefineValueClass.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/RedefineValueClass.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test for value class redefinition
+ * @comment The code is based on test/jdk/java/lang/instrument/RedefineNestmateAttr
+ * @comment modified for value classes.
+ *
+ * @library /test/lib
+ * @modules java.compiler
+ *          java.instrument
+ * @enablePreview
+ * @run main RedefineClassHelper
+ * @compile Host/Host.java
+ * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class*=trace RedefineValueClass Host
+ * @compile HostA/Host.java
+ * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class*=trace RedefineValueClass HostA
+ * @compile HostAB/Host.java
+ * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class*=trace RedefineValueClass HostAB
+ * @compile HostI/Host.java
+ * @run main/othervm -javaagent:redefineagent.jar -Xlog:redefine+class*=trace RedefineValueClass HostI
+ */
+
+/* Test Description
+
+The basic test class is called Host.
+Each variant of the class is defined in source code in its own directory i.e.
+
+Host/Host.java defines zero fields
+Class HostA/Host.java has field "int A"
+Class HostAB/Host.java has fields "int A" and "long B" (in that order)
+Class HostI/Host.java is an instance class with zero fields
+etc.
+
+Each Host class has the form:
+
+  public value class Host {
+    // fields here
+    public static String getID() { return "<directory name>/Host.java"; }
+
+    public int m() {
+        return 1; // original class
+    }
+
+    public Host(int A, long B, char C) {
+         ...
+    }
+  }
+
+The only exception is class in HostI dir which is instance class.
+
+Under each directory is a directory "redef" with a modified version of the Host
+class that changes the ID to e.g. Host/redef/Host.java, and the method m()
+returns 2. This allows us to check we have the redefined class loaded.
+
+Using Host' to represent the redefined version we test different redefinition combinations.
+
+We can only directly load one class Host per classloader, so to run all the
+groups we either need to use new classloaders, or we reinvoke the test
+requesting a different primary directory. We chose the latter using
+multiple @run tags. So we preceed as follows:
+
+ @compile Host/Host.java
+ @run RedefineValueClass Host
+ @compile HostA/Host.java  - replaces previous Host.class
+ @run RedefineValueClass HostA
+ @compile HostAB/Host.java  - replaces previous Host.class
+ @run RedefineValueClass HostAB
+etc.
+
+Within the test we directly compile redefined versions of the classes,
+using CompilerUtil, and then read the .class file directly as a byte[]
+to use with the RedefineClassHelper.
+*/
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.test.lib.compiler.CompilerUtils;
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class RedefineValueClass {
+
+    static final Path SRC = Paths.get(System.getProperty("test.src"));
+    static final Path DEST = Paths.get(System.getProperty("test.classes"));
+
+    public static void main(String[] args) throws Throwable {
+        String origin = args[0];
+        System.out.println("Testing original Host class from " + origin);
+
+        // Make sure the Host class loaded directly is an original version
+        // and from the expected location. Use a ctor common to all Host
+        // classes.
+        Host h = new Host(3, 4, 'a');
+        assertTrue(h.m() == 1);
+        assertTrue(Host.getID().startsWith(origin + "/"));
+
+        String[] badTransforms = null;  // directories of bad classes
+        String[] goodTransforms = null; // directories of good classes
+
+        switch (origin) {
+        case "Host":
+            badTransforms = new String[] {
+                "HostI", // value class to instance class
+                "HostA"  // add field
+            };
+            goodTransforms = new String[] {
+                origin
+            };
+            break;
+
+        case "HostA":
+            badTransforms = new String[] {
+                "Host",   // remove field
+                "HostAB", // add field
+                "HostB"   // change field
+            };
+            goodTransforms = new String[] {
+                origin
+            };
+            break;
+
+        case "HostAB":
+            badTransforms = new String[] {
+                "HostA",   // remove field
+                "HostABC", // add field
+                "HostAC",  // change fields
+                "HostBA"   // reorder fields
+            };
+            goodTransforms = new String[] {
+                origin,
+            };
+            break;
+
+        case "HostI":  // instance class
+            badTransforms = new String[] {
+                "Host",  // instance class to value class
+            };
+            break;
+
+        default:
+		    throw new RuntimeException("Unknown test directory: " + origin);
+        }
+
+        // Compile and check bad transformations
+        checkBadTransforms(Host.class, badTransforms);
+
+        // Compile and check good transformations
+		if (goodTransforms != null) {
+            checkGoodTransforms(Host.class, goodTransforms);
+		}
+    }
+
+    static void checkGoodTransforms(Class<?> c, String[] dirs) throws Throwable {
+        for (String dir : dirs) {
+            dir += "/redef";
+            System.out.println("Trying good retransform from " + dir);
+            byte[] buf = bytesForHostClass(dir);
+            RedefineClassHelper.redefineClass(c, buf);
+
+            // Test redefintion worked
+            Host h = new Host(3, 4, 'a');
+            assertTrue(h.m() == 2);
+            System.out.println("Redefined ID: " + Host.getID());
+            assertTrue(Host.getID().startsWith(dir));
+        }
+    }
+
+    static void checkBadTransforms(Class<?> c, String[] dirs) throws Throwable {
+        for (String dir : dirs) {
+            dir += "/redef";
+            System.out.println("Trying bad retransform from " + dir);
+            byte[] buf = bytesForHostClass(dir);
+            try {
+                RedefineClassHelper.redefineClass(c, buf);
+                throw new RuntimeException("Retransformation from directory " + dir +
+                                " succeeded unexpectedly");
+            }
+            catch (UnsupportedOperationException uoe) {
+                System.out.println("Got expected UnsupportedOperationException " + uoe);
+            }
+        }
+    }
+
+    static byte[] bytesForHostClass(String dir) throws Throwable {
+        compile(dir);
+        Path clsfile = DEST.resolve(dir).resolve("Host.class");
+        System.out.println("Reading bytes from " + clsfile);
+        return Files.readAllBytes(clsfile);
+    }
+
+    static void compile(String dir) throws Throwable {
+        Path src = SRC.resolve(dir);
+        Path dst = DEST.resolve(dir);
+        System.out.println("Compiling from: " + src + "\n" +
+                           "            to: " + dst);
+        CompilerUtils.compile(src, dst,
+                              false /* don't recurse */,
+                              "--enable-preview",
+                              "--source", String.valueOf(Runtime.version().feature()));
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/RedefineValueClass.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/RedefineValueClass.java
@@ -160,16 +160,16 @@ public class RedefineValueClass {
             break;
 
         default:
-		    throw new RuntimeException("Unknown test directory: " + origin);
+            throw new RuntimeException("Unknown test directory: " + origin);
         }
 
         // Compile and check bad transformations
         checkBadTransforms(Host.class, badTransforms);
 
         // Compile and check good transformations
-		if (goodTransforms != null) {
+        if (goodTransforms != null) {
             checkGoodTransforms(Host.class, goodTransforms);
-		}
+        }
     }
 
     static void checkGoodTransforms(Class<?> c, String[] dirs) throws Throwable {

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostACB/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostACB/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public record Host(int A, char C, long B) {
+    public static String getID() { return "HostACB/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this(A, C, B);
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostBAC/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostBAC/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public record Host(long B, int A, char C) {
+    public static String getID() { return "HostBAC/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this(B, A, C);
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostBCA/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostBCA/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public record Host(long B, char C, int A) {
+    public static String getID() { return "HostBCA/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this(B, C, A);
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostCAB/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostCAB/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public record Host(char C, int A, long B) {
+    public static String getID() { return "HostCAB/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this(C, A, B);
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostCBA/redef/Host.java
+++ b/test/jdk/java/lang/instrument/valhalla/RedefineValueClass/_HostCBA/redef/Host.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public record Host(char C, long B, int A) {
+    public static String getID() { return "HostCBA/redef/Host.java"; }
+    public int m() {
+        return 2; // redefined class
+    }
+    public Host(int A, long B, char C) {
+        this(C, B, A);
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RetransformValueClass.java
+++ b/test/jdk/java/lang/instrument/valhalla/RetransformValueClass.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test for value class retransformation
+ *
+ * @library /test/lib
+ * @modules java.instrument
+ * @enablePreview
+ *
+ * @run main RetransformValueClass buildAgent
+ *
+ * @run main/othervm -javaagent:testAgent.jar RetransformValueClass
+ */
+
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+/*
+ * The test verifies Instrumentation.retransformClasses() (and JVMTI function RetransformClasses)
+ * works with value classes (i.e. JVMTI JvmtiClassFileReconstituter correctly restores class bytes).
+ */
+
+value class ValueClass {
+    public int f1;
+    public String f2;
+
+    public ValueClass(int v1, String v2) {
+        f1 = v1;
+        f2 = v2;
+    }
+}
+
+public class RetransformValueClass {
+
+    public static void main (String[] args) throws Exception {
+        if (args.length == 1 && "buildAgent".equals(args[0])) {
+            buildAgent();
+        } else {
+            runTest();
+        }
+    }
+    
+    static void buildAgent() throws Exception {
+        String manifest = "Premain-Class: RetransformValueClass\nCan-Redefine-Classes: true\nCan-Retransform-Classes: true\n";
+        ClassFileInstaller.writeJar("testAgent.jar", ClassFileInstaller.Manifest.fromString(manifest), "RetransformValueClass");
+    }
+
+    // agent implementation
+    static Instrumentation instrumentation;
+    public static void premain(String agentArgs, Instrumentation inst) {
+        instrumentation = inst;
+    }
+
+    // test implementation
+    static final Class targetClass = ValueClass.class;
+    static final String targetClassName = targetClass.getName();
+    static boolean transformToOriginalClassbytes = false;
+
+    static void runTest() throws Exception {
+        instrumentation.addTransformer(new Transformer(), true);
+        
+        instrumentation.retransformClasses(targetClass);
+        
+        transformToOriginalClassbytes = true;
+        instrumentation.retransformClasses(targetClass);
+    }
+
+
+    static class Transformer implements ClassFileTransformer {
+        public Transformer() {
+        }
+
+        public byte[] transform(ClassLoader loader, String className,
+            Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+
+            if (className.equals(targetClassName)) {
+                log("Transformer sees '" + className + "' of " + classfileBuffer.length + " bytes.");
+                if (transformToOriginalClassbytes) {
+                    return classfileBuffer;
+                } else {
+                    return  null;
+                }
+            }
+            return null;
+        }
+    }
+    
+    static void log(Object o) {
+        System.out.println(String.valueOf(o));
+    }
+}

--- a/test/jdk/java/lang/instrument/valhalla/RetransformValueClass.java
+++ b/test/jdk/java/lang/instrument/valhalla/RetransformValueClass.java
@@ -64,7 +64,7 @@ public class RetransformValueClass {
             runTest();
         }
     }
-    
+
     static void buildAgent() throws Exception {
         String manifest = "Premain-Class: RetransformValueClass\nCan-Redefine-Classes: true\nCan-Retransform-Classes: true\n";
         ClassFileInstaller.writeJar("testAgent.jar", ClassFileInstaller.Manifest.fromString(manifest), "RetransformValueClass");
@@ -83,9 +83,9 @@ public class RetransformValueClass {
 
     static void runTest() throws Exception {
         instrumentation.addTransformer(new Transformer(), true);
-        
+
         instrumentation.retransformClasses(targetClass);
-        
+
         transformToOriginalClassbytes = true;
         instrumentation.retransformClasses(targetClass);
     }
@@ -109,7 +109,7 @@ public class RetransformValueClass {
             return null;
         }
     }
-    
+
     static void log(Object o) {
         System.out.println(String.valueOf(o));
     }


### PR DESCRIPTION
Added tests for redefine/retransform of value classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8325583](https://bugs.openjdk.org/browse/JDK-8325583): [lworld] Develop a test for value class redefinition (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1252/head:pull/1252` \
`$ git checkout pull/1252`

Update a local copy of the PR: \
`$ git checkout pull/1252` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1252`

View PR using the GUI difftool: \
`$ git pr show -t 1252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1252.diff">https://git.openjdk.org/valhalla/pull/1252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1252#issuecomment-2372534756)