### PR TITLE
8341182: [lworld] test CantAnnotateScoping.java fails after merge, due to experimental code for anonymous value classes

### DIFF
--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/common/arrays/DeclarationAnnotation.out
@@ -1,5 +1,5 @@
+DeclarationAnnotation.java:13:21: compiler.err.annotation.type.not.applicable.to.type: DA
 DeclarationAnnotation.java:10:21: compiler.err.annotation.type.not.applicable.to.type: DA
 DeclarationAnnotation.java:11:21: compiler.err.annotation.type.not.applicable.to.type: DA
 DeclarationAnnotation.java:12:21: compiler.err.annotation.type.not.applicable.to.type: DA
-DeclarationAnnotation.java:13:21: compiler.err.annotation.type.not.applicable.to.type: DA
 4 errors

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1003,38 +1003,6 @@ class ValueObjectCompilationTests extends CompilationTestCase {
     }
 
     @Test
-    void testAnonymousValue() throws Exception {
-        assertOK(
-                """
-                class Test {
-                    void m() {
-                        Object o = new value Comparable<String>() {
-                            @Override
-                            public int compareTo(String o) {
-                                return 0;
-                            }
-                        };
-                    }
-                }
-                """
-        );
-        assertOK(
-                """
-                class Test {
-                    void m() {
-                        Object o = new value Comparable<>() {
-                            @Override
-                            public int compareTo(Object o) {
-                                return 0;
-                            }
-                        };
-                    }
-                }
-                """
-        );
-    }
-
-    @Test
     void testNullAssigment() throws Exception {
         assertOK(
                 """


### PR DESCRIPTION
there was experimental code in lworld to allow anonymous value classes, after removing this code the test passed again

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341182](https://bugs.openjdk.org/browse/JDK-8341182): [lworld] test CantAnnotateScoping.java fails after merge, due to experimental code for anonymous value classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1264/head:pull/1264` \
`$ git checkout pull/1264`

Update a local copy of the PR: \
`$ git checkout pull/1264` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1264`

View PR using the GUI difftool: \
`$ git pr show -t 1264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1264.diff">https://git.openjdk.org/valhalla/pull/1264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1264#issuecomment-2392644282)