### PR TITLE
8347292: [lworld] oopDesc->print() is broken

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3891,18 +3891,19 @@ void InstanceKlass::print_value_on(outputStream* st) const {
 }
 
 void FieldPrinter::do_field(fieldDescriptor* fd) {
+  for (int i = 0; i < _indent; i++) _st->print("  ");
   _st->print(BULLET);
    if (_obj == nullptr) {
-     fd->print_on(_st);
+     fd->print_on(_st, _base_offset);
      _st->cr();
    } else {
-     fd->print_on_for(_st, _obj);
-     _st->cr();
+     fd->print_on_for(_st, _obj, _indent, _base_offset);
+     if (!fd->field_flags().is_flat()) _st->cr();
    }
 }
 
 
-void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
+void InstanceKlass::oop_print_on(oop obj, outputStream* st, int indent, int base_offset) {
   Klass::oop_print_on(obj, st);
 
   if (this == vmClasses::String_klass()) {
@@ -3918,7 +3919,7 @@ void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
   }
 
   st->print_cr(BULLET"---- fields (total size " SIZE_FORMAT " words):", oop_size(obj));
-  FieldPrinter print_field(st, obj);
+  FieldPrinter print_field(st, obj, indent, base_offset);
   print_nonstatic_fields(&print_field);
 
   if (this == vmClasses::Class_klass()) {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -91,8 +91,11 @@ public:
 class FieldPrinter: public FieldClosure {
    oop _obj;
    outputStream* _st;
+   int _indent;
+   int _base_offset;
  public:
-   FieldPrinter(outputStream* st, oop obj = nullptr) : _obj(obj), _st(st) {}
+   FieldPrinter(outputStream* st, oop obj = nullptr, int indent = 0, int base_offset = 0) :
+                 _obj(obj), _st(st), _indent(indent), _base_offset(base_offset) {}
    void do_field(fieldDescriptor* fd);
 };
 
@@ -1256,7 +1259,8 @@ public:
 
   void oop_print_value_on(oop obj, outputStream* st);
 
-  void oop_print_on      (oop obj, outputStream* st);
+  void oop_print_on      (oop obj, outputStream* st) { oop_print_on(obj, st, 0, 0); }
+  void oop_print_on      (oop obj, outputStream* st, int indent = 0, int base_offset = 0);
 
 #ifndef PRODUCT
   void print_dependent_nmethods(bool verbose = false);

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -170,7 +170,7 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj, int indent, int ba
         FieldPrinter print_field(st, obj, indent + 1, base_offset + field_offset );
         vk->do_nonstatic_fields(&print_field);
         if (this->field_flags().has_null_marker()) {
-          for (int i = 0; i <  + 1; i++) st->print("  ");
+          for (int i = 0; i < indent + 1; i++) st->print("  ");
           st->print_cr(" - [null_marker] @%d %s",
                     vk->null_marker_offset() - base_offset + field_offset,
                     obj->bool_field(vk->null_marker_offset()) ? "Field marked as non-null" : "Field marked as null");

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -109,8 +109,8 @@ class fieldDescriptor {
 
   // Print
   void print() const;
-  void print_on(outputStream* st) const;
-  void print_on_for(outputStream* st, oop obj);
+  void print_on(outputStream* st, int base_offset = 0) const;
+  void print_on_for(outputStream* st, oop obj, int indent = 0, int base_offset = 0);
 };
 
 #endif // SHARE_RUNTIME_FIELDDESCRIPTOR_HPP


### PR DESCRIPTION
Fix implementation of oopDesc->print():
  - remove invalid assert
  - fix printing for better readability
  - fix offsets of nested fields
  
More details are available in the CR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347292](https://bugs.openjdk.org/browse/JDK-8347292): [lworld] oopDesc-&gt;print() is broken (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer) ⚠️ Review applies to [a9cb6566](https://git.openjdk.org/valhalla/pull/1328/files/a9cb6566799c9ecc64670c4c3bab2f6dcaa84864)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1328/head:pull/1328` \
`$ git checkout pull/1328`

Update a local copy of the PR: \
`$ git checkout pull/1328` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1328`

View PR using the GUI difftool: \
`$ git pr show -t 1328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1328.diff">https://git.openjdk.org/valhalla/pull/1328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1328#issuecomment-2578598555)
</details>
