### PR TITLE
Reduce excessive testing in SerializedObjectCombo test.

### DIFF
--- a/test/jdk/java/io/Serializable/valueObjects/SerializedObjectCombo.java
+++ b/test/jdk/java/io/Serializable/valueObjects/SerializedObjectCombo.java
@@ -79,7 +79,7 @@ import jdk.test.lib.hexdump.ObjectStreamPrinter;
  *          jdk.compiler/com.sun.tools.javac.tree
  *          jdk.compiler/com.sun.tools.javac.util
  * @build combo.ComboTestHelper SerializedObjectCombo
- * @run main/othervm --enable-preview  SerializedObjectCombo --everything --no-pre-filter
+ * @run main/othervm --enable-preview  SerializedObjectCombo
  */
 
 


### PR DESCRIPTION
Drop the option to exhaustively test all combinations to reduce timeouts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1299/head:pull/1299` \
`$ git checkout pull/1299`

Update a local copy of the PR: \
`$ git checkout pull/1299` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1299`

View PR using the GUI difftool: \
`$ git pr show -t 1299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1299.diff">https://git.openjdk.org/valhalla/pull/1299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1299#issuecomment-2465198496)
</details>
