### PR TITLE
8346303: [lworld] Layout builder should not reuse gap before inherited fields

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1063,19 +1063,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
         assert(new_alignment % _layout->super_min_align_required() == 0, "Must be");
         _payload_alignment = new_alignment;
       }
-      if (_layout->first_empty_block()->offset() < _layout->first_field_block()->offset()) {
-        LayoutRawBlock* first_empty = _layout->start()->next_block();
-        if (first_empty->offset() % _payload_alignment != 0) {
-          int size =  _payload_alignment - (first_empty->offset() % _payload_alignment);
-          LayoutRawBlock* padding = new LayoutRawBlock(LayoutRawBlock::PADDING, size);
-          _layout->insert(first_empty, padding);
-          _layout->set_start(padding);
-        } else {
-          _layout->set_start( _layout->start());
-        }
-      } else {
-        _layout->set_start(_layout->first_field_block());
-      }
+      _layout->set_start(_layout->first_field_block());
     }
   } else {
     if (_is_abstract_value && _has_nonstatic_fields) {


### PR DESCRIPTION
Small fix to prevent a layout decision that can negatively impact the support of atomic layouts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346303](https://bugs.openjdk.org/browse/JDK-8346303): [lworld] Layout builder should not reuse gap before inherited fields (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1319/head:pull/1319` \
`$ git checkout pull/1319`

Update a local copy of the PR: \
`$ git checkout pull/1319` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1319`

View PR using the GUI difftool: \
`$ git pr show -t 1319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1319.diff">https://git.openjdk.org/valhalla/pull/1319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1319#issuecomment-2546684417)
</details>
