### PR TITLE
8345250: [lworld] C2: Array loads and stores on inexact flat arrays cause crashes

### DIFF
--- a/src/hotspot/share/ci/ciArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciArrayKlass.cpp
@@ -105,23 +105,25 @@ bool ciArrayKlass::is_leaf_type() {
 ciArrayKlass* ciArrayKlass::make(ciType* element_type, bool null_free) {
   if (element_type->is_primitive_type()) {
     return ciTypeArrayKlass::make(element_type->basic_type());
-  } else {
-    ciKlass* klass = element_type->as_klass();
-    if (null_free && klass->is_loaded()) {
-      GUARDED_VM_ENTRY(
-        EXCEPTION_CONTEXT;
-        Klass* ak = InlineKlass::cast(klass->get_Klass())->value_array_klass(THREAD);
-        if (HAS_PENDING_EXCEPTION) {
-          CLEAR_PENDING_EXCEPTION;
-        } else if (ak->is_flatArray_klass()) {
-          return CURRENT_THREAD_ENV->get_flat_array_klass(ak);
-        } else if (ak->is_objArray_klass()) {
-          return CURRENT_THREAD_ENV->get_obj_array_klass(ak);
-        }
-      )
-    }
-    return ciObjArrayKlass::make(klass);
   }
+
+  ciKlass* klass = element_type->as_klass();
+  assert(!null_free || !klass->is_loaded() || klass->is_inlinetype() || klass->is_abstract() ||
+         klass->is_java_lang_Object(), "only value classes are null free");
+  if (null_free && klass->is_loaded() && klass->is_inlinetype()) {
+    GUARDED_VM_ENTRY(
+      EXCEPTION_CONTEXT;
+      Klass* ak = InlineKlass::cast(klass->get_Klass())->value_array_klass(THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        CLEAR_PENDING_EXCEPTION;
+      } else if (ak->is_flatArray_klass()) {
+        return CURRENT_THREAD_ENV->get_flat_array_klass(ak);
+      } else if (ak->is_objArray_klass()) {
+        return CURRENT_THREAD_ENV->get_obj_array_klass(ak);
+      }
+    )
+  }
+  return ciObjArrayKlass::make(klass);
 }
 
 int ciArrayKlass::array_header_in_bytes() {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -3504,7 +3504,7 @@ Node* GraphKit::gen_checkcast(Node *obj, Node* superklass, Node* *failure_contro
   const TypeKlassPtr* improved_klass_ptr_type = klass_ptr_type->try_improve();
   const TypeOopPtr* toop = improved_klass_ptr_type->cast_to_exactness(false)->as_instance_type();
   bool safe_for_replace = (failure_control == nullptr);
-  assert(!null_free || toop->is_inlinetypeptr(), "must be an inline type pointer");
+  assert(!null_free || toop->can_be_inline_type(), "must be an inline type pointer");
 
   // Fast cutout:  Check the case that the cast is vacuously true.
   // This detects the common cases where the test will short-circuit

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1835,7 +1835,18 @@ void GraphKit::access_clone(Node* src, Node* dst, Node* size, bool is_array) {
 Node* GraphKit::array_element_address(Node* ary, Node* idx, BasicType elembt,
                                       const TypeInt* sizetype, Node* ctrl) {
   const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
-  uint shift = arytype->is_flat() ? arytype->flat_log_elem_size() : exact_log2(type2aelembytes(elembt));
+  assert(!arytype->is_flat() || elembt == T_OBJECT, "element type of flat arrays are T_OBJECT");
+  uint shift;
+  if (arytype->is_flat() && arytype->klass_is_exact()) {
+    // We can only determine the flat array layout statically if the klass is exact. Otherwise, we could have different
+    // value classes at runtime with a potentially different layout. The caller needs to fall back to call
+    // load/store_unknown_inline_Type() at runtime. We could return a sentinel node for the non-exact case but that
+    // might mess with other GVN transformations in between. Thus, we just continue in the else branch normally, even
+    // though we don't need the address node in this case and throw it away again.
+    shift = arytype->flat_log_elem_size();
+  } else {
+    shift = exact_log2(type2aelembytes(elembt));
+  }
   uint header = arrayOopDesc::base_offset_in_bytes(elembt);
 
   // short-circuit a common case (saves lots of confusing waste motion)

--- a/src/hotspot/share/opto/parse.hpp
+++ b/src/hotspot/share/opto/parse.hpp
@@ -494,8 +494,10 @@ class Parse : public GraphKit {
   Node* array_store_check(Node*& adr, const Type*& elemtype);
   // Helper function to generate array load
   void array_load(BasicType etype);
+  Node* load_from_unknown_flat_array(Node* array, Node* array_index, const TypeOopPtr* element_ptr);
   // Helper function to generate array store
   void array_store(BasicType etype);
+  void store_to_unknown_flat_array(Node* array, Node* idx, Node* non_null_stored_value);
   // Helper function to compute array addressing
   Node* array_addressing(BasicType type, int vals, const Type*& elemtype);
   bool needs_range_check(const TypeInt* size_type, const Node* index) const;

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -76,57 +76,64 @@ void Parse::array_load(BasicType bt) {
   Node* adr = array_addressing(bt, 0, elemtype);
   if (stopped())  return;     // guaranteed null or range check
 
-  Node* idx = pop();
-  Node* ary = pop();
+  Node* array_index = pop();
+  Node* array = pop();
 
   // Handle inline type arrays
-  const TypeOopPtr* elemptr = elemtype->make_oopptr();
-  const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
-  if (ary_t->is_flat()) {
+  const TypeOopPtr* element_ptr = elemtype->make_oopptr();
+  const TypeAryPtr* array_type = _gvn.type(array)->is_aryptr();
+  if (array_type->is_flat()) {
     // Load from flat inline type array
-    Node* vt = InlineTypeNode::make_from_flat(this, elemtype->inline_klass(), ary, adr);
-    push(vt);
+    Node* inline_type;
+    if (element_ptr->klass_is_exact()) {
+      inline_type = InlineTypeNode::make_from_flat(this, elemtype->inline_klass(), array, adr);
+    } else {
+      // Element type of flat array is not exact. Therefore, we cannot determine the flat array layout statically.
+      // Emit a runtime call to load the element from the flat array.
+      inline_type = load_from_unknown_flat_array(array, array_index, element_ptr);
+      inline_type = record_profile_for_speculation_at_array_load(inline_type);
+    }
+    push(inline_type);
     return;
-  } else if (ary_t->is_null_free()) {
-    // Load from non-flat inline type array (elements can never be null)
-    bt = T_OBJECT;
-  } else if (!ary_t->is_not_flat()) {
+  }
+
+  if (!array_type->is_not_flat()) {
     // Cannot statically determine if array is a flat array, emit runtime check
-    assert(UseFlatArray && is_reference_type(bt) && elemptr->can_be_inline_type() && !ary_t->is_not_null_free() &&
-           (!elemptr->is_inlinetypeptr() || elemptr->inline_klass()->flat_in_array()), "array can't be flat");
+    assert(UseFlatArray && is_reference_type(bt) && element_ptr->can_be_inline_type() && !array_type->is_not_null_free() &&
+           (!element_ptr->is_inlinetypeptr() || element_ptr->inline_klass()->flat_in_array()), "array can't be flat");
     IdealKit ideal(this);
     IdealVariable res(ideal);
     ideal.declarations_done();
-    ideal.if_then(flat_array_test(ary, /* flat = */ false)); {
-      // non-flat array
+    ideal.if_then(flat_array_test(array, /* flat = */ false)); {
+      // Non-flat array
       assert(ideal.ctrl()->in(0)->as_If()->is_flat_array_check(&_gvn), "Should be found");
       sync_kit(ideal);
       const TypeAryPtr* adr_type = TypeAryPtr::get_array_body_type(bt);
       DecoratorSet decorator_set = IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD;
-      if (needs_range_check(ary_t->size(), idx)) {
+      if (needs_range_check(array_type->size(), array_index)) {
         // We've emitted a RangeCheck but now insert an additional check between the range check and the actual load.
         // We cannot pin the load to two separate nodes. Instead, we pin it conservatively here such that it cannot
         // possibly float above the range check at any point.
         decorator_set |= C2_UNKNOWN_CONTROL_LOAD;
       }
-      Node* ld = access_load_at(ary, adr, adr_type, elemptr, bt, decorator_set);
-      if (elemptr->is_inlinetypeptr()) {
-        assert(elemptr->maybe_null(), "null free array should be handled above");
-        ld = InlineTypeNode::make_from_oop(this, ld, elemptr->inline_klass(), false);
+      Node* ld = access_load_at(array, adr, adr_type, element_ptr, bt, decorator_set);
+      if (element_ptr->is_inlinetypeptr()) {
+        assert(element_ptr->maybe_null(), "null free array should be handled above");
+        ld = InlineTypeNode::make_from_oop(this, ld, element_ptr->inline_klass(), false);
       }
       ideal.sync_kit(this);
       ideal.set(res, ld);
     } ideal.else_(); {
-      // flat array
+      // Flat array
       sync_kit(ideal);
-      if (elemptr->is_inlinetypeptr()) {
-        // Element type is known, cast and load from flat representation
-        ciInlineKlass* vk = elemptr->inline_klass();
-        assert(vk->flat_in_array() && elemptr->maybe_null(), "never/always flat - should be optimized");
+      if (element_ptr->is_inlinetypeptr()) {
+        // Element type is known, cast and load from flat array layout.
+        ciInlineKlass* vk = element_ptr->inline_klass();
+        assert(vk->flat_in_array() && element_ptr->maybe_null(), "never/always flat - should be optimized");
         ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
         const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
-        Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, arytype));
-        Node* casted_adr = array_element_address(cast, idx, T_OBJECT, ary_t->size(), control());
+        Node* cast = _gvn.transform(new CheckCastPPNode(control(), array, arytype));
+        Node* casted_adr = array_element_address(cast, array_index, T_OBJECT, array_type->size(), control());
         // Re-execute flat array load if buffering triggers deoptimization
         PreserveReexecuteState preexecs(this);
         jvms()->set_should_reexecute(true);
@@ -135,37 +142,11 @@ void Parse::array_load(BasicType bt) {
         ideal.set(res, vt);
         ideal.sync_kit(this);
       } else {
-        // Element type is unknown, emit runtime call
-
-        // Below membars keep this access to an unknown flat array correctly
-        // ordered with other unknown and known flat array accesses.
-        insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
-
-        Node* call = nullptr;
-        {
-          // Re-execute flat array load if runtime call triggers deoptimization
-          PreserveReexecuteState preexecs(this);
-          jvms()->set_bci(_bci);
-          jvms()->set_should_reexecute(true);
-          inc_sp(2);
-          kill_dead_locals();
-          call = make_runtime_call(RC_NO_LEAF | RC_NO_IO,
-                                   OptoRuntime::load_unknown_inline_Type(),
-                                   OptoRuntime::load_unknown_inline_Java(),
-                                   nullptr, TypeRawPtr::BOTTOM,
-                                   ary, idx);
-        }
-        make_slow_call_ex(call, env()->Throwable_klass(), false);
-        Node* buffer = _gvn.transform(new ProjNode(call, TypeFunc::Parms));
-
-        insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
-
-        // Keep track of the information that the inline type is in flat arrays
-        const Type* unknown_value = elemptr->is_instptr()->cast_to_flat_in_array();
-        buffer = _gvn.transform(new CheckCastPPNode(control(), buffer, unknown_value));
-
+        // Element type is unknown, and thus we cannot statically determine the exact flat array layout. Emit a
+        // runtime call to correctly load the inline type element from the flat array.
+        Node* inline_type = load_from_unknown_flat_array(array, array_index, element_ptr);
         ideal.sync_kit(this);
-        ideal.set(res, buffer);
+        ideal.set(res, inline_type);
       }
     } ideal.end_if();
     sync_kit(ideal);
@@ -175,98 +156,143 @@ void Parse::array_load(BasicType bt) {
     return;
   }
 
+  if (array_type->is_null_free()) {
+    // Load from non-flat inline type array (elements can never be null)
+    bt = T_OBJECT;
+  }
+
   if (elemtype == TypeInt::BOOL) {
     bt = T_BOOLEAN;
   }
   const TypeAryPtr* adr_type = TypeAryPtr::get_array_body_type(bt);
-  Node* ld = access_load_at(ary, adr, adr_type, elemtype, bt,
+  Node* ld = access_load_at(array, adr, adr_type, elemtype, bt,
                             IN_HEAP | IS_ARRAY | C2_CONTROL_DEPENDENT_LOAD);
   ld = record_profile_for_speculation_at_array_load(ld);
   // Loading an inline type from a non-flat array
-  if (elemptr != nullptr && elemptr->is_inlinetypeptr()) {
-    assert(!ary_t->is_null_free() || !elemptr->maybe_null(), "inline type array elements should never be null");
-    ld = InlineTypeNode::make_from_oop(this, ld, elemptr->inline_klass(), !elemptr->maybe_null());
+  if (element_ptr != nullptr && element_ptr->is_inlinetypeptr()) {
+    assert(!array_type->is_null_free() || !element_ptr->maybe_null(), "inline type array elements should never be null");
+    ld = InlineTypeNode::make_from_oop(this, ld, element_ptr->inline_klass(), !element_ptr->maybe_null());
   }
   push_node(bt, ld);
 }
 
+Node* Parse::load_from_unknown_flat_array(Node* array, Node* array_index, const TypeOopPtr* element_ptr) {
+  // Below membars keep this access to an unknown flat array correctly
+  // ordered with other unknown and known flat array accesses.
+  insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
+
+  Node* call = nullptr;
+  {
+    // Re-execute flat array load if runtime call triggers deoptimization
+    PreserveReexecuteState preexecs(this);
+    jvms()->set_bci(_bci);
+    jvms()->set_should_reexecute(true);
+    inc_sp(2);
+    kill_dead_locals();
+    call = make_runtime_call(RC_NO_LEAF | RC_NO_IO,
+                             OptoRuntime::load_unknown_inline_Type(),
+                             OptoRuntime::load_unknown_inline_Java(),
+                             nullptr, TypeRawPtr::BOTTOM,
+                             array, array_index);
+  }
+  make_slow_call_ex(call, env()->Throwable_klass(), false);
+  Node* buffer = _gvn.transform(new ProjNode(call, TypeFunc::Parms));
+
+  insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
+
+  // Keep track of the information that the inline type is in flat arrays
+  const Type* unknown_value = element_ptr->is_instptr()->cast_to_flat_in_array();
+  return _gvn.transform(new CheckCastPPNode(control(), buffer, unknown_value));
+}
 
 //--------------------------------array_store----------------------------------
 void Parse::array_store(BasicType bt) {
   const Type* elemtype = Type::TOP;
   Node* adr = array_addressing(bt, type2size[bt], elemtype);
   if (stopped())  return;     // guaranteed null or range check
-  Node* cast_val = nullptr;
+  Node* stored_value_casted = nullptr;
   if (bt == T_OBJECT) {
-    cast_val = array_store_check(adr, elemtype);
-    if (stopped()) return;
+    stored_value_casted = array_store_check(adr, elemtype);
+    if (stopped()) {
+      return;
+    }
   }
-  Node* val = pop_node(bt); // Value to store
-  Node* idx = pop();        // Index in the array
-  Node* ary = pop();        // The array itself
+  Node* const stored_value = pop_node(bt); // Value to store
+  Node* const array_index = pop();         // Index in the array
+  Node* array = pop();                     // The array itself
 
-  const TypeAryPtr* ary_t = _gvn.type(ary)->is_aryptr();
+  const TypeAryPtr* array_type = _gvn.type(array)->is_aryptr();
   const TypeAryPtr* adr_type = TypeAryPtr::get_array_body_type(bt);
 
   if (elemtype == TypeInt::BOOL) {
     bt = T_BOOLEAN;
   } else if (bt == T_OBJECT) {
     elemtype = elemtype->make_oopptr();
-    const Type* tval = _gvn.type(cast_val);
+    const Type* stored_value_casted_type = _gvn.type(stored_value_casted);
     // Based on the value to be stored, try to determine if the array is not null-free and/or not flat.
     // This is only legal for non-null stores because the array_store_check always passes for null, even
-    // if the array is null-free. Null stores are handled in GraphKit::gen_inline_array_null_guard().
-    bool not_null_free = !tval->maybe_null() && !tval->is_oopptr()->can_be_inline_type();
-    bool not_flat = not_null_free || (tval->is_inlinetypeptr() && !tval->inline_klass()->flat_in_array());
-    if (!ary_t->is_not_null_free() && not_null_free) {
+    // if the array is null-free. Null stores are handled in GraphKit::inline_array_null_guard().
+    bool not_null_free = !stored_value_casted_type->maybe_null() &&
+                         !stored_value_casted_type->is_oopptr()->can_be_inline_type();
+    bool not_flat = not_null_free || (stored_value_casted_type->is_inlinetypeptr() &&
+                                      !stored_value_casted_type->inline_klass()->flat_in_array());
+    if (!array_type->is_not_null_free() && not_null_free) {
       // Storing a non-inline type, mark array as not null-free (-> not flat).
-      ary_t = ary_t->cast_to_not_null_free();
-      Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, ary_t));
-      replace_in_map(ary, cast);
-      ary = cast;
-    } else if (!ary_t->is_not_flat() && not_flat) {
+      array_type = array_type->cast_to_not_null_free();
+      Node* cast = _gvn.transform(new CheckCastPPNode(control(), array, array_type));
+      replace_in_map(array, cast);
+      array = cast;
+    } else if (!array_type->is_not_flat() && not_flat) {
       // Storing to a non-flat array, mark array as not flat.
-      ary_t = ary_t->cast_to_not_flat();
-      Node* cast = _gvn.transform(new CheckCastPPNode(control(), ary, ary_t));
-      replace_in_map(ary, cast);
-      ary = cast;
+      array_type = array_type->cast_to_not_flat();
+      Node* cast = _gvn.transform(new CheckCastPPNode(control(), array, array_type));
+      replace_in_map(array, cast);
+      array = cast;
     }
 
-    if (ary_t->is_flat()) {
+    if (array_type->is_flat()) {
       // Store to flat inline type array
-      assert(!tval->maybe_null(), "should be guaranteed by array store check");
-      // Re-execute flat array store if buffering triggers deoptimization
-      PreserveReexecuteState preexecs(this);
-      inc_sp(3);
-      jvms()->set_should_reexecute(true);
-      cast_val->as_InlineType()->store_flat(this, ary, adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+      assert(!stored_value_casted_type->maybe_null(), "should be guaranteed by array store check");
+      if (array_type->klass_is_exact()) {
+        // Store to exact flat inline type array where we know the flat array layout statically.
+        // Re-execute flat array store if buffering triggers deoptimization
+        PreserveReexecuteState preexecs(this);
+        inc_sp(3);
+        jvms()->set_should_reexecute(true);
+        stored_value_casted->as_InlineType()->store_flat(this, array, adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+      } else {
+        // Element type of flat array is not exact. Therefore, we cannot determine the flat array layout statically.
+        // Emit a runtime call to store the element to the flat array.
+        store_to_unknown_flat_array(array, array_index, stored_value_casted);
+      }
       return;
-    } else if (ary_t->is_null_free()) {
-      // Store to non-flat inline type array (elements can never be null)
-      assert(!tval->maybe_null(), "should be guaranteed by array store check");
+    }
+    if (array_type->is_null_free()) {
+      // Store to non-flat null-free inline type array (elements can never be null)
+      assert(!stored_value_casted_type->maybe_null(), "should be guaranteed by array store check");
       if (elemtype->inline_klass()->is_empty()) {
         // Ignore empty inline stores, array is already initialized.
         return;
       }
-    } else if (!ary_t->is_not_flat() && (tval != TypePtr::NULL_PTR || StressReflectiveCode)) {
+    } else if (!array_type->is_not_flat() && (stored_value_casted_type != TypePtr::NULL_PTR || StressReflectiveCode)) {
       // Array might be a flat array, emit runtime checks (for nullptr, a simple inline_array_null_guard is sufficient).
       assert(UseFlatArray && !not_flat && elemtype->is_oopptr()->can_be_inline_type() &&
-             !ary_t->klass_is_exact() && !ary_t->is_not_null_free(), "array can't be a flat array");
+             !array_type->klass_is_exact() && !array_type->is_not_null_free(), "array can't be a flat array");
       IdealKit ideal(this);
-      ideal.if_then(flat_array_test(ary, /* flat = */ false)); {
-        // non-flat array
+      ideal.if_then(flat_array_test(array, /* flat = */ false)); {
+        // Non-flat array
         assert(ideal.ctrl()->in(0)->as_If()->is_flat_array_check(&_gvn), "Should be found");
         sync_kit(ideal);
-        Node* cast_ary = inline_array_null_guard(ary, cast_val, 3);
+        Node* cast_array = inline_array_null_guard(array, stored_value_casted, 3);
         inc_sp(3);
-        access_store_at(cast_ary, adr, adr_type, cast_val, elemtype, bt, MO_UNORDERED | IN_HEAP | IS_ARRAY, false);
+        access_store_at(cast_array, adr, adr_type, stored_value_casted, elemtype, bt, MO_UNORDERED | IN_HEAP | IS_ARRAY, false);
         dec_sp(3);
         ideal.sync_kit(this);
       } ideal.else_(); {
         sync_kit(ideal);
         // flat array
         Node* null_ctl = top();
-        Node* val = null_check_oop(cast_val, &null_ctl);
+        Node* null_checked_stored_value_casted = null_check_oop(stored_value_casted, &null_ctl);
         if (null_ctl != top()) {
           PreserveJVMState pjvms(this);
           inc_sp(3);
@@ -275,60 +301,67 @@ void Parse::array_store(BasicType bt) {
           dec_sp(3);
         }
         // Try to determine the inline klass
-        ciInlineKlass* vk = nullptr;
-        if (tval->is_inlinetypeptr()) {
-          vk = tval->inline_klass();
+        ciInlineKlass* inline_Klass = nullptr;
+        if (stored_value_casted_type->is_inlinetypeptr()) {
+          inline_Klass = stored_value_casted_type->inline_klass();
         } else if (elemtype->is_inlinetypeptr()) {
-          vk = elemtype->inline_klass();
+          inline_Klass = elemtype->inline_klass();
         }
-        Node* casted_ary = ary;
-        if (vk != nullptr && !stopped()) {
-          // Element type is known, cast and store to flat representation
-          assert(vk->flat_in_array() && elemtype->maybe_null(), "never/always flat - should be optimized");
-          ciArrayKlass* array_klass = ciArrayKlass::make(vk, /* null_free */ true);
-          const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
-          casted_ary = _gvn.transform(new CheckCastPPNode(control(), casted_ary, arytype));
-          Node* casted_adr = array_element_address(casted_ary, idx, T_OBJECT, arytype->size(), control());
-          if (!val->is_InlineType()) {
-            assert(!gvn().type(val)->maybe_null(), "inline type array elements should never be null");
-            val = InlineTypeNode::make_from_oop(this, val, vk);
+        if (!stopped()) {
+          if (inline_Klass != nullptr) {
+            // Element type is known, cast and store to flat array layout.
+            assert(inline_Klass->flat_in_array() && elemtype->maybe_null(), "never/always flat - should be optimized");
+            ciArrayKlass* array_klass = ciArrayKlass::make(inline_Klass, /* null_free */ true);
+            const TypeAryPtr* arytype = TypeOopPtr::make_from_klass(array_klass)->isa_aryptr();
+            Node* casted_array = _gvn.transform(new CheckCastPPNode(control(), array, arytype));
+            Node* casted_adr = array_element_address(casted_array, array_index, T_OBJECT, arytype->size(), control());
+            if (!null_checked_stored_value_casted->is_InlineType()) {
+              assert(!gvn().type(null_checked_stored_value_casted)->maybe_null(),
+                     "inline type array elements should never be null");
+              null_checked_stored_value_casted = InlineTypeNode::make_from_oop(this, null_checked_stored_value_casted,
+                                                                               inline_Klass);
+            }
+            // Re-execute flat array store if buffering triggers deoptimization
+            PreserveReexecuteState preexecs(this);
+            inc_sp(3);
+            jvms()->set_should_reexecute(true);
+            null_checked_stored_value_casted->as_InlineType()->store_flat(this, casted_array, casted_adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+          } else {
+            // Element type is unknown, emit a runtime call since the flat array layout is not statically known.
+            store_to_unknown_flat_array(array, array_index, null_checked_stored_value_casted);
           }
-          // Re-execute flat array store if buffering triggers deoptimization
-          PreserveReexecuteState preexecs(this);
-          inc_sp(3);
-          jvms()->set_should_reexecute(true);
-          val->as_InlineType()->store_flat(this, casted_ary, casted_adr, nullptr, 0, MO_UNORDERED | IN_HEAP | IS_ARRAY);
-        } else if (!stopped()) {
-          // Element type is unknown, emit runtime call
-
-          // Below membars keep this access to an unknown flat array correctly
-          // ordered with other unknown and known flat array accesses.
-          insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
-
-          make_runtime_call(RC_LEAF,
-                            OptoRuntime::store_unknown_inline_Type(),
-                            CAST_FROM_FN_PTR(address, OptoRuntime::store_unknown_inline_C),
-                            "store_unknown_inline", TypeRawPtr::BOTTOM,
-                            val, casted_ary, idx);
-
-          insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
         }
         ideal.sync_kit(this);
       }
       ideal.end_if();
       sync_kit(ideal);
       return;
-    } else if (!ary_t->is_not_null_free()) {
+    } else if (!array_type->is_not_null_free()) {
       // Array is not flat but may be null free
       assert(elemtype->is_oopptr()->can_be_inline_type(), "array can't be null-free");
-      ary = inline_array_null_guard(ary, cast_val, 3, true);
+      array = inline_array_null_guard(array, stored_value_casted, 3, true);
     }
   }
   inc_sp(3);
-  access_store_at(ary, adr, adr_type, val, elemtype, bt, MO_UNORDERED | IN_HEAP | IS_ARRAY);
+  access_store_at(array, adr, adr_type, stored_value, elemtype, bt, MO_UNORDERED | IN_HEAP | IS_ARRAY);
   dec_sp(3);
 }
 
+// Emit a runtime call to store to a flat array whose element type is either unknown (i.e. we do not know the flat
+// array layout) or not exact (could have different flat array layouts at runtime).
+void Parse::store_to_unknown_flat_array(Node* array, Node* const idx, Node* non_null_stored_value) {
+  // Below membars keep this access to an unknown flat array correctly
+  // ordered with other unknown and known flat array accesses.
+  insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
+
+  make_runtime_call(RC_LEAF,
+                    OptoRuntime::store_unknown_inline_Type(),
+                    CAST_FROM_FN_PTR(address, OptoRuntime::store_unknown_inline_C),
+                    "store_unknown_inline", TypeRawPtr::BOTTOM,
+                    non_null_stored_value, array, idx);
+
+  insert_mem_bar_volatile(Op_MemBarCPUOrder, C->get_alias_index(TypeAryPtr::INLINES));
+}
 
 //------------------------------array_addressing-------------------------------
 // Pull array and index from the stack.  Compute pointer-to-element.

--- a/src/hotspot/share/opto/parseHelper.cpp
+++ b/src/hotspot/share/opto/parseHelper.cpp
@@ -264,14 +264,14 @@ Node* Parse::array_store_check(Node*& adr, const Type*& elemtype) {
   const TypeAryPtr* arytype = _gvn.type(ary)->is_aryptr();
   const TypePtr* elem_ptr = elemtype->make_ptr();
   bool null_free;
-  if (elemtype->make_ptr()->is_inlinetypeptr()) {
+  if (elem_ptr->is_inlinetypeptr()) {
     // We statically know that this is an inline type array, use precise klass ptr
-    null_free = arytype->is_flat() || !elemtype->make_ptr()->maybe_null();
+    null_free = arytype->is_flat() || !elem_ptr->maybe_null();
     a_e_klass = makecon(TypeKlassPtr::make(elemtype->inline_klass()));
   } else {
     // TODO: Should move to TypeAry::is_null_free() with JDK-8345681
     TypePtr::PTR ptr = elem_ptr->ptr();
-    null_free = ptr == TypePtr::NotNull || ptr == TypePtr::AnyNull;
+    null_free = ((ptr == TypePtr::NotNull) || (ptr == TypePtr::AnyNull));
 #ifdef ASSERT
     // If the element type is exact, the array can be null-free (i.e. the element type is NotNull) if:
     //   - The elements are inline types

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6658,7 +6658,9 @@ const TypeKlassPtr *TypeAryKlassPtr::cast_to_exactness(bool klass_is_exact) cons
   bool not_null_free = is_not_null_free();
   if (_elem->isa_klassptr()) {
     if (klass_is_exact || _elem->isa_aryklassptr()) {
-      assert(!is_null_free() && !is_flat(), "null-free (or flat) inline type arrays should always be exact");
+      assert((!is_null_free() && !is_flat()) ||
+             _elem->is_klassptr()->klass()->is_abstract() || _elem->is_klassptr()->klass()->is_java_lang_Object(),
+             "null-free (or flat) concrete inline type arrays should always be exact");
       // An array can't be null-free (or flat) if the klass is exact
       not_null_free = true;
       not_flat = true;

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4567,9 +4567,9 @@ public class TestLWorld {
     static void testFlatArrayInexactObjectStore(Object o, boolean flag) {
         Object[] oArr;
         if (flag) {
-            oArr = VALUE_CLASS_WITH_INT_ARRAY; // EMPTY_VALUE_1_ARRAY is statically known to be flat.
+            oArr = VALUE_CLASS_WITH_INT_ARRAY; // VALUE_CLASS_WITH_INT_ARRAY is statically known to be flat.
         } else {
-            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // EMPTY_VALUE_2_ARRAY is statically known to be flat.
+            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // VALUE_CLASS_WITH_DOUBLE_ARRAY is statically known to be flat.
         }
         // The type of 'oArr' is inexact here because we merge two arrays. Since both arrays are flat, 'oArr' is also flat:
         //     Type: flat:narrowoop: java/lang/Object:NotNull * (flat in array)[int:2]
@@ -4582,9 +4582,9 @@ public class TestLWorld {
     static Object testFlatArrayInexactObjectLoad(boolean flag) {
         Object[] oArr;
         if (flag) {
-            oArr = VALUE_CLASS_WITH_INT_ARRAY; // EMPTY_VALUE_1_ARRAY is statically known to be flat.
+            oArr = VALUE_CLASS_WITH_INT_ARRAY; // VALUE_CLASS_WITH_INT_ARRAY is statically known to be flat.
         } else {
-            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // EMPTY_VALUE_2_ARRAY is statically known to be flat.
+            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // VALUE_CLASS_WITH_DOUBLE_ARRAY is statically known to be flat.
         }
         // The type of 'oArr' is inexact here because we merge two arrays. Since both arrays are flat, 'oArr' is also flat:
         //     Type: flat:narrowoop: java/lang/Object:NotNull * (flat in array)[int:2]
@@ -4603,7 +4603,7 @@ public class TestLWorld {
             avArr = SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY;
         }
         // Same as testFlatArrayInexactObjectStore() but the inexact type is with an abstract value class:
-        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractEmptyValue:NotNull * (flat in array)[int:2]
+        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractValueClassWithByte:NotNull * (flat in array)[int:2]
         avArr[0] = abstractValueClassWithByte;
     }
 
@@ -4616,7 +4616,7 @@ public class TestLWorld {
             avArr = SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY;
         }
         // Same as testFlatArrayInexactObjectLoad() but the inexact type is with an abstract value class:
-        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractEmptyValue:NotNull * (flat in array)[int:2]
+        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractValueClassWithByte:NotNull * (flat in array)[int:2]
         return avArr[0];
     }
 

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java
@@ -4497,4 +4497,161 @@ public class TestLWorld {
     public void test167_verifier() {
         Asserts.assertEquals(((MyValue1)test167()).hash(), hash());
     }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class ValueClassWithInt {
+        int i;
+
+        ValueClassWithInt(int i) {
+            this.i = i;
+        }
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class ValueClassWithDouble {
+        double d;
+
+        ValueClassWithDouble(double d) {
+            this.d = d;
+        }
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static abstract value class AbstractValueClassWithByte {
+        byte b;
+
+        AbstractValueClassWithByte(byte b) {
+            this.b = b;
+        }
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class SubValueClassWithInt extends AbstractValueClassWithByte {
+        int i;
+
+        SubValueClassWithInt(int i) {
+            this.i = i;
+            super((byte)(i + 1));
+        }
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class SubValueClassWithDouble extends AbstractValueClassWithByte {
+        double d;
+
+        SubValueClassWithDouble(double d) {
+            this.d = d;
+            super((byte)(d + 1));
+        }
+    }
+
+    static final ValueClassWithInt[] VALUE_CLASS_WITH_INT_ARRAY = (ValueClassWithInt[]) ValueClass.newNullRestrictedArray(ValueClassWithInt.class, 2);
+    static final ValueClassWithDouble[] VALUE_CLASS_WITH_DOUBLE_ARRAY = (ValueClassWithDouble[]) ValueClass.newNullRestrictedArray(ValueClassWithDouble.class, 2);
+    static final SubValueClassWithInt[] SUB_VALUE_CLASS_WITH_INT_ARRAY = (SubValueClassWithInt[]) ValueClass.newNullRestrictedArray(SubValueClassWithInt.class, 2);
+    static final SubValueClassWithDouble[] SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY = (SubValueClassWithDouble[]) ValueClass.newNullRestrictedArray(SubValueClassWithDouble.class, 2);
+
+// TODO: Can only be enabled once JDK-8343835 is fixed. Otherwise, we hit the mismatched stores assert.
+//    static {
+//        VALUE_CLASS_WITH_INT_ARRAY[0] = new ValueClassWithInt(5);
+//        VALUE_CLASS_WITH_DOUBLE_ARRAY[0] = new ValueClassWithDouble(6);
+//        SUB_VALUE_CLASS_WITH_INT_ARRAY[0] = new SubValueClassWithInt(7);
+//        SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY[0] = new SubValueClassWithDouble(8);
+//    }
+
+    @Test
+    static void testFlatArrayInexactObjectStore(Object o, boolean flag) {
+        Object[] oArr;
+        if (flag) {
+            oArr = VALUE_CLASS_WITH_INT_ARRAY; // EMPTY_VALUE_1_ARRAY is statically known to be flat.
+        } else {
+            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // EMPTY_VALUE_2_ARRAY is statically known to be flat.
+        }
+        // The type of 'oArr' is inexact here because we merge two arrays. Since both arrays are flat, 'oArr' is also flat:
+        //     Type: flat:narrowoop: java/lang/Object:NotNull * (flat in array)[int:2]
+        // Since the type is inexact, we do not know the exact flat array layout statically and thus need to fall back
+        // to call "store_unknown_inline_Type()" at runtime where we know the flat array layout
+        oArr[0] = o;
+    }
+
+    @Test
+    static Object testFlatArrayInexactObjectLoad(boolean flag) {
+        Object[] oArr;
+        if (flag) {
+            oArr = VALUE_CLASS_WITH_INT_ARRAY; // EMPTY_VALUE_1_ARRAY is statically known to be flat.
+        } else {
+            oArr = VALUE_CLASS_WITH_DOUBLE_ARRAY; // EMPTY_VALUE_2_ARRAY is statically known to be flat.
+        }
+        // The type of 'oArr' is inexact here because we merge two arrays. Since both arrays are flat, 'oArr' is also flat:
+        //     Type: flat:narrowoop: java/lang/Object:NotNull * (flat in array)[int:2]
+        // Since the type is inexact, we do not know the exact flat array layout statically and thus need to fall back
+        // to call "load_unknown_inline_Type()" at runtime where we know the flat array layout
+        return oArr[0];
+    }
+
+    @Test
+    static void testFlatArrayInexactAbstractValueClassStore(AbstractValueClassWithByte abstractValueClassWithByte,
+                                                            boolean flag) {
+        AbstractValueClassWithByte[] avArr;
+        if (flag) {
+            avArr = SUB_VALUE_CLASS_WITH_INT_ARRAY;
+        } else {
+            avArr = SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY;
+        }
+        // Same as testFlatArrayInexactObjectStore() but the inexact type is with an abstract value class:
+        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractEmptyValue:NotNull * (flat in array)[int:2]
+        avArr[0] = abstractValueClassWithByte;
+    }
+
+    @Test
+    static AbstractValueClassWithByte testFlatArrayInexactAbstractValueClassLoad(boolean flag) {
+        AbstractValueClassWithByte[] avArr;
+        if (flag) {
+            avArr = SUB_VALUE_CLASS_WITH_INT_ARRAY;
+        } else {
+            avArr = SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY;
+        }
+        // Same as testFlatArrayInexactObjectLoad() but the inexact type is with an abstract value class:
+        //    flat:narrowoop: compiler/valhalla/inlinetypes/TestLWorld$AbstractEmptyValue:NotNull * (flat in array)[int:2]
+        return avArr[0];
+    }
+
+    @Run(test = {"testFlatArrayInexactObjectStore",
+                 "testFlatArrayInexactObjectLoad",
+                 "testFlatArrayInexactAbstractValueClassStore",
+                 "testFlatArrayInexactAbstractValueClassLoad"})
+    static void runFlatArrayInexactLoadAndStore() {
+        // TODO: Remove these again once JDK-8343835 is fixed and uncomment static initializer above
+        VALUE_CLASS_WITH_INT_ARRAY[0] = new ValueClassWithInt(5);
+        VALUE_CLASS_WITH_DOUBLE_ARRAY[0] = new ValueClassWithDouble(6);
+        SUB_VALUE_CLASS_WITH_INT_ARRAY[0] = new SubValueClassWithInt(7);
+        SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY[0] = new SubValueClassWithDouble(8);
+
+        boolean flag = true;
+        ValueClassWithInt valueClassWithInt = new ValueClassWithInt(15);
+        ValueClassWithDouble valueClassWithDouble = new ValueClassWithDouble(16);
+
+        testFlatArrayInexactObjectStore(valueClassWithInt, true);
+        Asserts.assertEQ(valueClassWithInt, VALUE_CLASS_WITH_INT_ARRAY[0]);
+        testFlatArrayInexactObjectStore(valueClassWithDouble, false);
+        Asserts.assertEQ(valueClassWithDouble, VALUE_CLASS_WITH_DOUBLE_ARRAY[0]);
+
+        Asserts.assertEQ(valueClassWithInt, testFlatArrayInexactObjectLoad(true));
+        Asserts.assertEQ(valueClassWithDouble, testFlatArrayInexactObjectLoad(false));
+
+        SubValueClassWithInt subValueClassWithInt = new SubValueClassWithInt(17);
+        SubValueClassWithDouble subValueClassWithDouble = new SubValueClassWithDouble(18);
+
+        testFlatArrayInexactAbstractValueClassStore(subValueClassWithInt, true);
+        Asserts.assertEQ(subValueClassWithInt, SUB_VALUE_CLASS_WITH_INT_ARRAY[0]);
+        testFlatArrayInexactAbstractValueClassStore(subValueClassWithDouble, false);
+        Asserts.assertEQ(subValueClassWithDouble, SUB_VALUE_CLASS_WITH_DOUBLE_ARRAY[0]);
+
+        Asserts.assertEQ(subValueClassWithInt, testFlatArrayInexactAbstractValueClassLoad(true));
+        Asserts.assertEQ(subValueClassWithDouble, testFlatArrayInexactAbstractValueClassLoad(false));
+    }
 }


### PR DESCRIPTION
This PR fixes crashes that occur when trying to load/store from/to a flat array from which we statically know it is flat but we do not know the exact layout because the klass is inexact.

### The Layout of a Flat Array is only Statically Known If the Klass is Exact
Currently, the code for getting the array element address in `GraphKit::array_element_address()` assumes that whenever we have an array from which we know that it is flat, then we also know the exact array layout (i.e. assume the value klass is exact):
https://github.com/openjdk/valhalla/blob/5e876d607aba68e921cb8fa6a1a012acd1735825/src/hotspot/share/opto/graphKit.cpp#L1835-L1838

This does not need to be true as shown in the following test case where we have a flat array with an inexact klass/type:
https://github.com/openjdk/valhalla/blob/95fc9c71bffcf5b92a4cdbfb34ad9e3149266f79/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestLWorld.java#L4568-L4578

### Emit Runtime Call to Load/Store from/to the Correct Array Element Address
What we actually would need for a flat array with an inexact klass is to emit a runtime call to load/store from/to the correct array element address. We cannot do better statically because we do not know the exact layout.

### Challenges
However, the problem is that in `GraphKit::array_element_address()` we somehow need to bail out back to `Parse::array_load/store()` such that we can emit the runtime call there. We could use a sentinel node because we do not actually need the element address node. But this could mess with some GVN transformations in between. What we do instead is to just fall to the `else` case in `GraphKit::array_element_address()` for non-flat arrays and still construct the element address node, even though it's not needed (will be folded away later):
https://github.com/openjdk/valhalla/blob/0858ce110da58ed7f1b634ae381e7c4eb0f37c3a/src/hotspot/share/opto/graphKit.cpp#L1840-L1849

### Additionally Required Fixes
1. `TypeAryKlassPtr::cast_to_exactness()` asserts that all null-free or flat arrays are exact which is not the case as shown above. Fix: Adjust assert.
2. `ciArrayKlass::make()` assumes that all null-free arrays are concrete value classes which does not need to be the case as shown above. Fix: Add check whether the klass is an inline type (which is only true for concrete inline type klasses).
3. `Parse::array_store_check()` needs to pass `null_free` to the `gen_checkcast()` in case we have a null-free flat array that is inexact (i.e. either `Object` or an abstract value class) and thus `is_inlinetypeptr()` is false. If we don't do that, we will hit this assert with `-XX:-UncommonNullCast` that ensures that flat arrays are null-free:
https://github.com/openjdk/valhalla/blob/265189e2b311daaa8cac3d387c3a70051b1e419a/src/hotspot/share/opto/parse2.cpp#L235-L237
The right/complete way to fix this would be to change `TypeAry::is_null_free()` to also handle non-exact inline types. However, this is invasive since we use this check in many places. Changing this method could have a bigger impact due to possibly having more places where we assume that only exact inline types are null-free. I filed [JDK-8345681](https://bugs.openjdk.org/browse/JDK-8345681) to revisit this. For this PR, I just implemented a point fix in `array_store_check()` for now.

### Applied some Additional Renamings and Simple Refactorings
While trying to better understand the `array_load/store()`, I've applied some renamings and simple refactorings. I'm planning to do some more refactorings to reduce the size of `array_load/store()`. But I will do that separately with [JDK-8345696](https://bugs.openjdk.org/browse/JDK-8345696).

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8345250](https://bugs.openjdk.org/browse/JDK-8345250): [lworld] C2: Array loads and stores on inexact flat arrays cause crashes (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1314/head:pull/1314` \
`$ git checkout pull/1314`

Update a local copy of the PR: \
`$ git checkout pull/1314` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1314`

View PR using the GUI difftool: \
`$ git pr show -t 1314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1314.diff">https://git.openjdk.org/valhalla/pull/1314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1314#issuecomment-2523795743)
</details>
