### PR TITLE
8350283: [lworld] Layout helper can have incorrect is_null_free bit for flat arrays

### DIFF
--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -65,27 +65,31 @@ FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk
   set_layout_helper(array_layout_helper(InlineKlass::cast(element_klass), lk));
   assert(is_array_klass(), "sanity");
   assert(is_flatArray_klass(), "sanity");
-  assert(is_null_free_array_klass(), "sanity");
 
 #ifdef _LP64
   set_prototype_header(markWord::flat_array_prototype(lk));
-  assert(prototype_header().is_flat_array(), "sanity");
 #else
   fatal("Not supported yet");
   set_prototype_header(markWord::inline_type_prototype());
 #endif
 
 #ifdef ASSERT
+  assert(layout_helper_is_array(layout_helper()), "Must be");
+  assert(layout_helper_is_flatArray(layout_helper()), "Must be");
+  assert(layout_helper_element_type(layout_helper()) == T_FLAT_ELEMENT, "Must be");
+  assert(prototype_header().is_flat_array(), "Must be");
   switch(lk) {
     case NON_ATOMIC_FLAT:
+    case ATOMIC_FLAT:
       assert(layout_helper_is_null_free(layout_helper()), "Must be");
-      assert(layout_helper_is_array(layout_helper()), "Must be");
-      assert(layout_helper_is_flatArray(layout_helper()), "Must be");
-      assert(layout_helper_element_type(layout_helper()) == T_FLAT_ELEMENT, "Must be");
       assert(prototype_header().is_null_free_array(), "Must be");
-      assert(prototype_header().is_flat_array(), "Must be");
+    break;
+    case NULLABLE_ATOMIC_FLAT:
+      assert(!layout_helper_is_null_free(layout_helper()), "Must be");
+      assert(!prototype_header().is_null_free_array(), "Must be");
     break;
     default:
+      ShouldNotReachHere();
     break;
   }
 #endif // ASSERT
@@ -161,15 +165,15 @@ jint FlatArrayKlass::array_layout_helper(InlineKlass* vk, LayoutKind lk) {
   BasicType etype = T_FLAT_ELEMENT;
   int esize = log2i_exact(round_up_power_of_2(vk->layout_size_in_bytes(lk)));
   int hsize = arrayOopDesc::base_offset_in_bytes(etype);
-
-  int lh = Klass::array_layout_helper(_lh_array_tag_vt_value, true, hsize, etype, esize);
+  bool null_free = lk != NULLABLE_ATOMIC_FLAT;
+  int lh = Klass::array_layout_helper(_lh_array_tag_vt_value, null_free, hsize, etype, esize);
 
   assert(lh < (int)_lh_neutral_value, "must look like an array layout");
   assert(layout_helper_is_array(lh), "correct kind");
   assert(layout_helper_is_flatArray(lh), "correct kind");
   assert(!layout_helper_is_typeArray(lh), "correct kind");
   assert(!layout_helper_is_objArray(lh), "correct kind");
-  assert(layout_helper_is_null_free(lh), "correct kind");
+  assert(layout_helper_is_null_free(lh) == null_free, "correct kind");
   assert(layout_helper_header_size(lh) == hsize, "correct decode");
   assert(layout_helper_element_type(lh) == etype, "correct decode");
   assert(layout_helper_log2_element_size(lh) == esize, "correct decode");


### PR DESCRIPTION
Small fix to correct the generation of the layout helper for flat arrays using the NULLABLE_ATOMIC_FLAT layout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350283](https://bugs.openjdk.org/browse/JDK-8350283): [lworld] Layout helper can have incorrect is_null_free bit for flat arrays (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1370/head:pull/1370` \
`$ git checkout pull/1370`

Update a local copy of the PR: \
`$ git checkout pull/1370` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1370`

View PR using the GUI difftool: \
`$ git pr show -t 1370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1370.diff">https://git.openjdk.org/valhalla/pull/1370.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1370#issuecomment-2667023536)
</details>
