### PR TITLE
8343846: [lworld] implement spec changes to stack map tables

### DIFF
--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -31,10 +31,10 @@
 #include "runtime/handles.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-StackMapFrame::StackMapFrame(u2 max_locals, u2 max_stack, ClassVerifier* v) :
+StackMapFrame::StackMapFrame(u2 max_locals, u2 max_stack, AssertUnsetFieldTable* initial_strict_fields, ClassVerifier* v) :
                       _offset(0), _locals_size(0), _stack_size(0),
                       _stack_mark(0), _max_locals(max_locals),
-                      _max_stack(max_stack), _flags(0), _verifier(v) {
+                      _max_stack(max_stack), _flags(0), _assert_unset_fields(initial_strict_fields), _verifier(v) {
   Thread* thr = v->thread();
   _locals = NEW_RESOURCE_ARRAY_IN_THREAD(thr, VerificationType, max_locals);
   _stack = NEW_RESOURCE_ARRAY_IN_THREAD(thr, VerificationType, max_stack);
@@ -50,7 +50,9 @@ StackMapFrame::StackMapFrame(u2 max_locals, u2 max_stack, ClassVerifier* v) :
 StackMapFrame* StackMapFrame::frame_in_exception_handler(u1 flags) {
   Thread* thr = _verifier->thread();
   VerificationType* stack = NEW_RESOURCE_ARRAY_IN_THREAD(thr, VerificationType, 1);
-  StackMapFrame* frame = new StackMapFrame(_offset, flags, _locals_size, 0, _max_locals, _max_stack, _locals, stack, _verifier);
+  StackMapFrame* frame = new StackMapFrame(_offset, flags, _locals_size, 0,
+                                           _max_locals, _max_stack, _locals, stack,
+                                           _assert_unset_fields, _verifier);
   return frame;
 }
 
@@ -185,6 +187,14 @@ bool StackMapFrame::is_assignable_to(
     *ctx = ErrorContext::bad_type(target->offset(),
         TypeOrigin::stack(mismatch_loc, (StackMapFrame*)this),
         TypeOrigin::sm_stack(mismatch_loc, (StackMapFrame*)target));
+    return false;
+  }
+
+  // Check that assert unset fields are compatible
+  bool compatible = unset_fields_compatible(target->assert_unset_fields());
+  if (!compatible) {
+    *ctx = ErrorContext::strict_fields_mismatch(target->offset(),
+        (StackMapFrame*)this, (StackMapFrame*)target);
     return false;
   }
 

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -49,11 +49,11 @@ StackMapFrame::StackMapFrame(u2 max_locals, u2 max_stack, AssertUnsetFieldTable*
 
 void StackMapFrame::print_strict_fields(AssertUnsetFieldTable* table) {
   ResourceMark rm;
-  auto printfields = [&] (const NameAndSig& key, const NameAndSig& value) {
+  auto printfields = [&] (const NameAndSig& key, const bool& value) {
     log_info(verification)("Strict field: %s%s (Satisfied: %s)",
-                           value._name->as_C_string(),
-                           value._signature->as_C_string(),
-                           value._satisfied ? "true" : "false");
+                           key._name->as_C_string(),
+                           key._signature->as_C_string(),
+                           value ? "true" : "false");
   };
   table->iterate_all(printfields);
 }

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -202,7 +202,7 @@ bool StackMapFrame::is_assignable_to(
   }
 
   // Check that assert unset fields are compatible
-  bool compatible = unset_fields_compatible(target->assert_unset_fields());
+  bool compatible = is_unset_fields_compatible(target->assert_unset_fields());
   if (!compatible) {
     *ctx = ErrorContext::strict_fields_mismatch(target->offset(),
         (StackMapFrame*)this, (StackMapFrame*)target);

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -202,7 +202,7 @@ bool StackMapFrame::is_assignable_to(
   }
 
   // Check that assert unset fields are compatible
-  bool compatible = is_unset_fields_compatible(target->assert_unset_fields());
+  bool compatible = verify_unset_fields_compatibility(target->assert_unset_fields());
   if (!compatible) {
     *ctx = ErrorContext::strict_fields_mismatch(target->offset(),
         (StackMapFrame*)this, (StackMapFrame*)target);

--- a/src/hotspot/share/classfile/stackMapFrame.cpp
+++ b/src/hotspot/share/classfile/stackMapFrame.cpp
@@ -47,6 +47,17 @@ StackMapFrame::StackMapFrame(u2 max_locals, u2 max_stack, AssertUnsetFieldTable*
   }
 }
 
+void StackMapFrame::print_strict_fields(AssertUnsetFieldTable* table) {
+  ResourceMark rm;
+  auto printfields = [&] (const NameAndSig& key, const NameAndSig& value) {
+    log_info(verification)("Strict field: %s%s (Satisfied: %s)",
+                           value._name->as_C_string(),
+                           value._signature->as_C_string(),
+                           value._satisfied ? "true" : "false");
+  };
+  table->iterate_all(printfields);
+}
+
 StackMapFrame* StackMapFrame::frame_in_exception_handler(u1 flags) {
   Thread* thr = _verifier->thread();
   VerificationType* stack = NEW_RESOURCE_ARRAY_IN_THREAD(thr, VerificationType, 1);

--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -163,6 +163,7 @@ class StackMapFrame : public ResourceObj {
     _assert_unset_fields = table;
   }
 
+  // Called when verifying putfields to mark strict instance fields as satisfied
   bool satisfy_unset_field(Symbol* name, Symbol* signature) {
     NameAndSig dummy_field(name, signature);
 
@@ -174,7 +175,9 @@ class StackMapFrame : public ResourceObj {
     return false;
   }
 
-  bool is_unset_fields_satisfied() {
+  // Verify that all strict fields have been initialized
+  // Strict fields must be initialized before the super constructor is called
+  bool verify_unset_fields_satisfied() {
     bool all_satisfied = true;
     auto check_satisfied = [&] (const NameAndSig& key, const NameAndSig& value) {
       all_satisfied &= value._satisfied;
@@ -197,7 +200,9 @@ class StackMapFrame : public ResourceObj {
     return new_fields;
   }
 
-  bool is_unset_fields_compatible(AssertUnsetFieldTable* target_table) const {
+  // Verify that strict fields are compatible between the current frame and the successor
+  // Called during merging of frames
+  bool verify_unset_fields_compatibility(AssertUnsetFieldTable* target_table) const {
     bool compatible = true;
     auto is_unset = [&] (const NameAndSig& key, const NameAndSig& value) {
       // Successor must have same debts as current frame

--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -174,9 +174,9 @@ class StackMapFrame : public ResourceObj {
     return false;
   }
 
-  bool unset_fields_satisfied() {
+  bool is_unset_fields_satisfied() {
     bool all_satisfied = true;
-    auto check_satisfied = [&all_satisfied] (const NameAndSig& key, const NameAndSig& value) {
+    auto check_satisfied = [&] (const NameAndSig& key, const NameAndSig& value) {
       all_satisfied &= value._satisfied;
     };
     _assert_unset_fields->iterate_all(check_satisfied);
@@ -197,7 +197,7 @@ class StackMapFrame : public ResourceObj {
     return new_fields;
   }
 
-  bool unset_fields_compatible(AssertUnsetFieldTable* target_table) const {
+  bool is_unset_fields_compatible(AssertUnsetFieldTable* target_table) const {
     bool compatible = true;
     auto is_unset = [&] (const NameAndSig& key, const NameAndSig& value) {
       // Successor must have same debts as current frame

--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,20 @@ enum {
 };
 
 class StackMapFrame : public ResourceObj {
+ public:
+  static unsigned int nameandsig_hash(NameAndSig const& field) {
+    Symbol* name = field._name;
+    return (unsigned int) name->identity_hash();
+  }
+
+  static inline bool nameandsig_equals(NameAndSig const& f1, NameAndSig const& f2) {
+    return f1._name == f2._name &&
+           f1._signature == f2._signature;
+  }
+
+  typedef ResourceHashtable<NameAndSig, NameAndSig, 17,
+                    AnyObj::RESOURCE_AREA, mtInternal,
+                    nameandsig_hash, nameandsig_equals> AssertUnsetFieldTable;
  private:
   int32_t _offset;
 
@@ -59,6 +73,8 @@ class StackMapFrame : public ResourceObj {
   u1 _flags;
   VerificationType* _locals; // local variable type array
   VerificationType* _stack;  // operand stack type array
+
+  AssertUnsetFieldTable* _assert_unset_fields; // List of unsatisfied strict fields in the basic block
 
   ClassVerifier* _verifier;  // the verifier verifying this method
 
@@ -85,6 +101,7 @@ class StackMapFrame : public ResourceObj {
         _stack[i] = VerificationType::bogus_type();
       }
     }
+    _assert_unset_fields = cp._assert_unset_fields;
     _verifier = nullptr;
   }
 
@@ -94,7 +111,7 @@ class StackMapFrame : public ResourceObj {
   // This constructor is used by the type checker to allocate frames
   // in type state, which have _max_locals and _max_stack array elements
   // in _locals and _stack.
-  StackMapFrame(u2 max_locals, u2 max_stack, ClassVerifier* verifier);
+  StackMapFrame(u2 max_locals, u2 max_stack, AssertUnsetFieldTable* initial_strict_fields, ClassVerifier* verifier);
 
   // This constructor is used to initialize stackmap frames in stackmap table,
   // which have _locals_size and _stack_size array elements in _locals and _stack.
@@ -106,6 +123,7 @@ class StackMapFrame : public ResourceObj {
                 u2 max_stack,
                 VerificationType* locals,
                 VerificationType* stack,
+                AssertUnsetFieldTable* assert_unset_fields,
                 ClassVerifier* v) : _offset(offset),
                                     _locals_size(locals_size),
                                     _stack_size(stack_size),
@@ -113,6 +131,7 @@ class StackMapFrame : public ResourceObj {
                                     _max_locals(max_locals),
                                     _max_stack(max_stack),  _flags(flags),
                                     _locals(locals), _stack(stack),
+                                    _assert_unset_fields(assert_unset_fields),
                                     _verifier(v) { }
 
   static StackMapFrame* copy(StackMapFrame* smf) {
@@ -135,6 +154,73 @@ class StackMapFrame : public ResourceObj {
   inline u2 max_locals() const                { return _max_locals; }
   inline u2 max_stack() const                 { return _max_stack; }
   inline bool flag_this_uninit() const        { return _flags & FLAG_THIS_UNINIT; }
+
+  AssertUnsetFieldTable* assert_unset_fields() const {
+    return _assert_unset_fields;
+  }
+
+  void set_assert_unset_fields(AssertUnsetFieldTable* table) {
+    _assert_unset_fields = table;
+  }
+
+  bool satisfy_unset_field(Symbol* name, Symbol* signature) {
+    NameAndSig dummy_field(name, signature);
+
+    if (_assert_unset_fields->contains(dummy_field)) {
+      NameAndSig* field = _assert_unset_fields->get(dummy_field);
+      field->_satisfied = true;
+      return true;
+    }
+    return false;
+  }
+
+  bool unset_fields_satisfied() {
+    bool all_satisfied = true;
+    auto check_satisfied = [&all_satisfied] (const NameAndSig& key, const NameAndSig& value) {
+      all_satisfied &= value._satisfied;
+    };
+    _assert_unset_fields->iterate_all(check_satisfied);
+    return all_satisfied;
+  }
+
+  // Merge incoming unset strict fields from StackMapTable with
+  // initial strict instance fields
+  AssertUnsetFieldTable* merge_unset_fields(AssertUnsetFieldTable* new_fields) {
+    auto merge_satisfied = [&] (const NameAndSig& key, const NameAndSig& value) {
+      if (!new_fields->contains(key)) {
+        NameAndSig dummy = value;
+        dummy._satisfied = true;
+        new_fields->put(key, dummy);
+      }
+    };
+    _assert_unset_fields->iterate_all(merge_satisfied);
+    return new_fields;
+  }
+
+  bool unset_fields_compatible(AssertUnsetFieldTable* target_table) const {
+    bool compatible = true;
+    auto is_unset = [&] (const NameAndSig& key, const NameAndSig& value) {
+      // Successor must have same debts as current frame
+      if (!value._satisfied) {
+        if (target_table->get(key)->_satisfied == true) {
+          compatible = false;
+        }
+      }
+    };
+    _assert_unset_fields->iterate_all(is_unset);
+    return compatible;
+  }
+
+  static void print_strict_fields(AssertUnsetFieldTable* table) {
+    ResourceMark rm;
+    auto printfields = [&] (const NameAndSig& key, const NameAndSig& value) {
+      log_info(verification)("Strict field: %s%s (Satisfied: %s)",
+                             value._name->as_C_string(),
+                             value._signature->as_C_string(),
+                             value._satisfied ? "true" : "false");
+    };
+    table->iterate_all(printfields);
+  }
 
   // Set locals and stack types to bogus
   inline void reset() {

--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -211,16 +211,7 @@ class StackMapFrame : public ResourceObj {
     return compatible;
   }
 
-  static void print_strict_fields(AssertUnsetFieldTable* table) {
-    ResourceMark rm;
-    auto printfields = [&] (const NameAndSig& key, const NameAndSig& value) {
-      log_info(verification)("Strict field: %s%s (Satisfied: %s)",
-                             value._name->as_C_string(),
-                             value._signature->as_C_string(),
-                             value._satisfied ? "true" : "false");
-    };
-    table->iterate_all(printfields);
-  }
+  static void print_strict_fields(AssertUnsetFieldTable* table);
 
   // Set locals and stack types to bogus
   inline void reset() {

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -245,7 +245,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
   int offset;
   VerificationType* locals = nullptr;
   u1 frame_type = _stream->get_u1(CHECK_NULL);
-  if (frame_type == 246) {
+  if (frame_type == ASSERT_UNSET_FIELDS) {
     u2 num_unset_fields = _stream->get_u2(CHECK_NULL);
     StackMapFrame::AssertUnsetFieldTable* new_fields = new StackMapFrame::AssertUnsetFieldTable();
 
@@ -272,7 +272,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
     } else if (new_fields->number_of_entries() > 0) {
       _prev_frame->verifier()->verify_error(
         ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
-        "Cannot have uninitialzied strict fields after class initialization");
+        "Cannot have uninitialized strict fields after class initialization");
     }
 
     return nullptr;

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -127,6 +127,7 @@ bool StackMapTable::match_stackmap(
     frame->set_stack_size(ssize);
     frame->copy_stack(stackmap_frame);
     frame->set_flags(stackmap_frame->flags());
+    frame->set_assert_unset_fields(stackmap_frame->assert_unset_fields());
   }
   return result;
 }
@@ -157,11 +158,13 @@ void StackMapTable::print_on(outputStream* str) const {
 StackMapReader::StackMapReader(ClassVerifier* v, StackMapStream* stream,
                                char* code_data, int32_t code_len,
                                StackMapFrame* init_frame,
-                               u2 max_locals, u2 max_stack, TRAPS) :
+                               u2 max_locals, u2 max_stack,
+                               StackMapFrame::AssertUnsetFieldTable* initial_strict_fields, TRAPS) :
                                   _verifier(v), _stream(stream), _code_data(code_data),
                                   _code_length(code_len), _parsed_frame_count(0),
                                   _prev_frame(init_frame), _max_locals(max_locals),
-                                  _max_stack(max_stack), _first(true) {
+                                  _max_stack(max_stack), _assert_unset_fields_buffer(initial_strict_fields),
+                                  _first(true) {
   methodHandle m = v->method();
   if (m->has_stackmap_table()) {
     _cp = constantPoolHandle(THREAD, m->constants());
@@ -242,6 +245,38 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
   int offset;
   VerificationType* locals = nullptr;
   u1 frame_type = _stream->get_u1(CHECK_NULL);
+  if (frame_type == 246) {
+    u2 num_unset_fields = _stream->get_u2(CHECK_NULL);
+    StackMapFrame::AssertUnsetFieldTable* new_fields = new StackMapFrame::AssertUnsetFieldTable();
+
+    for (u2 i = 0; i < num_unset_fields; i++) {
+      u2 index = _stream->get_u2(CHECK_NULL);
+      Symbol* name = _cp->symbol_at(_cp->name_ref_index_at(index));
+      Symbol* sig = _cp->symbol_at(_cp->signature_ref_index_at(index));
+      NameAndSig tmp(name, sig);
+
+      if (!_prev_frame->assert_unset_fields()->contains(tmp)) {
+        log_info(verification)("Field %s%s is not found among initial strict instance fields", name->as_C_string(), sig->as_C_string());
+        StackMapFrame::print_strict_fields(_prev_frame->assert_unset_fields());
+        _prev_frame->verifier()->verify_error(
+            ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
+            "Strict fields not a subset of initial strict instance fields");
+      } else {
+        new_fields->put(tmp, tmp);
+      }
+    }
+
+    // Only modify strict instance fields the frame has uninitialized this
+    if (_prev_frame->flag_this_uninit()) {
+      _assert_unset_fields_buffer = _prev_frame->merge_unset_fields(new_fields);
+    } else if (new_fields->number_of_entries() > 0) {
+      _prev_frame->verifier()->verify_error(
+        ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
+        "Cannot have uninitialzied strict fields after class initialization");
+    }
+
+    return nullptr;
+  }
   if (frame_type < 64) {
     // same_frame
     if (_first) {
@@ -257,7 +292,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
     }
     frame = new StackMapFrame(
       offset, _prev_frame->flags(), _prev_frame->locals_size(), 0,
-      _max_locals, _max_stack, locals, nullptr, _verifier);
+      _max_locals, _max_stack, locals, nullptr,
+      _assert_unset_fields_buffer, _verifier);
     if (_first && locals != nullptr) {
       frame->copy_locals(_prev_frame);
     }
@@ -289,7 +325,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
       stack_size, _max_stack, CHECK_VERIFY_(_verifier, nullptr));
     frame = new StackMapFrame(
       offset, _prev_frame->flags(), _prev_frame->locals_size(), stack_size,
-      _max_locals, _max_stack, locals, stack, _verifier);
+      _max_locals, _max_stack, locals, stack,
+      _assert_unset_fields_buffer, _verifier);
     if (_first && locals != nullptr) {
       frame->copy_locals(_prev_frame);
     }
@@ -299,7 +336,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
 
   u2 offset_delta = _stream->get_u2(CHECK_NULL);
 
-  if (frame_type < SAME_LOCALS_1_STACK_ITEM_EXTENDED) {
+  if (frame_type < ASSERT_UNSET_FIELDS) {
     // reserved frame types
     _stream->stackmap_format_error(
       "reserved frame type", CHECK_VERIFY_(_verifier, nullptr));
@@ -330,7 +367,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
       stack_size, _max_stack, CHECK_VERIFY_(_verifier, nullptr));
     frame = new StackMapFrame(
       offset, _prev_frame->flags(), _prev_frame->locals_size(), stack_size,
-      _max_locals, _max_stack, locals, stack, _verifier);
+      _max_locals, _max_stack, locals, stack,
+      _assert_unset_fields_buffer, _verifier);
     if (_first && locals != nullptr) {
       frame->copy_locals(_prev_frame);
     }
@@ -372,7 +410,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
     }
     frame = new StackMapFrame(
       offset, flags, new_length, 0, _max_locals, _max_stack,
-      locals, nullptr, _verifier);
+      locals, nullptr,
+      _assert_unset_fields_buffer, _verifier);
     if (_first && locals != nullptr) {
       frame->copy_locals(_prev_frame);
     }
@@ -406,7 +445,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
     }
     frame = new StackMapFrame(
       offset, flags, real_length, 0, _max_locals,
-      _max_stack, locals, nullptr, _verifier);
+      _max_stack, locals, nullptr,
+      _assert_unset_fields_buffer, _verifier);
     _first = false;
     return frame;
   }
@@ -454,7 +494,8 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
     }
     frame = new StackMapFrame(
       offset, flags, real_locals_size, real_stack_size,
-      _max_locals, _max_stack, locals, stack, _verifier);
+      _max_locals, _max_stack, locals, stack,
+      _assert_unset_fields_buffer, _verifier);
     _first = false;
     return frame;
   }

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -263,7 +263,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
             ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
             "Strict fields not a subset of initial strict instance fields");
       } else {
-        new_fields->put(tmp, tmp);
+        new_fields->put(tmp, false);
       }
     }
 

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -256,6 +256,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
       NameAndSig tmp(name, sig);
 
       if (!_prev_frame->assert_unset_fields()->contains(tmp)) {
+        ResourceMark rm(THREAD);
         log_info(verification)("Field %s%s is not found among initial strict instance fields", name->as_C_string(), sig->as_C_string());
         StackMapFrame::print_strict_fields(_prev_frame->assert_unset_fields());
         _prev_frame->verifier()->verify_error(

--- a/src/hotspot/share/classfile/stackMapTable.hpp
+++ b/src/hotspot/share/classfile/stackMapTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,6 +127,9 @@ class StackMapReader : StackObj {
   u2 _max_locals;
   u2 _max_stack;
 
+  // Contains assert_unset_fields generated from classfile
+  StackMapFrame::AssertUnsetFieldTable* _assert_unset_fields_buffer;
+
   // Check if reading first entry
   bool _first;
 
@@ -148,6 +151,7 @@ class StackMapReader : StackObj {
   }
 
   enum {
+    ASSERT_UNSET_FIELDS = 246,
     SAME_LOCALS_1_STACK_ITEM_EXTENDED = 247,
     SAME_EXTENDED = 251,
     FULL = 255
@@ -158,7 +162,8 @@ class StackMapReader : StackObj {
   StackMapReader(ClassVerifier* v, StackMapStream* stream,
                  char* code_data, int32_t code_len,
                  StackMapFrame* init_frame,
-                 u2 max_locals, u2 max_stack, TRAPS);
+                 u2 max_locals, u2 max_stack,
+                 StackMapFrame::AssertUnsetFieldTable* initial_strict_fields, TRAPS);
 
   inline int32_t get_frame_count()   const { return _frame_count; }
   inline StackMapFrame* prev_frame() const { return _prev_frame; }

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -734,7 +734,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 
     // Ignore processing of strict fields
     if (VerifyNoDebts) {
-      auto satisfy_all = [&, strict_fields] (const NameAndSig& key, const NameAndSig& value) {
+      auto satisfy_all = [&] (const NameAndSig& key, const NameAndSig& value) {
         NameAndSig* field = strict_fields->get(key);
         field->_satisfied = true;
       };
@@ -2418,7 +2418,7 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
           if (fd.access_flags().is_strict()) {
             ResourceMark rm(THREAD);
             if (!current_frame->satisfy_unset_field(fd.name(), fd.signature())) {
-              log_info(verification)("Attempting to initialize field not found in initial stict instance fields: %s%s",
+              log_info(verification)("Attempting to initialize field not found in initial strict instance fields: %s%s",
                                      fd.name()->as_C_string(), fd.signature()->as_C_string());
               verify_error(ErrorContext::bad_strict_fields(bci, current_frame),
                            "Initializing unknown strict field");
@@ -2715,7 +2715,7 @@ void ClassVerifier::verify_invoke_init(
       return;
     } else if (ref_class_type.name() == superk->name()) {
       // Strict final fields must be satisfied by this point
-      if (!current_frame->unset_fields_satisfied()) {
+      if (!current_frame->is_unset_fields_satisfied()) {
         log_info(verification)("Strict instance fields not initialized");
         StackMapFrame::print_strict_fields(current_frame->assert_unset_fields());
         verify_error(ErrorContext::bad_code(bci), "All strict final fields must be initialized before super()");

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -729,9 +729,10 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
       if (fs.access_flags().is_strict() && !fs.access_flags().is_static()) {
         NameAndSig new_field(fs.name(), fs.signature());
         if (IgnoreAssertUnsetFields) {
-          new_field._satisfied = true;
+          strict_fields->put(new_field, true);
+        } else {
+          strict_fields->put(new_field, false);
         }
-        strict_fields->put(new_field, new_field);
       }
     }
   }

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -44,12 +44,13 @@
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/constantPool.inline.hpp"
+#include "oops/fieldStreams.inline.hpp"
 #include "oops/instanceKlass.inline.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/typeArrayOop.hpp"
 #include "runtime/arguments.hpp"
-#include "runtime/fieldDescriptor.hpp"
+#include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaCalls.hpp"
@@ -721,8 +722,28 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
   assert(SignatureVerifier::is_valid_method_signature(m->signature()),
          "Invalid method signature");
 
+  // Collect the initial strict instance fields
+  StackMapFrame::AssertUnsetFieldTable* strict_fields = new StackMapFrame::AssertUnsetFieldTable();
+  if (m->is_object_constructor()) {
+    for (AllFieldStream fs(m->method_holder()); !fs.done(); fs.next()) {
+      if (fs.access_flags().is_strict() && !fs.access_flags().is_static()) {
+        NameAndSig new_field(fs.name(), fs.signature());
+        strict_fields->put(new_field, new_field);
+      }
+    }
+
+    // Ignore processing of strict fields
+    if (VerifyNoDebts) {
+      auto satisfy_all = [&, strict_fields] (const NameAndSig& key, const NameAndSig& value) {
+        NameAndSig* field = strict_fields->get(key);
+        field->_satisfied = true;
+      };
+      strict_fields->iterate_all(satisfy_all);
+    }
+  }
+
   // Initial stack map frame: offset is 0, stack is initially empty.
-  StackMapFrame current_frame(max_locals, max_stack, this);
+  StackMapFrame current_frame(max_locals, max_stack, strict_fields, this);
   // Set initial locals
   VerificationType return_type = current_frame.set_locals_from_arg( m, current_type());
 
@@ -749,7 +770,7 @@ void ClassVerifier::verify_method(const methodHandle& m, TRAPS) {
 
   Array<u1>* stackmap_data = m->stackmap_data();
   StackMapStream stream(stackmap_data);
-  StackMapReader reader(this, &stream, code_data, code_length, &current_frame, max_locals, max_stack, THREAD);
+  StackMapReader reader(this, &stream, code_data, code_length, &current_frame, max_locals, max_stack, strict_fields, THREAD);
   StackMapTable stackmap_table(&reader, CHECK_VERIFY(this));
 
   LogTarget(Debug, verification) lt;
@@ -2393,6 +2414,16 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
         if (is_local_field) {
           // Set the type to the current type so the is_assignable check passes.
           stack_object_type = current_type();
+
+          if (fd.access_flags().is_strict()) {
+            ResourceMark rm(THREAD);
+            if (!current_frame->satisfy_unset_field(fd.name(), fd.signature())) {
+              log_info(verification)("Attempting to initialize field not found in initial stict instance fields: %s%s",
+                                     fd.name()->as_C_string(), fd.signature()->as_C_string());
+              verify_error(ErrorContext::bad_strict_fields(bci, current_frame),
+                           "Initializing unknown strict field");
+            }
+          }
         }
       } else if (supports_strict_fields(_klass)) {
         // `strict` fields are not writable, but only local fields produce verification errors
@@ -2682,6 +2713,13 @@ void ClassVerifier::verify_invoke_init(
           TypeOrigin::implicit(current_type())),
           "Bad <init> method call");
       return;
+    } else if (ref_class_type.name() == superk->name()) {
+      // Strict final fields must be satisfied by this point
+      if (!current_frame->unset_fields_satisfied()) {
+        log_info(verification)("Strict instance fields not initialized");
+        StackMapFrame::print_strict_fields(current_frame->assert_unset_fields());
+        verify_error(ErrorContext::bad_code(bci), "All strict final fields must be initialized before super()");
+      }
     }
 
     // If this invokespecial call is done from inside of a TRY block then make

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -36,9 +36,8 @@
 struct NameAndSig {
   Symbol* _name;
   Symbol* _signature;
-  bool _satisfied;
 
-  NameAndSig(Symbol* n, Symbol* s) : _name(n), _signature(s), _satisfied(false) {}
+  NameAndSig(Symbol* n, Symbol* s) : _name(n), _signature(s) {}
 };
 
 // The verifier class

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,14 @@
 #include "utilities/exceptions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/resourceHash.hpp"
+
+struct NameAndSig {
+  Symbol* _name;
+  Symbol* _signature;
+  bool _satisfied;
+
+  NameAndSig(Symbol* n, Symbol* s) : _name(n), _signature(s), _satisfied(false) {}
+};
 
 // The verifier class
 class Verifier : AllStatic {
@@ -150,8 +158,10 @@ class ErrorContext {
     FLAGS_MISMATCH,       // Frame flags are not assignable
     BAD_CP_INDEX,         // Invalid constant pool index
     BAD_LOCAL_INDEX,      // Invalid local index
+    BAD_STRICT_FIELDS,    // Strict instance fields must be initialized before super constructor
     LOCALS_SIZE_MISMATCH, // Frames have differing local counts
     STACK_SIZE_MISMATCH,  // Frames have different stack sizes
+    STRICT_FIELDS_MISMATCH, // Frames have incompatible uninitialized strict instance fields
     STACK_OVERFLOW,       // Attempt to push onto a full expression stack
     STACK_UNDERFLOW,      // Attempt to pop and empty expression stack
     MISSING_STACKMAP,     // No stackmap for this location and there should be
@@ -198,6 +208,9 @@ class ErrorContext {
   static ErrorContext bad_local_index(int bci, int index) {
     return ErrorContext(bci, BAD_LOCAL_INDEX, TypeOrigin::bad_index(index));
   }
+  static ErrorContext bad_strict_fields(int bci, StackMapFrame* cur) {
+    return ErrorContext(bci, BAD_STRICT_FIELDS, TypeOrigin::frame(cur));
+  }
   static ErrorContext locals_size_mismatch(
       int bci, StackMapFrame* frame0, StackMapFrame* frame1) {
     return ErrorContext(bci, LOCALS_SIZE_MISMATCH,
@@ -207,6 +220,11 @@ class ErrorContext {
       int bci, StackMapFrame* frame0, StackMapFrame* frame1) {
     return ErrorContext(bci, STACK_SIZE_MISMATCH,
         TypeOrigin::frame(frame0), TypeOrigin::frame(frame1));
+  }
+  static ErrorContext strict_fields_mismatch(
+      int bci, StackMapFrame* frame0, StackMapFrame* frame1) {
+        return ErrorContext(bci, STRICT_FIELDS_MISMATCH,
+          TypeOrigin::frame(frame0), TypeOrigin::frame(frame1));
   }
   static ErrorContext stack_overflow(int bci, StackMapFrame* frame) {
     return ErrorContext(bci, STACK_OVERFLOW, TypeOrigin::frame(frame));

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1785,6 +1785,9 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, VerifyMethodHandles, trueInDebug, DIAGNOSTIC,               \
           "perform extra checks when constructing method handles")          \
+                                                                            \
+  product(bool, VerifyNoDebts, false, DIAGNOSTIC,                           \
+          "Ignore assert_unset_fields")                                     \
                                                                             \
   product(bool, ShowHiddenFrames, false, DIAGNOSTIC,                        \
           "show method handle implementation frames (usually hidden)")      \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1786,7 +1786,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, VerifyMethodHandles, trueInDebug, DIAGNOSTIC,               \
           "perform extra checks when constructing method handles")          \
                                                                             \
-  product(bool, VerifyNoDebts, false, DIAGNOSTIC,                           \
+  product(bool, IgnoreAssertUnsetFields, false, DIAGNOSTIC,                           \
           "Ignore assert_unset_fields")                                     \
                                                                             \
   product(bool, ShowHiddenFrames, false, DIAGNOSTIC,                        \

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
@@ -30,6 +30,7 @@ import java.lang.classfile.Label;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.instruction.BranchInstruction;
+import java.lang.classfile.constantpool.NameAndTypeEntry;
 import java.lang.constant.ClassDesc;
 import java.util.List;
 
@@ -78,6 +79,13 @@ public sealed interface StackMapFrameInfo
     List<VerificationTypeInfo> stack();
 
     /**
+     * {@return the expanded unset fields}
+     *
+     * @see <a href="https://cr.openjdk.org/~dlsmith/jep401/jep401-20241108/specs/value-objects-jvms.html">Specs</a>
+     */
+    List<NameAndTypeEntry> unsetFields();
+
+    /**
      * {@return a new stack map frame}
      *
      * @param target the location of the frame
@@ -87,7 +95,23 @@ public sealed interface StackMapFrameInfo
     public static StackMapFrameInfo of(Label target,
             List<VerificationTypeInfo> locals,
             List<VerificationTypeInfo> stack) {
-        return new StackMapDecoder.StackMapFrameImpl(255, target, locals, stack);
+
+        return of(target, locals, stack, List.of());
+    }
+
+    /**
+     * {@return a new stack map frame}
+     * @param target the location of the frame
+     * @param locals the complete list of frame locals
+     * @param stack the complete frame stack
+     * @param unsetFields the complete list of unset fields
+     */
+    public static StackMapFrameInfo of(Label target,
+                                       List<VerificationTypeInfo> locals,
+                                       List<VerificationTypeInfo> stack,
+                                       List<NameAndTypeEntry> unsetFields) {
+
+        return new StackMapDecoder.StackMapFrameImpl(255, target, locals, stack, unsetFields);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationTable.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerificationTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,9 +159,11 @@ class VerificationTable {
         }
 
         private static final int
+                        ASSERT_UNSET_FIELDS = 246,
                         SAME_LOCALS_1_STACK_ITEM_EXTENDED = 247,
                         SAME_EXTENDED = 251,
                         FULL = 255;
+        private static final int RESERVED_TAGS_UPPER_LIMIT = ASSERT_UNSET_FIELDS; // not inclusive
 
         public int get_frame_count() {
             return _frame_count;
@@ -278,7 +280,7 @@ class VerificationTable {
                 return frame;
             }
             int offset_delta = _stream.get_u2();
-            if (frame_type < SAME_LOCALS_1_STACK_ITEM_EXTENDED) {
+            if (frame_type < RESERVED_TAGS_UPPER_LIMIT) {
                 _verifier.classError("reserved frame type");
             }
             if (frame_type == SAME_LOCALS_1_STACK_ITEM_EXTENDED) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -27,6 +27,7 @@
 
 package com.sun.tools.javac.comp;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.HashMap;
@@ -216,6 +217,7 @@ public class Flow {
     private Env<AttrContext> attrEnv;
     private       Lint lint;
     private final Infer infer;
+    private final UnsetFieldsInfo unsetFieldsInfo;
 
     public static Flow instance(Context context) {
         Flow instance = context.get(flowKey);
@@ -341,7 +343,7 @@ public class Flow {
         infer = Infer.instance(context);
         rs = Resolve.instance(context);
         diags = JCDiagnostic.Factory.instance(context);
-        Source source = Source.instance(context);
+        unsetFieldsInfo = UnsetFieldsInfo.instance(context);
     }
 
     /**
@@ -2290,11 +2292,21 @@ public class Flow {
          *  record an initialization of the variable.
          */
         void letInit(JCTree tree) {
+            letInit(tree, (JCAssign) null);
+        }
+
+        void letInit(JCTree tree, JCAssign assign) {
             tree = TreeInfo.skipParens(tree);
             if (tree.hasTag(IDENT) || tree.hasTag(SELECT)) {
                 Symbol sym = TreeInfo.symbol(tree);
                 if (sym.kind == VAR) {
                     letInit(tree.pos(), (VarSymbol)sym);
+                    if (isConstructor && sym.isStrict()) {
+                        /* we are initializing a strict field inside of a constructor, we now need to find which fields
+                         * haven't been initialized yet
+                         */
+                        unsetFieldsInfo.addUnsetFieldsInfo(classDef.sym, assign != null ? assign : tree, findUninitStrictFields());
+                    }
                 }
             }
         }
@@ -2526,6 +2538,13 @@ public class Flow {
                          */
                         initParam(def);
                     }
+                    if (isConstructor) {
+                        Set<VarSymbol> unsetFields = findUninitStrictFields();
+                        if (unsetFields != null && !unsetFields.isEmpty()) {
+                            unsetFieldsInfo.addUnsetFieldsInfo(classDef.sym, tree.body, unsetFields);
+                        }
+                    }
+
                     // else we are in an instance initializer block;
                     // leave caught unchanged.
                     scan(tree.body);
@@ -2579,6 +2598,17 @@ public class Flow {
             } finally {
                 lint = lintPrev;
             }
+        }
+
+        Set<VarSymbol> findUninitStrictFields() {
+            Set<VarSymbol> unsetFields = new LinkedHashSet<>();
+            for (int i = uninits.nextBit(0); i >= 0; i = uninits.nextBit(i + 1)) {
+                JCVariableDecl variableDecl = vardecls[i];
+                if (variableDecl.sym.isStrict()) {
+                    unsetFields.add(variableDecl.sym);
+                }
+            }
+            return unsetFields;
         }
 
         private void clearPendingExits(boolean inMethod) {
@@ -3145,7 +3175,7 @@ public class Flow {
             if (!TreeInfo.isIdentOrThisDotIdent(tree.lhs))
                 scanExpr(tree.lhs);
             scanExpr(tree.rhs);
-            letInit(tree.lhs);
+            letInit(tree.lhs, tree);
         }
 
         // check fields accessed through this.<field> are definitely

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/UnsetFieldsInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/UnsetFieldsInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.javac.comp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import com.sun.tools.javac.util.List;
+
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.Context;
+
+/**
+ * A Context class, that can keep useful information about unset fields.
+ * This information will be produced during flow analysis and used during
+ * code generation.
+ *
+ * <p><b>This is NOT part of any supported API.
+ * If you write code that depends on this, you do so at your own risk.
+ * This code and its internal interfaces are subject to change or
+ * deletion without notice.</b>
+ */
+public class UnsetFieldsInfo {
+    protected static final Context.Key<UnsetFieldsInfo> unsetFieldsInfoKey = new Context.Key<>();
+
+    public static UnsetFieldsInfo instance(Context context) {
+        UnsetFieldsInfo instance = context.get(unsetFieldsInfoKey);
+        if (instance == null)
+            instance = new UnsetFieldsInfo(context);
+        return instance;
+    }
+
+    @SuppressWarnings("this-escape")
+    protected UnsetFieldsInfo(Context context) {
+        context.put(unsetFieldsInfoKey, this);
+    }
+
+    private WeakHashMap<ClassSymbol, Map<JCTree, Set<VarSymbol>>> unsetFieldsMap = new WeakHashMap<>();
+
+    public void addUnsetFieldsInfo(ClassSymbol csym, JCTree tree, Set<VarSymbol> unsetFields) {
+        Map<JCTree, Set<VarSymbol>> treeToFieldsMap = unsetFieldsMap.get(csym);
+        if (treeToFieldsMap == null) {
+            treeToFieldsMap = new HashMap<>();
+            treeToFieldsMap.put(tree, unsetFields);
+            unsetFieldsMap.put(csym, treeToFieldsMap);
+        } else {
+            if (!treeToFieldsMap.containsKey(tree)) {
+                // only add if there is no info for the given tree
+                treeToFieldsMap.put(tree, unsetFields);
+            }
+        }
+    }
+
+    public Set<VarSymbol> getUnsetFields(ClassSymbol csym, JCTree tree) {
+        Map<JCTree, Set<VarSymbol>> treeToFieldsMap = unsetFieldsMap.get(csym);
+        if (treeToFieldsMap != null) {
+            Set<VarSymbol> result = treeToFieldsMap.get(tree);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,6 +146,7 @@ public class ClassWriter extends ClassFile {
 
     /** The tags and constants used in compressed stackmap. */
     static final int SAME_FRAME_SIZE = 64;
+    static final int ASSERT_UNSET_FIELDS = 246;
     static final int SAME_LOCALS_1_STACK_ITEM_EXTENDED = 247;
     static final int SAME_FRAME_EXTENDED = 251;
     static final int FULL_FRAME = 255;
@@ -1263,7 +1264,7 @@ public class ClassWriter extends ClassFile {
             Assert.checkNull(code.stackMapBuffer);
             for (int i=0; i<nframes; i++) {
                 if (debugstackmap) System.out.print("  " + i + ":");
-                StackMapTableFrame frame = code.stackMapTableBuffer[i];
+                StackMapTableEntry frame = code.stackMapTableBuffer[i];
                 frame.write(this);
                 if (debugstackmap) System.out.println();
             }
@@ -1329,27 +1330,33 @@ public class ClassWriter extends ClassFile {
         }
 
     /** An entry in the JSR202 StackMapTable */
-    abstract static class StackMapTableFrame {
-        abstract int getFrameType();
+    abstract static class StackMapTableEntry {
+        abstract int getEntryType();
+        int pc;
 
-        void write(ClassWriter writer) {
-            int frameType = getFrameType();
-            writer.databuf.appendByte(frameType);
-            if (writer.debugstackmap) System.out.print(" frame_type=" + frameType);
+        StackMapTableEntry(int pc) {
+            this.pc = pc;
         }
 
-        static class SameFrame extends StackMapTableFrame {
+        void write(ClassWriter writer) {
+            int entryType = getEntryType();
+            writer.databuf.appendByte(entryType);
+            if (writer.debugstackmap) System.out.println(" frame_type=" + entryType + " bytecode offset " + pc);
+        }
+
+        static class SameFrame extends StackMapTableEntry {
             final int offsetDelta;
-            SameFrame(int offsetDelta) {
+            SameFrame(int pc, int offsetDelta) {
+                super(pc);
                 this.offsetDelta = offsetDelta;
             }
-            int getFrameType() {
+            int getEntryType() {
                 return (offsetDelta < SAME_FRAME_SIZE) ? offsetDelta : SAME_FRAME_EXTENDED;
             }
             @Override
             void write(ClassWriter writer) {
                 super.write(writer);
-                if (getFrameType() == SAME_FRAME_EXTENDED) {
+                if (getEntryType() == SAME_FRAME_EXTENDED) {
                     writer.databuf.appendChar(offsetDelta);
                     if (writer.debugstackmap){
                         System.out.print(" offset_delta=" + offsetDelta);
@@ -1358,14 +1365,15 @@ public class ClassWriter extends ClassFile {
             }
         }
 
-        static class SameLocals1StackItemFrame extends StackMapTableFrame {
+        static class SameLocals1StackItemFrame extends StackMapTableEntry {
             final int offsetDelta;
             final Type stack;
-            SameLocals1StackItemFrame(int offsetDelta, Type stack) {
+            SameLocals1StackItemFrame(int pc, int offsetDelta, Type stack) {
+                super(pc);
                 this.offsetDelta = offsetDelta;
                 this.stack = stack;
             }
-            int getFrameType() {
+            int getEntryType() {
                 return (offsetDelta < SAME_FRAME_SIZE) ?
                        (SAME_FRAME_SIZE + offsetDelta) :
                        SAME_LOCALS_1_STACK_ITEM_EXTENDED;
@@ -1373,7 +1381,7 @@ public class ClassWriter extends ClassFile {
             @Override
             void write(ClassWriter writer) {
                 super.write(writer);
-                if (getFrameType() == SAME_LOCALS_1_STACK_ITEM_EXTENDED) {
+                if (getEntryType() == SAME_LOCALS_1_STACK_ITEM_EXTENDED) {
                     writer.databuf.appendChar(offsetDelta);
                     if (writer.debugstackmap) {
                         System.out.print(" offset_delta=" + offsetDelta);
@@ -1386,14 +1394,15 @@ public class ClassWriter extends ClassFile {
             }
         }
 
-        static class ChopFrame extends StackMapTableFrame {
+        static class ChopFrame extends StackMapTableEntry {
             final int frameType;
             final int offsetDelta;
-            ChopFrame(int frameType, int offsetDelta) {
+            ChopFrame(int pc, int frameType, int offsetDelta) {
+                super(pc);
                 this.frameType = frameType;
                 this.offsetDelta = offsetDelta;
             }
-            int getFrameType() { return frameType; }
+            int getEntryType() { return frameType; }
             @Override
             void write(ClassWriter writer) {
                 super.write(writer);
@@ -1404,16 +1413,17 @@ public class ClassWriter extends ClassFile {
             }
         }
 
-        static class AppendFrame extends StackMapTableFrame {
+        static class AppendFrame extends StackMapTableEntry {
             final int frameType;
             final int offsetDelta;
             final Type[] locals;
-            AppendFrame(int frameType, int offsetDelta, Type[] locals) {
+            AppendFrame(int pc, int frameType, int offsetDelta, Type[] locals) {
+                super(pc);
                 this.frameType = frameType;
                 this.offsetDelta = offsetDelta;
                 this.locals = locals;
             }
-            int getFrameType() { return frameType; }
+            int getEntryType() { return frameType; }
             @Override
             void write(ClassWriter writer) {
                 super.write(writer);
@@ -1428,16 +1438,17 @@ public class ClassWriter extends ClassFile {
             }
         }
 
-        static class FullFrame extends StackMapTableFrame {
+        static class FullFrame extends StackMapTableEntry {
             final int offsetDelta;
             final Type[] locals;
             final Type[] stack;
-            FullFrame(int offsetDelta, Type[] locals, Type[] stack) {
+            FullFrame(int pc, int offsetDelta, Type[] locals, Type[] stack) {
+                super(pc);
                 this.offsetDelta = offsetDelta;
                 this.locals = locals;
                 this.stack = stack;
             }
-            int getFrameType() { return FULL_FRAME; }
+            int getEntryType() { return FULL_FRAME; }
             @Override
             void write(ClassWriter writer) {
                 super.write(writer);
@@ -1461,41 +1472,68 @@ public class ClassWriter extends ClassFile {
             }
         }
 
+        static class AssertUnsetFields extends StackMapTableEntry {
+            Set<VarSymbol> unsetFields;
+
+            AssertUnsetFields(int pc, Set<VarSymbol> unsetFields) {
+                super(pc);
+                this.unsetFields = unsetFields;
+            }
+
+            int getEntryType() { return ASSERT_UNSET_FIELDS; }
+
+            @Override
+            void write(ClassWriter writer) {
+                super.write(writer);
+                writer.databuf.appendChar(unsetFields.size());
+                if (writer.debugstackmap) {
+                    System.out.println("    # writing: AssertUnsetFields stackmap entry with " + unsetFields.size() + " fields");
+                }
+                for (VarSymbol vsym : unsetFields) {
+                    int index = writer.poolWriter.putNameAndType(vsym);
+                    writer.databuf.appendChar(index);
+                    if (writer.debugstackmap) {
+                        System.out.println("    #writing unset field: " + index + ", with name: " + vsym.name.toString());
+                    }
+                }
+            }
+        }
+
        /** Compare this frame with the previous frame and produce
         *  an entry of compressed stack map frame. */
-        static StackMapTableFrame getInstance(Code.StackMapFrame this_frame,
-                                              int prev_pc,
-                                              Type[] prev_locals,
-                                              Types types) {
+        static StackMapTableEntry getInstance(Code.StackMapFrame this_frame,
+                                              Code.StackMapFrame prevFrame,
+                                              Types types,
+                                              int pc) {
             Type[] locals = this_frame.locals;
             Type[] stack = this_frame.stack;
-            int offset_delta = this_frame.pc - prev_pc - 1;
+            int offset_delta = this_frame.pc - prevFrame.pc - 1;
             if (stack.length == 1) {
-                if (locals.length == prev_locals.length
-                    && compare(prev_locals, locals, types) == 0) {
-                    return new SameLocals1StackItemFrame(offset_delta, stack[0]);
+                if (locals.length == prevFrame.locals.length
+                    && compare(prevFrame.locals, locals, types) == 0) {
+                    return new SameLocals1StackItemFrame(pc, offset_delta, stack[0]);
                 }
             } else if (stack.length == 0) {
-                int diff_length = compare(prev_locals, locals, types);
+                int diff_length = compare(prevFrame.locals, locals, types);
                 if (diff_length == 0) {
-                    return new SameFrame(offset_delta);
+                    return new SameFrame(pc, offset_delta);
                 } else if (-MAX_LOCAL_LENGTH_DIFF < diff_length && diff_length < 0) {
                     // APPEND
                     Type[] local_diff = new Type[-diff_length];
-                    for (int i=prev_locals.length, j=0; i<locals.length; i++,j++) {
+                    for (int i=prevFrame.locals.length, j=0; i<locals.length; i++,j++) {
                         local_diff[j] = locals[i];
                     }
-                    return new AppendFrame(SAME_FRAME_EXTENDED - diff_length,
+                    return new AppendFrame(pc, SAME_FRAME_EXTENDED - diff_length,
                                            offset_delta,
                                            local_diff);
                 } else if (0 < diff_length && diff_length < MAX_LOCAL_LENGTH_DIFF) {
                     // CHOP
-                    return new ChopFrame(SAME_FRAME_EXTENDED - diff_length,
+                    return new ChopFrame(pc, SAME_FRAME_EXTENDED - diff_length,
                                          offset_delta);
                 }
             }
             // FULL_FRAME
-            return new FullFrame(offset_delta, locals, stack);
+            return new FullFrame(pc, offset_delta, locals, stack);
         }
 
         static boolean isInt(Type t) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,8 @@ public class Gen extends JCTree.Visitor {
      */
     final PoolWriter poolWriter;
 
+    private final UnsetFieldsInfo unsetFieldsInfo;
+
     @SuppressWarnings("this-escape")
     protected Gen(Context context) {
         context.put(genKey, this);
@@ -127,11 +129,13 @@ public class Gen extends JCTree.Visitor {
         debugCode = options.isSet("debug.code");
         disableVirtualizedPrivateInvoke = options.isSet("disableVirtualizedPrivateInvoke");
         poolWriter = new PoolWriter(types, names);
+        unsetFieldsInfo = UnsetFieldsInfo.instance(context);
 
         // ignore cldc because we cannot have both stackmap formats
         this.stackMap = StackMapFormat.JSR202;
         annotate = Annotate.instance(context);
         qualifiedSymbolCache = new HashMap<>();
+        generateAssertUnsetFieldsFrame = options.isSet("generateAssertUnsetFieldsFrame");
     }
 
     /** Switches
@@ -141,6 +145,7 @@ public class Gen extends JCTree.Visitor {
     private final boolean genCrt;
     private final boolean debugCode;
     private boolean disableVirtualizedPrivateInvoke;
+    private boolean generateAssertUnsetFieldsFrame;
 
     /** Code buffer, set by genMethod.
      */
@@ -989,6 +994,10 @@ public class Gen extends JCTree.Visitor {
             else if (tree.body != null) {
                 // Create a new code structure and initialize it.
                 int startpcCrt = initCode(tree, env, fatcode);
+                Set<VarSymbol> prevUnsetFields = code.currentUnsetFields;
+                if (meth.isConstructor()) {
+                    code.currentUnsetFields = unsetFieldsInfo.getUnsetFields(env.enclClass.sym, tree.body);
+                }
 
                 try {
                     genStat(tree.body, env);
@@ -996,6 +1005,8 @@ public class Gen extends JCTree.Visitor {
                     // Failed due to code limit, try again with jsr/ret
                     startpcCrt = initCode(tree, env, fatcode);
                     genStat(tree.body, env);
+                } finally {
+                    code.currentUnsetFields = prevUnsetFields;
                 }
 
                 if (code.state.stacksize != 0) {
@@ -1064,7 +1075,8 @@ public class Gen extends JCTree.Visitor {
                                                : null,
                                         syms,
                                         types,
-                                        poolWriter);
+                                        poolWriter,
+                                        generateAssertUnsetFieldsFrame);
             items = new Items(poolWriter, code, syms, types);
             if (code.debugCode) {
                 System.err.println(meth + " for body " + tree);
@@ -1200,6 +1212,19 @@ public class Gen extends JCTree.Visitor {
                              JCExpression cond,
                              List<JCExpressionStatement> step,
                              boolean testFirst) {
+            Set<VarSymbol> prevCodeUnsetFields = code.currentUnsetFields;
+            try {
+                genLoopHelper(loop, body, cond, step, testFirst);
+            } finally {
+                code.currentUnsetFields = prevCodeUnsetFields;
+            }
+        }
+
+        private void genLoopHelper(JCStatement loop,
+                             JCStatement body,
+                             JCExpression cond,
+                             List<JCExpressionStatement> step,
+                             boolean testFirst) {
             Env<GenContext> loopEnv = env.dup(loop, new GenContext());
             int startpc = code.entryPoint();
             if (testFirst) { //while or for loop
@@ -1266,11 +1291,13 @@ public class Gen extends JCTree.Visitor {
     public void visitSwitchExpression(JCSwitchExpression tree) {
         code.resolvePending();
         boolean prevInCondSwitchExpression = inCondSwitchExpression;
+        Set<VarSymbol> prevCodeUnsetFields = code.currentUnsetFields;
         try {
             inCondSwitchExpression = false;
             doHandleSwitchExpression(tree);
         } finally {
             inCondSwitchExpression = prevInCondSwitchExpression;
+            code.currentUnsetFields = prevCodeUnsetFields;
         }
         result = items.makeStackItem(pt);
     }
@@ -1346,6 +1373,16 @@ public class Gen extends JCTree.Visitor {
 
     private void handleSwitch(JCTree swtch, JCExpression selector, List<JCCase> cases,
                               boolean patternSwitch) {
+        Set<VarSymbol> prevCodeUnsetFields = code.currentUnsetFields;
+        try {
+            handleSwitchHelper(swtch, selector, cases, patternSwitch);
+        } finally {
+            code.currentUnsetFields = prevCodeUnsetFields;
+        }
+    }
+
+    void handleSwitchHelper(JCTree swtch, JCExpression selector, List<JCCase> cases,
+                      boolean patternSwitch) {
         int limit = code.nextreg;
         Assert.check(!selector.type.hasTag(CLASS));
         int switchStart = patternSwitch ? code.entryPoint() : -1;
@@ -1357,13 +1394,13 @@ public class Gen extends JCTree.Visitor {
             sel.load().drop();
             if (genCrt)
                 code.crt.put(TreeInfo.skipParens(selector),
-                             CRT_FLOW_CONTROLLER, startpcCrt, code.curCP());
+                        CRT_FLOW_CONTROLLER, startpcCrt, code.curCP());
         } else {
             // We are seeing a nonempty switch.
             sel.load();
             if (genCrt)
                 code.crt.put(TreeInfo.skipParens(selector),
-                             CRT_FLOW_CONTROLLER, startpcCrt, code.curCP());
+                        CRT_FLOW_CONTROLLER, startpcCrt, code.curCP());
             Env<GenContext> switchEnv = env.dup(swtch, new GenContext());
             switchEnv.info.isSwitch = true;
 
@@ -1399,11 +1436,11 @@ public class Gen extends JCTree.Visitor {
             long lookup_space_cost = 3 + 2 * (long) nlabels;
             long lookup_time_cost = nlabels;
             int opcode =
-                nlabels > 0 &&
-                table_space_cost + 3 * table_time_cost <=
-                lookup_space_cost + 3 * lookup_time_cost
-                ?
-                tableswitch : lookupswitch;
+                    nlabels > 0 &&
+                            table_space_cost + 3 * table_time_cost <=
+                                    lookup_space_cost + 3 * lookup_time_cost
+                            ?
+                            tableswitch : lookupswitch;
 
             int startpc = code.curCP();    // the position of the selector operation
             code.emitop0(opcode);
@@ -1439,8 +1476,8 @@ public class Gen extends JCTree.Visitor {
                 if (i != defaultIndex) {
                     if (opcode == tableswitch) {
                         code.put4(
-                            tableBase + 4 * (labels[i] - lo + 3),
-                            pc - startpc);
+                                tableBase + 4 * (labels[i] - lo + 3),
+                                pc - startpc);
                     } else {
                         offsets[i] = pc - startpc;
                     }
@@ -1494,8 +1531,8 @@ public class Gen extends JCTree.Visitor {
             }
 
             if (swtch instanceof JCSwitchExpression) {
-                 // Emit line position for the end of a switch expression
-                 code.statBegin(TreeInfo.endPos(swtch));
+                // Emit line position for the end of a switch expression
+                code.statBegin(TreeInfo.endPos(swtch));
             }
         }
         code.endScopes(limit);
@@ -1598,6 +1635,15 @@ public class Gen extends JCTree.Visitor {
          *  @param env       The current environment of the body.
          */
         void genTry(JCTree body, List<JCCatch> catchers, Env<GenContext> env) {
+            Set<VarSymbol> prevCodeUnsetFields = code.currentUnsetFields;
+            try {
+                genTryHelper(body, catchers, env);
+            } finally {
+                code.currentUnsetFields = prevCodeUnsetFields;
+            }
+        }
+
+        void genTryHelper(JCTree body, List<JCCatch> catchers, Env<GenContext> env) {
             int limit = code.nextreg;
             int startpc = code.curCP();
             Code.State stateTry = code.state.dup();
@@ -1617,8 +1663,8 @@ public class Gen extends JCTree.Visitor {
             endFinalizerGap(env);
             env.info.finalize.afterBody();
             boolean hasFinalizer =
-                env.info.finalize != null &&
-                env.info.finalize.hasFinalizer();
+                    env.info.finalize != null &&
+                            env.info.finalize.hasFinalizer();
             if (startpc != endpc) for (List<JCCatch> l = catchers; l.nonEmpty(); l = l.tail) {
                 // start off with exception on stack
                 code.entryPoint(stateTry, l.head.param.sym.type);
@@ -1627,7 +1673,7 @@ public class Gen extends JCTree.Visitor {
                 if (hasFinalizer || l.tail.nonEmpty()) {
                     code.statBegin(TreeInfo.endPos(env.tree));
                     exitChain = Code.mergeChains(exitChain,
-                                                 code.branch(goto_));
+                            code.branch(goto_));
                 }
                 endFinalizerGap(env);
             }
@@ -1650,7 +1696,7 @@ public class Gen extends JCTree.Visitor {
                 while (env.info.gaps.nonEmpty()) {
                     int endseg = env.info.gaps.next().intValue();
                     registerCatch(body.pos(), startseg, endseg,
-                                  catchallpc, 0);
+                            catchallpc, 0);
                     startseg = env.info.gaps.next().intValue();
                 }
                 code.statBegin(TreeInfo.finalizerPos(env.tree, PosKind.FIRST_STAT_POS));
@@ -1665,8 +1711,8 @@ public class Gen extends JCTree.Visitor {
 
                 excVar.load();
                 registerCatch(body.pos(), startseg,
-                              env.info.gaps.next().intValue(),
-                              catchallpc, 0);
+                        env.info.gaps.next().intValue(),
+                        catchallpc, 0);
                 code.emitop0(athrow);
                 code.markDead();
 
@@ -1809,11 +1855,20 @@ public class Gen extends JCTree.Visitor {
         }
 
     public void visitIf(JCIf tree) {
+        Set<VarSymbol> prevCodeUnsetFields = code.currentUnsetFields;
+        try {
+            visitIfHelper(tree);
+        } finally {
+            code.currentUnsetFields = prevCodeUnsetFields;
+        }
+    }
+
+    public void visitIfHelper(JCIf tree) {
         int limit = code.nextreg;
         Chain thenExit = null;
         Assert.check(code.isStatementStart());
         CondItem c = genCond(TreeInfo.skipParens(tree.cond),
-                             CRT_FLOW_CONTROLLER);
+                CRT_FLOW_CONTROLLER);
         Chain elseChain = c.jumpFalse();
         Assert.check(code.isStatementStart());
         if (!c.isFalse()) {
@@ -2140,6 +2195,8 @@ public class Gen extends JCTree.Visitor {
     public void visitAssign(JCAssign tree) {
         Item l = genExpr(tree.lhs, tree.lhs.type);
         genExpr(tree.rhs, tree.lhs.type).load();
+        Set<VarSymbol> tmpUnsetSymbols = unsetFieldsInfo.getUnsetFields(env.enclClass.sym, tree);
+        code.currentUnsetFields = tmpUnsetSymbols != null ? tmpUnsetSymbols : code.currentUnsetFields;
         if (tree.rhs.type.hasTag(BOT)) {
             /* This is just a case of widening reference conversion that per 5.1.5 simply calls
                for "regarding a reference as having some other type in a manner that can be proved

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Bits.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,10 @@ public class Bits {
     private static final int wordshift = 5;
     private static final int wordmask = wordlen - 1;
 
-    public int[] bits = null;
+    /* every int in the bits array is used to represent 32 bits, so the bits array will have
+     * length == 1 until we need to represent the 33rd bit and so on.
+     */
+    private int[] bits = null;
     // This field will store last version of bits after every change.
     private static final int[] unassignedBits = new int[0];
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/ClassWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -733,7 +733,7 @@ public class ClassWriter {
                 stackMapWriter = new StackMapTableWriter();
 
             out.writeShort(attr.entries.length);
-            for (stack_map_frame f: attr.entries)
+            for (stack_map_entry f: attr.entries)
                 stackMapWriter.write(f, out);
             return null;
         }
@@ -744,7 +744,7 @@ public class ClassWriter {
                 stackMapWriter = new StackMapTableWriter();
 
             out.writeShort(attr.entries.length);
-            for (stack_map_frame f: attr.entries)
+            for (stack_map_entry f: attr.entries)
                 stackMapWriter.write(f, out);
             return null;
         }
@@ -773,10 +773,10 @@ public class ClassWriter {
      * Writer for the frames of StackMap and StackMapTable attributes.
      */
     protected static class StackMapTableWriter
-            implements stack_map_frame.Visitor<Void,ClassOutputStream> {
+            implements stack_map_entry.Visitor<Void,ClassOutputStream> {
 
-        public void write(stack_map_frame frame, ClassOutputStream out) {
-            out.write(frame.frame_type);
+        public void write(stack_map_entry frame, ClassOutputStream out) {
+            out.write(frame.entry_type);
             frame.accept(this, out);
         }
 
@@ -827,6 +827,15 @@ public class ClassWriter {
             out.writeShort(frame.stack.length);
             for (verification_type_info s: frame.stack)
                 writeVerificationTypeInfo(s, out);
+            return null;
+        }
+
+        @Override
+        public Void visit_assert_unset_fields(assert_unset_fields frame, ClassOutputStream out) {
+            out.writeShort(frame.number_of_unset_fields);
+            for (int uf: frame.unset_fields) {
+                out.writeShort(uf);
+            }
             return null;
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/classfile/StackMap_attribute.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/classfile/StackMap_attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,17 +38,17 @@ public class StackMap_attribute extends Attribute {
             throws IOException, StackMapTable_attribute.InvalidStackMap {
         super(name_index, length);
         number_of_entries = cr.readUnsignedShort();
-        entries = new stack_map_frame[number_of_entries];
+        entries = new stack_map_entry[number_of_entries];
         for (int i = 0; i < number_of_entries; i++)
-            entries[i] = new stack_map_frame(cr);
+            entries[i] = new stack_map_entry(cr);
     }
 
-    public StackMap_attribute(ConstantPool constant_pool, stack_map_frame[] entries)
+    public StackMap_attribute(ConstantPool constant_pool, stack_map_entry[] entries)
             throws ConstantPoolException {
         this(constant_pool.getUTF8Index(Attribute.StackMap), entries);
     }
 
-    public StackMap_attribute(int name_index, stack_map_frame[] entries) {
+    public StackMap_attribute(int name_index, stack_map_entry[] entries) {
         super(name_index, StackMapTable_attribute.length(entries));
         this.number_of_entries = entries.length;
         this.entries = entries;
@@ -59,10 +59,10 @@ public class StackMap_attribute extends Attribute {
     }
 
     public final int number_of_entries;
-    public final stack_map_frame entries[];
+    public final stack_map_entry entries[];
 
-    public static class stack_map_frame extends StackMapTable_attribute.full_frame {
-        stack_map_frame(ClassReader cr)
+    public static class stack_map_entry extends StackMapTable_attribute.full_frame {
+        stack_map_entry(ClassReader cr)
                 throws IOException, StackMapTable_attribute.InvalidStackMap {
             super(255, cr);
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -569,10 +569,23 @@ public class AttributeWriter extends BasicWriter {
                         printMap("stack", frame.stack(), lr);
                         indent(-1);
                     } else {
-                        int offsetDelta = lr.labelToBci(frame.target()) - lastOffset - 1;
+                        int offsetDelta = frameType != 246 ? lr.labelToBci(frame.target()) - lastOffset - 1 : 0;
                         switch (frameType) {
+                            case 246 -> {
+                                printHeader(frameType, "/* assert_unset_fields */");
+                                indent(+1);
+                                println("number of unset_fields = " + frame.unsetFields().size());
+                                    indent(+1);
+                                    for (NameAndTypeEntry field : frame.unsetFields()) {
+                                        print("unset_field = #");
+                                        constantWriter.write(field.index());
+                                        println();
+                                    }
+                                    indent(-1);
+                                indent(-1);
+                            }
                             case 247 -> {
-                                printHeader(frameType, "/* same_locals_1_stack_item_frame_extended */");
+                                printHeader(frameType, "/* same_locals_1_stack_item_entry_extended */");
                                 indent(+1);
                                 println("offset_delta = " + offsetDelta);
                                 printMap("stack", frame.stack(), lr);
@@ -585,7 +598,7 @@ public class AttributeWriter extends BasicWriter {
                                 indent(-1);
                             }
                             case 251 -> {
-                                printHeader(frameType, "/* same_frame_extended */");
+                                printHeader(frameType, "/* same_entry_extended */");
                                 indent(+1);
                                 println("offset_delta = " + offsetDelta);
                                 indent(-1);
@@ -600,7 +613,7 @@ public class AttributeWriter extends BasicWriter {
                                 indent(-1);
                             }
                             case 255 -> {
-                                printHeader(frameType, "/* full_frame */");
+                                printHeader(frameType, "/* full_entry */");
                                 indent(+1);
                                 println("offset_delta = " + offsetDelta);
                                 printMap("locals", frame.locals(), lr);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/StackMapWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/StackMapWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package com.sun.tools.javap;
 
+import java.lang.classfile.constantpool.NameAndTypeEntry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -98,8 +99,27 @@ public class StackMapWriter extends InstructionDetailWriter {
         if (m != null) {
             print("StackMap locals: ", m.locals(), true);
             print("StackMap stack: ", m.stack(), false);
+            if (!m.unsetFields().isEmpty()) {
+                printFields("StackMap unset fields: ", m.unsetFields());
+            }
         }
 
+    }
+
+    void printFields(String label, List<NameAndTypeEntry> entries) {
+        print(label);
+        boolean first = true;
+        for (var e : entries) {
+            if (!first) {
+                print(", ");
+            } else {
+                first = false;
+            }
+            print(e::name);
+            print(":");
+            print(e::type);
+        }
+        println();
     }
 
     void print(String label, List<StackMapFrameInfo.VerificationTypeInfo> entries,

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFields.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFields.java
@@ -42,7 +42,8 @@ public class StrictFields {
             c = Class.forName("PostInitStrict");
             throw new Error("VerifyError was not thrown as expected!");
         } catch (VerifyError ve) {
-            if (!ve.getMessage().startsWith("Illegal use of putfield on a strict field")) {
+            // Once strict non-final is possible, expect "Illegal use of putfield on a strict field"
+            if (!ve.getMessage().startsWith("All strict final fields must be initialized before super()")) {
                 throw new Error("Wrong VerifyError thrown", ve);
             } else {
                 System.out.println("Expected VerifyError was thrown");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @compile --add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED -XDgenerateAssertUnsetFieldsFrame StrictFinalInstanceFieldsTest.java
+ * @run main/othervm -Xlog:verification StrictFinalInstanceFieldsTest
+ */
+
+import jdk.internal.vm.annotation.Strict;
+
+public class StrictFinalInstanceFieldsTest {
+    public static void main(String[] args) {
+        // Base case
+        Child c = new Child();
+        System.out.println(c);
+
+        // Field not initialized before super call
+        try {
+            BadChild0 bc0 = new BadChild0();
+            System.out.println(bc0);
+            throw new RuntimeException("Should fail verification");
+        } catch (java.lang.VerifyError e) {
+            if (!e.getMessage().contains("All strict final fields must be initialized before super()")) {
+                throw new RuntimeException("wrong exception: " + e.getMessage());
+            }
+            e.printStackTrace();
+        }
+
+        // Field not initialized before super call
+        try {
+            BadChild1 bc1 = new BadChild1();
+            System.out.println(bc1);
+            throw new RuntimeException("Should fail verification");
+        } catch (java.lang.VerifyError e) {
+            if (!e.getMessage().contains("All strict final fields must be initialized before super()")) {
+                throw new RuntimeException("wrong exception: " + e.getMessage());
+            }
+            e.printStackTrace();
+        }
+
+        // Test constructor with control flow. Should pass
+        Child1 c1 = new Child1(true, false);
+        System.out.println(c1);
+
+        // Test constructor with control flow and nested constructor calls. Should pass
+        Child1 c1_2 = new Child1();
+        System.out.println(c1_2);
+
+        // Test assignment in conditional. Should pass
+        Child2 c2 = new Child2();
+        System.out.println(c2);
+
+        // Test constructor with control flow in switch case. Should pass
+        Child3 c3 = new Child3(2);
+        System.out.println(c3);
+
+        System.out.println("Passed");
+    }
+}
+
+class Parent {
+    int z;
+
+    Parent() {
+        z = 0;
+    }
+
+    int get_z() { return z; }
+
+    @Override
+    public String toString() {
+        return "z: " + get_z();
+    }
+}
+
+class Child extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    Child() {
+        x = y = 1;
+        super();
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}
+
+class BadChild0 extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    // Should fail with "All strict final fields must be initialized before super()"
+    BadChild0() {
+        x = 1;
+        super();
+        y = 1;
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}
+
+class BadChild1 extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    // Should fail with "All strict final fields must be initialized before super()"
+    BadChild1() {
+        y = 1;
+        super();
+        x = 1;
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}
+
+class Child1 extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    Child1(boolean a, boolean b) {
+        if (a) {
+            x = 1;
+            if (b) {
+                y = 1;
+            } else {
+                y = 2;
+            }
+        } else {
+            x = y = 3;
+        }
+        super();
+    }
+
+    Child1() {
+        this(true, true);
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}
+
+class Child2 extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    Child2() {
+        if ((x=1) == 1) {
+            y = 1;
+        } else {
+            y = 2;
+        }
+        super();
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}
+
+class Child3 extends Parent {
+
+    @Strict
+    final int x;
+    @Strict
+    final int y;
+
+    Child3(int n) {
+        switch(n) {
+            case 0:
+                x = y = 0;
+                break;
+            case 1:
+                x = y = 1;
+                break;
+            case 2:
+                x = y = 2;
+                break;
+            default:
+                x = y = 100;
+                break;
+        }
+        super();
+    }
+
+    int get_x() { return x; }
+    int get_y() { return y; }
+
+    @Override
+    public String toString() {
+        return "x: " + get_x() + "\n" + "y: " + get_y() + "\n" + super.toString();
+    }
+}

--- a/test/langtools/tools/javap/stackmap/StackmapTest.java
+++ b/test/langtools/tools/javap/stackmap/StackmapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,10 +66,10 @@ public class StackmapTest {
         "}\n";
 
     private static final String goldenOut =
-        "        frame_type = 255 /* full_frame */\n" +
-        "        frame_type = 255 /* full_frame */\n" +
+        "        frame_type = 255 /* full_entry */\n" +
+        "        frame_type = 255 /* full_entry */\n" +
         "        frame_type = 73 /* same_locals_1_stack_item */\n" +
-        "        frame_type = 255 /* full_frame */\n" +
+        "        frame_type = 255 /* full_entry */\n" +
         "          offset_delta = 19\n" +
         "          offset_delta = 0\n" +
         "          offset_delta = 2\n" +


### PR DESCRIPTION
This patch implements the spec changes needed to realize the ACC_STRICT flag. See the JBS issue for more details. 

The patch is divided across 3 major commits:
1. VM changes for asserting that strict fields are initialized before the super constructor is called
2. Javac changes for generating the stack map table entries
3. Test

Verified with tier 1-3 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343846](https://bugs.openjdk.org/browse/JDK-8343846): [lworld] implement spec changes to stack map tables (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - no project role)


### Contributors
 * Vicente Romero `<vromero@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1373/head:pull/1373` \
`$ git checkout pull/1373`

Update a local copy of the PR: \
`$ git checkout pull/1373` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1373`

View PR using the GUI difftool: \
`$ git pr show -t 1373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1373.diff">https://git.openjdk.org/valhalla/pull/1373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1373#issuecomment-2675573635)
</details>
