### PR TITLE
8342036: [lworld] tools/javap/UndefinedAccessFlagTest.java fails after merge of jdk-24+4

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -450,7 +450,7 @@ public class ClassWriter extends BasicWriter {
 
         if (options.verbose)
             writeList(String.format("flags: (0x%04x) ", flags.flagsMask()),
-                    flagsReportUnknown(flags).stream().map(fl -> "ACC_" + fl.toString()).toList(),
+                    flagsReportUnknown(flags).stream().map(fl -> "ACC_" + fl.name()).toList(),
                     "\n");
 
         if (options.showAllAttrs) {
@@ -810,16 +810,16 @@ public class ClassWriter extends BasicWriter {
         return getModifiers(set);
     }
 
-    private static Set<String> getClassModifiers(AccessFlags flags, int majorVersion, int minorVersion) {
+    private Set<String> getClassModifiers(AccessFlags flags, int majorVersion, int minorVersion) {
         boolean previewClassFile = minorVersion == ClassFile.PREVIEW_MINOR_VERSION;
-        Set<AccessFlag> flagSet = flags.flags();
+        Set<AccessFlag> flagSet = flagsReportUnknown(flags);
         if (flagSet.contains(AccessFlag.INTERFACE)) {
             flagSet = EnumSet.copyOf(flagSet);
             flagSet.remove(AccessFlag.ABSTRACT);
         } else if (Source.isSupported(Source.Feature.VALUE_CLASSES, majorVersion) && previewClassFile) {
-          Set<String> classModifers = getModifiers(flagSet);
-          classModifers.add("value");
-          return classModifers;
+            Set<String> classModifers = getModifiers(flagSet);
+            classModifers.add("value");
+            return classModifers;
         }
         return getModifiers(flagSet);
     }

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -67,7 +67,6 @@ tools/javac/modules/SourceInSymlinkTest.java                                    
 # javap
 
 tools/javap/output/RepeatingTypeAnnotations.java                                8057687    generic-all    emit correct byte code an attributes for type annotations
-tools/javap/UndefinedAccessFlagTest.java                                        8342036    generic-all
 ###########################################################################
 #
 # jdeps

--- a/test/langtools/tools/javap/UndefinedAccessFlagTest.java
+++ b/test/langtools/tools/javap/UndefinedAccessFlagTest.java
@@ -92,7 +92,7 @@ public class UndefinedAccessFlagTest {
                     });
                 case InnerClassesAttribute attr when location == TestLocation.INNER_CLASS -> cb
                     .with(InnerClassesAttribute.of(attr.classes().stream()
-                        .map(ic -> InnerClassInfo.of(ic.innerClass(), ic.outerClass(), ic.innerName(), ic.flagsMask() | 0x0020))
+                        .map(ic -> InnerClassInfo.of(ic.innerClass(), ic.outerClass(), ic.innerName(), ic.flagsMask() | 0x0050))
                         .toList()));
                 default -> cb.with(ce);
             }


### PR DESCRIPTION
fixing `com.sun.tools.javap.ClassWriter::getClassModifiers` to use method `flagsReportUnknown` which capture exceptions thrown by `AccessFlag.maskToAccessFlags`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8342036](https://bugs.openjdk.org/browse/JDK-8342036): [lworld] tools/javap/UndefinedAccessFlagTest.java fails after merge of jdk-24+4 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1310/head:pull/1310` \
`$ git checkout pull/1310`

Update a local copy of the PR: \
`$ git checkout pull/1310` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1310`

View PR using the GUI difftool: \
`$ git pr show -t 1310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1310.diff">https://git.openjdk.org/valhalla/pull/1310.diff</a>

</details>
