### PR TITLE
8343554: [lworld] VM crashes when running runtime/valhalla/inlinetypes/InlineOops.java with ZGC in interpreted mode

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1949,10 +1949,6 @@ class CollectObjectOops : public BasicOopIterateClosure {
       _array = new GrowableArray<Handle>(128);
   }
 
-  void add_oop(Handle oh) {
-
-  }
-
   void add_oop(oop o) {
     Handle oh = Handle(Thread::current(), o);
     if (oh != nullptr && oh->is_inline_type()) {
@@ -1962,8 +1958,9 @@ class CollectObjectOops : public BasicOopIterateClosure {
     }
   }
 
-  void do_oop(oop* o) { add_oop(HeapAccess<>::oop_load(o)); }
-  void do_oop(narrowOop* v) { add_oop(HeapAccess<>::oop_load(v)); }
+  template <class T> inline void add_oop(T* p) { add_oop(HeapAccess<>::oop_load(p)); }
+  void do_oop(oop* o) { add_oop(o); }
+  void do_oop(narrowOop* v) { add_oop(v); }
 
   jobjectArray create_jni_result(JNIEnv* env, TRAPS) {
     objArrayHandle result_array =
@@ -1980,12 +1977,9 @@ class CollectFrameObjectOops : public BasicOopIterateClosure {
  public:
   CollectObjectOops _collect;
 
-  void add_oop(oop o) {
-    _collect.add_oop(o);
-  }
-
-  void do_oop(oop* o) { add_oop(*o); }
-  void do_oop(narrowOop* v) { add_oop(CompressedOops::decode(*v)); }
+  template <class T> inline void add_oop(T* p) { _collect.add_oop(RawAccess<>::oop_load(p)); }
+  void do_oop(oop* o) { add_oop(o); }
+  void do_oop(narrowOop* v) { add_oop(v); }
 
   jobjectArray create_jni_result(JNIEnv* env, TRAPS) {
     return _collect.create_jni_result(env, THREAD);


### PR DESCRIPTION
Don't use HeapAccess for frame roots

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343554](https://bugs.openjdk.org/browse/JDK-8343554): [lworld] VM crashes when running runtime/valhalla/inlinetypes/InlineOops.java with ZGC in interpreted mode (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1313/head:pull/1313` \
`$ git checkout pull/1313`

Update a local copy of the PR: \
`$ git checkout pull/1313` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1313`

View PR using the GUI difftool: \
`$ git pr show -t 1313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1313.diff">https://git.openjdk.org/valhalla/pull/1313.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1313#issuecomment-2518025833)
</details>
