### PR TITLE
8343346: [lworld] IR matching need updating after merging JDK-8339849

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -84,11 +84,6 @@ compiler/valhalla/inlinetypes/TestIntrinsics.java          8342064 generic-all
 compiler/valhalla/inlinetypes/TestNullableInlineTypes.java 8342064 generic-all
 compiler/valhalla/inlinetypes/TestNullableArrays.java      8342064 generic-all
 
-compiler/valhalla/inlinetypes/TestArrays.java              8343346 generic-all
-compiler/valhalla/inlinetypes/TestBasicFunctionality.java  8343346 generic-all
-compiler/valhalla/inlinetypes/TestLWorld.java              8343346 generic-all
-compiler/valhalla/inlinetypes/TestLWorldProfiling.java     8343346 generic-all
-
 compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java  8342488 generic-all
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
@@ -29,12 +29,12 @@ public class InlineTypeRegexes {
     private static final String MID = ".*)+(\\s){2}===.*";
     private static final String END = ")";
     // Generic allocation
-    public static final String ALLOC_G = "(.*call,static.*wrapper for: _new_instance_Java" + END;
-    public static final String ALLOCA_G = "(.*call,static.*wrapper for: _new_array_Java" + END;
+    public static final String ALLOC_G = "(.*call,static.*wrapper for: C2 Runtime new_instance" + END;
+    public static final String ALLOCA_G = "(.*call,static.*wrapper for: C2 Runtime new_array" + END;
     // Inline type allocation
     public static final String MYVALUE_ARRAY_KLASS = "\\[(precise )?compiler/valhalla/inlinetypes/MyValue";
-    public static final String ALLOC = "(.*precise compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_instance_Java" + END;
-    public static final String ALLOCA = "(.*" + MYVALUE_ARRAY_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*_new_array_Java" + END;
+    public static final String ALLOC = "(.*precise compiler/valhalla/inlinetypes/MyValue.*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*C2 Runtime new_instance" + END;
+    public static final String ALLOCA = "(.*" + MYVALUE_ARRAY_KLASS + ".*\\R(.*(?i:mov|xorl|nop|spill).*\\R)*.*C2 Runtime new_array" + END;
     public static final String LOAD = START + "Load(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/.*" + END;
     public static final String LOADK = START + "LoadK" + MID + END;
     public static final String STORE = START + "Store(B|C|S|I|L|F|D|P|N)" + MID + "@compiler/valhalla/inlinetypes/.*" + END;
@@ -50,7 +50,7 @@ public class InlineTypeRegexes {
     protected static final String CALL_UNSAFE = START + "CallStaticJava" + MID + "# Static  jdk.internal.misc.Unsafe::" + END;
     public static final String STORE_INLINE_FIELDS = START + "CallStaticJava" + MID + "store_inline_type_fields" + END;
     public static final String SCOBJ = "(.*# ScObj.*" + END;
-    public static final String LOAD_UNKNOWN_INLINE = START + "CallStaticJava" + MID + "_load_unknown_inline" + END;
+    public static final String LOAD_UNKNOWN_INLINE = START + "CallStaticJava" + MID + "C2 Runtime load_unknown_inline" + END;
     public static final String STORE_UNKNOWN_INLINE = "(.*" + CALL_LEAF + ".*store_unknown_inline.*" + END;
     public static final String INLINE_ARRAY_NULL_GUARD = "(.*call,static.*wrapper for: uncommon_trap.*reason='null_check' action='none'.*" + END;
     public static final String INTRINSIC_SLOW_PATH = "(.*call,static.*wrapper for: uncommon_trap.*reason='intrinsic_or_type_checked_inlining'.*" + END;


### PR DESCRIPTION
Adjusted the Valhalla specific IR rules to [JDK-8339849](https://bugs.openjdk.org/browse/JDK-8339849).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343346](https://bugs.openjdk.org/browse/JDK-8343346): [lworld] IR matching need updating after merging JDK-8339849 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1287/head:pull/1287` \
`$ git checkout pull/1287`

Update a local copy of the PR: \
`$ git checkout pull/1287` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1287`

View PR using the GUI difftool: \
`$ git pr show -t 1287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1287.diff">https://git.openjdk.org/valhalla/pull/1287.diff</a>

</details>
