### PR TITLE
8344590: [lworld] non-abstract value classes can not be sealed or non-sealed

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1330,6 +1330,10 @@ public class Check {
             } else {
                 mask = ExtendedClassFlags;
             }
+            if ((flags & (VALUE_CLASS | SEALED | ABSTRACT)) == (VALUE_CLASS | SEALED) ||
+                (flags & (VALUE_CLASS | NON_SEALED | ABSTRACT)) == (VALUE_CLASS | NON_SEALED)) {
+                log.error(pos, Errors.NonAbstractValueClassCantBeSealedOrNonSealed);
+            }
             // Interfaces are always ABSTRACT
             if ((flags & INTERFACE) != 0) implicit |= ABSTRACT;
 
@@ -1415,9 +1419,6 @@ public class Check {
                 && checkDisjoint(pos, flags,
                                 VALUE_CLASS,
                                 ANNOTATION)
-                && checkDisjoint(pos, flags,
-                                VALUE_CLASS,
-                                NON_SEALED)
                 && checkDisjoint(pos, flags,
                                 VALUE_CLASS,
                                 INTERFACE) ) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -4135,6 +4135,9 @@ compiler.err.super.class.method.cannot.be.synchronized=\
 compiler.err.cant.ref.after.ctor.called=\
     cannot assign to {0} after supertype constructor has been called
 
+compiler.err.non.abstract.value.class.cant.be.sealed.or.non.sealed=\
+    ''sealed'' or ''non-sealed'' modifiers are only applicable to abstract value classes
+
 # 0: symbol
 compiler.err.deconstruction.pattern.only.records=\
     deconstruction patterns can only be applied to records, {0} is not a record

--- a/test/langtools/tools/javac/diags/examples/NonAbstractValueClassCantBeSealed.java
+++ b/test/langtools/tools/javac/diags/examples/NonAbstractValueClassCantBeSealed.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.non.abstract.value.class.cant.be.sealed.or.non.sealed
+// key: compiler.note.preview.filename
+// key: compiler.note.preview.recompile
+// options: --enable-preview -source ${jdk.version}
+
+sealed value class NonAbstractValueClassCantBeSealed {}
+

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -560,7 +560,7 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     false // local sealed classes are not allowed
             ),
             new TestData(
-                    "compiler.err.illegal.combination.of.modifiers",
+                    "compiler.err.non.abstract.value.class.cant.be.sealed.or.non.sealed",
                     """
                     abstract sealed value class SC {}
                     non-sealed value class VC extends SC {}
@@ -568,10 +568,37 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     false
             ),
             new TestData(
-                    "compiler.err.illegal.combination.of.modifiers",
+                    "compiler.err.non.abstract.value.class.cant.be.sealed.or.non.sealed",
                     """
                     sealed value class SI {}
-                    non-sealed value class VC extends SI {}
+                    """,
+                    false
+            ),
+            new TestData(
+                    """
+                    sealed abstract value class SI {}
+                    value class V extends SI {}
+                    """,
+                    false
+            ),
+            new TestData(
+                    """
+                    sealed abstract value class SI permits V {}
+                    value class V extends SI {}
+                    """,
+                    false
+            ),
+            new TestData(
+                    """
+                    sealed interface I {}
+                    non-sealed abstract value class V implements I {}
+                    """,
+                    false
+            ),
+            new TestData(
+                    """
+                    sealed interface I permits V {}
+                    non-sealed abstract value class V implements I {}
                     """,
                     false
             )


### PR DESCRIPTION
Non abstract value classes can't be sealed or non-sealed