### PR TITLE
8342575: [lworld] Compiler should reject volatile fields in value classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -460,7 +460,7 @@ public class Flags {
         ExtendedClassFlags                = (long)ClassFlags | SEALED | NON_SEALED | VALUE_CLASS,
         ExtendedLocalClassFlags           = (long) LocalClassFlags | VALUE_CLASS,
         ExtendedStaticLocalClassFlags     = (long) StaticLocalClassFlags | VALUE_CLASS,
-        ExtendedVarFlags                  = (long) VarFlags | STRICT,
+        ValueFieldFlags                   = (long) VarFlags | STRICT | FINAL,
         ModifierFlags                     = ((long)StandardFlags & ~INTERFACE) | DEFAULT | SEALED | NON_SEALED | VALUE_CLASS,
         InterfaceMethodMask               = ABSTRACT | PRIVATE | STATIC | PUBLIC | STRICTFP | DEFAULT,
         AnnotationTypeElementMask         = ABSTRACT | PUBLIC,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1262,7 +1262,7 @@ public class Check {
                 mask = implicit = InterfaceVarFlags;
             else {
                 boolean isInstanceFieldOfValueClass = sym.owner.type.isValueClass() && (flags & STATIC) == 0;
-                mask = !isInstanceFieldOfValueClass ? VarFlags : ExtendedVarFlags;
+                mask = !isInstanceFieldOfValueClass ? VarFlags : ValueFieldFlags;
                 if (isInstanceFieldOfValueClass) {
                     implicit |= FINAL | STRICT;
                 }
@@ -1371,8 +1371,7 @@ public class Check {
                 log.error(pos,
                         Errors.ModNotAllowedHere(asFlagSet(illegal)));
             }
-        }
-        else if ((sym.kind == TYP ||
+        } else if ((sym.kind == TYP ||
                   // ISSUE: Disallowing abstract&private is no longer appropriate
                   // in the presence of inner classes. Should it be deleted here?
                   checkDisjoint(pos, flags,
@@ -1395,7 +1394,8 @@ public class Check {
                                PRIVATE,
                                PUBLIC | PROTECTED)
                  &&
-                 checkDisjoint(pos, flags,
+                 // we are using `implicit` here as instance fields of value classes are implicitly final
+                 checkDisjoint(pos, flags | implicit,
                                FINAL,
                                VOLATILE)
                  &&

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -510,6 +510,14 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     }
                     """,
                     new String[] {"--source", Integer.toString(Runtime.version().feature())}
+            ),
+            new TestData(
+                    "compiler.err.illegal.combination.of.modifiers", // --enable-preview -source"
+                    """
+                    value class V {
+                        volatile int f = 1;
+                    }
+                    """
             )
     );
 


### PR DESCRIPTION
programs like:

```
value class V {
    volatile int f = 1;
}
```

should be rejected by javac as instance fields of value classes are implicitly final and according to the `JLS 23`, `8.3.1.4 volatile Fields`:
```
It is a compile-time error if a final variable is also declared volatile
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8342575](https://bugs.openjdk.org/browse/JDK-8342575): [lworld] Compiler should reject volatile fields in value classes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1297/head:pull/1297` \
`$ git checkout pull/1297`

Update a local copy of the PR: \
`$ git checkout pull/1297` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1297`

View PR using the GUI difftool: \
`$ git pr show -t 1297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1297.diff">https://git.openjdk.org/valhalla/pull/1297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1297#issuecomment-2463242620)
</details>
