### PR TITLE
8345070: [lworld] Correct ProblemList.txt for SinceChecker

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -839,4 +839,4 @@ java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java 8344541 generic-all
+tools/sincechecker/modules/java_base/CheckSince_javaBase.java 8344541 generic-all


### PR DESCRIPTION
Correct entry for SinceChecker to remove "jdk/" prefix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8345070](https://bugs.openjdk.org/browse/JDK-8345070): [lworld] Correct ProblemList.txt for SinceChecker (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1309/head:pull/1309` \
`$ git checkout pull/1309`

Update a local copy of the PR: \
`$ git checkout pull/1309` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1309`

View PR using the GUI difftool: \
`$ git pr show -t 1309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1309.diff">https://git.openjdk.org/valhalla/pull/1309.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1309#issuecomment-2501750421)
</details>
