### PR TITLE
8343423: [lworld] compiler/valhalla/inlinetypes/TestArrays.java IR mismatches after after merging JDK-8334060 in jdk-24+18

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -28,6 +28,7 @@ import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
 import compiler.lib.ir_framework.shared.CheckedTestFrameworkException;
 import compiler.lib.ir_framework.shared.TestFormat;
 import compiler.lib.ir_framework.shared.TestFormatException;
+import compiler.valhalla.inlinetypes.InlineTypeIRNode;
 import jdk.test.lib.Platform;
 import jdk.test.whitebox.WhiteBox;
 
@@ -151,6 +152,12 @@ public class IRNode {
      *    // definitions.
      * }
      */
+
+    // Valhalla: Make sure that all Valhalla specific IR nodes are also properly initialized. Doing it here also
+    //           ensures that the Flag VM is able to pick up the correct compile phases.
+    static {
+        InlineTypeIRNode.forceStaticInitialization();
+    }
 
     public static final String ABS_D = PREFIX + "ABS_D" + POSTFIX;
     static {
@@ -1703,7 +1710,7 @@ public class IRNode {
 
     public static final String SUBTYPE_CHECK = PREFIX + "SUBTYPE_CHECK" + POSTFIX;
     static {
-        beforeMatchingNameRegex(SUBTYPE_CHECK, "SubTypeCheck");
+        macroNodes(SUBTYPE_CHECK, "SubTypeCheck");
     }
 
     public static final String TRAP = PREFIX + "TRAP" + POSTFIX;
@@ -2483,6 +2490,19 @@ public class IRNode {
         IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.PRINT_IDEAL, regex,
                                                                           CompilePhase.OPTIMIZE_FINISHED,
                                                                           CompilePhase.BEFORE_MATCHING));
+    }
+
+    /**
+     * Apply a regex that matches a macro node IR node name {@code macroNodeName} exactly on all machine independent
+     * ideal graph phases up to and including {@link CompilePhase#BEFORE_MACRO_EXPANSION}. By default, we match on
+     * {@link CompilePhase#BEFORE_MACRO_EXPANSION} when no {@link CompilePhase} is chosen.
+     */
+    private static void macroNodes(String irNodePlaceholder, String macroNodeName) {
+        String macroNodeRegex = START + macroNodeName + "\\b" + MID + END;
+        IR_NODE_MAPPINGS.put(irNodePlaceholder, new SinglePhaseRangeEntry(CompilePhase.BEFORE_MACRO_EXPANSION,
+                                                                          macroNodeRegex,
+                                                                          CompilePhase.BEFORE_STRINGOPTS,
+                                                                          CompilePhase.BEFORE_MACRO_EXPANSION));
     }
 
     private static void trapNodes(String irNodePlaceholder, String trapReason) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeIRNode.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeIRNode.java
@@ -187,11 +187,6 @@ public class InlineTypeIRNode {
         IRNode.beforeMatching(MEMBAR, InlineTypeRegexes.MEMBAR);
     }
 
