### PR TITLE
8341061: [lworld] final field initialization bug with instance block initializers

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -327,7 +327,6 @@ public class Attr extends JCTree.Visitor {
 
         if (!env.info.ctorPrologue &&
                 v.owner.isValueClass() &&
-                !env.info.instanceInitializerBlock && // it is OK instance initializer blocks will go after super() anyways
                 v.owner.kind == TYP &&
                 v.owner == env.enclClass.sym &&
                 (v.flags() & STATIC) == 0 &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4113,7 +4113,7 @@ compiler.err.super.class.method.cannot.be.synchronized=\
 
 # 0: symbol or name
 compiler.err.cant.ref.after.ctor.called=\
-    cannot reference {0} after supertype constructor has been called
+    cannot assign to {0} after supertype constructor has been called
 
 # 0: symbol
 compiler.err.deconstruction.pattern.only.records=\


### PR DESCRIPTION
javac is allowing final fields of a value class to be assigned in an instance initialization block. But those are executed after the `super()` invocation, so code like:
```
value class V {
    int f;
    {
        f = 1;
    }
}
```
should be rejected as `f` would be initialized after the implicit `super` invocation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341061](https://bugs.openjdk.org/browse/JDK-8341061): [lworld] final field initialization bug with instance block initializers (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1262/head:pull/1262` \
`$ git checkout pull/1262`

Update a local copy of the PR: \
`$ git checkout pull/1262` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1262`

View PR using the GUI difftool: \
`$ git pr show -t 1262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1262.diff">https://git.openjdk.org/valhalla/pull/1262.diff</a>

</details>
