### PR TITLE
8341061 [lworld]: Mark and fail compilation in non-discardable values are discarded

### DIFF
--- a/src/java.base/share/classes/java/lang/MustUse.java
+++ b/src/java.base/share/classes/java/lang/MustUse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+
+/**
+ * A method element annotated {@code @MustUse} is one that returns a value
+ * which is supposed to be used, since not consuming it will likely be a mistake.
+ *
+ * In some cases, the compiler can be certain that the value is not used, and
+ * in such cases, it may issue an error even in the absense of this annotation.
+ *
+ * <p>Compilers issue warnings when a computed value is returned but not assigned
+ * to a variable or similarly used in different fashion.
+ *
+ * @since 24
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value={METHOD})
+public @interface MustUse {
+}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -339,6 +339,11 @@ public class Flags {
     public static final long MIGRATED_VALUE_CLASS = 1L<<57; //ClassSymbols only
 
     /**
+     * Flag to indicate the given MethodSymbol returns a value which should be used.
+     */
+    public static final long MUST_USE = 1L<<53; //MethodSymbols only
+
+    /**
      * Flag to indicate the given symbol has a @Deprecated annotation.
      */
     public static final long DEPRECATED_ANNOTATION = 1L<<54;
@@ -563,6 +568,7 @@ public class Flags {
         MODULE(Flags.MODULE),
         AUTOMATIC_MODULE(Flags.AUTOMATIC_MODULE),
         SYSTEM_MODULE(Flags.SYSTEM_MODULE),
+        MUST_USE(Flags.MUST_USE),
         DEPRECATED_ANNOTATION(Flags.DEPRECATED_ANNOTATION),
         DEPRECATED_REMOVAL(Flags.DEPRECATED_REMOVAL),
         HAS_RESOURCE(Flags.HAS_RESOURCE),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -371,6 +371,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return (flags_field & DEPRECATED) != 0;
     }
 
+    public boolean isPrecious() {
+        return (flags_field & MUST_USE) != 0;
+    }
+
     public boolean hasDeprecatedAnnotation() {
         return (flags_field & DEPRECATED_ANNOTATION) != 0;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -205,6 +205,7 @@ public class Symtab {
     public final Type overrideType;
     public final Type retentionType;
     public final Type deprecatedType;
+    public final Type mustUseType;
     public final Type suppressWarningsType;
     public final Type supplierType;
     public final Type inheritedType;
@@ -602,6 +603,7 @@ public class Symtab {
         overrideType = enterClass("java.lang.Override");
         retentionType = enterClass("java.lang.annotation.Retention");
         deprecatedType = enterClass("java.lang.Deprecated");
+        mustUseType = enterClass("java.lang.MustUse");
         suppressWarningsType = enterClass("java.lang.SuppressWarnings");
         supplierType = enterClass("java.util.function.Supplier");
         inheritedType = enterClass("java.lang.annotation.Inherited");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -367,6 +367,12 @@ public class Annotate {
             }
 
             if (!c.type.isErroneous()
+                    && toAnnotate.kind == MTH
+                    && types.isSameType(c.type, syms.mustUseType)) {
+                toAnnotate.flags_field |= Flags.MUST_USE;
+            }
+
+            if (!c.type.isErroneous()
                     && types.isSameType(c.type, syms.previewFeatureType)) {
                 toAnnotate.flags_field |= Flags.PREVIEW_API;
                 if (isAttributeTrue(c.member(names.reflective))) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2379,6 +2379,18 @@ public class Attr extends JCTree.Visitor {
         //see Infer.instantiatePolymorphicSignatureInstance()
         Env<AttrContext> localEnv = env.dup(tree);
         attribExpr(tree.expr, localEnv);
+        // Check if a returned value is a "MustUse"
+        // TODO: Should likely do more more inference
+        if (tree.expr instanceof JCMethodInvocation invocation) {
+            if (invocation.meth instanceof JCFieldAccess select) {
+                if (select.sym != null && select.sym.kind == MTH) {
+                    if (select.sym.isPrecious()) {
+                        log.error(invocation.meth.pos(), Errors.MethodReturnedMustUseValue(select.selected.type.tsym, select.sym));
+                    }
+                }
+            }
+        }
+
         result = null;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1938,6 +1938,10 @@ compiler.warn.has.been.deprecated.module=\
 compiler.warn.has.been.deprecated.for.removal.module=\
     module {0} has been deprecated and marked for removal
 
+# 0: symbol, 1: symbol
+compiler.err.method.returned.must.use.value=\
+    The return value from {0}.{1} should be used, or not called
+
 # 0: symbol
 compiler.warn.sun.proprietary=\
     {0} is internal proprietary API and may be removed in a future release

--- a/test/langtools/tools/javac/valhalla/must_use/MustUseValueTest.java
+++ b/test/langtools/tools/javac/valhalla/must_use/MustUseValueTest.java
@@ -1,0 +1,36 @@
+/*
+ * @test /nodynamiccopyright/
+ * @summary Xxx.
+ * @enablePreview
+ *
+ * @compile/fail/ref=MustUseValueTest.out -XDrawDiagnostics MustUseValueTest.java
+ */
+public value final class MustUseValueTest implements java.io.Serializable {
+
+    public static void main(String[] args) {
+        var array = new String[] { "A", "B", "C",  };
+
+        Cursor c = new Cursor(array, 0, 3);
+        c.next(); // bad code - ERROR
+        c = c.next(); // good code - NOT ERROR
+
+        System.out.println("Should be B: " + c.current());
+    }
+
+    value record Cursor<T>(T[] array, int position, int length) {
+        Cursor {
+            if (position < 0 || position >= length) {
+                throw new IndexOutOfBoundsException("index %d outside array bounds [0;%d[".formatted(position, length));
+            }
+        }
+
+        T current() {
+            return array[position];
+        }
+
+        @MustUse
+        Cursor<T> next() {
+            return new Cursor(array, position+1, length);
+        }
+    }
+}

--- a/test/langtools/tools/javac/valhalla/must_use/MustUseValueTest.out
+++ b/test/langtools/tools/javac/valhalla/must_use/MustUseValueTest.out
@@ -1,0 +1,6 @@
+MustUseValueTest.java:14:10: compiler.err.method.returned.must.use.value: MustUseValueTest.Cursor, next()
+- compiler.note.unchecked.filename: MustUseValueTest.java
+- compiler.note.unchecked.recompile
+- compiler.note.preview.filename: MustUseValueTest.java, DEFAULT
+- compiler.note.preview.recompile
+1 error


### PR DESCRIPTION
... as per https://bugs.openjdk.org/browse/JDK-8199429

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8341061](https://bugs.openjdk.org/browse/JDK-8341061)

### Issue
 * [JDK-8341061](https://bugs.openjdk.org/browse/JDK-8341061): [lworld] final field initialization bug with instance block initializers (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1273/head:pull/1273` \
`$ git checkout pull/1273`

Update a local copy of the PR: \
`$ git checkout pull/1273` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1273`

View PR using the GUI difftool: \
`$ git pr show -t 1273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1273.diff">https://git.openjdk.org/valhalla/pull/1273.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1273#issuecomment-2405464392)