-    public static final String CHECKCAST_ARRAY = PREFIX + "CHECKCAST_ARRAY" + POSTFIX;
-    static {
-        IRNode.optoOnly(CHECKCAST_ARRAY, InlineTypeRegexes.CHECKCAST_ARRAY);
-    }
-
     public static final String CHECKCAST_ARRAYCOPY = PREFIX + "CHECKCAST_ARRAYCOPY" + POSTFIX;
     static {
         IRNode.optoOnly(CHECKCAST_ARRAYCOPY, InlineTypeRegexes.CHECKCAST_ARRAYCOPY);

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypeRegexes.java
@@ -62,7 +62,6 @@ public class InlineTypeRegexes {
     public static final String UNHANDLED_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*unhandled" + END;
     public static final String PREDICATE_TRAP = START + "CallStaticJava" + MID + "uncommon_trap.*predicate" + END;
     public static final String MEMBAR = START + "MemBar" + MID + END;
-    public static final String CHECKCAST_ARRAY = "(((?i:cmp|CLFI|CLR).*" + MYVALUE_ARRAY_KLASS + ".*:|.*(?i:mov|or).*" + MYVALUE_ARRAY_KLASS + ".*:.*\\R(.*(decode|mov|nop).*\\R)*.*(cmp|CMP|CLR))" + END;
     public static final String CHECKCAST_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*checkcast_arraycopy.*" + END;
     public static final String JLONG_ARRAYCOPY = "(.*" + CALL_LEAF_NOFP + ".*jlong_disjoint_arraycopy.*" + END;
     public static final String FIELD_ACCESS = "(.*Field: *" + END;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/InlineTypes.java
@@ -125,7 +125,6 @@ public class InlineTypes {
     };
 
     public static TestFramework getFramework() {
-        InlineTypeIRNode.forceStaticInitialization();
         StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
         return new TestFramework(walker.getCallerClass()).setDefaultWarmup(251);
     }

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2420,14 +2420,14 @@ public class TestArrays {
         // feeding into the array store sub type check.
         // At runtime, we will hit the ArrayStoreException in the first execution when array is a MyValue1[].
         // With the default IR framework warm-up, we will profile the ArrayStoreException in the interpreter and
-        // pass it in the MDO to the C2 compiler which treat these exceptions as traps being hit (see
+        // pass it in the MDO to the C2 compiler which treats these exceptions as traps being hit (see
         // InterpreterRuntime::create_klass_exception). As a result, C2 is not able to speculatively cast the array of
         // type Object[] to an exact type before the first sub type check because we've seen too many traps being taken
         // at that bci due to the ArrayStoreException that was hit at the very same bci (see Compile::too_many_traps()
-        // which checks that zero traps have been taken  so far). Thus, neither the first sub type check for the array
+        // which checks that zero traps have been taken so far). Thus, neither the first sub type check for the array
         // check cast nor the second sub type check for the instanceof can be removed.
         // By not executing test97() with MyValue1[] during warm-up, which would trigger the ArrayStoreException,
-        // we will not observe an ArrayStoreException before C2 compilation. Note that C2 also require
+        // we will not observe an ArrayStoreException before C2 compilation. Note that C2 also requires
         // MonomorphicArrayCheck in order to emit the speculative exactness check.
         // The same is required for test98-100().
         if (!runInfo.isWarmUp()) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2415,16 +2415,17 @@ public class TestArrays {
         MyValue1[] array1 = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 1);
         NonValueClass[] array2 = new NonValueClass[1];
         // When emitting the array store check "NonValueClass <: Object[]" for "array[0] = new NonValueClass(42)" in
-        // test97(), we speculatively assume that Object[] is exact and emit such a check with an uncommont trap before
+        // test97(), we speculatively assume that Object[] is exact and emit such a check with an uncommon trap before
         // the array store check at the same bci. We propagate that information with an additional CheckCastPP node
-        // feeding into the array store subtype check.
+        // feeding into the array store sub type check.
         // At runtime, we will hit the ArrayStoreException in the first execution when array is a MyValue1[].
-        // With the default IR framework warm-up, we will profile the ArrayStoreException already in the interpreter and
-        // pass it in the MDO to the C2 compiler (see InterpreterRuntime::create_klass_exception). As a result, C2 is
-        // not able to speculatively cast the array of type Object[] to an exact type before the first subtype check
-        // because we've seen too many traps being taken at that bci due to the ArrayStoreException that was hit at the
-        // very same bci (see Compile::too_many_traps() which checks that zero traps have been taken  so far). Thus,
-        // the second subtype check for the value class cannot be removed either.
+        // With the default IR framework warm-up, we will profile the ArrayStoreException in the interpreter and
+        // pass it in the MDO to the C2 compiler which treat these exceptions as traps being hit (see
+        // InterpreterRuntime::create_klass_exception). As a result, C2 is not able to speculatively cast the array of
+        // type Object[] to an exact type before the first sub type check because we've seen too many traps being taken
+        // at that bci due to the ArrayStoreException that was hit at the very same bci (see Compile::too_many_traps()
+        // which checks that zero traps have been taken  so far). Thus, neither the first sub type check for the array
+        // check cast nor the second sub type check for the instanceof can be removed.
         // By not executing test97() with MyValue1[] during warm-up, which would trigger the ArrayStoreException,
         // we will not observe an ArrayStoreException before C2 compilation. Note that C2 also require
         // MonomorphicArrayCheck in order to emit the speculative exactness check.

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -2401,7 +2401,7 @@ public class TestArrays {
 
     // Same as test95 but with instanceof instead of cast
     @Test
-    @IR(failOn = IRNode.SUBTYPE_CHECK)
+    @IR(applyIf = {"MonomorphicArrayCheck", "true"}, failOn = IRNode.SUBTYPE_CHECK)
     public boolean test97(Object[] array) {
         array[0] = new NonValueClass(42);
         // Always throws a ClassCastException because we just successfully stored
@@ -2412,10 +2412,11 @@ public class TestArrays {
     @Run(test = "test97")
     // With the default warm-up, we will profile the ArrayStoreException already in the interpreter and pass it in the
     // MDO to the C2 compiler (see InterpreterRuntime::create_klass_exception). As a result, C2 is not able to propagate
-    // the improved type in the CheckCastPP after the sub type check because we've seen too many traps being taken at
-    // that bci (see Compile::too_many_traps() which checks that zero traps have been taken so far). Thus, the sub type
+    // the improved type in the CheckCastPP after the subtype check because we've seen too many traps being taken at
+    // that bci (see Compile::too_many_traps() which checks that zero traps have been taken so far). Thus, the subtype
     // check for the value class cannot be removed either. Set a warm-up value of zero to avoid that the trap is
-    // observed in the interpreter. Same for test98-100().
+    // observed in the interpreter. Note that C2 also required MonomorphicArrayCheck to be set in order to propagate
+    // the type. Same for test98-100().
     @Warmup(0)
     public void test97_verifier() {
         MyValue1[] array1 = (MyValue1[])ValueClass.newNullRestrictedArray(MyValue1.class, 1);
@@ -2432,7 +2433,7 @@ public class TestArrays {
 
     // Same as test95 but with non-flattenable store
     @Test
-    @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
+    @IR(applyIfAnd = {"FlatArrayElementMaxSize", "= -1", "MonomorphicArrayCheck", "true"},
         failOn = IRNode.SUBTYPE_CHECK)
     public MyValue1[] test98(Object[] array) {
         array[0] = new NotFlattenable();
@@ -2462,7 +2463,7 @@ public class TestArrays {
 
     // Same as test98 but with cmp user of cast result
     @Test
-    @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
+    @IR(applyIfAnd = {"FlatArrayElementMaxSize", "= -1", "MonomorphicArrayCheck", "true"},
         failOn = IRNode.SUBTYPE_CHECK)
     public boolean test99(Object[] array) {
         array[0] = new NotFlattenable();
@@ -2493,7 +2494,7 @@ public class TestArrays {
 
     // Same as test98 but with instanceof instead of cast
     @Test
-    @IR(applyIf = {"FlatArrayElementMaxSize", "= -1"},
+    @IR(applyIfAnd = {"FlatArrayElementMaxSize", "= -1", "MonomorphicArrayCheck", "true"},
         failOn = IRNode.SUBTYPE_CHECK)
     public boolean test100(Object[] array) {
         array[0] = new NotFlattenable();


### PR DESCRIPTION
There are several events that need to be taken into consideration to understand why `TestArray::test97-100()` are now failing after the merge of JDK-24+18:

### Background
#### Original Intent of `test95-101()`:
Orignally, the tests were added with [JDK-8251442](https://bugs.openjdk.org/browse/JDK-8251442) to check that sub type checks are properly folded with a new regex `CHECKCAST_ARRAY`. Back there, we did not have the possibility to match on compilation phases. We could only match on the output of `PrintIdeal` or `PrintOptoAssembly`. `PrintIdeal` is after the macro node expansion and thus `SubTypeCheck` nodes cannot be found anymore. As an alternative, a matching on `PrintOptoAssembly` was chosen by matching multiple lines.

Note that only `test101()` is a positive test for a sub type check (it requires that one is found) while `test95-100()` are negative tests that checks the absense of a sub type check.

#### Matching on Multiple Lines in Opto Assembly Is Fragile
As seen in the past, matching multiples lines on Opto Assembly is fragile when some unrelated instructions are inserted in between (for example spills). The regexes can become quite complicated and also slow to process.

#### `CHECKCAST_ARRAY` Stopped Working Correctly at some Point Due to Scheduling Bool and If Apart
At some point, code emission started to schedule the nodes for the bool/comparison earlier, then scheduled an unrelated If and only then the actual jump for the sub type check. Example:

![image](https://github.com/user-attachments/assets/bc9fb4b9-3493-48a1-8c0a-f3cb5a22808f)

The nodes for `74 compP_reg` are first emitted. Then we emit `101 testL_reg` together with `100 jmpCon_short` and only then `73 jmpConU`:
```
--- 74 compP_rReg nodes ---
0c4     B7: #	out( B9 B8 ) <- in( B32 B21 B19 B6 )  Freq: 0.87277
0c4     # checkcastPP of RBP
0c4     movl    R11, [RBP + #8 (8-bit)]	# compressed klass ptr
0c8     encode_heap_oop_not_null R8,RBX
10d     movl    [R13], R8	# compressed ptr
111     movq    R10, R13	# ptr -> long
114     movq    R8, RBX	# ptr -> long
117     xorq    R8, R10	# long
11a     shrq    R8, #22
11e     movq    RBX, precise [precise compiler/valhalla/inlinetypes/MyValue1: 0x00006ffd384d65a8 (compiler/valhalla/inlinetypes/MyInterface):Constant:exact * (java/lang/Cloneable,java/io/Serializable): :Constant:exact *	# ptr
128     decode_and_move_klass_not_null R9,R11
12b     movq    RBP, [R9 + #80 (8-bit)]	# class

--- 100 jmpCon_short nodes ---
12f     testq   R8, R8
132     je,s   B9  P=0.001000 C=-1.000000

--- True Path of 100 jmpCon_short  ---
134     B8: #	out( B22 B9 ) <- in( B7 )  Freq: 0.871897
134     shrq    R10, #9
138     movq    RDI, 0x00006ffd51000000	# ptr
142     addq    RDI, R10	# ptr
145     cmpb    [RDI], #2
148     jne     B22  P=0.001000 C=-1.000000

--- False Path of 100 jmpCon_short ---
14e     B9: #	out( B18 B10 ) <- in( B24 B25 B22 B8 B7 )  Freq: 0.87277

--- 73 jmpConU ---
14e     cmpq    RBP, RBX	# ptr
```

#### `test101()` still Working
Unfortunately, this only seemed to have affected the negative tests and not the positive `test101()`. I have not investigated further there why but it's not important for this bug fix.

#### Starting to Track `ArrayStoreExceptions` in Interpreter
With [JDK-8275908](https://bugs.openjdk.org/browse/JDK-8275908), we started to profile `ArrayStoreExceptions` in the interpreter already and propagate that information over the MDO to the C2 compiler:
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/interpreter/interpreterRuntime.cpp#L566-L567

#### Speculative Exactness Cast for Array Check Store
For array store checks, we speculatively assume that the super type in the sub type check is exact:
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/opto/parseHelper.cpp#L166-L169
This is done with an additional check with an uncommon trap:
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/opto/parseHelper.cpp#L218-L229

The check is attached to the same bci as the array store check itself.

#### Cannot Emit Speculative Exactness Cast for Array Check Store Due to Non-Zero Trap Count in `test97-100()`
With the additional profiling in the interpreter with JDK-8275908, we keep track of thrown `ArrayStoreExceptions`. In the very first iteration of `test97-100()`, we throw an `ArrayStoreException`. As a result, we are no longer able to emit the speculative exactness cast for the array store check at the same bci because we require that no traps are taken at that bci at runtime (JDK-8275908 now profiles that we took `ArrayStoreException` at that bci):
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/opto/parseHelper.cpp#L196
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/opto/compile.cpp#L4617
As a consequence, we cannot propagate that `array` with type `Object[]` is exact and thus the sub type checks cannot be removed because C2 must assume that `Object[]` could be anything and is always potentially a super type of any array.

#### Test Failures Not Noticed with Broken `CHECKCAST_ARRAY` but only after the Late Barrier Expansion for G1 JEP
We should actually have found that `test97-100()` no longer work  after JDK-8275908 but as described above, `CHECKCAST_ARRAY` was broken. We only started to notice it when merging in the Late Barrier Expansion for G1 JEP which must have changed the scheduling decisions.

### Proposed Fix
To simulate the pre-JDK-8275908 behavior, we can simply not call `test97-100()` with an array that would trigger an `ArrayStoreException` during warm-up. This ensures that no trap is ever recorded to have been taken before C2 compilation. We additionally require that the IR rules are only evaluated if `MonomorphicArrayCheck` is set which is a requirement to perform the speculative exactness check and propagate that type information:
https://github.com/openjdk/valhalla/blob/115d3dea17c1c8cc2f06f0b83ca9617a56099744/src/hotspot/share/opto/parseHelper.cpp#L171

#### Additional Tweaks
To get this working, I've also changed the following:
- Using `IRNode.SUBTYPE_CHECK` instead of `CHECKCAST_ARRAY` is easier and less fragile which does the matching on `CompilePhase.BEFORE_MACRO_EXPANSION`. 
  - Allowed us to remove `CHECKCAST_ARRAY`. 
- Noticed that `IRNode.SUBTYPE_CHECK` had the wrong default `CompilePhase` set (`CompilePhase.PRINT_IDEAL`). I've changed that by introducing a new `IRNode.macroNodes()` method which sets it to `CompilePhase.BEFORE_MACRO_EXPANSION` (this means if you omit `phase = ...` it will fall back to `CompilePhase.BEFORE_MACRO_EXPANSION` when using `IRNode.SUBTYPE_CHECK`).
  - This could also be upstreamed to mainline. 
  - As a result, I've noticed that `InlineTypeIRNode` is not initialized when we trying to fetch the default compile phases in the flag VM. Added `InlineTypeIRNode.forceStaticInitialization()` to `IRNode` and removed the other call. This should now ensure that we always have properly initialized the Valhalla specific IR nodes.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343423](https://bugs.openjdk.org/browse/JDK-8343423): [lworld] compiler/valhalla/inlinetypes/TestArrays.java IR mismatches after after merging JDK-8334060 in jdk-24+18 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer) ⚠️ Review applies to [c0fbd0c2](https://git.openjdk.org/valhalla/pull/1296/files/c0fbd0c2577f534a2cd7a56e0f609a57c7971e46)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1296/head:pull/1296` \
`$ git checkout pull/1296`

Update a local copy of the PR: \
`$ git checkout pull/1296` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1296`

View PR using the GUI difftool: \
`$ git pr show -t 1296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1296.diff">https://git.openjdk.org/valhalla/pull/1296.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1296#issuecomment-2461540838)
</details>
