### PR TITLE
8350109: [lworld] Adopt jtreg 7.5.1

### DIFF
--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 ################################################################################
 
 # Minimum supported versions
-JTREG_MINIMUM_VERSION=7.4
+JTREG_MINIMUM_VERSION=7.5.1
 GTEST_MINIMUM_VERSION=1.14.0
 
 ################################################################################

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
 GTEST_VERSION=1.14.0
-JTREG_VERSION=7.4+1
+JTREG_VERSION=7.5.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL/openjdk-23_linux-x64_bin.tar.gz

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1186,9 +1186,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "7.5",
-            build_number: "ci/31",
-            file: "bundles/jtreg-7.5+1.zip",
+            version: "7.5.1",
+            build_number: "1",
+            file: "bundles/jtreg-7.5.1+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "home_path") + "/bin",
             configure_args: "--with-jtreg=" + input.get("jtreg", "home_path"),

--- a/test/docs/TEST.ROOT
+++ b/test/docs/TEST.ROOT
@@ -38,7 +38,7 @@
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.5+1
+requiredVersion=7.5.1+1
 
 # Use new module options
 useNewOptions=true

--- a/test/docs/TEST.ROOT
+++ b/test/docs/TEST.ROOT
@@ -38,7 +38,7 @@
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5+1
 
 # Use new module options
 useNewOptions=true

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -95,7 +95,7 @@ requires.properties= \
     jlink.packagedModules
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../../ notation to reach them

--- a/test/jaxp/TEST.ROOT
+++ b/test/jaxp/TEST.ROOT
@@ -23,7 +23,7 @@ modules=java.xml
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -834,4 +834,3 @@ java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-valhalla/valuetypes/ObjectMethodsViaCondy.java 8349725 generic-all

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -114,7 +114,7 @@ requires.properties= \
     jlink.packagedModules
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/java/lang/invoke/common/LIBRARY.properties
+++ b/test/jdk/java/lang/invoke/common/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = true

--- a/test/jdk/tools/lib/LIBRARY.properties
+++ b/test/jdk/tools/lib/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = true

--- a/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @summary Test ObjectMethods::bootstrap call via condy
- * @library /testlibrary/asm
  * @modules java.base/jdk.internal.value
  * @enablePreview
  * @run testng/othervm ObjectMethodsViaCondy
@@ -33,35 +32,29 @@
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup.ClassOption;
 import java.lang.invoke.MethodType;
-import java.lang.invoke.TypeDescriptor;
+import java.lang.runtime.ObjectMethods;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.ConstantDynamic;
-import org.objectweb.asm.Handle;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Type;
 import org.testng.annotations.Test;
+
+import static java.lang.classfile.ClassFile.*;
+import static java.lang.constant.ConstantDescs.*;
 import static java.lang.invoke.MethodType.methodType;
