### PR TITLE
8348904: [lworld] Remove concept of default value object and zeroInstance

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -411,13 +411,6 @@ UNSAFE_ENTRY(jboolean, Unsafe_IsFlatArray(JNIEnv *env, jobject unsafe, jclass c)
   return k->is_flatArray_klass();
 } UNSAFE_END
 
-UNSAFE_ENTRY(jobject, Unsafe_UninitializedDefaultValue(JNIEnv *env, jobject unsafe, jclass vc)) {
-  Klass* k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(vc));
-  InlineKlass* vk = InlineKlass::cast(k);
-  oop v = vk->default_value();
-  return JNIHandles::make_local(THREAD, v);
-} UNSAFE_END
-
 UNSAFE_ENTRY(jobject, Unsafe_GetValue(JNIEnv *env, jobject unsafe, jobject obj, jlong offset, jclass vc)) {
   oop base = JNIHandles::resolve(obj);
   if (base == nullptr) {
@@ -1119,7 +1112,6 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "getFlatValue",         CC "(" OBJ "JI" CLS ")" OBJ, FN_PTR(Unsafe_GetFlatValue)},
     {CC "putValue",             CC "(" OBJ "J" CLS OBJ ")V", FN_PTR(Unsafe_PutValue)},
     {CC "putFlatValue",         CC "(" OBJ "JI" CLS OBJ ")V", FN_PTR(Unsafe_PutFlatValue)},
-    {CC "uninitializedDefaultValue", CC "(" CLS ")" OBJ,  FN_PTR(Unsafe_UninitializedDefaultValue)},
     {CC "makePrivateBuffer",     CC "(" OBJ ")" OBJ,      FN_PTR(Unsafe_MakePrivateBuffer)},
     {CC "finishPrivateBuffer",   CC "(" OBJ ")" OBJ,      FN_PTR(Unsafe_FinishPrivateBuffer)},
     {CC "valueHeaderSize",       CC "(" CLS ")J",         FN_PTR(Unsafe_ValueHeaderSize)},

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -499,7 +499,6 @@ class LambdaForm {
         int maxOutArity = 0;
         for (int i = 0; i < names.length; i++) {
             Name n = names[i];
-            if (n == null) System.err.println("i: " + i);
             names[i] = n.withIndex(i);
             if (n.arguments != null && maxOutArity < n.arguments.length)
                 maxOutArity = n.arguments.length;

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,12 +374,6 @@ public final class Unsafe {
      *         {@link NullPointerException}
      */
     public native <V> void putFlatValue(Object o, long offset, int layoutKind, Class<?> valueType, V v);
-
-
-    /**
-     * Returns an uninitialized default instance of the given value class.
-     */
-    public native <V> V uninitializedDefaultValue(Class<?> type);
 
     /**
      * Returns an object instance with a private buffered value whose layout

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -46,24 +46,6 @@ public class ValueClass {
     public static native boolean isImplicitlyConstructible(Class<?> cls);
 
     /**
-     * {@return the default value of the given value class type}
-     *
-     * @throws IllegalArgumentException if {@code cls} is not a
-     *         value class type or is not annotated with
-     *         {@link jdk.internal.vm.annotation.ImplicitlyConstructible}
-     */
-    public static <T> T zeroInstance(Class<T> cls) {
-        if (!cls.isValue()) {
-            throw new IllegalArgumentException(cls.getName() + " not a value class");
-        }
-        if (!isImplicitlyConstructible(cls)) {
-            throw new IllegalArgumentException(cls.getName() + " not implicitly constructible");
-        }
-        UNSAFE.ensureClassInitialized(cls);
-        return UNSAFE.uninitializedDefaultValue(cls);
-    }
-
-    /**
      * {@return {@code CheckedType} representing the type of the given field}
      */
     public static CheckedType checkedType(Field f) {

--- a/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
+++ b/test/hotspot/jtreg/compiler/valhalla/inlinetypes/TestArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1431,7 +1431,7 @@ public class TestArrays {
         }
         Object[] result = test59(va);
         // Result is a null-restricted array
-        Asserts.assertEQ(result[len], ValueClass.zeroInstance(MyValue1.class));
+        Asserts.assertEQ(result[len], MyValue1.createDefaultInline());
         result[len] = MyValue1.createDefaultInline();
         verify(verif, result);
     }
@@ -1452,7 +1452,7 @@ public class TestArrays {
         }
         Object[] result = test60(va, va.getClass());
         // Result is a null-restricted array
-        Asserts.assertEQ(result[len], ValueClass.zeroInstance(MyValue1.class));
+        Asserts.assertEQ(result[len], MyValue1.createDefaultInline());
         result[len] = MyValue1.createDefaultInline();
         verify(verif, result);
     }

--- a/test/jdk/valhalla/valuetypes/MethodHandleTest.java
+++ b/test/jdk/valhalla/valuetypes/MethodHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ public class MethodHandleTest {
         for (int i=0; i < ARRAY_SIZE; i++) {
             var v = getter.invoke(array, i);
             if (nullRestricted) {
-                assertTrue(v == ValueClass.zeroInstance(componentType));
+                assertTrue(v != null);
             } else {
                 assertTrue(v == null);
             }

--- a/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ public class NullRestrictedArraysTest {
         for (int i=0; i < newArray2.length; i++) {
             if (from+1 >= nullRestrictedArray.length) {
                 // padded with zero instance
-                assertTrue(newArray2[i] == ValueClass.zeroInstance(componentType));
+                assertTrue(newArray2[i] == null);
             }
         }
     }

--- a/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
+++ b/test/jdk/valhalla/valuetypes/NullRestrictedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,10 @@ public class NullRestrictedTest {
             this.o = null;
             this.empty = new EmptyValue();
         }
+        Value(EmptyValue empty) {
+            this.o = null;
+            this.empty = empty;
+        }
     }
 
     static class Mutable {
@@ -80,15 +84,14 @@ public class NullRestrictedTest {
     }
 
     @Test
-    public void lazyInitializedDefaultValue() {
-        // VM lazily sets the null-restricted non-flat field to zero default
-        assertTrue(new Value() == ValueClass.zeroInstance(Value.class));
-        assertTrue(new Value().empty == ValueClass.zeroInstance(EmptyValue.class));
+    public void testNonNullFieldAssignment() {
+        var npe = assertThrows(NullPointerException.class, () -> new Value(null));
+        System.err.println(npe);    // log the exception message
     }
 
     static Stream<Arguments> getterCases() {
         Value v = new Value();
-        EmptyValue emptyValue = ValueClass.zeroInstance(EmptyValue.class);
+        EmptyValue emptyValue = new EmptyValue();
         Mutable m = new Mutable();
 
         return Stream.of(
@@ -118,7 +121,7 @@ public class NullRestrictedTest {
     }
 
     static Stream<Arguments> setterCases() {
-        EmptyValue emptyValue = ValueClass.zeroInstance(EmptyValue.class);
+        EmptyValue emptyValue = new EmptyValue();
         Mutable m = new Mutable();
         return Stream.of(
                 Arguments.of(Mutable.class, "o", EmptyValue.class, m, null),

--- a/test/jdk/valhalla/valuetypes/ObjectMethods.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,8 +170,6 @@ public class ObjectMethods {
                 Arguments.of(R1, new Ref(P1, L1), false),   // identity object
 
                 // uninitialized default value
-                Arguments.of(ValueClass.zeroInstance(Line.class), new Line(0, 0, 0, 0), true),
-                Arguments.of(ValueClass.zeroInstance(Value.class), ValueClass.zeroInstance(Value.class), true),
                 Arguments.of(new ValueOptional(L1), new ValueOptional(L1), true),
                 Arguments.of(new ValueOptional(List.of(P1)), new ValueOptional(List.of(P1)), false)
         );
@@ -190,10 +188,8 @@ public class ObjectMethods {
                 Arguments.of(V),
                 Arguments.of(R1),
                 // enclosing instance field `this$0` should be filtered
-                Arguments.of(ValueClass.zeroInstance(Value.class)),
                 Arguments.of(new Value(P1, L1, null, null)),
                 Arguments.of(new Value(P2, L2, new Ref(P1, null), "value")),
-                Arguments.of(ValueClass.zeroInstance(ValueOptional.class)),
                 Arguments.of(new ValueOptional(P1))
         );
     }
@@ -211,11 +207,9 @@ public class ObjectMethods {
         assertEquals(o.toString(), "ValueRecord[i=30, name=thirty]");
     }
 
-
     static Stream<Arguments> hashcodeTests() {
-        Point p = ValueClass.zeroInstance(Point.class);
-        Line l = ValueClass.zeroInstance(Line.class);
-        Value v = ValueClass.zeroInstance(Value.class);
+        Point p = new Point(0, 0);
+        Line l = new Line(0, 0, 0, 0);
         // this is sensitive to the order of the returned fields from Class::getDeclaredFields
         return Stream.of(
                 Arguments.of(P1, hash(Point.class, 1, 2)),
@@ -223,7 +217,6 @@ public class ObjectMethods {
                 Arguments.of(V, hash(Value.class, P1, L1, V.r, V.s)),
                 Arguments.of(new Point(0, 0), hash(Point.class, 0, 0)),
                 Arguments.of(p, hash(Point.class, 0, 0)),
-                Arguments.of(v, hash(Value.class, p, l, null, null)),
                 Arguments.of(new ValueOptional(P1), hash(ValueOptional.class, P1))
         );
     }

--- a/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
+++ b/test/jdk/valhalla/valuetypes/RecursiveValueClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@
 
 import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
-import jdk.internal.vm.annotation.NullRestricted;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -133,23 +132,23 @@ public class RecursiveValueClass {
     }
 
     static Stream<Arguments> objectsProvider() {
-        var n1 = ValueClass.zeroInstance(Node.class);
+        var n1 = new Node(null, null);
         var n2 = new Node(n1, null);
         var n3 = new Node(n2, n1);
         var n4 = new Node(n2, n1);
-        var v1 = ValueClass.zeroInstance(V.class);
+        var v1 = new V(null);
         var p1 = new P(n3, v1);
         var p2 = new P(n4, v1);
         var v2 = new V(p1);
         var v3 = new V(p2);
         var p3 = new P(n3, v2);
 
-        var e1 = new E(ValueClass.zeroInstance(F.class));
+        var e1 = new E(new F(null));
         var f1 = new F(e1);
         var e2 = new E(f1);
         var f2 = new F(e2);
 
-        var a = new A(ValueClass.zeroInstance(B.class), ValueClass.zeroInstance(E.class));
+        var a = new A(new B(null, null), new E(null));
 
         var d1 = new D(1);
         var d2 = new D(2);
@@ -202,19 +201,19 @@ public class RecursiveValueClass {
     }
 
     static Stream<Arguments> hashCodeProvider() {
-        var n1 = ValueClass.zeroInstance(Node.class);
+        var n1 = new Node(null, null);
         var n2 = new Node(n1, null);
         var n3 = new Node(n2, n1);
         var v1 = new V(null);
         var p1 = new P(n3, v1);
         var v2 = new V(p1);
 
-        var e1 = new E(ValueClass.zeroInstance(F.class));
+        var e1 = new E(new F(null));
         var f1 = new F(e1);
         var e2 = new E(f1);
         var f2 = new F(e2);
 
-        var a = new A(ValueClass.zeroInstance(B.class), ValueClass.zeroInstance(E.class));
+        var a = new A(new B(null, null), new E(null));
 
         var d1 = new D(1);
         var d2 = new D(2);

--- a/test/jdk/valhalla/valuetypes/Reflection.java
+++ b/test/jdk/valhalla/valuetypes/Reflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ public class Reflection {
         for (int i = 0; i < array.length; i++) {
             Object o = Array.get(array, i);
             if (nullRestricted) {
-                assertTrue(o == ValueClass.zeroInstance(componentType));
+                assertTrue(o != null);
             } else {
                 assertTrue(o == null);
             }

--- a/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
+++ b/test/jdk/valhalla/valuetypes/SubstitutabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ public class SubstitutabilityTest {
         Point p1 = new Point(10, 10);
         Point p2 = new Point(20, 20);
         Line l1 = new Line(p1, p2);
-        MyValue v1 = new MyValue(null, ValueClass.zeroInstance(MyValue2.class));
+        MyValue v1 = new MyValue(null, new MyValue2(0));
         MyValue v2 = new MyValue(new MyValue2(2), new MyValue2(3));
         MyValue2 value2 = new MyValue2(2);
         MyValue2 value3 = new MyValue2(3);
@@ -135,7 +135,6 @@ public class SubstitutabilityTest {
                 Arguments.of(p1, new Point(10, 10)),
                 Arguments.of(p2, new Point(20, 20)),
                 Arguments.of(l1, new Line(10,10, 20,20)),
-                Arguments.of(v1, ValueClass.zeroInstance(MyValue.class)),
                 Arguments.of(v2, new MyValue(value2, value3)),
                 Arguments.of(va[0], null)
         );
@@ -148,9 +147,6 @@ public class SubstitutabilityTest {
     }
 
     static Stream<Arguments> notSubstitutableCases() {
-        // MyValue![] va = new MyValue![1];
-        MyValue[] va = new MyValue[] { ValueClass.zeroInstance(MyValue.class) };
-        Object[] oa = new Object[] { va };
         return Stream.of(
                 Arguments.of(new MyFloat(1.0f), new MyFloat(2.0f)),
                 Arguments.of(new MyDouble(1.0), new MyDouble(2.0)),
@@ -162,11 +158,6 @@ public class SubstitutabilityTest {
                  * throw an exception if any one of parameter is null or if
                  * the parameters are of different types.
                  */
-                Arguments.of(va[0], null),
-                Arguments.of(null, va[0]),
-                Arguments.of(va[0], oa),
-                Arguments.of(va[0], oa[0]),
-                Arguments.of(va, oa),
                 Arguments.of(new Point(10, 10), Integer.valueOf(10)),
                 Arguments.of(Integer.valueOf(10), Integer.valueOf(20))
         );


### PR DESCRIPTION
Remove support for the default value object and zeroInstance, no longer included in the spec.
In related tests, test cases were removed if no longer applicable or replaced by a hand created zero/null object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348904](https://bugs.openjdk.org/browse/JDK-8348904): [lworld] Remove concept of default value object and zeroInstance (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1346/head:pull/1346` \
`$ git checkout pull/1346`

Update a local copy of the PR: \
`$ git checkout pull/1346` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1346`

View PR using the GUI difftool: \
`$ git pr show -t 1346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1346.diff">https://git.openjdk.org/valhalla/pull/1346.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1346#issuecomment-2628349898)
</details>
