### PR TITLE
8344454: [lworld] Nullable flat fields fixes

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -380,7 +380,7 @@ LayoutRawBlock* FieldLayout::insert_field_block(LayoutRawBlock* slot, LayoutRawB
     LayoutRawBlock* adj = new LayoutRawBlock(LayoutRawBlock::EMPTY, adjustment);
     insert(slot, adj);
   }
-  assert(block->size() >= block->size(), "Enough space must remain afte adjustment");
+  assert(block->size() >= block->size(), "Enough space must remain after adjustment");
   insert(slot, block);
   if (slot->size() == 0) {
     remove(slot);
@@ -557,6 +557,12 @@ void FieldLayout::shift_fields(int shift) {
     b->set_offset(b->offset() + shift);
     if (b->block_kind() == LayoutRawBlock::REGULAR || b->block_kind() == LayoutRawBlock::FLAT) {
       _field_info->adr_at(b->field_index())->set_offset(b->offset());
+      if (b->layout_kind() == LayoutKind::NULLABLE_ATOMIC_FLAT) {
+        int new_nm_offset = _field_info->adr_at(b->field_index())->null_marker_offset() + shift;
+        _field_info->adr_at(b->field_index())->set_null_marker_offset(new_nm_offset);
+        _inline_layout_info_array->adr_at(b->field_index())->set_null_marker_offset(new_nm_offset);
+
+      }
     }
     assert(b->block_kind() == LayoutRawBlock::EMPTY || b->offset() % b->alignment() == 0, "Must still be correctly aligned");
     b = b->next_block();

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -31,7 +31,7 @@
 
 #define JVM_BYTECODES_DO(def)                                                                                                     \
   def(_fast_agetfield            , "fast_agetfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _getfield          ) \
-  def(_fast_vgetfield            , "fast_qgetfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _getfield          ) \
+  def(_fast_vgetfield            , "fast_vgetfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _getfield          ) \
   def(_fast_bgetfield            , "fast_bgetfield"            , "bJJ"  , nullptr    , T_INT    ,  0, true , _getfield          ) \
   def(_fast_cgetfield            , "fast_cgetfield"            , "bJJ"  , nullptr    , T_CHAR   ,  0, true , _getfield          ) \
   def(_fast_dgetfield            , "fast_dgetfield"            , "bJJ"  , nullptr    , T_DOUBLE ,  0, true , _getfield          ) \
@@ -41,7 +41,7 @@
   def(_fast_sgetfield            , "fast_sgetfield"            , "bJJ"  , nullptr    , T_SHORT  ,  0, true , _getfield          ) \
                                                                                                                                   \
   def(_fast_aputfield            , "fast_aputfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _putfield          ) \
-  def(_fast_vputfield            , "fast_qputfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _putfield          ) \
+  def(_fast_vputfield            , "fast_vputfield"            , "bJJ"  , nullptr    , T_OBJECT ,  0, true , _putfield          ) \
   def(_fast_bputfield            , "fast_bputfield"            , "bJJ"  , nullptr    , T_INT    ,  0, true , _putfield          ) \
   def(_fast_zputfield            , "fast_zputfield"            , "bJJ"  , nullptr    , T_INT    ,  0, true , _putfield          ) \
   def(_fast_cputfield            , "fast_cputfield"            , "bJJ"  , nullptr    , T_CHAR   ,  0, true , _putfield          ) \

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -179,7 +179,7 @@ oop InlineKlass::read_flat_field(oop obj, int offset, LayoutKind lk, TRAPS) {
     InstanceKlass* recv = InstanceKlass::cast(obj->klass());
     int nm_offset = offset + (null_marker_offset() - first_field_offset());
     jbyte nm = obj->byte_field(nm_offset);
-    if (nm_offset == 0) {
+    if (nm == 0) {
       return nullptr;
     }
   }


### PR DESCRIPTION
Various fixes in nullable flat fields:
   - null marker test in the interpreter runtime is incorrect
   - during field layout computation, if the payload is shifted to satisfy alignment requirement, null marker offsets are not updated accordingly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8344454](https://bugs.openjdk.org/browse/JDK-8344454): [lworld] Nullable flat fields fixes (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1302/head:pull/1302` \
`$ git checkout pull/1302`

Update a local copy of the PR: \
`$ git checkout pull/1302` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1302`

View PR using the GUI difftool: \
`$ git pr show -t 1302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1302.diff">https://git.openjdk.org/valhalla/pull/1302.diff</a>

</details>
