### PR TITLE
8348428: [lworld] ProcessReaper stack size too small in debug build

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -93,7 +93,7 @@ final class ProcessHandleImpl implements ProcessHandle {
 
                 // For a debug build, the stack shadow zone is larger;
                 // Increase the total stack size to avoid potential stack overflow.
-                int debugDelta = "release".equals(System.getProperty("jdk.debug")) ? 0 : (4*4096);
+                int debugDelta = "release".equals(System.getProperty("jdk.debug")) ? 0 : (16*4096);
                 final long stackSize = Boolean.getBoolean("jdk.lang.processReaperUseDefaultStackSize")
                         ? 0 : REAPER_DEFAULT_STACKSIZE + debugDelta;
 


### PR DESCRIPTION
Increase process reaper debug stack size to 64kb

Some tests of the fastdebug Java Runtime with -Xcomp experience a StackOverflow exception in the ProcessReaper in ProcessHandleImpl.
Some combination of -Xcomp and the MH generation done by isSubstitutability for value objects in debug mode is larger.

The current 16kb bump for the non-release builds should be raised to 64k.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348428](https://bugs.openjdk.org/browse/JDK-8348428): [lworld] ProcessReaper stack size too small in debug build (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1335/head:pull/1335` \
`$ git checkout pull/1335`

Update a local copy of the PR: \
`$ git checkout pull/1335` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1335`

View PR using the GUI difftool: \
`$ git pr show -t 1335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1335.diff">https://git.openjdk.org/valhalla/pull/1335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1335#issuecomment-2611065732)
</details>
