### PR TITLE
8344764: [lworld] add more binary compatibility tests after refinements to JEP 401

### DIFF
--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectsBinaryCompatibilityTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectsBinaryCompatibilityTests.java
@@ -273,5 +273,30 @@ public class ValueObjectsBinaryCompatibilityTests extends TestRunner {
                 true,
                 IncompatibleClassChangeError.class
         );
+        /* Removing the value modifier from a non-abstract value class does not break compatibility with
+         * pre-existing binaries.
+         */
+        testCompatibilityAfterChange(
+                base,
+                """
+                package pkg;
+                public value class A {}
+                """,
+                """
+                package pkg;
+                public class A {}
+                """,
+                """
+                package pkg;
+                public class Client {
+                    public static void main(String... args) {
+                        A a = new A();
+                        System.out.println("Hello World!");
+                    }
+                }
+                """,
+                false,
+                null
+        );
     }
 }


### PR DESCRIPTION
adding a regression test to reflect latest changes to `Chapter 13: Binary Compatibility`, see:

https://cr.openjdk.org/~dlsmith/jep401/jep401-20241108/specs/value-objects-jls.html#jls-13.4.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8344764](https://bugs.openjdk.org/browse/JDK-8344764): [lworld] add more binary compatibility tests after refinements to JEP 401 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1307/head:pull/1307` \
`$ git checkout pull/1307`

Update a local copy of the PR: \
`$ git checkout pull/1307` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1307`

View PR using the GUI difftool: \
`$ git pr show -t 1307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1307.diff">https://git.openjdk.org/valhalla/pull/1307.diff</a>

</details>
