### PR TITLE
8344541: [lworld] jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java finds "@since" version errors

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessFlag.java
@@ -574,6 +574,8 @@ public enum AccessFlag {
      * @param cffv the class file format version
      * @throws IllegalArgumentException if the mask contains bit
      * positions not supported for the location in question
+     *
+     * @since Valhalla
      */
     public static Set<AccessFlag> maskToAccessFlags(int mask, Location location,
                                                     ClassFileFormatVersion cffv) {

--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -185,6 +185,7 @@ public final class Objects {
     *
     * @param obj an object
     * @throws NullPointerException if {@code obj} is {@code null}
+    * @since Valhalla
     */
    @PreviewFeature(feature = PreviewFeature.Feature.VALUE_OBJECTS)
 //    @IntrinsicCandidate

--- a/src/java.base/share/classes/java/util/WeakHashMap.java
+++ b/src/java.base/share/classes/java/util/WeakHashMap.java
@@ -250,6 +250,7 @@ public class WeakHashMap<K,V>
      * @throws IllegalArgumentException if the initial capacity is negative,
      *         or if the load factor is nonpositive.
      * @throws NullPointerException if {@code valuePolicy} is null
+     * @since Valhalla
      */
     public WeakHashMap(int initialCapacity, float loadFactor, ValuePolicy valuePolicy) {
         if (initialCapacity < 0)
@@ -301,6 +302,8 @@ public class WeakHashMap<K,V>
      *
      * @param  valuePolicy     The {@link ValuePolicy} for keys that are value objects; non-null
      * @throws NullPointerException if {@code valuePolicy} is null
+     *
+     * @since Valhalla
      */
     public WeakHashMap(ValuePolicy valuePolicy) {
         this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR, valuePolicy);
@@ -328,6 +331,8 @@ public class WeakHashMap<K,V>
 
     /**
      * {@return the {@link ValuePolicy} for this WeakHashMap.}
+     *
+     * @since Valhalla
      */
     public ValuePolicy valuePolicy() {
         return valuePolicy;

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -839,4 +839,3 @@ java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java 8344541 generic-all

--- a/test/jdk/tools/sincechecker/SinceChecker.java
+++ b/test/jdk/tools/sincechecker/SinceChecker.java
@@ -101,8 +101,12 @@ note: The `<unique-Element-ID>` for methods looks like
 it is somewhat inspired from the VM Method Descriptors. But we use the erased return so that methods
 that were later generified remain the same.
 
+To help projects still in development, unsure of actual `@since` tag value, one may want to use token name instead of continuely
+updating the current version since tags. For example, `@since LongRunningProjectName`. The option `--ignoreSince` maybe used to
+ignore these tags (`-ignoreSince LongRunningProjectName`). Maybe be specified multiple times.
+
 usage: the checker is run from a module specific test
-        `@run main SinceChecker <moduleName> [--exclude package1,package2 | --exclude package1 package2]`
+        `@run main SinceChecker <moduleName> [--ignoreSince <string>] [--exclude package1,package2 | --exclude package1 package2]`
 */
 
 public class SinceChecker {
@@ -110,6 +114,11 @@ public class SinceChecker {
     private final Map<String, IntroducedIn> classDictionary = new HashMap<>();
     private final JavaCompiler tool;
     private int errorCount = 0;
+
+    // Ignored since tags
+    private static final Set<String> IGNORE_SINCE = new HashSet<>();
+    // Simply replace ignored since tags with the latest version
+    private static final Version     IGNORE_VERSION = Version.parse(Integer.toString(Runtime.version().major()));
 
     // packages to skip during the test
     private static final Set<String> EXCLUDE_LIST = new HashSet<>();
@@ -127,7 +136,11 @@ public class SinceChecker {
         boolean excludeFlag = false;
 
         for (int i = 1; i < args.length; i++) {
-            if ("--exclude".equals(args[i])) {
+            if ("--ignoreSince".equals(args[i])) {
+                i++;
+                IGNORE_SINCE.add("@since " + args[i]);
+            }
+            else if ("--exclude".equals(args[i])) {
                 excludeFlag = true;
                 continue;
             }
@@ -452,6 +465,11 @@ public class SinceChecker {
     }
 
     private Version extractSinceVersionFromText(String documentation) {
+        for (String ignoreSince : IGNORE_SINCE) {
+            if (documentation.contains(ignoreSince)) {
+                return IGNORE_VERSION;
+            }
+        }
         Pattern pattern = Pattern.compile("@since\\s+(\\d+(?:\\.\\d+)?)");
         Matcher matcher = pattern.matcher(documentation);
         if (matcher.find()) {

--- a/test/jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java
+++ b/test/jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java
@@ -30,5 +30,5 @@
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.util
  *          jdk.compiler/com.sun.tools.javac.code
- * @run main SinceChecker java.base --exclude java.lang.classfile
+ * @run main SinceChecker java.base --ignoreSince Valhalla --exclude java.lang.classfile
  */


### PR DESCRIPTION
Added `--ignoreSince <string>` option to SinceChecker to allow the project keep using the token "Valhalla" as `since` version until integration time, at which point, a simple replace `@since Valhalla` with the appropriate version.

This also requires new API to use the since tag, since the checker still requires it (even if its just a token).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8344541](https://bugs.openjdk.org/browse/JDK-8344541): [lworld] jdk/tools/sincechecker/modules/java_base/CheckSince_javaBase.java finds "@<!---->since" version errors (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1312/head:pull/1312` \
`$ git checkout pull/1312`

Update a local copy of the PR: \
`$ git checkout pull/1312` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1312`

View PR using the GUI difftool: \
`$ git pr show -t 1312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1312.diff">https://git.openjdk.org/valhalla/pull/1312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1312#issuecomment-2503261782)
</details>
