### PR TITLE
8348743: [lworld] GetObjectHashCode crashes with ShouldNotReachHere()

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -3069,9 +3069,12 @@ JvmtiEnv::GetObjectHashCode(jobject object, jint* hash_code_ptr) {
   NULL_CHECK(mirror, JVMTI_ERROR_INVALID_OBJECT);
   NULL_CHECK(hash_code_ptr, JVMTI_ERROR_NULL_POINTER);
 
-  {
-    jint result = (jint) mirror->identity_hash();
-    *hash_code_ptr = result;
+  if (mirror->is_inline_type()) {
+    // For inline types, use the klass as a hash code.
+    // TBD to improve this (see also JvmtiTagMapKey::get_hash for similar case).
+    *hash_code_ptr = (jint)((int64_t)mirror->klass() >> 3);
+  } else {
+    *hash_code_ptr = (jint)mirror->identity_hash();
   }
   return JVMTI_ERROR_NONE;
 } /* end GetObjectHashCode */

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8348743
+ * @summary Tests ValueGetObjectHashCodeTest functionality for value objects.
+ * @requires vm.jvmti
+ * @modules java.base/jdk.internal.vm.annotation
+ * @enablePreview
+ * @run main/othervm/native -agentlib:ValueGetObjectHashCodeTest
+ *                          -XX:+PrintInlineLayout
+ *                          ValueGetObjectHashCodeTest
+ */
+
+import jdk.internal.vm.annotation.ImplicitlyConstructible;
+import jdk.internal.vm.annotation.NullRestricted;
+
+public class ValueGetObjectHashCodeTest {
+
+    @ImplicitlyConstructible
+    private static value class ValueClass {
+        public int f1;
+        public ValueClass(int v1) { f1 = v1; }
+        public String toString() {
+            return "value(" + String.valueOf(f1) + ")";
+        }
+    }
+
+    @ImplicitlyConstructible
+    private static value class ValueHolder {
+        public ValueClass f1;
+        @NullRestricted
+        public ValueClass f2;
+
+        public ValueHolder(int v1, int v2) {
+            f1 = new ValueClass(v1);
+            f2 = new ValueClass(v2);
+        }
+        public String toString() {
+            return "holder{" + f1 + ", " + f2 + "}";
+        }
+    }
+
+    private static native int getHash0(Object object);
+
+    private static int getHash(Object object) {
+        int hash = getHash0(object);
+        System.out.println("hash (" + object + "): " + hash);
+        return hash;
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("ValueGetObjectHashCodeTest");
+        ValueClass v1 = new ValueClass(8);
+        ValueHolder h1 = new ValueHolder(8, 8);
+
+        // expect the same hash code for equal value objects
+        int hash1 = getHash(v1);
+        int hash2 = getHash(h1.f1);
+        int hash3 = getHash(h1.f2);
+
+        if (hash1 != hash2 || hash2 != hash3) {
+            throw new RuntimeException("Hash should be equal");
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/libValueGetObjectHashCodeTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/libValueGetObjectHashCodeTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jvmti.h>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+jvmtiEnv *jvmti = nullptr;
+
+void checkJvmti(int code, const char* message) {
+  if (code != JVMTI_ERROR_NONE) {
+    printf("Error %s: %d\n", message, code);
+    abort();
+  }
+}
+
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_ValueGetObjectHashCodeTest_getHash0(JNIEnv* jni_env, jclass clazz, jobject object) {
+  jint hash = 0;
+  jvmtiError err = jvmti->GetObjectHashCode(object, &hash);
+  checkJvmti(err, "GetObjectHashCode failed");
+  return hash;
+}
+
+extern "C" JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
+  if (vm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION) != JNI_OK || !jvmti) {
+    printf("Could not initialize JVMTI\n");
+    abort();
+  }
+  return JVMTI_ERROR_NONE;
+}
+


### PR DESCRIPTION
The change fixes GetObjectHashCode JVMTI function.
Hashcode is the same for all instances of a value class - similar to fix for heap walking functions ([JDK-8310655](https://bugs.openjdk.org/browse/JDK-8310655)). The solution is far from perfect, but it's better than crash

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348743](https://bugs.openjdk.org/browse/JDK-8348743): [lworld] GetObjectHashCode crashes with ShouldNotReachHere() (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1354/head:pull/1354` \
`$ git checkout pull/1354`

Update a local copy of the PR: \
`$ git checkout pull/1354` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1354`

View PR using the GUI difftool: \
`$ git pr show -t 1354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1354.diff">https://git.openjdk.org/valhalla/pull/1354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1354#issuecomment-2641479720)
</details>
