### PR TITLE
8346467: [lworld] Value record cannot be implicitly constructible

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -6125,7 +6125,8 @@ void ClassFileParser::post_process_parsed_stream(const ClassFileStream* const st
       _must_be_atomic = false;
     }
     if (_parsed_annotations->has_annotation(ClassAnnotationCollector::_jdk_internal_ImplicitlyConstructible)
-        && (_super_klass == vmClasses::Object_klass() || _super_klass->is_implicitly_constructible())) {
+        && (_super_klass == vmClasses::Object_klass() || _super_klass == vmClasses::Record_klass()
+        || _super_klass->is_implicitly_constructible())) {
       _is_implicitly_constructible = true;
     }
     // Apply VM options override

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/AnnotationsTests.java
@@ -425,5 +425,26 @@ import jdk.internal.vm.annotation.LooselyConsistentValue;
         Asserts.assertNull(exception, "Unexpected IncompatibleClassChangeError received");
     }
 
+    // Test that value record can be considered @ImplicitlyConstructible
+    // (note java.lang.Record is a special super-class because it is not annotated with @ImplicitlyConstructible)
+
+    @ImplicitlyConstructible
+    static value record Value16(byte b) { }
+
+    static class Test16 {
+        @NullRestricted
+        Value16 v = new Value16((byte)1);
+    }
+
+    void test_16() {
+        Throwable exception = null;
+        try {
+            Test16 t16 = new Test16();
+        } catch(Throwable e) {
+            exception = e;
+            System.out.println("Received "+ e);
+        }
+        Asserts.assertNull(exception, "Unexpected exception " + exception);
+    }
  }
 


### PR DESCRIPTION
Small fix to support implicitly constructible value records.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346467](https://bugs.openjdk.org/browse/JDK-8346467): [lworld] Value record cannot be implicitly constructible (**Bug** - P3)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1322/head:pull/1322` \
`$ git checkout pull/1322`

Update a local copy of the PR: \
`$ git checkout pull/1322` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1322`

View PR using the GUI difftool: \
`$ git pr show -t 1322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1322.diff">https://git.openjdk.org/valhalla/pull/1322.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1322#issuecomment-2549569871)
</details>
