### PR TITLE
8315003: [lworld] C2: Implement full support for JDK-8287061 and JDK-8316991

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2763,6 +2763,17 @@ bool PhiNode::can_push_inline_types_down(PhaseGVN* phase, const bool can_reshape
   return true;
 }
 
+#ifdef ASSERT
+bool PhiNode::can_push_inline_types_down(PhaseGVN* phase) {
+  if (!can_be_inline_type()) {
+    return false;
+  }
+
+  ciInlineKlass* inline_klass;
+  return can_push_inline_types_down(phase, true, inline_klass);
+}
+#endif // ASSERT
+
 static int compare_types(const Type* const& e1, const Type* const& e2) {
   return (intptr_t)e1 - (intptr_t)e2;
 }

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -262,6 +262,7 @@ public:
   }
 
   Node* try_push_inline_types_down(PhaseGVN* phase, bool can_reshape);
+  DEBUG_ONLY(bool can_push_inline_types_down(PhaseGVN* phase);)
 
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -866,8 +866,6 @@ SafePointScalarObjectNode* PhaseMacroExpand::create_scalarized_object_descriptio
     }
 
     if (res->bottom_type()->is_inlinetypeptr()) {
-      // TODO 8315003 This starts to fail after JDK-8316991. Fix and re-enable.
-      // assert(C->has_circular_inline_type(), "non-circular inline types should have been replaced earlier");
       // Nullable inline types have an IsInit field which is added to the safepoint when scalarizing them (see
       // InlineTypeNode::make_scalar_in_safepoint()). When having circular inline types, we stop scalarizing at depth 1
       // to avoid an endless recursion. Therefore, we do not have a SafePointScalarObjectNode node here, yet.

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,8 +67,6 @@ compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
 compiler/startup/StartupOutput.java 8326615 generic-x64
 
-compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java 8315003 generic-all
-
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 #############################################################################

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestAllocationMergeAndFolding.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315003
+ * @summary Test that removing allocation merges of non-value and value types at EA is working properly.
+ * @library /test/lib /
+ * @enablePreview
+ * @run main compiler.valhalla.inlinetypes.TestAllocationMergeAndFolding
+ */
+
+package compiler.valhalla.inlinetypes;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Utils;
+
+import java.util.Random;
+
+public class TestAllocationMergeAndFolding {
+    private static final Random RANDOM = Utils.getRandomInstance();
+
+    public static void main(String[] args) {
+        InlineTypes.getFramework()
+                .addScenarios(InlineTypes.DEFAULT_SCENARIOS)
+                .addScenarios(new Scenario(6, "--enable-preview", "-XX:-UseCompressedOops"))
+                .addScenarios(new Scenario(7, "--enable-preview", "-XX:+UseCompressedOops"))
+                .start();
+    }
+
+    @Test
+    @IR(failOn = IRNode.ALLOC)
+    static int test(boolean flag) {
+        Object o;
+        if (flag) {
+            o = new V(34);
+        } else {
+            o = new Object();
+        }
+        dontInline(); // Not inlined and thus we have a safepoint where keep phi(o) = [V, Object].
+
+        // 'o' escapes as store to 'f'. However, 'f' does not escape and can be removed. As a result, we can also remove
+        // the allocations in both branches with EA after JDK-8287061. Since V has an inline type field v2, we put it
+        // on a list to scalarize it as well. The improved allocation merge was disabled in Valhalla but is now enabled
+        // and fixed with JDK-8315003.
+        Foo f = new Foo(o);
+        return f.i;
+    }
+
+    @DontInline
+    static void dontInline() {
+    }
+
+    @Run(test = "test")
+    static void run() {
+        test(RANDOM.nextBoolean());
+    }
+
+    static class Foo {
+        Object o;
+        int i;
+
+        Foo(Object o) {
+            this.o = o;
+        }
+    }
+
+    static value class V {
+        int i;
+        V2 v2;
+
+        V(int i) {
+            this.i = i;
+            this.v2 = new V2();
+        }
+    }
+
+    static value class V2 {
+    }
+}

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestBasicFunctionality.java
@@ -287,8 +287,6 @@ static MyValue1 tmp = null;
     }
 
     // Test loop with uncommon trap referencing a value object
-    // TODO 8315003 Re-enable
-    /*
     @Test
     @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
         counts = {SCOBJ, ">= 1", LOAD, "<= 12"}) // TODO 8227588 (loads should be removed)
@@ -319,7 +317,6 @@ static MyValue1 tmp = null;
         long result = test12(info.isWarmUp());
         Asserts.assertEQ(result, info.isWarmUp() ? rL + (1000 * rI) : ((Math.abs(rI) % 10) + 1) * hash());
     }
-    */
 
     // Test loop with uncommon trap referencing a value object
     @Test


### PR DESCRIPTION
This patch makes the improved allocation merge at EA work with inline types.

Before this patch, the assumption was that we do **not** have non-scalarized inline types at safepoints which EA is going to scalarize (and if we do, then there is a missed opportunity which can be considered a bug). We should have pushed all `InlineTypeNodes` down through phis in order to have them scalarized before EA.

This, however, changes with the improved allocation merge RFEs that have been merged into Valhalla ([JDK-8287061](https://bugs.openjdk.org/browse/JDK-8287061) and [JDK-8316991](https://bugs.openjdk.org/browse/JDK-8316991)). We could now the following graph as found in the test case:

![image](https://github.com/user-attachments/assets/4e5174d3-9a52-4c43-8dcd-b6a119438ca0)

Here, `272 Phi` merges the non-value type allocation `238 CheckCastPP` with the value type allocation `217 InlineType`. Before the improved allocation merge RFEs, we would not be able to remove the allocations. But now, we can do it at EA: We create a special `SafePointScalarMergeNode` which in case has `SafePointScalarObjectNodes` as inputs for the merged allocations. Additionally, each field of the merged allocations are added to the safepoint, which also includes the value type field `v2` of `V`:

![image](https://github.com/user-attachments/assets/eb8e7012-262d-492f-ae30-a3962f5ae931)

We should not have safepoint uses for `InlineType` and thus now replace them with `SafePointScalarObjectNodes` as well (newly done with this patch). As a result, we have the following graph after EA:

![image](https://github.com/user-attachments/assets/0cf521c4-dee1-4cb7-bb7c-3479b459ed34)

Note that the safepoint node inputs for fields are well-defined to keep track of which field belong to each of the `SafePointScalarObjectNodes` of the `SafePointScalarMergeNode`.


### Additional Code Changes
- There was a bug in mainline with the new allocation merge implementation that is already fixed in mainline but not integrated in Valhalla, yet: [JDK-8335220](https://bugs.openjdk.org/browse/JDK-8335220). I cherry-picked these changes (L589-605 in escape.cpp).
- I added assertion code to verify that when we are going to scalar replace an inline type allocation that is an input into a phi at EA, we would not have been able to push the `InlineTypeNode` down (which should have been done earlier if possible).
- Re-enabled uncommented tests and removed problem-listed `AllocationMergesTests.java` that had been added with the allocation merge RFE.

### Future Work
There is currently an open bug for the allocation merges ([JDK-8335977](https://bugs.openjdk.org/browse/JDK-8335977)) which has been found by extending `AllocationMergesTests.java` with various deoptimization points and checking for correct values (similar to what we do in `TestValueConstruction.java`). Once this bug is fixed in mainline (it should extend this test and add these deoptimization checks), we should extend `AllocationMergesTests.java` and add tests for value types as well. I filed [JDK-8341856](https://bugs.openjdk.org/browse/JDK-8341856) to keep track of that.

Thanks,
Christian 