### PR TITLE
[lworld] Remove InlineOops.java from problem list after JDK-8313607 got fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -129,7 +129,6 @@ containers/docker/TestJFREvents.java 8327723 linux-x64
 
 # Valhalla
 runtime/AccModule/ConstModule.java 8294051 generic-all
-runtime/valhalla/inlinetypes/InlineOops.java#ZGen 8313607 linux-aarch64,macosx-aarch64
 
 #############################################################################
 


### PR DESCRIPTION
[JDK-8313607](https://bugs.openjdk.org/browse/JDK-8313607) was fixed but the test is still problem listed. Let's fix that.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1291/head:pull/1291` \
`$ git checkout pull/1291`

Update a local copy of the PR: \
`$ git checkout pull/1291` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1291`

View PR using the GUI difftool: \
`$ git pr show -t 1291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1291.diff">https://git.openjdk.org/valhalla/pull/1291.diff</a>

</details>
