### PR TITLE
8341368: Refactor to use nextUp/nextDown and scalb in Float16 impl. and tests

### DIFF
--- a/src/java.base/share/classes/java/lang/Float16.java
+++ b/src/java.base/share/classes/java/lang/Float16.java
@@ -78,8 +78,6 @@ public final class Float16
     // Functionality for future consideration:
     // float16ToShortBits that normalizes NaNs, c.f. floatToIntBits vs floatToRawIntBits
     // copysign
-    // scalb
-    // nextUp / nextDown
     // IEEEremainder / remainder operator remainder
     // signum
 
@@ -1189,7 +1187,7 @@ public final class Float16
             assert exp <= MAX_EXPONENT && exp >= MIN_EXPONENT;
             // ulp(x) is usually 2^(SIGNIFICAND_WIDTH-1)*(2^ilogb(x))
             // Let float -> float16 conversion handle encoding issues.
-            yield valueOf(Math.scalb(1.0f, exp - (PRECISION - 1)));
+            yield scalb(valueOf(1), exp - (PRECISION - 1));
         }
         };
     }

--- a/test/jdk/java/math/BigDecimal/DoubleFloatValueTests.java
+++ b/test/jdk/java/math/BigDecimal/DoubleFloatValueTests.java
@@ -64,20 +64,6 @@ public class DoubleFloatValueTests {
         return bv.subtract(ulp.multiply(HALF));
     }
 
-    /*
-     * Not a fully fledged implementation, only for finite positive values.
-     */
-    private static Float16 nextUp(Float16 v) {
-        return Float16.shortBitsToFloat16((short) (Float16.float16ToRawShortBits(v) + 1));
-    }
-
-    /*
-     * Not a fully fledged implementation, only for finite positive values.
-     */
-    private static Float16 nextDown(Float16 v) {
-        return Float16.shortBitsToFloat16((short) (Float16.float16ToRawShortBits(v) - 1));
-    }
-
     private static BigDecimal nextHalfUp(Float16 v) {
         BigDecimal bv = new BigDecimal(v.doubleValue());
         BigDecimal ulp = new BigDecimal(Float16.ulp(v).doubleValue());
@@ -86,7 +72,7 @@ public class DoubleFloatValueTests {
 
     private static BigDecimal nextHalfDown(Float16 v) {
         BigDecimal bv = new BigDecimal(v.doubleValue());
-        BigDecimal ulp = new BigDecimal(v.doubleValue() - nextDown(v).doubleValue());
+        BigDecimal ulp = new BigDecimal(v.doubleValue() - Float16.nextDown(v).doubleValue());
         return bv.subtract(ulp.multiply(HALF));
     }
 
@@ -202,18 +188,18 @@ public class DoubleFloatValueTests {
         Float16 v = Float16.MIN_NORMAL;
         for (int n = 0; n < 100; ++n) {
             BigDecimal bv = nextHalfDown(v);
-            checkFloat16(bv, isOdd(n) ? nextDown(v) : v);
-            checkFloat16(bv.subtract(EPS), nextDown(v));
+            checkFloat16(bv, isOdd(n) ? Float16.nextDown(v) : v);
+            checkFloat16(bv.subtract(EPS), Float16.nextDown(v));
             checkFloat16(bv.add(EPS), v);
-            v = nextDown(v);
+            v = Float16.nextDown(v);
         }
         v = Float16.MIN_NORMAL;
         for (int n = 0; n < 100; ++n) {
             BigDecimal bv = nextHalfUp(v);
-            checkFloat16(bv, isOdd(n) ? nextUp(v) : v);
+            checkFloat16(bv, isOdd(n) ? Float16.nextUp(v) : v);
             checkFloat16(bv.subtract(EPS), v);
-            checkFloat16(bv.add(EPS), nextUp(v));
-            v = nextUp(v);
+            checkFloat16(bv.add(EPS), Float16.nextUp(v));
+            v = Float16.nextUp(v);
         }
     }
 
@@ -251,10 +237,10 @@ public class DoubleFloatValueTests {
         Float16 v = Float16.MAX_VALUE;
         for (int n = 0; n < 100; ++n) {
             BigDecimal bv = nextHalfDown(v);
-            checkFloat16(bv, isOdd(n) ? v : nextDown(v));
-            checkFloat16(bv.subtract(EPS), nextDown(v));
+            checkFloat16(bv, isOdd(n) ? v : Float16.nextDown(v));
+            checkFloat16(bv.subtract(EPS), Float16.nextDown(v));
             checkFloat16(bv.add(EPS), v);
-            v = nextDown(v);
+            v = Float16.nextDown(v);
         }
         BigDecimal bv = nextHalfUp(Float16.MAX_VALUE);
         checkFloat16(bv, Float16.POSITIVE_INFINITY);


### PR DESCRIPTION
Make use of `Float16.nextUp()`, `Float16.nextDown()`, `Float16.scalb()` in tests and code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341368](https://bugs.openjdk.org/browse/JDK-8341368): Refactor to use nextUp/nextDown and scalb in Float16 impl. and tests (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1265/head:pull/1265` \
`$ git checkout pull/1265`

Update a local copy of the PR: \
`$ git checkout pull/1265` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1265`

View PR using the GUI difftool: \
`$ git pr show -t 1265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1265.diff">https://git.openjdk.org/valhalla/pull/1265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1265#issuecomment-2393998001)