### PR TITLE
8348585: [lworld] ProcessReaper stack size too small

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -87,13 +87,17 @@ final class ProcessHandleImpl implements ProcessHandle {
     private static final Executor processReaperExecutor = initReaper();
 
     private static Executor initReaper() {
-        // Initialize ThreadLocalRandom now to avoid using the smaller stack
+        // Initialize ThreadLocalRandom and ValueObjectMethods now to avoid using the smaller stack
         // of the processReaper threads.
         ThreadLocalRandom.current();
-
+        try {
+            Class.forName("java.lang.runtime.ValueObjectMethods$MethodHandleBuilder", true, null);
+        } catch (ClassNotFoundException cnfe) {
+            throw new InternalError("unable to initialize ValueObjectMethodds", cnfe);
+        }
         // For a debug build, the stack shadow zone is larger;
         // Increase the total stack size to avoid potential stack overflow.
-        int debugDelta = "release".equals(System.getProperty("jdk.debug")) ? 0 : (16 * 4096);
+        int debugDelta = "release".equals(System.getProperty("jdk.debug")) ? 0 : (4*4096);
         final long stackSize = Boolean.getBoolean("jdk.lang.processReaperUseDefaultStackSize")
                 ? 0 : REAPER_DEFAULT_STACKSIZE + debugDelta;
 


### PR DESCRIPTION
The reaper stack size is insufficient to initialize the method handles for the equals methods of the primitive classes.
Instead of incrasing the stack size, perform the initialization before the reaper thread is created.

An earlier change to increase the stack only for a debug build is reverted, it is no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348585](https://bugs.openjdk.org/browse/JDK-8348585): [lworld] ProcessReaper stack size too small (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1339/head:pull/1339` \
`$ git checkout pull/1339`

Update a local copy of the PR: \
`$ git checkout pull/1339` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1339`

View PR using the GUI difftool: \
`$ git pr show -t 1339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1339.diff">https://git.openjdk.org/valhalla/pull/1339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1339#issuecomment-2620261121)
</details>
