### PR TITLE
8341639: Add float16ToShortBits(), signum(), copySign() to Float16

### DIFF
--- a/test/jdk/java/lang/Math/IeeeRecommendedTests.java
+++ b/test/jdk/java/lang/Math/IeeeRecommendedTests.java
@@ -871,6 +871,69 @@ public class IeeeRecommendedTests {
 
     /* ******************** copySign tests******************************** */
 
+    public static int testFloat16CopySign() {
+        int failures = 0;
+
+        // testCases[0] are logically positive numbers;
+        // testCases[1] are negative numbers.
+        float testCases [][] = {
+                {+0.0f,
+                        Float16.MIN_VALUE.floatValue(),
+                        Float16_MAX_SUBNORMALmm.floatValue(),
+                        Float16_MAX_SUBNORMAL.floatValue(),
+                        Float16.MIN_NORMAL.floatValue(),
+                        1.0f,
+                        3.0f,
+                        Float16_MAX_VALUEmm.floatValue(),
+                        Float16.MAX_VALUE.floatValue(),
+                        infinityF16.floatValue(),
+                },
+                {-infinityF16.floatValue(),
+                        -Float16.MAX_VALUE.floatValue(),
+                        -3.0f,
+                        -1.0f,
+                        -Float16.MIN_NORMAL.floatValue(),
+                        -Float16_MAX_SUBNORMALmm.floatValue(),
+                        -Float16_MAX_SUBNORMAL.floatValue(),
+                        -Float16.MIN_VALUE.floatValue(),
+                        -0.0f}
+        };
+
+        float NaNs[] = {Float16.shortBitsToFloat16((short) 0x7e00).floatValue(),       // "positive" NaN
+                Float16.shortBitsToFloat16((short) 0xfe00).floatValue()};      // "negative" NaN
+
+        // Tests shared between raw and non-raw versions
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < 2; j++) {
+                for(int m = 0; m < testCases[i].length; m++) {
+                    for(int n = 0; n < testCases[j].length; n++) {
+                        // copySign(magnitude, sign)
+                        failures+=Tests.test("Float16.copySign(Float16,Float16)",
+                                Float16.valueOf(testCases[i][m]),Float16.valueOf(testCases[j][n]),
+                                Float16.copySign(Float16.valueOf(testCases[i][m]), Float16.valueOf(testCases[j][n])),
+                                Float16.valueOf((j==0?1.0f:-1.0f)*Math.abs(testCases[i][m])) );
+                    }
+                }
+            }
+        }
+
+        // For rawCopySign, NaN may effectively have either sign bit
+        // while for copySign NaNs are treated as if they always have
+        // a zero sign bit (i.e. as positive numbers)
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < NaNs.length; j++) {
+                for(int m = 0; m < testCases[i].length; m++) {
+                    // copySign(magnitude, sign)
+
+                    failures += (Float16.abs(Float16.copySign(Float16.valueOf(testCases[i][m]), Float16.valueOf(NaNs[j]))).floatValue() ==
+                            Float16.abs(Float16.valueOf(testCases[i][m])).floatValue()) ? 0:1;
+                }
+            }
+        }
+
+        return failures;
+    }
+
     public static int testFloatCopySign() {
         int failures = 0;
 
@@ -1892,6 +1955,38 @@ public class IeeeRecommendedTests {
         return failures;
     }
 
+    public static int testFloat16Signum() {
+        int failures = 0;
+        float testCases [][] = {
+                {NaNf16.floatValue(),                      NaNf16.floatValue()},
+                {-infinityF16.floatValue(),                -1.0f},
+                {-Float16.MAX_VALUE.floatValue(),          -1.0f},
+                {-Float16.MIN_NORMAL.floatValue(),         -1.0f},
+                {-1.0f,                                    -1.0f},
+                {-2.0f,                                    -1.0f},
+                {-Float16_MAX_SUBNORMAL.floatValue(),      -1.0f},
+                {-Float16.MIN_VALUE.floatValue(),          -1.0f},
+                {-0.0f,                                    -0.0f},
+                {+0.0f,                                    +0.0f},
+                {Float16.MIN_VALUE.floatValue(),            1.0f},
+                {Float16_MAX_SUBNORMALmm.floatValue(),      1.0f},
+                {Float16_MAX_SUBNORMAL.floatValue(),        1.0f},
+                {Float16.MIN_NORMAL.floatValue(),           1.0f},
+                {1.0f,                                      1.0f},
+                {2.0f,                                      1.0f},
+                {Float16_MAX_VALUEmm.floatValue(),          1.0f},
+                {Float16.MAX_VALUE.floatValue(),            1.0f},
+                {infinityF16.floatValue(),                  1.0f}
+        };
+
+        for(int i = 0; i < testCases.length; i++) {
+            failures+=Tests.test("Float16.signum(Float16)",
+                    Float16.valueOf(testCases[i][0]), Float16.signum(Float16.valueOf(testCases[i][0])), Float16.valueOf(testCases[i][1]));
+        }
+
+        return failures;
+    }
+
     public static int testFloatSignum() {
         int failures = 0;
         float testCases [][] = {
@@ -1981,6 +2076,7 @@ public class IeeeRecommendedTests {
         failures += testFloatBooleanMethods();
         failures += testDoubleBooleanMethods();
 
+        failures += testFloat16CopySign();
         failures += testFloatCopySign();
         failures += testDoubleCopySign();
 
@@ -1991,6 +2087,7 @@ public class IeeeRecommendedTests {
         failures += testFloatUlp();
         failures += testDoubleUlp();
 
+        failures += testFloat16Signum();
         failures += testFloatSignum();
         failures += testDoubleSignum();
 

--- a/test/jdk/java/lang/Math/Tests.java
+++ b/test/jdk/java/lang/Math/Tests.java
@@ -501,6 +501,21 @@ public class Tests {
     }
 
     public static int test(String testName,
+            Float16 input1, Float16 input2,
+            Float16 result, Float16 expected) {
+        if (Float16.compare(expected, result ) != 0) {
+            System.err.println("Failure for "  + testName + ":\n" +
+                    "\tFor inputs " + input1   + "\t(" + toHexString(input1) + ") and "
+                    + input2   + "\t(" + toHexString(input2) + ")\n" +
+                    "\texpected  "  + expected + "\t(" + toHexString(expected) + ")\n" +
+                    "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    public static int test(String testName,
                            double input1, int input2,
                            double result, double expected) {
         if (Double.compare(expected, result ) != 0) {


### PR DESCRIPTION
These common operations are currently lacking for Float16, and should be added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341639](https://bugs.openjdk.org/browse/JDK-8341639): Add float16ToShortBits(), signum(), copySign() to Float16 (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1268/head:pull/1268` \
`$ git checkout pull/1268`

Update a local copy of the PR: \
`$ git checkout pull/1268` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1268`

View PR using the GUI difftool: \
`$ git pr show -t 1268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1268.diff">https://git.openjdk.org/valhalla/pull/1268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1268#issuecomment-2396934746)