### PR TITLE
8347754: [lw5] fix the order of nullness markers in signatures

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -159,7 +159,7 @@ public class PoolWriter {
         if (s.kind == TYP) {
             return putName(classSig(s.type));
         } else {
-            return putName(typeSig(s.type));
+            return putName(typeSig(s.type, true));
         }
     }
 
@@ -302,15 +302,24 @@ public class PoolWriter {
          */
         @Override
         public void assembleSig(Type type) {
+            assembleSig(type, false);
+        }
+
+        /**
+         * Assemble signature of given type in string buffer.
+         * Check for uninitialized types before calling the general case.
+         */
+        @Override
+        public void assembleSig(Type type, boolean includeNullMarkers) {
             switch (type.getTag()) {
                 case UNINITIALIZED_THIS:
                 case UNINITIALIZED_OBJECT:
                     // we don't yet have a spec for uninitialized types in the
                     // local variable table
-                    assembleSig(types.erasure(((UninitializedType)type).qtype));
+                    assembleSig(types.erasure(((UninitializedType)type).qtype), includeNullMarkers);
                     break;
                 default:
-                    super.assembleSig(type);
+                    super.assembleSig(type, includeNullMarkers);
             }
         }
 
@@ -507,8 +516,12 @@ public class PoolWriter {
      * Return signature of given type
      */
     private Name typeSig(Type type) {
+        return typeSig(type, false);
+    }
+
+    private Name typeSig(Type type, boolean includeNullMarkers) {
         signatureGen.reset();
-        signatureGen.assembleSig(type);
+        signatureGen.assembleSig(type, includeNullMarkers);
         return signatureGen.toName();
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -2931,7 +2931,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
                     case "?" -> NULLABLE;
                     case "*" -> PARAMETRIC;
                     case "" -> UNSPECIFIED;
-                    default -> throw new AssertionError("invalid type suffix");
+                    default -> throw new AssertionError("invalid type suffix " + typeSuffix);
                 };
             }
         }


### PR DESCRIPTION
Null markers must be at the end of signatures, currently they are being generated at the beginning see [1]

[1] https://bugs.openjdk.org/browse/JDK-8317766

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8347754](https://bugs.openjdk.org/browse/JDK-8347754): [lw5] fix the order of nullness markers in signatures (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1331/head:pull/1331` \
`$ git checkout pull/1331`

Update a local copy of the PR: \
`$ git checkout pull/1331` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1331`

View PR using the GUI difftool: \
`$ git pr show -t 1331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1331.diff">https://git.openjdk.org/valhalla/pull/1331.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1331#issuecomment-2596911745)
</details>
