### PR TITLE
8346702: [lworld] ShouldNotReachHere in FieldLayout::remove_null_marker()

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1164,7 +1164,9 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
       } else {
         // If the nullable layout is rejected, the NULL_MARKER block should be removed
         // from the layout, otherwise it will appear anyway if the layout is printer
-        _layout->remove_null_marker();
+        if (!_is_empty_inline_class) {  // empty values don't have a dedicated NULL_MARKER block
+          _layout->remove_null_marker();
+        }
         _null_marker_offset = -1;
       }
     }


### PR DESCRIPTION
Small fix to prevent calls to remove_null_marker() when processing an empty value (empty values don't have a dedicated slot for null markers, the injected field is used instead).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346702](https://bugs.openjdk.org/browse/JDK-8346702): [lworld] ShouldNotReachHere in FieldLayout::remove_null_marker() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1330/head:pull/1330` \
`$ git checkout pull/1330`

Update a local copy of the PR: \
`$ git checkout pull/1330` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1330`

View PR using the GUI difftool: \
`$ git pr show -t 1330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1330.diff">https://git.openjdk.org/valhalla/pull/1330.diff</a>

</details>
