### PR TITLE
8341844: [lworld] Test crashing in genzgc in ZBarrier::mark_from_old_slow_path(zaddress)+0x4c

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -479,24 +479,54 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
   ZIterator::oop_iterate(dst, &cl_sg);
 }
 
+static inline void copy_primitive_payload(const void* src, const void* dst, const size_t payload_size_bytes, size_t& copied_bytes) {
+  if (payload_size_bytes == 0) {
+    return;
+  }
+  void* src_payload = (void*)(address(src) + copied_bytes);
+  void* dst_payload = (void*)(address(dst) + copied_bytes);
+  Copy::copy_value_content(src_payload, dst_payload, payload_size_bytes);
+  copied_bytes += payload_size_bytes;
+}
+
 template <DecoratorSet decorators, typename BarrierSetT>
 inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::value_copy_in_heap(void* src, void* dst, InlineKlass* md, LayoutKind lk) {
   if (md->contains_oops()) {
-    // src/dst aren't oops, need offset to adjust oop map offset
-    const address src_oop_addr_offset = ((address) src) - md->first_field_offset();
+    // Iterate over each oop map, performing:
+    //   1) possibly raw copy for any primitive payload before each map
+    //   2) load and store barrier for each oop
+    //   3) possibly raw copy for any primitive payload trailer
+    assert(lk == NON_ATOMIC_FLAT || lk == PAYLOAD, "Cannot support layout other than NON_ATOMIC_FLAT"); // Note: PAYLOAD is incorrect, resolve when transistioned to new flattening
 
+    // src/dst may not be oops, need offset to adjust oop map offset
+    const address src_oop_addr_offset = ((address) src) - md->first_field_offset();
     OopMapBlock* map = md->start_of_nonstatic_oop_maps();
     const OopMapBlock* const end = map + md->nonstatic_oop_map_count();
+    size_t size_in_bytes = md->layout_size_in_bytes(lk);
+    size_t copied_bytes = 0;
     while (map != end) {
-      const address soop_address = src_oop_addr_offset + map->offset();
-      zpointer *p = (zpointer*) soop_address;
-      for (const zpointer* const end = p + map->count(); p < end; p++) {
-        ZBarrier::load_barrier_on_oop_field(p);
+      zpointer *src_p = (zpointer*)(src_oop_addr_offset + map->offset());
+      const uintptr_t oop_offset = uintptr_t(src_p) - uintptr_t(src);
+      zpointer *dst_p = (zpointer*)(uintptr_t(dst) + oop_offset);
+
+      // Copy any leading primitive payload before every cluster of oops
+      assert(copied_bytes < oop_offset || copied_bytes == oop_offset, "Negative sized leading payload segment");
+      copy_primitive_payload(src, dst, oop_offset - copied_bytes, copied_bytes);
+
+      // Copy a cluster of oops
+      for (const zpointer* const src_end = src_p + map->count(); src_p < src_end; src_p++, dst_p++) {
+        oop_copy_one(dst_p, src_p);
+        copied_bytes += sizeof(zpointer);
       }
       map++;
     }
+
+    // Copy trailing primitive payload after potential oops
+    assert(copied_bytes < size_in_bytes || copied_bytes == size_in_bytes, "Negative sized trailing payload segment");
+    copy_primitive_payload(src, dst, size_in_bytes - copied_bytes, copied_bytes);
+  } else {
+    Raw::value_copy_in_heap(src, dst, md, lk);
   }
-  Raw::value_copy_in_heap(src, dst, md, lk);
 }
 
 //

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -498,10 +498,6 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::value_copy_in_h
     //   2) load and store barrier for each oop
     //   3) possibly raw copy for any primitive payload trailer
 
-    assert(lk == NON_ATOMIC_FLAT || (!md->must_be_atomic()) ||
-           (md->layout_size_in_bytes(lk) == sizeof(zpointer) && md->nonstatic_oop_count() == 1), // If atomic with oops, only a single oop suppported
-           "Cannot support layout other than NON_ATOMIC_FLAT or single oop");
-
     // src/dst may not be oops, need offset to adjust oop map offset
     const address src_oop_addr_offset = ((address) src) - md->first_field_offset();
     OopMapBlock* map = md->start_of_nonstatic_oop_maps();

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -24,6 +24,7 @@
 #ifndef SHARE_GC_Z_ZBARRIERSET_INLINE_HPP
 #define SHARE_GC_Z_ZBARRIERSET_INLINE_HPP
 
+#include "gc/z/zAddress.hpp"
 #include "gc/z/zBarrierSet.hpp"
 
 #include "gc/shared/accessBarrierSupport.inline.hpp"
@@ -496,7 +497,10 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::value_copy_in_h
     //   1) possibly raw copy for any primitive payload before each map
     //   2) load and store barrier for each oop
     //   3) possibly raw copy for any primitive payload trailer
-    assert(lk == NON_ATOMIC_FLAT || lk == PAYLOAD, "Cannot support layout other than NON_ATOMIC_FLAT"); // Note: PAYLOAD is incorrect, resolve when transistioned to new flattening
+
+    assert(lk == NON_ATOMIC_FLAT || (!md->must_be_atomic()) ||
+           (md->layout_size_in_bytes(lk) == sizeof(zpointer) && md->nonstatic_oop_count() == 1), // If atomic with oops, only a single oop suppported
+           "Cannot support layout other than NON_ATOMIC_FLAT or single oop");
 
     // src/dst may not be oops, need offset to adjust oop map offset
     const address src_oop_addr_offset = ((address) src) - md->first_field_offset();

--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -118,13 +118,11 @@ serviceability/sa/sadebugd/SADebugDTest.java                  8307393   generic-
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
 # Valhalla...
-compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java      8341844   generic-all
-compiler/valhalla/inlinetypes/TestCallingConvention.java      8341844   generic-all
-compiler/valhalla/inlinetypes/TestNullableInlineTypes.java    8341844   generic-all
-runtime/valhalla/inlinetypes/InlineTypesTest.java             8341844   generic-all
+compiler/valhalla/inlinetypes/TestArrayCopyWithOops.java      8346466   generic-all
 
+
+# Once jdk-24+22 are merged (remove singlegen zgc) together with 8341844, many of these issues are resolved...
 compiler/valhalla/inlinetypes/TestStressReturnBuffering.java  8341846   generic-all
-
 compiler/valhalla/inlinetypes/TestUnloadedInlineTypeArray.java   8341848 generic-all
 compiler/valhalla/inlinetypes/TestArrays.java                 8341848   generic-all
 compiler/valhalla/inlinetypes/TestBasicFunctionality.java     8341848   generic-all

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/InlineOops.java
@@ -107,6 +107,23 @@ import static test.java.lang.invoke.lib.InstructionHelper.classDesc;
  */
 
 /**
+ * @test id=ZXint
+ * @requires vm.gc.Z
+ * @summary Test embedding oops into Inline types (sanity check with interpreter only the most complex GC)
+ * @modules java.base/jdk.internal.value
+ *          java.base/jdk.internal.vm.annotation
+ * @library /test/lib /test/jdk/java/lang/invoke/common
+ * @enablePreview
+ * @compile Person.java InlineOops.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *                   jdk.test.whitebox.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -Xint -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx128m
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ZVerifyViews -XX:InlineFieldMaxFlatSize=160
+ *                   -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   runtime.valhalla.inlinetypes.InlineOops
+ */
+
+/**
  * @test id=ZGen
  * @requires vm.gc.Z & vm.opt.final.ZGenerational
  * @summary Test embedding oops into Inline types


### PR DESCRIPTION
Generational zgc requires a store barrier in addition to the load barrier.
load barrier followed by bulk copy isn't enough

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8341844](https://bugs.openjdk.org/browse/JDK-8341844): [lworld] Test crashing in genzgc in ZBarrier::mark_from_old_slow_path(zaddress)+0x4c (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - no project role) ⚠️ Review applies to [672d282d](https://git.openjdk.org/valhalla/pull/1321/files/672d282d1554874c540f976f07aa38e4a8aea631)


### Contributors
 * Erik Österlund `<eosterlund@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1321/head:pull/1321` \
`$ git checkout pull/1321`

Update a local copy of the PR: \
`$ git checkout pull/1321` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1321`

View PR using the GUI difftool: \
`$ git pr show -t 1321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1321.diff">https://git.openjdk.org/valhalla/pull/1321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1321#issuecomment-2549505190)
</details>
