### PR TITLE
8341180: [lworld] Some classfile tests failing on LoadableDescriptorsAttribute after merge jdk-23+26 and jdk-23+27

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
@@ -260,6 +260,8 @@ public record ParserVerifier(ClassModel classModel) {
             }
             case LineNumberTableAttribute lta ->
                 2 + 4 * lta.lineNumbers().size();
+            case LoadableDescriptorsAttribute lda ->
+                2 + 2 * lda.loadableDescriptors().size();
             case LocalVariableTableAttribute lvta ->
                 2 + 10 * lvta.localVariables().size();
             case LocalVariableTypeTableAttribute lvta ->


### PR DESCRIPTION
class `jdk.internal.classfile.impl.verifier.ParserVerifier` is failing with an assertion error as it doesn't know about `LoadableDescriptorsAttribute` which is specific to valhalla

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341180](https://bugs.openjdk.org/browse/JDK-8341180): [lworld] Some classfile tests failing on LoadableDescriptorsAttribute after merge jdk-23+26 and jdk-23+27 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1266/head:pull/1266` \
`$ git checkout pull/1266`

Update a local copy of the PR: \
`$ git checkout pull/1266` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1266`

View PR using the GUI difftool: \
`$ git pr show -t 1266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1266.diff">https://git.openjdk.org/valhalla/pull/1266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1266#issuecomment-2393998361)