### PR TITLE
8342033: [lworld] Rename ClassDescImpl back to ReferenceClassDescImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -29,7 +29,7 @@ import java.lang.invoke.TypeDescriptor;
 import java.util.stream.Stream;
 
 import jdk.internal.constant.PrimitiveClassDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import sun.invoke.util.Wrapper;
 
 import static java.util.stream.Collectors.joining;
@@ -62,7 +62,7 @@ public sealed interface ClassDesc
         extends ConstantDesc,
                 TypeDescriptor.OfField<ClassDesc>
         permits PrimitiveClassDescImpl,
-                ClassDescImpl {
+                ReferenceClassDescImpl {
 
     /**
      * Returns a {@linkplain ClassDesc} for a class or interface type,
@@ -166,7 +166,7 @@ public sealed interface ClassDesc
         return (descriptor.length() == 1)
                ? Wrapper.forPrimitiveType(descriptor.charAt(0)).basicClassDescriptor()
                // will throw IAE on descriptor.length == 0 or if array dimensions too long
-               : ClassDescImpl.of(descriptor);
+               : ReferenceClassDescImpl.of(descriptor);
     }
 
     /**
@@ -190,7 +190,7 @@ public sealed interface ClassDesc
         if (desc.length() == 1 && desc.charAt(0) == 'V') {
             throw new IllegalArgumentException("not a valid reference type descriptor: " + newDesc);
         }
-        return ClassDescImpl.ofValidated(newDesc);
+        return ReferenceClassDescImpl.ofValidated(newDesc);
     }
 
     /**
@@ -220,7 +220,7 @@ public sealed interface ClassDesc
         if (desc.length() == 1 && desc.charAt(0) == 'V') {
             throw new IllegalArgumentException("not a valid reference type descriptor: " + newDesc);
         }
-        return ClassDescImpl.ofValidated(newDesc);
+        return ReferenceClassDescImpl.ofValidated(newDesc);
     }
 
     /**
@@ -247,7 +247,7 @@ public sealed interface ClassDesc
         String desc = descriptorString();
         StringBuilder sb = new StringBuilder(desc.length() + nestedName.length() + 1);
         sb.append(desc, 0, desc.length() - 1).append('$').append(nestedName).append(';');
-        return ClassDescImpl.ofValidated(sb.toString());
+        return ReferenceClassDescImpl.ofValidated(sb.toString());
     }
 
     /**
@@ -316,7 +316,7 @@ public sealed interface ClassDesc
             if (desc.length() == 2) {
                 return Wrapper.forBasicType(desc.charAt(1)).basicClassDescriptor();
             } else {
-                return ClassDescImpl.ofValidated(desc.substring(1));
+                return ReferenceClassDescImpl.ofValidated(desc.substring(1));
             }
         }
         return null;

--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -26,7 +26,7 @@ package java.lang.constant;
 
 import jdk.internal.constant.MethodTypeDescImpl;
 import jdk.internal.constant.PrimitiveClassDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 
 import java.lang.Enum.EnumDesc;
 import java.lang.invoke.CallSite;
@@ -68,115 +68,115 @@ public final class ConstantDescs {
     // Don't change the order of these declarations!
 
     /** {@link ClassDesc} representing {@link Object} */
-    public static final ClassDesc CD_Object = ClassDescImpl.ofValidated("Ljava/lang/Object;");
+    public static final ClassDesc CD_Object = ReferenceClassDescImpl.ofValidated("Ljava/lang/Object;");
 
     /** {@link ClassDesc} representing {@link String} */
-    public static final ClassDesc CD_String = ClassDescImpl.ofValidated("Ljava/lang/String;");
+    public static final ClassDesc CD_String = ReferenceClassDescImpl.ofValidated("Ljava/lang/String;");
 
     /** {@link ClassDesc} representing {@link Class} */
-    public static final ClassDesc CD_Class = ClassDescImpl.ofValidated("Ljava/lang/Class;");
+    public static final ClassDesc CD_Class = ReferenceClassDescImpl.ofValidated("Ljava/lang/Class;");
 
     /** {@link ClassDesc} representing {@link Number} */
-    public static final ClassDesc CD_Number = ClassDescImpl.ofValidated("Ljava/lang/Number;");
+    public static final ClassDesc CD_Number = ReferenceClassDescImpl.ofValidated("Ljava/lang/Number;");
 
     /** {@link ClassDesc} representing {@link Integer} */
-    public static final ClassDesc CD_Integer = ClassDescImpl.ofValidated("Ljava/lang/Integer;");
+    public static final ClassDesc CD_Integer = ReferenceClassDescImpl.ofValidated("Ljava/lang/Integer;");
 
     /** {@link ClassDesc} representing {@link Long} */
-    public static final ClassDesc CD_Long = ClassDescImpl.ofValidated("Ljava/lang/Long;");
+    public static final ClassDesc CD_Long = ReferenceClassDescImpl.ofValidated("Ljava/lang/Long;");
 
     /** {@link ClassDesc} representing {@link Float} */
-    public static final ClassDesc CD_Float = ClassDescImpl.ofValidated("Ljava/lang/Float;");
+    public static final ClassDesc CD_Float = ReferenceClassDescImpl.ofValidated("Ljava/lang/Float;");
 
     /** {@link ClassDesc} representing {@link Double} */
-    public static final ClassDesc CD_Double = ClassDescImpl.ofValidated("Ljava/lang/Double;");
+    public static final ClassDesc CD_Double = ReferenceClassDescImpl.ofValidated("Ljava/lang/Double;");
 
     /** {@link ClassDesc} representing {@link Short} */
-    public static final ClassDesc CD_Short = ClassDescImpl.ofValidated("Ljava/lang/Short;");
+    public static final ClassDesc CD_Short = ReferenceClassDescImpl.ofValidated("Ljava/lang/Short;");
 
     /** {@link ClassDesc} representing {@link Byte} */
-    public static final ClassDesc CD_Byte = ClassDescImpl.ofValidated("Ljava/lang/Byte;");
+    public static final ClassDesc CD_Byte = ReferenceClassDescImpl.ofValidated("Ljava/lang/Byte;");
 
     /** {@link ClassDesc} representing {@link Character} */
-    public static final ClassDesc CD_Character = ClassDescImpl.ofValidated("Ljava/lang/Character;");
+    public static final ClassDesc CD_Character = ReferenceClassDescImpl.ofValidated("Ljava/lang/Character;");
 
     /** {@link ClassDesc} representing {@link Boolean} */
-    public static final ClassDesc CD_Boolean = ClassDescImpl.ofValidated("Ljava/lang/Boolean;");
+    public static final ClassDesc CD_Boolean = ReferenceClassDescImpl.ofValidated("Ljava/lang/Boolean;");
 
     /** {@link ClassDesc} representing {@link Void} */
-    public static final ClassDesc CD_Void = ClassDescImpl.ofValidated("Ljava/lang/Void;");
+    public static final ClassDesc CD_Void = ReferenceClassDescImpl.ofValidated("Ljava/lang/Void;");
 
     /** {@link ClassDesc} representing {@link Throwable} */
-    public static final ClassDesc CD_Throwable = ClassDescImpl.ofValidated("Ljava/lang/Throwable;");
+    public static final ClassDesc CD_Throwable = ReferenceClassDescImpl.ofValidated("Ljava/lang/Throwable;");
 
     /** {@link ClassDesc} representing {@link Exception} */
-    public static final ClassDesc CD_Exception = ClassDescImpl.ofValidated("Ljava/lang/Exception;");
+    public static final ClassDesc CD_Exception = ReferenceClassDescImpl.ofValidated("Ljava/lang/Exception;");
 
     /** {@link ClassDesc} representing {@link Enum} */
-    public static final ClassDesc CD_Enum = ClassDescImpl.ofValidated("Ljava/lang/Enum;");
+    public static final ClassDesc CD_Enum = ReferenceClassDescImpl.ofValidated("Ljava/lang/Enum;");
 
     /** {@link ClassDesc} representing {@link VarHandle} */
-    public static final ClassDesc CD_VarHandle = ClassDescImpl.ofValidated("Ljava/lang/invoke/VarHandle;");
+    public static final ClassDesc CD_VarHandle = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/VarHandle;");
 
     /** {@link ClassDesc} representing {@link MethodHandles} */
-    public static final ClassDesc CD_MethodHandles = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandles;");
+    public static final ClassDesc CD_MethodHandles = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandles;");
 
     /** {@link ClassDesc} representing {@link MethodHandles.Lookup} */
-    public static final ClassDesc CD_MethodHandles_Lookup = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandles$Lookup;");
+    public static final ClassDesc CD_MethodHandles_Lookup = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandles$Lookup;");
 
     /** {@link ClassDesc} representing {@link MethodHandle} */
-    public static final ClassDesc CD_MethodHandle = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandle;");
+    public static final ClassDesc CD_MethodHandle = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandle;");
 
     /** {@link ClassDesc} representing {@link MethodType} */
-    public static final ClassDesc CD_MethodType = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodType;");
+    public static final ClassDesc CD_MethodType = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodType;");
 
     /** {@link ClassDesc} representing {@link CallSite} */
-    public static final ClassDesc CD_CallSite = ClassDescImpl.ofValidated("Ljava/lang/invoke/CallSite;");
+    public static final ClassDesc CD_CallSite = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/CallSite;");
 
     /** {@link ClassDesc} representing {@link Collection} */
-    public static final ClassDesc CD_Collection = ClassDescImpl.ofValidated("Ljava/util/Collection;");
+    public static final ClassDesc CD_Collection = ReferenceClassDescImpl.ofValidated("Ljava/util/Collection;");
 
     /** {@link ClassDesc} representing {@link List} */
-    public static final ClassDesc CD_List = ClassDescImpl.ofValidated("Ljava/util/List;");
+    public static final ClassDesc CD_List = ReferenceClassDescImpl.ofValidated("Ljava/util/List;");
 
     /** {@link ClassDesc} representing {@link Set} */
-    public static final ClassDesc CD_Set = ClassDescImpl.ofValidated("Ljava/util/Set;");
+    public static final ClassDesc CD_Set = ReferenceClassDescImpl.ofValidated("Ljava/util/Set;");
 
     /** {@link ClassDesc} representing {@link Map} */
-    public static final ClassDesc CD_Map = ClassDescImpl.ofValidated("Ljava/util/Map;");
+    public static final ClassDesc CD_Map = ReferenceClassDescImpl.ofValidated("Ljava/util/Map;");
 
     /** {@link ClassDesc} representing {@link ConstantDesc} */
-    public static final ClassDesc CD_ConstantDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/ConstantDesc;");
+    public static final ClassDesc CD_ConstantDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/ConstantDesc;");
 
     /** {@link ClassDesc} representing {@link ClassDesc} */
-    public static final ClassDesc CD_ClassDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/ClassDesc;");
+    public static final ClassDesc CD_ClassDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/ClassDesc;");
 
     /** {@link ClassDesc} representing {@link EnumDesc} */
-    public static final ClassDesc CD_EnumDesc = ClassDescImpl.ofValidated("Ljava/lang/Enum$EnumDesc;");
+    public static final ClassDesc CD_EnumDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/Enum$EnumDesc;");
 
     /** {@link ClassDesc} representing {@link MethodTypeDesc} */
-    public static final ClassDesc CD_MethodTypeDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/MethodTypeDesc;");
+    public static final ClassDesc CD_MethodTypeDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/MethodTypeDesc;");
 
     /** {@link ClassDesc} representing {@link MethodHandleDesc} */
-    public static final ClassDesc CD_MethodHandleDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/MethodHandleDesc;");
+    public static final ClassDesc CD_MethodHandleDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/MethodHandleDesc;");
 
     /** {@link ClassDesc} representing {@link DirectMethodHandleDesc} */
-    public static final ClassDesc CD_DirectMethodHandleDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/DirectMethodHandleDesc;");
+    public static final ClassDesc CD_DirectMethodHandleDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/DirectMethodHandleDesc;");
 
     /** {@link ClassDesc} representing {@link VarHandleDesc} */
-    public static final ClassDesc CD_VarHandleDesc = ClassDescImpl.ofValidated("Ljava/lang/invoke/VarHandle$VarHandleDesc;");
+    public static final ClassDesc CD_VarHandleDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/VarHandle$VarHandleDesc;");
 
     /** {@link ClassDesc} representing {@link DirectMethodHandleDesc.Kind} */
-    public static final ClassDesc CD_MethodHandleDesc_Kind = ClassDescImpl.ofValidated("Ljava/lang/constant/DirectMethodHandleDesc$Kind;");
+    public static final ClassDesc CD_MethodHandleDesc_Kind = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/DirectMethodHandleDesc$Kind;");
 
     /** {@link ClassDesc} representing {@link DynamicConstantDesc} */
-    public static final ClassDesc CD_DynamicConstantDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/DynamicConstantDesc;");
+    public static final ClassDesc CD_DynamicConstantDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/DynamicConstantDesc;");
 
     /** {@link ClassDesc} representing {@link DynamicCallSiteDesc} */
-    public static final ClassDesc CD_DynamicCallSiteDesc = ClassDescImpl.ofValidated("Ljava/lang/constant/DynamicCallSiteDesc;");
+    public static final ClassDesc CD_DynamicCallSiteDesc = ReferenceClassDescImpl.ofValidated("Ljava/lang/constant/DynamicCallSiteDesc;");
 
     /** {@link ClassDesc} representing {@link ConstantBootstraps} */
-    public static final ClassDesc CD_ConstantBootstraps = ClassDescImpl.ofValidated("Ljava/lang/invoke/ConstantBootstraps;");
+    public static final ClassDesc CD_ConstantBootstraps = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/ConstantBootstraps;");
 
     private static final ClassDesc[] INDY_BOOTSTRAP_ARGS = {
             CD_MethodHandles_Lookup,

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -44,7 +44,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.vm.annotation.Stable;
 import sun.invoke.util.BytecodeName;
@@ -66,8 +66,8 @@ import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 /*non-public*/
 abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesData> {
 
-    private static final ClassDesc CD_LambdaForm = ClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm;");
-    private static final ClassDesc CD_BoundMethodHandle = ClassDescImpl.ofValidated("Ljava/lang/invoke/BoundMethodHandle;");
+    private static final ClassDesc CD_LambdaForm = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm;");
+    private static final ClassDesc CD_BoundMethodHandle = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/BoundMethodHandle;");
     private static final Consumer<FieldBuilder> STATIC_FIELD_FLAGS = new InnerClassLambdaMetafactory.FieldFlags(ACC_STATIC);
     private static final Consumer<FieldBuilder> FINAL_FIELD_FLAGS = new InnerClassLambdaMetafactory.FieldFlags(ACC_FINAL);
 
@@ -977,7 +977,7 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
              : cls == MethodType.class ? CD_MethodType
              : cls == LambdaForm.class ? CD_LambdaForm
              : cls == BoundMethodHandle.class ? CD_BoundMethodHandle
-             : ClassDescImpl.ofValidated(cls.descriptorString());
+             : ReferenceClassDescImpl.ofValidated(cls.descriptorString());
     }
 
     static MethodTypeDesc methodDesc(MethodType mt) {

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -67,7 +67,7 @@ import static java.lang.invoke.MethodHandles.Lookup.ClassOption.STRONG;
 import static java.lang.invoke.MethodType.methodType;
 import jdk.internal.constant.ConstantUtils;
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import sun.invoke.util.Wrapper;
 
 /**
@@ -433,9 +433,9 @@ import sun.invoke.util.Wrapper;
 
     private static class SerializationSupport {
         // Serialization support
-        private static final ClassDesc CD_SerializedLambda = ClassDescImpl.ofValidated("Ljava/lang/invoke/SerializedLambda;");
-        private static final ClassDesc CD_ObjectOutputStream = ClassDescImpl.ofValidated("Ljava/io/ObjectOutputStream;");
-        private static final ClassDesc CD_ObjectInputStream = ClassDescImpl.ofValidated("Ljava/io/ObjectInputStream;");
+        private static final ClassDesc CD_SerializedLambda = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/SerializedLambda;");
+        private static final ClassDesc CD_ObjectOutputStream = ReferenceClassDescImpl.ofValidated("Ljava/io/ObjectOutputStream;");
+        private static final ClassDesc CD_ObjectInputStream = ReferenceClassDescImpl.ofValidated("Ljava/io/ObjectInputStream;");
         private static final MethodTypeDesc MTD_Object = MethodTypeDescImpl.ofValidated(CD_Object);
         private static final MethodTypeDesc MTD_void_ObjectOutputStream = MethodTypeDescImpl.ofValidated(CD_void, CD_ObjectOutputStream);
         private static final MethodTypeDesc MTD_void_ObjectInputStream = MethodTypeDescImpl.ofValidated(CD_void, CD_ObjectInputStream);
@@ -444,10 +444,10 @@ import sun.invoke.util.Wrapper;
         private static final String NAME_METHOD_READ_OBJECT = "readObject";
         private static final String NAME_METHOD_WRITE_OBJECT = "writeObject";
 
-        static final ClassDesc CD_NotSerializableException = ClassDescImpl.ofValidated("Ljava/io/NotSerializableException;");
+        static final ClassDesc CD_NotSerializableException = ReferenceClassDescImpl.ofValidated("Ljava/io/NotSerializableException;");
         static final MethodTypeDesc MTD_CTOR_NOT_SERIALIZABLE_EXCEPTION = MethodTypeDescImpl.ofValidated(CD_void, CD_String);
         static final MethodTypeDesc MTD_CTOR_SERIALIZED_LAMBDA = MethodTypeDescImpl.ofValidated(CD_void,
-                CD_Class, CD_String, CD_String, CD_String, CD_int, CD_String, CD_String, CD_String, CD_String, ClassDescImpl.ofValidated("[Ljava/lang/Object;"));
+                CD_Class, CD_String, CD_String, CD_String, CD_int, CD_String, CD_String, CD_String, CD_String, ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;"));
 
     }
 
@@ -650,12 +650,12 @@ import sun.invoke.util.Wrapper;
     }
 
     static ClassDesc implClassDesc(Class<?> cls) {
-        return cls.isHidden() ? null : ClassDescImpl.ofValidated(cls.descriptorString());
+        return cls.isHidden() ? null : ReferenceClassDescImpl.ofValidated(cls.descriptorString());
     }
 
     static ClassDesc classDesc(Class<?> cls) {
         return cls.isPrimitive() ? Wrapper.forPrimitiveType(cls).basicClassDescriptor()
-                                 : ClassDescImpl.ofValidated(cls.descriptorString());
+                                 : ReferenceClassDescImpl.ofValidated(cls.descriptorString());
     }
 
     static MethodTypeDesc methodDesc(MethodType mt) {

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -48,7 +48,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 
 import static java.lang.classfile.ClassFile.*;
 import static java.lang.constant.ConstantDescs.*;
@@ -65,15 +65,15 @@ import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
  */
 class InvokerBytecodeGenerator {
     /** Define class names for convenience. */
-    private static final ClassDesc CD_CasesHolder = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl$CasesHolder;");
-    private static final ClassDesc CD_DirectMethodHandle = ClassDescImpl.ofValidated("Ljava/lang/invoke/DirectMethodHandle;");
-    private static final ClassDesc CD_MethodHandleImpl = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl;");
-    private static final ClassDesc CD_LambdaForm = ClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm;");
-    private static final ClassDesc CD_LambdaForm_Name = ClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm$Name;");
-    private static final ClassDesc CD_LoopClauses = ClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl$LoopClauses;");
-    private static final ClassDesc CD_Object_array  = ClassDescImpl.ofValidated("[Ljava/lang/Object;");
-    private static final ClassDesc CD_MethodHandle_array = ClassDescImpl.ofValidated("[Ljava/lang/invoke/MethodHandle;");
-    private static final ClassDesc CD_MethodHandle_array2 = ClassDescImpl.ofValidated("[[Ljava/lang/invoke/MethodHandle;");
+    private static final ClassDesc CD_CasesHolder = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl$CasesHolder;");
+    private static final ClassDesc CD_DirectMethodHandle = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/DirectMethodHandle;");
+    private static final ClassDesc CD_MethodHandleImpl = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl;");
+    private static final ClassDesc CD_LambdaForm = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm;");
+    private static final ClassDesc CD_LambdaForm_Name = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm$Name;");
+    private static final ClassDesc CD_LoopClauses = ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/MethodHandleImpl$LoopClauses;");
+    private static final ClassDesc CD_Object_array  = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;");
+    private static final ClassDesc CD_MethodHandle_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/invoke/MethodHandle;");
+    private static final ClassDesc CD_MethodHandle_array2 = ReferenceClassDescImpl.ofValidated("[[Ljava/lang/invoke/MethodHandle;");
 
     private static final MethodTypeDesc MTD_boolean_Object = MethodTypeDescImpl.ofValidated(CD_boolean, CD_Object);
     private static final MethodTypeDesc MTD_Object_int = MethodTypeDescImpl.ofValidated(CD_Object, CD_int);
@@ -542,11 +542,11 @@ class InvokerBytecodeGenerator {
         return true;
     }
 
-    static final Annotation DONTINLINE      = Annotation.of(ClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/DontInline;"));
-    static final Annotation FORCEINLINE     = Annotation.of(ClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/ForceInline;"));
-    static final Annotation HIDDEN          = Annotation.of(ClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/Hidden;"));
-    static final Annotation INJECTEDPROFILE = Annotation.of(ClassDescImpl.ofValidated("Ljava/lang/invoke/InjectedProfile;"));
-    static final Annotation LF_COMPILED     = Annotation.of(ClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm$Compiled;"));
+    static final Annotation DONTINLINE      = Annotation.of(ReferenceClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/DontInline;"));
+    static final Annotation FORCEINLINE     = Annotation.of(ReferenceClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/ForceInline;"));
+    static final Annotation HIDDEN          = Annotation.of(ReferenceClassDescImpl.ofValidated("Ljdk/internal/vm/annotation/Hidden;"));
+    static final Annotation INJECTEDPROFILE = Annotation.of(ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/InjectedProfile;"));
+    static final Annotation LF_COMPILED     = Annotation.of(ReferenceClassDescImpl.ofValidated("Ljava/lang/invoke/LambdaForm$Compiled;"));
 
     /**
      * Generate an invoker method for the passed {@link LambdaForm}.
@@ -1688,7 +1688,7 @@ class InvokerBytecodeGenerator {
              : cls == MethodHandle.class ? CD_MethodHandle
              : cls == DirectMethodHandle.class ? CD_DirectMethodHandle
              : cls == Object.class ? CD_Object
-             : ClassDescImpl.ofValidated(cls.descriptorString());
+             : ReferenceClassDescImpl.ofValidated(cls.descriptorString());
     }
 
     static MethodTypeDesc methodDesc(MethodType mt) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -28,7 +28,7 @@ package java.lang.invoke;
 import jdk.internal.access.JavaLangInvokeAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import jdk.internal.foreign.abi.NativeEntryPoint;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
@@ -1040,7 +1040,7 @@ abstract class MethodHandleImpl {
     // That way we can lazily load the code and set up the constants.
     private static class BindCaller {
 
-        private static final ClassDesc CD_Object_array = ClassDescImpl.ofValidated("[Ljava/lang/Object;");
+        private static final ClassDesc CD_Object_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;");
         private static final MethodType INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object[].class);
         private static final MethodType REFLECT_INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object.class, Object[].class);
 
@@ -1269,7 +1269,7 @@ abstract class MethodHandleImpl {
             //     }
             // }
             // }
-            return ClassFile.of().build(ClassDescImpl.ofValidated("LInjectedInvoker;"), clb -> clb
+            return ClassFile.of().build(ReferenceClassDescImpl.ofValidated("LInjectedInvoker;"), clb -> clb
                     .withFlags(ACC_PRIVATE | ACC_SUPER)
                     .withMethodBody(
                         "invoke_V",

--- a/src/java.base/share/classes/java/lang/invoke/TypeConvertingMethodAdapter.java
+++ b/src/java.base/share/classes/java/lang/invoke/TypeConvertingMethodAdapter.java
@@ -31,7 +31,7 @@ import java.lang.classfile.TypeKind;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.MethodRefEntry;
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import sun.invoke.util.Wrapper;
 
 import static java.lang.constant.ConstantDescs.*;
@@ -202,6 +202,6 @@ class TypeConvertingMethodAdapter {
         return cls.isPrimitive() ? Wrapper.forPrimitiveType(cls).basicClassDescriptor()
              : cls == Object.class ? CD_Object
              : cls == String.class ? CD_String
-             : ClassDescImpl.ofValidated(cls.descriptorString());
+             : ReferenceClassDescImpl.ofValidated(cls.descriptorString());
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
+++ b/src/java.base/share/classes/java/lang/reflect/ProxyGenerator.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import jdk.internal.constant.ConstantUtils;
 import jdk.internal.constant.MethodTypeDescImpl;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import sun.security.action.GetBooleanAction;
 
 import static java.lang.classfile.ClassFile.*;
@@ -64,18 +64,18 @@ final class ProxyGenerator {
             ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS);
 
     private static final ClassDesc
-            CD_ClassLoader = ClassDescImpl.ofValidated("Ljava/lang/ClassLoader;"),
-            CD_Class_array = ClassDescImpl.ofValidated("[Ljava/lang/Class;"),
-            CD_ClassNotFoundException = ClassDescImpl.ofValidated("Ljava/lang/ClassNotFoundException;"),
-            CD_NoClassDefFoundError = ClassDescImpl.ofValidated("Ljava/lang/NoClassDefFoundError;"),
-            CD_IllegalAccessException = ClassDescImpl.ofValidated("Ljava/lang/IllegalAccessException;"),
-            CD_InvocationHandler = ClassDescImpl.ofValidated("Ljava/lang/reflect/InvocationHandler;"),
-            CD_Method = ClassDescImpl.ofValidated("Ljava/lang/reflect/Method;"),
-            CD_NoSuchMethodError = ClassDescImpl.ofValidated("Ljava/lang/NoSuchMethodError;"),
-            CD_NoSuchMethodException = ClassDescImpl.ofValidated("Ljava/lang/NoSuchMethodException;"),
-            CD_Object_array = ClassDescImpl.ofValidated("[Ljava/lang/Object;"),
-            CD_Proxy = ClassDescImpl.ofValidated("Ljava/lang/reflect/Proxy;"),
-            CD_UndeclaredThrowableException = ClassDescImpl.ofValidated("Ljava/lang/reflect/UndeclaredThrowableException;");
+            CD_ClassLoader = ReferenceClassDescImpl.ofValidated("Ljava/lang/ClassLoader;"),
+            CD_Class_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Class;"),
+            CD_ClassNotFoundException = ReferenceClassDescImpl.ofValidated("Ljava/lang/ClassNotFoundException;"),
+            CD_NoClassDefFoundError = ReferenceClassDescImpl.ofValidated("Ljava/lang/NoClassDefFoundError;"),
+            CD_IllegalAccessException = ReferenceClassDescImpl.ofValidated("Ljava/lang/IllegalAccessException;"),
+            CD_InvocationHandler = ReferenceClassDescImpl.ofValidated("Ljava/lang/reflect/InvocationHandler;"),
+            CD_Method = ReferenceClassDescImpl.ofValidated("Ljava/lang/reflect/Method;"),
+            CD_NoSuchMethodError = ReferenceClassDescImpl.ofValidated("Ljava/lang/NoSuchMethodError;"),
+            CD_NoSuchMethodException = ReferenceClassDescImpl.ofValidated("Ljava/lang/NoSuchMethodException;"),
+            CD_Object_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;"),
+            CD_Proxy = ReferenceClassDescImpl.ofValidated("Ljava/lang/reflect/Proxy;"),
+            CD_UndeclaredThrowableException = ReferenceClassDescImpl.ofValidated("Ljava/lang/reflect/UndeclaredThrowableException;");
 
     private static final MethodTypeDesc
             MTD_boolean = MethodTypeDescImpl.ofValidated(CD_boolean),

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -49,7 +49,7 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.Label;
 import java.lang.classfile.instruction.SwitchCase;
 
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 import jdk.internal.constant.ConstantUtils;
 import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.vm.annotation.Stable;
@@ -92,7 +92,7 @@ public class SwitchBootstraps {
     private static final MethodTypeDesc CHECK_INDEX_DESCRIPTOR =
             MethodTypeDesc.ofDescriptor("(II)I");
 
-    private static final ClassDesc CD_Objects = ClassDescImpl.ofValidated("Ljava/util/Objects;");
+    private static final ClassDesc CD_Objects = ReferenceClassDescImpl.ofValidated("Ljava/util/Objects;");
 
     private static class StaticHolders {
         private static final MethodHandle NULL_CHECK;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -45,7 +45,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import jdk.internal.constant.ClassDescImpl;
+import jdk.internal.constant.ReferenceClassDescImpl;
 
 import static java.lang.classfile.ClassFile.*;
 import static java.lang.constant.ConstantDescs.*;
@@ -1248,14 +1248,14 @@ public final class StackMapGenerator {
         //frequently used types to reduce footprint
         static final Type OBJECT_TYPE = referenceType(CD_Object),
             THROWABLE_TYPE = referenceType(CD_Throwable),
-            INT_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[I")),
-            BOOLEAN_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[Z")),
-            BYTE_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[B")),
-            CHAR_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[C")),
-            SHORT_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[S")),
-            LONG_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[J")),
-            DOUBLE_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[D")),
-            FLOAT_ARRAY_TYPE = referenceType(ClassDescImpl.ofValidated("[F")),
+            INT_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[I")),
+            BOOLEAN_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[Z")),
+            BYTE_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[B")),
+            CHAR_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[C")),
+            SHORT_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[S")),
+            LONG_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[J")),
+            DOUBLE_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[D")),
+            FLOAT_ARRAY_TYPE = referenceType(ReferenceClassDescImpl.ofValidated("[F")),
             STRING_TYPE = referenceType(CD_String),
             CLASS_TYPE = referenceType(CD_Class),
             METHOD_HANDLE_TYPE = referenceType(CD_MethodHandle),
@@ -1320,8 +1320,8 @@ public final class StackMapGenerator {
             }
         }
 
-        private static final ClassDesc CD_Cloneable = ClassDescImpl.ofValidated("Ljava/lang/Cloneable;");
-        private static final ClassDesc CD_Serializable = ClassDescImpl.ofValidated("Ljava/io/Serializable;");
+        private static final ClassDesc CD_Cloneable = ReferenceClassDescImpl.ofValidated("Ljava/lang/Cloneable;");
+        private static final ClassDesc CD_Serializable = ReferenceClassDescImpl.ofValidated("Ljava/io/Serializable;");
 
         private Type mergeReferenceFrom(Type from, ClassHierarchyImpl context) {
             if (from == NULL_TYPE) {

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -64,7 +64,7 @@ public final class ConstantUtils {
      * @param binaryName a binary name
      */
     public static ClassDesc binaryNameToDesc(String binaryName) {
-        return ClassDescImpl.ofValidated("L" + binaryToInternal(binaryName) + ";");
+        return ReferenceClassDescImpl.ofValidated("L" + binaryToInternal(binaryName) + ";");
     }
 
     /**
@@ -85,7 +85,7 @@ public final class ConstantUtils {
      * class or interface or an array type with a non-hidden component type.
      */
     public static ClassDesc referenceClassDesc(Class<?> type) {
-        return ClassDescImpl.ofValidated(type.descriptorString());
+        return ReferenceClassDescImpl.ofValidated(type.descriptorString());
     }
 
     /**
@@ -309,7 +309,7 @@ public final class ConstantUtils {
             return Wrapper.forPrimitiveType(descriptor.charAt(start)).basicClassDescriptor();
         }
         // Pre-verified in parseMethodDescriptor; avoid redundant verification
-        return ClassDescImpl.ofValidated(descriptor.substring(start, start + len));
+        return ReferenceClassDescImpl.ofValidated(descriptor.substring(start, start + len));
     }
 
     private static final char JVM_SIGNATURE_ARRAY = '[';

--- a/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
@@ -31,13 +31,13 @@ import static jdk.internal.constant.ConstantUtils.*;
 
 /**
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a class,
- * interface, or array type.  A {@linkplain ClassDescImpl} corresponds to a
+ * interface, or array type.  A {@linkplain ReferenceClassDescImpl} corresponds to a
  * {@code Constant_Class_info} entry in the constant pool of a classfile.
  */
-public final class ClassDescImpl implements ClassDesc {
+public final class ReferenceClassDescImpl implements ClassDesc {
     private final String descriptor;
 
-    private ClassDescImpl(String descriptor) {
+    private ReferenceClassDescImpl(String descriptor) {
         this.descriptor = descriptor;
     }
 
@@ -50,12 +50,12 @@ public final class ClassDescImpl implements ClassDesc {
      * field descriptor string, or does not describe a class or interface type
      * @jvms 4.3.2 Field Descriptors
      */
-    public static ClassDescImpl of(String descriptor) {
+    public static ReferenceClassDescImpl of(String descriptor) {
         int dLen = descriptor.length();
         int len = ConstantUtils.skipOverFieldSignature(descriptor, 0, dLen, false);
         if (len <= 1 || len != dLen)
             throw new IllegalArgumentException(String.format("not a valid reference type descriptor: %s", descriptor));
-        return new ClassDescImpl(descriptor);
+        return new ReferenceClassDescImpl(descriptor);
     }
 
     /**
@@ -65,10 +65,10 @@ public final class ClassDescImpl implements ClassDesc {
      * @param descriptor a field descriptor string for a class or interface type
      * @jvms 4.3.2 Field Descriptors
      */
-    public static ClassDescImpl ofValidated(String descriptor) {
+    public static ReferenceClassDescImpl ofValidated(String descriptor) {
         assert ConstantUtils.skipOverFieldSignature(descriptor, 0, descriptor.length(), false)
                 == descriptor.length() : descriptor;
-        return new ClassDescImpl(descriptor);
+        return new ReferenceClassDescImpl(descriptor);
     }
 
     @Override
@@ -104,8 +104,8 @@ public final class ClassDescImpl implements ClassDesc {
     }
 
     /**
-     * Returns {@code true} if this {@linkplain ClassDescImpl} is
-     * equal to another {@linkplain ClassDescImpl}.  Equality is
+     * Returns {@code true} if this {@linkplain ReferenceClassDescImpl} is
+     * equal to another {@linkplain ReferenceClassDescImpl}.  Equality is
      * determined by the two class descriptors having equal class descriptor
      * strings.
      *
@@ -117,7 +117,7 @@ public final class ClassDescImpl implements ClassDesc {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o instanceof ClassDescImpl constant) {
+        if (o instanceof ReferenceClassDescImpl constant) {
             return descriptor.equals(constant.descriptor);
         }
         return false;


### PR DESCRIPTION
ClassDescImpl -> ReferenceClassDescImpl

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8342033](https://bugs.openjdk.org/browse/JDK-8342033): [lworld] Rename ClassDescImpl back to ReferenceClassDescImpl (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1277/head:pull/1277` \
`$ git checkout pull/1277`

Update a local copy of the PR: \
`$ git checkout pull/1277` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1277`

View PR using the GUI difftool: \
`$ git pr show -t 1277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1277.diff">https://git.openjdk.org/valhalla/pull/1277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1277#issuecomment-2411517353)