### PR TITLE
8340984: [lworld] instance variable initializer erroneously allows to refer to instance variables, methods, this, or super

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -301,7 +301,9 @@ public class MemberEnter extends JCTree.Visitor {
                 needsLazyConstValue(tree.init)) {
                 Env<AttrContext> initEnv = getInitEnv(tree, env);
                 initEnv.info.enclVar = v;
-                v.setLazyConstValue(initEnv(tree, initEnv), attr, tree);
+                initEnv = initEnv(tree, initEnv);
+                initEnv.info.ctorPrologue = (v.owner.kind == TYP && v.owner.isValueClass() && !v.isStatic());
+                v.setLazyConstValue(initEnv, attr, tree);
             }
         }
 

--- a/test/langtools/tools/javac/DefiniteAssignment/DA_DUConstructors.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DA_DUConstructors.java
@@ -48,44 +48,4 @@ public class DA_DUConstructors {
             x = i;
         }
     }
-
-    // value classes
-    value class V1 {
-        int x;
-        int y = x + 1; // allowed
-        V1() {
-            x = 12;
-            // super();
-        }
-    }
-
-    value class V2 {
-        int x;
-        V2() { this(x = 3); } // error
-        V2(int i) { x = 4; }
-    }
-
-    abstract value class AV1 {
-        AV1(int i) {}
-    }
-
-    value class V3 extends AV1 {
-        int x;
-        V3() {
-            super(x = 3); // ok
-        }
-    }
-
-    value class V4 { // OK
-        int x;
-        int y = x + 1;
-
-        V4() {
-            x = 12;
-        }
-
-        V4(int i) {
-            x = i;
-        }
-    }
 }

--- a/test/langtools/tools/javac/DefiniteAssignment/DA_DUConstructors.out
+++ b/test/langtools/tools/javac/DefiniteAssignment/DA_DUConstructors.out
@@ -1,6 +1,5 @@
 DA_DUConstructors.java:23:17: compiler.err.var.might.already.be.assigned: x
 DA_DUConstructors.java:42:23: compiler.err.var.might.not.have.been.initialized: x
-DA_DUConstructors.java:64:20: compiler.err.var.might.already.be.assigned: x
 - compiler.note.preview.filename: DA_DUConstructors.java, DEFAULT
 - compiler.note.preview.recompile
-3 errors
+2 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -26,7 +26,7 @@
  *
  * @test
  * @bug 8287136 8292630 8279368 8287136 8287770 8279840 8279672 8292753 8287763 8279901 8287767 8293183 8293120
- *      8329345 8341061
+ *      8329345 8341061 8340984
  * @summary Negative compilation tests, and positive compilation (smoke) tests for Value Objects
  * @library /lib/combo /tools/lib
  * @modules
@@ -884,6 +884,54 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     int f;
                     {
                         f = 1;
+                    }
+                }
+                """
+        );
+        assertFail("compiler.err.cant.ref.before.ctor.called",
+                """
+                value class V {
+                    int x;
+                    int y = x + 1; // allowed
+                    V1() {
+                        x = 12;
+                        // super();
+                    }
+                }
+                """
+        );
+        assertFail("compiler.err.var.might.already.be.assigned",
+                """
+                value class V2 {
+                    int x;
+                    V2() { this(x = 3); } // error
+                    V2(int i) { x = 4; }
+                }
+                """
+        );
+        assertOK(
+                """
+                abstract value class AV1 {
+                    AV1(int i) {}
+                }
+                value class V3 extends AV1 {
+                    int x;
+                    V3() {
+                        super(x = 3); // ok
+                    }
+                }
+                """
+        );
+        assertFail("compiler.err.cant.ref.before.ctor.called",
+                """
+                value class V4 {
+                    int x;
+                    int y = x + 1;
+                    V4() {
+                        x = 12;
+                    }
+                    V4(int i) {
+                        x = i;
                     }
                 }
                 """


### PR DESCRIPTION
environment for variable initializers were not aware of being in a constructor prologue and thus javac is failing to issue errors for incorrect programs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8340984](https://bugs.openjdk.org/browse/JDK-8340984): [lworld] instance variable initializer erroneously allows to refer to instance variables, methods, this, or super (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1263/head:pull/1263` \
`$ git checkout pull/1263`

Update a local copy of the PR: \
`$ git checkout pull/1263` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1263`

View PR using the GUI difftool: \
`$ git pr show -t 1263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1263.diff">https://git.openjdk.org/valhalla/pull/1263.diff</a>

</details>
