### PR TITLE
8349073: [lworld] minimal support for @Strict

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -421,6 +421,11 @@ public class Flags {
     public static final long NON_SEALED = 1L<<63; // ClassSymbols
 
     /**
+     * Flag to indicate that a class has at least one strict field
+     */
+    public static final long HAS_STRICT = 1L<<52; // ClassSymbols, temporary hack
+
+    /**
      * Flag to indicate that a field is strict
      */
     public static final long STRICT = 1L<<53; // VarSymbols

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -407,6 +407,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         return (flags() & STRICT) != 0;
     }
 
+    public boolean hasStrict() {
+        return (flags() & HAS_STRICT) != 0;
+    }
+
     public boolean isInterface() {
         return (flags_field & INTERFACE) != 0;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -391,6 +391,8 @@ public class Annotate {
                     && toAnnotate.owner.kind == TYP
                     && types.isSameType(c.type, syms.strictType)) {
                 toAnnotate.flags_field |= Flags.STRICT;
+                // temporary hack to indicate that a class has at least one strict field
+                toAnnotate.owner.flags_field |= Flags.HAS_STRICT;
             }
 
             if (!c.type.isErroneous()

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1212,7 +1212,7 @@ public class Attr extends JCTree.Visitor {
                     if (!TreeInfo.hasAnyConstructorCall(tree)) {
                         JCStatement supCall = make.at(tree.body.pos).Exec(make.Apply(List.nil(),
                                 make.Ident(names._super), make.Idents(List.nil())));
-                        if (owner.isValueClass()) {
+                        if (owner.isValueClass() || owner.hasStrict()) {
                             tree.body.stats = tree.body.stats.append(supCall);
                         } else {
                             tree.body.stats = tree.body.stats.prepend(supCall);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -442,7 +442,7 @@ public class Gen extends JCTree.Visitor {
                 if ((block.flags & STATIC) != 0)
                     clinitCode.append(block);
                 else if ((block.flags & SYNTHETIC) == 0) {
-                    if (c.isValueClass()) {
+                    if (c.isValueClass() || c.hasStrict()) {
                         initBlocks.append(block);
                     } else {
                         initCode.append(block);
@@ -557,7 +557,7 @@ public class Gen extends JCTree.Visitor {
         if (TreeInfo.isConstructor(md) && TreeInfo.hasConstructorCall(md, names._super)) {
             // We are seeing a constructor that has a super() call.
             // Find the super() invocation and append the given initializer code.
-            if (md.sym.owner.isValueClass()) {
+            if (md.sym.owner.isValueClass() || md.sym.owner.hasStrict()) {
                 rewriteInitializersIfNeeded(md, initCode);
                 TreeInfo.mapSuperCalls(md.body, supercall -> make.Block(0, initCode.append(supercall).appendList(initBlocks)));
             } else {


### PR DESCRIPTION
Additional experimental support for `@Strict` annotation in javac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349073](https://bugs.openjdk.org/browse/JDK-8349073): [lworld] minimal support for @<!---->Strict (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1344.diff">https://git.openjdk.org/valhalla/pull/1344.diff</a>

</details>
