### PR TITLE
8343408: TestJNIIsSameObject should be run on all platforms

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsSameObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsSameObject.java
@@ -32,8 +32,6 @@ import jdk.test.lib.Asserts;
  * @summary Test JNI IsSameObject semantic with inline types
  * @library /testlibrary /test/lib
  * @modules java.base/jdk.internal.vm.annotation
- * @requires (os.simpleArch == "x64" | os.simpleArch == "aarch64")
- * @requires (os.family == "linux" | os.family == "mac")
  * @enablePreview
  * @compile TestJNIIsSameObject.java
  * @run main/othervm/native TestJNIIsSameObject

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libJNIIsSameObject.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libJNIIsSameObject.c
@@ -26,11 +26,7 @@
 #include <string.h>
 #include <jni.h>
 
-#if !defined(_WIN32) && !defined(_WIN64)
-
 JNIEXPORT jboolean JNICALL
 Java_TestJNIIsSameObject_isSameObject(JNIEnv* env, jclass klass, jobject obj0, jobject obj1) {
   return (*env)->IsSameObject(env, obj0, obj1);
 }
-
-#endif


### PR DESCRIPTION
The fix drops the test requirements to run it on all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343408](https://bugs.openjdk.org/browse/JDK-8343408): TestJNIIsSameObject should be run on all platforms (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1292/head:pull/1292` \
`$ git checkout pull/1292`

Update a local copy of the PR: \
`$ git checkout pull/1292` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1292`

View PR using the GUI difftool: \
`$ git pr show -t 1292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1292.diff">https://git.openjdk.org/valhalla/pull/1292.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1292#issuecomment-2450676149)
</details>
