### PR TITLE
8341005: [lworld+fp16] Disable intrinsification of Float16.abs and Float16.negate for x86 target

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1463,14 +1463,12 @@ bool Matcher::match_rule_supported(int opcode) {
         return false;
       }
       break;
-    case Op_AbsHF:
     case Op_AddHF:
     case Op_DivHF:
     case Op_FmaHF:
     case Op_MaxHF:
     case Op_MinHF:
     case Op_MulHF:
-    case Op_NegHF:
     case Op_ReinterpretS2HF:
     case Op_ReinterpretHF2S:
     case Op_SubHF:
@@ -1743,14 +1741,12 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
   //   * 128bit vroundpd instruction is present only in AVX1
   int size_in_bits = vlen * type2aelembytes(bt) * BitsPerByte;
   switch (opcode) {
-    case Op_AbsVHF:
     case Op_AddVHF:
     case Op_DivVHF:
     case Op_FmaVHF:
     case Op_MaxVHF:
     case Op_MinVHF:
     case Op_MulVHF:
-    case Op_NegVHF:
     case Op_SubVHF:
     case Op_SqrtVHF:
       if (!VM_Version::supports_avx512_fp16()) {
@@ -10190,32 +10186,6 @@ instruct reinterpretH2S(rRegI dst, regF src)
   ins_pipe(pipe_slow);
 %}
 
-instruct scalar_abs_fp16(regF dst, regF src, rRegI rtmp, vec xtmp)
-%{
-  match(Set dst (AbsHF src));
-  effect(TEMP rtmp, TEMP xtmp);
-  format %{ "eabssh $dst, $src !\t using $rtmp and $xtmp as TEMP" %}
-  ins_encode %{
-    __ movl($rtmp$$Register, 0x7FFF);
-    __ vmovw($xtmp$$XMMRegister, $rtmp$$Register);
-    __ vpand($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister, Assembler::AVX_128bit);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct scalar_neg_fp16(regF dst, regF src, rRegI rtmp, vec xtmp)
-%{
-  match(Set dst (NegHF src));
-  effect(TEMP rtmp, TEMP xtmp);
-  format %{ "enegsh $dst, $src !\t using $rtmp and $xtmp as TEMP" %}
-  ins_encode %{
-    __ movl($rtmp$$Register, 0x8000);
-    __ vmovw($xtmp$$XMMRegister, $rtmp$$Register);
-    __ vpxor($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister, Assembler::AVX_128bit);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 instruct scalar_sqrt_fp16(regF dst, regF src)
 %{
   match(Set dst (SqrtHF src));
@@ -10281,36 +10251,6 @@ instruct vector_abs_fp16_mem(vec dst, memory src, rRegI rtmp, vec xtmp)
     __ movl($rtmp$$Register, 0x7FFF7FFF);
     __ vpbroadcast(T_FLOAT, $xtmp$$XMMRegister, $rtmp$$Register, vlen_enc);
     __ vpand($dst$$XMMRegister, $xtmp$$XMMRegister, $src$$Address, vlen_enc);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vector_neg_fp16_reg(vec dst, vec src, rRegI rtmp, vec xtmp)
-%{
-  match(Set dst (NegVHF src));
-  effect(TEMP rtmp, TEMP xtmp);
-  format %{ "evnegph_reg $dst, $src !\t using $rtmp and $xtmp as TEMP" %}
-  ins_cost(150);
-  ins_encode %{
-    int vlen_enc = vector_length_encoding(this);
-    __ movl($rtmp$$Register, 0x80008000);
-    __ vpbroadcast(T_FLOAT, $xtmp$$XMMRegister, $rtmp$$Register, vlen_enc);
-    __ vpxor($dst$$XMMRegister, $src$$XMMRegister, $xtmp$$XMMRegister, vlen_enc);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-instruct vector_neg_fp16_mem(vec dst, memory src, rRegI rtmp, vec xtmp)
-%{
-  match(Set dst (NegVHF src));
-  effect(TEMP rtmp, TEMP xtmp);
-  format %{ "evnegph_reg $dst, $src !\t using $rtmp and $xtmp as TEMP" %}
-  ins_cost(150);
-  ins_encode %{
-    int vlen_enc = vector_length_encoding(this);
-    __ movl($rtmp$$Register, 0x80008000);
-    __ vpbroadcast(T_FLOAT, $xtmp$$XMMRegister, $rtmp$$Register, vlen_enc);
-    __ vpxor($dst$$XMMRegister, $xtmp$$XMMRegister, $src$$Address, vlen_enc);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/jdk/java/lang/Float16/FP16ScalarOperations.java
+++ b/test/jdk/java/lang/Float16/FP16ScalarOperations.java
@@ -84,8 +84,8 @@ public class FP16ScalarOperations {
     public static void validate(String oper, Float16... input) {
         int arity = input.length;
 
-        short actual = Float16.float16ToRawShortBits(actual_value(oper, input));
-        short expected = Float16.float16ToRawShortBits(expected_value(oper, input));
+        Float16 actual = actual_value(oper, input);
+        Float16 expected = expected_value(oper, input);
 
         if (actual != expected) {
             switch (arity) {


### PR DESCRIPTION
- Java side implementation is efficient and auto-vectorizable.
- Unlike AARCH64 SVE, x86 FP16 ISA does not support direct negation instruction.

No performance impact seen in benchmarks.

Best Regard,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341005](https://bugs.openjdk.org/browse/JDK-8341005): [lworld+fp16] Disable intrinsification of Float16.abs and Float16.negate for x86 target (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1255/head:pull/1255` \
`$ git checkout pull/1255`

Update a local copy of the PR: \
`$ git checkout pull/1255` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1255`

View PR using the GUI difftool: \
`$ git pr show -t 1255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1255.diff">https://git.openjdk.org/valhalla/pull/1255.diff</a>

</details>