-import static org.objectweb.asm.Opcodes.ACC_FINAL;
-import static org.objectweb.asm.Opcodes.ACC_IDENTITY;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.ARETURN;
-import static org.objectweb.asm.Opcodes.H_GETFIELD;
-import static org.objectweb.asm.Opcodes.H_INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
-import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V19;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
@@ -70,14 +63,19 @@ public class ObjectMethodsViaCondy {
     public static value record ValueRecord(int i, String name) {
         static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
         static final MethodType TO_STRING_DESC = methodType(String.class, ValueRecord.class);
-        static final Handle[] ACCESSORS = accessors();
         static final String NAME_LIST = "i;name";
-        private static Handle[] accessors() {
+        private static final ClassDesc CD_ValueRecord = ValueRecord.class.describeConstable().orElseThrow();
+        private static final ClassDesc CD_ObjectMethods = ObjectMethods.class.describeConstable().orElseThrow();
+        private static final MethodTypeDesc MTD_ObjectMethods_bootstrap = MethodTypeDesc.of(CD_Object, CD_MethodHandles_Lookup, CD_String,
+                ClassDesc.ofInternalName("java/lang/invoke/TypeDescriptor"), CD_Class, CD_String, CD_MethodHandle.arrayType());
+        static final List<DirectMethodHandleDesc> ACCESSORS = accessors();
+
+        private static List<DirectMethodHandleDesc> accessors() {
             try {
-                return  new Handle[]{
-                        new Handle(H_GETFIELD, Type.getInternalName(ValueRecord.class), "i", "I", false),
-                        new Handle(H_GETFIELD, Type.getInternalName(ValueRecord.class), "name", String.class.descriptorString(), false)
-                };
+                return List.of(
+                        MethodHandleDesc.ofField(DirectMethodHandleDesc.Kind.GETTER, CD_ValueRecord, "i", CD_int),
+                        MethodHandleDesc.ofField(DirectMethodHandleDesc.Kind.GETTER, CD_ValueRecord, "name", CD_String)
+                );
             } catch (Exception e) {
                 throw new AssertionError(e);
             }
@@ -92,9 +90,32 @@ public class ObjectMethodsViaCondy {
          *                     {@code "equals"}, {@code "hashCode"}, or {@code "toString"}
          */
         static MethodHandle makeBootstrapMethod(String methodName) throws Throwable {
-            ClassFileBuilder builder = new ClassFileBuilder("Test-" + methodName);
-            builder.bootstrapMethod(methodName, TO_STRING_DESC, ValueRecord.class, NAME_LIST, ACCESSORS);
-            byte[] bytes = builder.build();
+            String className = "Test-" + methodName;
+            ClassDesc testClass = ClassDesc.of(className);
+            byte[] bytes = ClassFile.of().build(testClass, clb -> clb
+                    .withVersion(JAVA_19_VERSION, 0)
+                    .withFlags(ACC_FINAL | ACC_SUPER)
+                    .withMethodBody(INIT_NAME, MTD_void, ACC_PUBLIC, cob -> cob
+                            .aload(0)
+                            .invokespecial(CD_Object, INIT_NAME, MTD_void)
+                            .return_())
+                    .withMethodBody("bootstrap", MethodTypeDesc.of(CD_Object), ACC_PUBLIC | ACC_STATIC, cob -> cob
+                            .loadConstant(DynamicConstantDesc.ofNamed(
+                                    MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_ObjectMethods,
+                                            "bootstrap", MTD_ObjectMethods_bootstrap),
+                                    methodName,
+                                    CD_MethodHandle,
+                                    Stream.concat(Stream.of(CD_ValueRecord, NAME_LIST), ACCESSORS.stream()).toArray(ConstantDesc[]::new)))
+                            .areturn())
+            );
+
+            Path p = Paths.get(className + ".class");
+            try (OutputStream os = Files.newOutputStream(p)) {
+                os.write(bytes);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
             MethodHandles.Lookup lookup = LOOKUP.defineHiddenClass(bytes, true, ClassOption.NESTMATE);
             MethodType mtype = MethodType.methodType(Object.class);
             MethodHandle mh = lookup.findStatic(lookup.lookupClass(), "bootstrap", mtype);
@@ -114,64 +135,5 @@ public class ObjectMethodsViaCondy {
         MethodHandle handle = ValueRecord.makeBootstrapMethod("equals");
         assertTrue((boolean)handle.invoke(new ValueRecord(10, "ten"), new ValueRecord(10, "ten")));
         assertFalse((boolean)handle.invoke(new ValueRecord(11, "eleven"), new ValueRecord(10, "ten")));
-    }
-
-    static class ClassFileBuilder {
-        private static final String OBJECT_CLS = "java/lang/Object";
-        private static final String OBJ_METHODS_CLS = "java/lang/runtime/ObjectMethods";
-        private static final String BSM_DESCR =
-                MethodType.methodType(Object.class, MethodHandles.Lookup.class, String.class,
-                                      TypeDescriptor.class, Class.class, String.class, MethodHandle[].class)
-                          .descriptorString();
-        private final ClassWriter cw;
-        private final String classname;
-
-        /**
-         * A builder to generate a class file to access class data
-         *
-         * @param classname
-         */
-        ClassFileBuilder(String classname) {
-            this.classname = classname;
-            this.cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
-            cw.visit(V19, ACC_FINAL | ACC_IDENTITY, classname, null, OBJECT_CLS, null);
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-            mv.visitCode();
-            mv.visitVarInsn(ALOAD, 0);
-            mv.visitMethodInsn(INVOKESPECIAL, OBJECT_CLS, "<init>", "()V", false);
-            mv.visitInsn(RETURN);
-            mv.visitMaxs(0, 0);
-            mv.visitEnd();
-        }
-
-        byte[] build() {
-            cw.visitEnd();
-            byte[] bytes = cw.toByteArray();
-            Path p = Paths.get(classname + ".class");
-            try (OutputStream os = Files.newOutputStream(p)) {
-                os.write(bytes);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-            return bytes;
-        }
-
-        /*
-         * Generate the bootstrap method that invokes ObjectMethods::bootstrap via condy
-         */
-        void bootstrapMethod(String name, TypeDescriptor descriptor, Class<?> recordClass, String names, Handle[] getters) {
-            MethodType mtype = MethodType.methodType(Object.class);
-            MethodVisitor mv = cw.visitMethod(ACC_PUBLIC|ACC_STATIC,
-                    "bootstrap", mtype.descriptorString(), null, null);
-            mv.visitCode();
-            Handle bsm = new Handle(H_INVOKESTATIC, OBJ_METHODS_CLS, "bootstrap",
-                                    BSM_DESCR, false);
-            Object[] args = Stream.concat(Stream.of(Type.getType(recordClass), names), Arrays.stream(getters)).toArray();
-            ConstantDynamic dynamic = new ConstantDynamic(name, MethodHandle.class.descriptorString(), bsm, args);
-            mv.visitLdcInsn(dynamic);
-            mv.visitInsn(ARETURN);
-            mv.visitMaxs(0, 0);
-            mv.visitEnd();
-        }
     }
 }

--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -15,7 +15,7 @@ keys=intermittent randomness needs-src needs-src-jdk_javadoc
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Use new module options
 useNewOptions=true

--- a/test/langtools/lib/annotations/LIBRARY.properties
+++ b/test/langtools/lib/annotations/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = true

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerAnnotationTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerAnnotationTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner annotations in inner annotation.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerClassTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner annotations in inner class.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerEnumTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerEnumTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner annotations in inner enum.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerInterfaceTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerAnnotationsInInnerInterfaceTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner annotations in inner interface.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesHierarchyTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesHierarchyTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Test that inner classes have in its inner classes attribute enclosing classes and its immediate members.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox InMemoryFileManager TestResult TestBase

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInAnonymousClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInAnonymousClassTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251 8062373
  * @summary Testing InnerClasses_attribute of inner classes in anonymous class.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerAnnotationTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerAnnotationTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner classes in inner annotation.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerClassTest.java
@@ -26,6 +26,7 @@
  * @bug 8034854 8042251
  * @summary Testing InnerClasses_attribute of inner classes in inner class.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerEnumTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerEnumTest.java
@@ -26,6 +26,7 @@
  * @bug 8034854 8042251
  * @summary Testing InnerClasses_attribute of inner classes in inner enum.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerInterfaceTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInInnerInterfaceTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner classes in inner interface.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInLocalClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesInLocalClassTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner classes in local class.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules java.base/jdk.internal.classfile.impl
  *          jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesIndexTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesIndexTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Test that outer_class_info_index of local and anonymous class is zero.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox InMemoryFileManager TestResult TestBase

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerClassesTest.java
@@ -26,6 +26,7 @@
  * @bug 8034854 8042251
  * @summary Testing inner classes attributes.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerAnnotationTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerAnnotationTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner enums in inner annotation.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerEnumTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerEnumTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner enums in inner enum.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerInterfaceTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumInInnerInterfaceTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner enums in inner interface.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumsInInnerClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerEnumsInInnerClassTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner enums in inner class.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerAnnotationTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerAnnotationTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner interfaces in inner annotation.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerClassTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerClassTest.java
@@ -26,6 +26,7 @@
  * @summary Testing InnerClasses_attribute of inner interfaces in inner class.
  * @author aeremeev
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerEnumTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerEnumTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner interfaces in inner enum.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerInterfaceTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/InnerInterfacesInInnerInterfaceTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Testing InnerClasses_attribute of inner interfaces in inner interface.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          java.base/jdk.internal.classfile.impl

--- a/test/langtools/tools/javac/classfiles/attributes/innerclasses/NoInnerClassesTest.java
+++ b/test/langtools/tools/javac/classfiles/attributes/innerclasses/NoInnerClassesTest.java
@@ -26,6 +26,7 @@
  * @bug 8042251
  * @summary Test that there are no inner classes attributes in case of there are no inner classes.
  * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox InMemoryFileManager TestBase

--- a/test/langtools/tools/javac/classfiles/attributes/lib/LIBRARY.properties
+++ b/test/langtools/tools/javac/classfiles/attributes/lib/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = true

--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 keys=randomness
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/lib/LIBRARY.properties
+++ b/test/lib/LIBRARY.properties
@@ -1,1 +1,0 @@
-enablePreview = false   # false so the common build is NOT --enable-preview


### PR DESCRIPTION
Jtreg is updated to 7.5.1
7.5.1 drops support for LIBRARY.properties.
Some tests have added @enableProperties to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350109](https://bugs.openjdk.org/browse/JDK-8350109): [lworld] Adopt jtreg 7.5.1 (**Bug** - P4)


### Reviewers
 * [David Simms](https://openjdk.org/census#dsimms) (@MrSimms - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1369/head:pull/1369` \
`$ git checkout pull/1369`

Update a local copy of the PR: \
`$ git checkout pull/1369` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1369`

View PR using the GUI difftool: \
`$ git pr show -t 1369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1369.diff">https://git.openjdk.org/valhalla/pull/1369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1369#issuecomment-2659686592)
</details>
