### PR TITLE
8348961: [lworld] C2: Joining "Object:flat_in_array" with "Object:exact" does not properly work

### DIFF
--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -51,8 +51,8 @@ const Type* SubTypeCheckNode::sub(const Type* sub_t, const Type* super_t) const 
   // Similar to logic in CmpPNode::sub()
   bool unrelated_classes = false;
   // Handle inline type arrays
-  if (subk->flat_in_array() && superk->not_flat_in_array()) {
-    // The subtype is in flat arrays and the supertype is not in flat arrays. Must be unrelated.
+  if (subk->flat_in_array() && superk->not_flat_in_array_inexact()) {
+    // The subtype is in flat arrays and the supertype is not in flat arrays and no subklass can be. Must be unrelated.
     unrelated_classes = true;
   } else if (subk->is_not_flat() && superk->is_flat()) {
     // The subtype is a non-flat array and the supertype is a flat array. Must be unrelated.
@@ -68,18 +68,16 @@ const Type* SubTypeCheckNode::sub(const Type* sub_t, const Type* super_t) const 
     }
   }
 
-  if (subk != nullptr) {
-    switch (Compile::current()->static_subtype_check(superk, subk, false)) {
-      case Compile::SSC_always_false:
-        return TypeInt::CC_GT;
-      case Compile::SSC_always_true:
-        return TypeInt::CC_EQ;
-      case Compile::SSC_easy_test:
-      case Compile::SSC_full_test:
-        break;
-      default:
-        ShouldNotReachHere();
-    }
+  switch (Compile::current()->static_subtype_check(superk, subk, false)) {
+    case Compile::SSC_always_false:
+      return TypeInt::CC_GT;
+    case Compile::SSC_always_true:
+      return TypeInt::CC_EQ;
+    case Compile::SSC_easy_test:
+    case Compile::SSC_full_test:
+      break;
+    default:
+      ShouldNotReachHere();
   }
 
   return bottom_type();

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -1018,11 +1018,14 @@ void Type::check_symmetrical(const Type* t, const Type* mt, const VerifyMeet& ve
   // Interface:NotNull meet Oop:NotNull == java/lang/Object:NotNull
 
   // Verify that:
-  //      !(t meet this)  meet !t ==
-  //      (!t join !this) meet !t == !t
-  // and
-  //      !(t meet this)  meet !this ==
-  //      (!t join !this) meet !this == !this
+  // 1)     mt_dual meet t_dual    == t_dual
+  //    which corresponds to
+  //       !(t meet this)  meet !t ==
+  //       (!t join !this) meet !t == !t
+  // 2)    mt_dual meet this_dual     == this_dual
+  //    which corresponds to
+  //       !(t meet this)  meet !this ==
+  //       (!t join !this) meet !this == !this
   if (t2t != t->_dual || t2this != this->_dual) {
     tty->print_cr("=== Meet Not Symmetric ===");
     tty->print("t   =                   ");              t->dump(); tty->cr();
@@ -1033,7 +1036,9 @@ void Type::check_symmetrical(const Type* t, const Type* mt, const VerifyMeet& ve
     tty->print("this_dual=              ");          _dual->dump(); tty->cr();
     tty->print("mt_dual=                ");      mt->_dual->dump(); tty->cr();
 
+    // 1)
     tty->print("mt_dual meet t_dual=    "); t2t           ->dump(); tty->cr();
+    // 2)
     tty->print("mt_dual meet this_dual= "); t2this        ->dump(); tty->cr();
 
     fatal("meet not symmetric");
@@ -4579,40 +4584,110 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
   // If both types are equal to the subtype, exactness is and-ed below the
   // centerline and or-ed above it.  (N.B. Constants are always exact.)
 
-  // Check for subtyping:
-  // Flat in array matrix, yes = y, no = n, maybe = m, top/empty = T:
-  //        yes maybe no   -> Super Klass
-  //   yes   y    y    y
-  // maybe   y    m    m
-  //    no   T    n    n
-  //    |
-  //    v
-  // Sub Klass
+  // Flat in Array property _flat_in_array.
+  // For simplicity, _flat_in_array is a boolean but we actually have a tri state:
+  // - Flat in array       -> flat_in_array()
+  // - Not flat in array   -> not_flat_in_array()
+  // - Maybe flat in array -> !not_flat_in_array()
+  //
+  // Maybe we should convert _flat_in_array to a proper lattice with four elements at some point:
+  //
+  //                  Top
+  //    Flat in Array     Not Flat in Array
+  //          Maybe Flat in Array
+  //
+  // where
+  //     Top = dual(maybe Flat In Array) = "Flat in Array AND Not Flat in Array"
+  //
+  // But for now we stick with the current model with _flat_in_array as a boolean.
+  //
+  // When meeting two InstPtr types, we want to have the following behavior:
+  //
+  // (FiA-M) Meet(this, other):
+  //     'this' and 'other' are either the same klass OR sub klasses:
+  //
+  //                yes maybe no
+  //           yes   y    m    m                      y = Flat in Array
+  //         maybe   m    m    m                      n = Not Flat in Array
+  //            no   m    m    n                      m = Maybe Flat in Array
+  //
+  //  Join(this, other):
+  //     (FiA-J-Same) 'this' and 'other' are the SAME klass:
+  //
+  //                yes maybe no                      E = Empty set
+  //           yes   y    y    E                      y = Flat in Array
+  //         maybe   y    m    m                      n = Not Flat in Array
+  //            no   E    m    n                      m = Maybe Flat in Array
+  //
+  //     (FiA-J-Sub) 'this' and 'other' are SUB klasses:
+  //
+  //               yes maybe no   -> Super Klass      E = Empty set
+  //          yes   y    y    y                       y = Flat in Array
+  //        maybe   y    m    m                       n = Not Flat in Array
+  //           no   E    m    n                       m = Maybe Flat in Array
+  //           |
+  //           v
+  //       Sub Klass
+  //
+  //     Note the difference when joining a super klass that is not flat in array with a sub klass that is compared to
+  //     the same klass case. We will take over the flat in array property of the sub klass. This can be done because
+  //     the super klass could be Object (i.e. not an inline type and thus not flat in array) while the sub klass is a
+  //     value class which can be flat in array.
+  //
+  //     The empty set is only a possible result when matching 'ptr' above the center line (i.e. joining). In this case,
+  //     we can "fall hard" by setting 'ptr' to NotNull such that when we take the dual of that meet above the center
+  //     line, we get an empty set again.
+  //
+  //     Note: When changing to a separate lattice with _flat_in_array we may want to add TypeInst(Klass)Ptr::empty()
+  //           that returns true when the meet result is FlatInArray::Top (i.e. dual(maybe flat in array)).
 
   const T* subtype = nullptr;
   bool subtype_exact = false;
   bool flat_in_array = false;
+  bool is_empty = false;
   if (this_type->is_same_java_type_as(other_type)) {
+    // Same klass
     subtype = this_type;
     subtype_exact = below_centerline(ptr) ? (this_xk && other_xk) : (this_xk || other_xk);
-    flat_in_array = below_centerline(ptr) ? (this_flat_in_array && other_flat_in_array) : (this_flat_in_array || other_flat_in_array);
+    if (above_centerline(ptr)) {
+      // Case (FiA-J-Same)
+      // One is flat in array and the other not? Result is empty/"fall hard".
+      is_empty = (this_flat_in_array && other_not_flat_in_array) || (this_not_flat_in_array && other_flat_in_array);
+    }
   } else if (!other_xk && is_meet_subtype_of(this_type, other_type)) {
     subtype = this_type;     // Pick subtyping class
     subtype_exact = this_xk;
-    bool other_flat_this_maybe_flat = other_flat_in_array && (!this_flat_in_array && !this_not_flat_in_array);
-    flat_in_array = this_flat_in_array || other_flat_this_maybe_flat;
+    if (above_centerline(ptr)) {
+      // Case (FiA-J-Sub)
+      is_empty = this_not_flat_in_array && other_flat_in_array;
+      if (!is_empty) {
+        bool other_flat_this_maybe_flat = other_flat_in_array && (!this_flat_in_array && !this_not_flat_in_array);
+        flat_in_array = this_flat_in_array || other_flat_this_maybe_flat;
+      }
+    }
   } else if (!this_xk && is_meet_subtype_of(other_type, this_type)) {
     subtype = other_type;    // Pick subtyping class
     subtype_exact = other_xk;
-    bool this_flat_other_maybe_flat = this_flat_in_array && (!other_flat_in_array && !other_not_flat_in_array);
-    flat_in_array = other_flat_in_array || this_flat_other_maybe_flat;
+    if (above_centerline(ptr)) {
+      is_empty = this_flat_in_array && other_not_flat_in_array;
+      if (!is_empty) {
+        bool this_flat_other_maybe_flat = this_flat_in_array && (!other_flat_in_array && !other_not_flat_in_array);
+        flat_in_array = other_flat_in_array || this_flat_other_maybe_flat;
+      }
+    }
   }
 
-  if (subtype) {
+
+  if (subtype && !is_empty) {
     if (above_centerline(ptr)) {
       // Both types are empty.
       this_type = other_type = subtype;
       this_xk = other_xk = subtype_exact;
+      // Case (FiA-J-Sub)
+      bool other_flat_this_maybe_flat = other_flat_in_array && (!this_flat_in_array && !this_not_flat_in_array);
+      flat_in_array = this_flat_in_array || other_flat_this_maybe_flat;
+      // One is flat in array and the other not? Result is empty/"fall hard".
+      is_empty = (this_flat_in_array && other_not_flat_in_array) || (this_not_flat_in_array && other_flat_in_array);
     } else if (above_centerline(this_ptr) && !above_centerline(other_ptr)) {
       // this_type is empty while other_type is not. Take other_type.
       this_type = other_type;
@@ -4625,17 +4700,20 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
     } else {
       // this_type and other_type are both non-empty.
       this_xk = subtype_exact;  // either they are equal, or we'll do an LCA
+      // Case (FiA-M)
+      // Meeting two types below the center line: Only flat in array if both are.
+      flat_in_array = this_flat_in_array && other_flat_in_array;
     }
   }
 
   // Check for classes now being equal
-  if (this_type->is_same_java_type_as(other_type)) {
+  if (this_type->is_same_java_type_as(other_type) && !is_empty) {
     // If the klasses are equal, the constants may still differ.  Fall to
     // NotNull if they do (neither constant is null; that is a special case
     // handled elsewhere).
     res_klass = this_type->klass();
     res_xk = this_xk;
-    res_flat_in_array = subtype ? flat_in_array : this_flat_in_array;
+    res_flat_in_array = flat_in_array;
     return SUBTYPE;
   } // Else classes are not equal
 
@@ -6118,6 +6196,10 @@ void TypeKlassPtr::dump2(Dict & d, uint depth, outputStream *st) const {
   }
   _offset.dump2(st);
   st->print(" *");
+
+  if (flat_in_array() && !klass()->is_inlinetype()) {
+    st->print(" (flat in array)");
+  }
 }
 #endif
 

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -4669,6 +4669,7 @@ template<class T> TypePtr::MeetResult TypePtr::meet_instptr(PTR& ptr, const Type
     subtype = other_type;    // Pick subtyping class
     subtype_exact = other_xk;
     if (above_centerline(ptr)) {
+      // Case (FiA-J-Sub)
       is_empty = this_flat_in_array && other_not_flat_in_array;
       if (!is_empty) {
         bool this_flat_other_maybe_flat = this_flat_in_array && (!other_flat_in_array && !other_not_flat_in_array);

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1699,6 +1699,11 @@ public:
   virtual const TypeKlassPtr* with_offset(intptr_t offset) const { ShouldNotReachHere(); return nullptr; }
 
   virtual bool can_be_inline_array() const { ShouldNotReachHere(); return false; }
+
+  virtual bool not_flat_in_array_inexact() const {
+    return true;
+  }
+
   virtual const TypeKlassPtr* try_improve() const { return this; }
 
 #ifndef PRODUCT
@@ -1783,7 +1788,23 @@ public:
   virtual const TypeKlassPtr* try_improve() const;
 
   virtual bool flat_in_array() const { return _flat_in_array; }
-  virtual bool not_flat_in_array() const { return !_klass->can_be_inline_klass() || (_klass->is_inlinetype() && !flat_in_array()); }
+
+  // Checks if this klass pointer is not flat in array by also considering exactness information.
+  virtual bool not_flat_in_array() const {
+    return !_klass->can_be_inline_klass(klass_is_exact()) || (_klass->is_inlinetype() && !flat_in_array());
+  }
+
+  // not_flat_in_array() version that assumes that the klass is inexact. This is used for sub type checks where the
+  // super klass is always an exact klass constant (and thus possibly known to be not flat in array), while a sub
+  // klass could very well be flat in array:
+  //
+  //           MyValue       <:       Object
+  //        flat in array       not flat in array
+  //
+  // Thus, this version checks if we know that the klass is not flat in array even if it's not exact.
+  virtual bool not_flat_in_array_inexact() const {
+    return !_klass->can_be_inline_klass() || (_klass->is_inlinetype() && !flat_in_array());
+  }
 
   virtual bool can_be_inline_array() const;
 

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/showTypes.filter
@@ -23,6 +23,7 @@ function simplify_reference_type(type) {
 
 // Remove fixed input types for calls and simplify references.
 function simplifyType(type) {
+  var original_type = type;
   var callTypeStart = "{0:control, 1:abIO, 2:memory, 3:rawptr:BotPTR, 4:return_address";
   if (type.startsWith(callTypeStart)) {
     // Exclude types of the first five outputs of call-like nodes.
@@ -40,6 +41,10 @@ function simplifyType(type) {
     type = simplify_reference_type(type);
   }
   type = type.replace(">=", "≥").replace("<=", "≤");
+  if (original_type.indexOf("(flat in array)") !== -1) {
+    // Always append "flat in array" property last if found in original type.
+    type += " (flat in array)";
+  }
   return type;
 }
 


### PR DESCRIPTION
This patch fixes the wrong joining operation of two types of the same klass with regard to flat in array. We have the following shape in the test case (how we end up with such a graph can be found as comments in the added tests):
 
![image](https://github.com/user-attachments/assets/3ea680fa-d93c-4994-92b7-dd1c271c0030)

The type of `341 CheckCastPP` is `Object:exact`, so we definitely know that the type is `Object` and nothing else and thus also not flat in array (Object is not a value class). For `339 CheckCastPP`, we know that it is some kind of value class but definitely not `Object` itself - it's just chosen because we do not know more about the klass.

Joining these two should result in an empty set since they are unrelated. However, the type system is not handling it correctly and we conclude that one is a sub type of the other and we later fail with an assert.

### Reworking flat in array Meet Operation
I revisited the way we meet two instruction types with regard to the flat in array property. The code was a little hard to understand, so I added a summary how the flat in array property should be treated when doing a meet or join:

https://github.com/openjdk/valhalla/blob/b6b30301998e09e61b9c05282878f0596bc2f61b/src/hotspot/share/opto/type.cpp#L4604-L4630

I added a new case for joining the same klasses (see `(FiA-J-Same)`) which was missing before and resulting in an assertion failure.

### Adding dual of `_flat_in_array`?
I kept asking myself if we should introduce a proper lattice with a dual for flat in array:

https://github.com/openjdk/valhalla/blob/b6b30301998e09e61b9c05282878f0596bc2f61b/src/hotspot/share/opto/type.cpp#L4593-L4597

While it's probably the proper way to address this long term, I think we should investigate this separately as we would need to touch quite some code. I therefore left the idea as a comment and went with a point fix on top - keeping the way we currently handle `_flat_in_array` in meet operations without a proper dual.

### Including Changes
- More detailed summary how the meet/join of `flat_in_array` is done .
- Refactored the code in `meet_instptr()` to make it more readable/clear how the `flat_in_array` property is treated.
- For better debugging:
  - Dumping `(flat in array)` also for `TypeInstKlassPtr` and not only for `TypeInstPtr`.
  - Adapting "Show types" IGV filter to also show the flat in array property (see image of graph above).

### Additionally Required Fixes
- (i) With the type system fix above, we sanely remove the conflicting data nodes but we fail to remove the corresponding control path as well. The reason is that `TypeInstKlassPtr::not_flat_in_array()` does not take exactness information into account:
https://github.com/openjdk/valhalla/blob/991ec927a2a111e5021b12be3413dfc96efbc74a/src/hotspot/share/opto/type.hpp#L1787

   `_klass->can_be_inline_klass()` will treat the klass as inexact (note that `TypeInstPtr::not_flat_in_array()` takes exactness into account). As a result, `TypeInstKlassPtr::not_flat_in_array()` called on `Object:exact` returns false even though it is statically known that this should be true (i.e. not flat in array). This is fixed by passing `klass_is_exact()` to `_klass->can_be_inline_klass()`:
https://github.com/openjdk/valhalla/blob/b6b30301998e09e61b9c05282878f0596bc2f61b/src/hotspot/share/opto/type.hpp#L1793-L1795

- (ii) Applying (i) resulted in some assertion failures because we now wrongly treat a sub type check of the form `X <: Object` as false even though this should be true for any class `X`. We check in `SubTypeCheckNode::Value()` -> `SybTypeCheckNode::sub()` the following:
https://github.com/openjdk/valhalla/blob/991ec927a2a111e5021b12be3413dfc96efbc74a/src/hotspot/share/opto/subtypenode.cpp#L53-L54

  In a failing case, `subk` is a value class that is flat in array while `superk` is `Object:exact`. Due to now passing the exactness information in `TypeInstKlassPtr::not_flat_in_array()` with (i), this returns true. We wrongly assume the classes are unrelated  due to conflicting `flat_in_array` information and thus the check is wrongly treated as false. 

  The fix I propose for this is to introduce a special `not_flat_in_array_inexact()` that reflects the old behavior of `not_flat_in_array()` to ignore exactness information.
 
I added some comments in the PR to help understanding the change better.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348961](https://bugs.openjdk.org/browse/JDK-8348961): [lworld] C2: Joining "Object:flat_in_array" with "Object:exact" does not properly work (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1367/head:pull/1367` \
`$ git checkout pull/1367`

Update a local copy of the PR: \
`$ git checkout pull/1367` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1367`

View PR using the GUI difftool: \
`$ git pr show -t 1367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1367.diff">https://git.openjdk.org/valhalla/pull/1367.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1367#issuecomment-2659074709)
</details>
