### PR TITLE
8331501: [lworld] Unsafe support for null marker

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -486,6 +486,8 @@ class InstanceKlass: public Klass {
   bool field_is_null_free_inline_type(int index) const;
   bool is_class_in_loadable_descriptors_attribute(Symbol* name) const;
 
+  int null_marker_offset(int index) const { return inline_layout_info(index).null_marker_offset(); }
+
   // Number of Java declared fields
   int java_fields_count() const;
   int total_fields_count() const;

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -362,18 +362,18 @@ UNSAFE_ENTRY(jboolean, Unsafe_IsFlatField(JNIEnv *env, jobject unsafe, jobject o
   return InstanceKlass::cast(k)->field_is_flat(slot);
 } UNSAFE_END
 
-UNSAFE_ENTRY(jboolean, Unsafe_HasNullMarker(JNIEnv *env, jobject unsage, jobject o)) {
+UNSAFE_ENTRY(jboolean, Unsafe_HasNullMarker(JNIEnv *env, jobject unsafe, jobject o)) {
   oop f = JNIHandles::resolve_non_null(o);
   Klass* k = java_lang_Class::as_Klass(java_lang_reflect_Field::clazz(f));
   int slot = java_lang_reflect_Field::slot(f);
   return InstanceKlass::cast(k)->field_has_null_marker(slot);
 } UNSAFE_END
 
-UNSAFE_ENTRY(jint, Unsafe_NullMarkerOffset(JNIEnv *env, jobject unsage, jobject o)) {
+UNSAFE_ENTRY(jint, Unsafe_NullMarkerOffset(JNIEnv *env, jobject unsafe, jobject o)) {
   oop f = JNIHandles::resolve_non_null(o);
   Klass* k = java_lang_Class::as_Klass(java_lang_reflect_Field::clazz(f));
   int slot = java_lang_reflect_Field::slot(f);
-  fatal("Not supported yet");
+  return InstanceKlass::cast(k)->null_marker_offset(slot);
 } UNSAFE_END
 
 UNSAFE_ENTRY(jboolean, Unsafe_IsFlatArray(JNIEnv *env, jobject unsafe, jclass c)) {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/UnsafeTest.java
@@ -34,7 +34,7 @@ package runtime.valhalla.inlinetypes;
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @compile Point.java UnsafeTest.java
- * @run main/othervm -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
+ * @run main/othervm -XX:+NullableFieldFlattening -XX:FlatArrayElementMaxSize=-1 -XX:InlineFieldMaxFlatSize=-1 runtime.valhalla.inlinetypes.UnsafeTest
  */
 
 import jdk.internal.misc.Unsafe;
@@ -166,6 +166,7 @@ public class UnsafeTest {
         }
     }
 
+    // Requires -XX:+NullableFieldFlattening
     static value class MyValue0 {
         int val;
 
@@ -201,7 +202,7 @@ public class UnsafeTest {
 
     public static void main(String[] args) throws Throwable {
         test0();
-        // test1();  // test1 is about nullable flat fields which are not fully supported yet
+        test1();
     }
 
 }


### PR DESCRIPTION
Shouldn't this be getNullMarkerOffset? This was mostly implemented.  Fixed the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8331501](https://bugs.openjdk.org/browse/JDK-8331501): [lworld] Unsafe support for null marker (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1317/head:pull/1317` \
`$ git checkout pull/1317`

Update a local copy of the PR: \
`$ git checkout pull/1317` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1317`

View PR using the GUI difftool: \
`$ git pr show -t 1317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1317.diff">https://git.openjdk.org/valhalla/pull/1317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1317#issuecomment-2539951595)
</details>
