### PR TITLE
8349260: [lworld] minimal support for @Strict, follow-up of JDK-8349073

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1332,7 +1332,7 @@ public class Attr extends JCTree.Visitor {
                     initEnv.info.enclVar = v;
                     boolean previousCtorPrologue = initEnv.info.ctorPrologue;
                     try {
-                        if (v.owner.kind == TYP && v.owner.isValueClass() && !v.isStatic()) {
+                        if (v.owner.kind == TYP && !v.isStatic() && v.isStrict()) {
                             // strict instance initializer in a value class
                             initEnv.info.ctorPrologue = true;
                         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -513,7 +513,7 @@ public class Flow {
                     if (!def.hasTag(METHODDEF) && (isDefStatic == isStatic)) {
                         if (def instanceof JCVariableDecl varDecl) {
                             boolean isEarly = varDecl.init != null &&
-                                    varDecl.sym.owner.isValueClass() &&
+                                    varDecl.sym.isStrict() &&
                                     !varDecl.sym.isStatic();
                             if (isEarly == earlyOnly) {
                                 handler.accept(def);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2765,7 +2765,7 @@ public class Lower extends TreeTranslator {
                 }
             }
             if (initializers.nonEmpty()) {
-                if (tree.sym.owner.isValueClass()) {
+                if (tree.sym.owner.isValueClass() || tree.sym.owner.hasStrict()) {
                     TreeInfo.mapSuperCalls(tree.body, supercall -> make.Block(0, initializers.toList().append(supercall)));
                 } else {
                     tree.body.stats = tree.body.stats.appendList(initializers);

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -1068,6 +1068,53 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     }
                 }
             }
+
+            assertFail("compiler.err.cant.ref.before.ctor.called",
+                    """
+                    import jdk.internal.vm.annotation.NullRestricted;
+                    import jdk.internal.vm.annotation.Strict;
+                    class StrictNR {
+                        static value class IValue {
+                            int i = 0;
+                        }
+                        value class SValue {
+                            short s = 0;
+                        }
+                        @Strict
+                        @NullRestricted
+                        IValue val = new IValue();
+                        @Strict
+                        @NullRestricted
+                        final IValue val2;
+                        @Strict
+                        @NullRestricted
+                        SValue val3 = new SValue();
+                    }
+                    """
+            );
+            assertFail("compiler.err.cant.ref.before.ctor.called",
+                    """
+                    import jdk.internal.vm.annotation.NullRestricted;
+                    import jdk.internal.vm.annotation.Strict;
+                    class StrictNR {
+                        static value class IValue {
+                            int i = 0;
+                        }
+                        value class SValue {
+                            short s = 0;
+                        }
+                        @Strict
+                        @NullRestricted
+                        IValue val = new IValue();
+                            @Strict
+                            @NullRestricted
+                            SValue val4;
+                        public StrictNR() {
+                            val4 = new SValue();
+                        }
+                    }
+                    """
+            );
         } finally {
             setCompileOptions(previousOptions);
         }


### PR DESCRIPTION
additional support for @Strict anno

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8349260](https://bugs.openjdk.org/browse/JDK-8349260): [lworld] minimal support for @<!---->Strict, follow-up of JDK-8349073 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1349/head:pull/1349` \
`$ git checkout pull/1349`

Update a local copy of the PR: \
`$ git checkout pull/1349` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1349`

View PR using the GUI difftool: \
`$ git pr show -t 1349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1349.diff">https://git.openjdk.org/valhalla/pull/1349.diff</a>

</details>
