### PR TITLE
8341949: [lworld] compiler/valhalla/inlinetypes/TestMethodHandles.java broken after merging jdk-24+3

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -78,8 +78,6 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 compiler/interpreter/Test6833129.java 8335266 generic-i586
 
-compiler/valhalla/inlinetypes/TestMethodHandles.java 8341949 generic-all
-
 compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java  8342488 generic-all
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestMethodHandles.java
@@ -145,6 +145,7 @@ public class TestMethodHandles {
         InlineTypes.getFramework()
                    .addScenarios(scenarios)
                    .addFlags("-XX:CompileCommand=inline,java.lang.invoke.MethodHandleImpl::*")
+                   .addFlags("-XX:CompileCommand=inline,java.lang.invoke.LambdaForm*::*")
                    .addHelperClasses(MyValue1.class,
                                      MyValue2.class,
                                      MyValue2Inline.class,


### PR DESCRIPTION
Force inlining of LambdaForm methods to ensure that the IR always looks as expected.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341949](https://bugs.openjdk.org/browse/JDK-8341949): [lworld] compiler/valhalla/inlinetypes/TestMethodHandles.java broken after merging jdk-24+3 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1289/head:pull/1289` \
`$ git checkout pull/1289`

Update a local copy of the PR: \
`$ git checkout pull/1289` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1289`

View PR using the GUI difftool: \
`$ git pr show -t 1289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1289.diff">https://git.openjdk.org/valhalla/pull/1289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1289#issuecomment-2449799756)
</details>
