### PR TITLE
8340977: Remove ignore tag from FieldAccessModify test

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/FieldAccessModify.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/FieldAccessModify.java
@@ -22,7 +22,6 @@
  */
 
 /**
- * @ignore Fix JDK-8328461
  * @test
  * @summary Tests that all FieldAccess and FieldModification notifications
             are generated for value classes.


### PR DESCRIPTION
removed missed ignore tag

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8340977](https://bugs.openjdk.org/browse/JDK-8340977): Remove ignore tag from FieldAccessModify test (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1253/head:pull/1253` \
`$ git checkout pull/1253`

Update a local copy of the PR: \
`$ git checkout pull/1253` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1253`

View PR using the GUI difftool: \
`$ git pr show -t 1253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1253.diff">https://git.openjdk.org/valhalla/pull/1253.diff</a>

</details>
