### PR TITLE
8350444: Check for verifer error in StackMapReader::check_offset()

### DIFF
--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -232,6 +232,9 @@ StackMapFrame* StackMapReader::next(TRAPS) {
   StackMapFrame* frame = next_helper(CHECK_VERIFY_(_verifier, nullptr));
   if (frame != nullptr) {
     check_offset(frame);
+    if (frame->verifier()->has_error()) {
+      return nullptr;
+    }
     _prev_frame = frame;
   }
   return frame;


### PR DESCRIPTION
This patch upstreams a change from mainline that is needed to implement strict fields. 
Originally reviewed-by: coleenp, dholmes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350444](https://bugs.openjdk.org/browse/JDK-8350444): Check for verifer error in StackMapReader::check_offset() (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1372/head:pull/1372` \
`$ git checkout pull/1372`

Update a local copy of the PR: \
`$ git checkout pull/1372` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1372`

View PR using the GUI difftool: \
`$ git pr show -t 1372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1372.diff">https://git.openjdk.org/valhalla/pull/1372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1372#issuecomment-2675143024)
</details>
