### PR TITLE
8341657: [lworld] some valhalla tests are failing after fix for JDK-8341182

### DIFF
--- a/test/jdk/valhalla/valuetypes/Nest.java
+++ b/test/jdk/valhalla/valuetypes/Nest.java
@@ -33,25 +33,6 @@ import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 public class Nest {
-    static interface I {
-        String toString();
-    }
-
-    static I of(int value, Object next) {
-        // anonymous class capturing outer locals
-        return new value I() {
-            public String toString() {
-                return value + " -> " + next;
-            }
-        };
-    }
-
-    @Test
-    public void test1() {
-        assertEquals(Nest.of(1, null), Nest.of(1, null));
-        assertNotEquals(Nest.of(1, null), Nest.of(2, null));
-    }
-
     @Test
     public void test2() {
         Outer n = new Outer(1);


### PR DESCRIPTION
removing anonymous classes related code and tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341657](https://bugs.openjdk.org/browse/JDK-8341657): [lworld] some valhalla tests are failing after fix for JDK-8341182 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1269/head:pull/1269` \
`$ git checkout pull/1269`

Update a local copy of the PR: \
`$ git checkout pull/1269` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1269`

View PR using the GUI difftool: \
`$ git pr show -t 1269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1269.diff">https://git.openjdk.org/valhalla/pull/1269.diff</a>

</details>
