### PR TITLE
8350641: [lworld] NULL rather than nullptr still in Valhalla project repo

### DIFF
--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -216,7 +216,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), NULL_WORD);
 
   if (state == atos && InlineTypeReturnedAsFields) {
-    __ store_inline_type_fields_to_buf(NULL);
+    __ store_inline_type_fields_to_buf(nullptr);
   }
 
   __ restore_bcp();

--- a/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
+++ b/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
@@ -59,7 +59,7 @@ int SharedRuntime::java_return_convention(const BasicType *sig_bt,
 
 BufferedInlineTypeBlob* SharedRuntime::generate_buffered_inline_type_adapter(const InlineKlass* vk) {
   Unimplemented();
-  return NULL;
+  return nullptr;
 }
 
 AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm,
@@ -74,7 +74,7 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler* masm
                                                             AdapterBlob*& new_adapter,
                                                             bool allocate_code_blob) {
   if (allocate_code_blob) {
-    new_adapter = AdapterBlob::create(masm->code(), 0, 0, NULL);
+    new_adapter = AdapterBlob::create(masm->code(), 0, 0, nullptr);
   }
   return AdapterHandlerLibrary::new_entry(
     fingerprint,

--- a/src/hotspot/share/runtime/signature.hpp
+++ b/src/hotspot/share/runtime/signature.hpp
@@ -583,7 +583,7 @@ class SigEntry {
   Symbol* _symbol;    // Symbol for printing
 
   SigEntry()
-    : _bt(T_ILLEGAL), _offset(-1), _sort_offset(-1), _symbol(NULL) {}
+    : _bt(T_ILLEGAL), _offset(-1), _sort_offset(-1), _symbol(nullptr) {}
 
   SigEntry(BasicType bt, int offset = -1, float sort_offset = -1, Symbol* symbol = nullptr)
     : _bt(bt), _offset(offset), _sort_offset(sort_offset), _symbol(symbol) {}

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -155,7 +155,7 @@ TEST_VM(markWord, prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 
   assert_copy_set_hash(mark);
   assert_type(mark);
@@ -177,7 +177,7 @@ TEST_VM(markWord, inline_type_prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 
   markWord larval = mark.enter_larval_state();
   EXPECT_TRUE(larval.is_larval_state());
@@ -188,7 +188,7 @@ TEST_VM(markWord, inline_type_prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 }
 
 #if _LP64
@@ -209,7 +209,7 @@ TEST_VM(markWord, null_free_flat_array_prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 
   assert_copy_set_hash(mark);
   assert_flat_array_type(mark);
@@ -226,7 +226,7 @@ TEST_VM(markWord, nullable_flat_array_prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 
   assert_copy_set_hash(mark);
   assert_flat_array_type(mark);
@@ -249,7 +249,7 @@ TEST_VM(markWord, null_free_array_prototype) {
 
   EXPECT_TRUE(mark.has_no_hash());
   EXPECT_FALSE(mark.is_marked());
-  EXPECT_TRUE(mark.decode_pointer() == NULL);
+  EXPECT_TRUE(mark.decode_pointer() == nullptr);
 
   assert_copy_set_hash(mark);
   assert_null_free_array_type(mark);

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/libFieldAccessModify.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/FieldAccessModify/libFieldAccessModify.cpp
@@ -283,7 +283,7 @@ Java_FieldAccessModify_initWatchers(JNIEnv *env, jclass thisClass, jclass cls, j
     jvmtiError err;
 
     if (jvmti == nullptr) {
-        reportError("jvmti is NULL", 0);
+        reportError("jvmti is nullptr", 0);
         return JNI_FALSE;
     }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage/libValueGetObjectMonitorUsage.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectMonitorUsage/libValueGetObjectMonitorUsage.cpp
@@ -62,7 +62,7 @@ Java_ValueGetObjectMonitorUsage_nTestGetObjectMonitorUsage(JNIEnv *jni, jclass t
   check_jvmti_error(jvmti->GetObjectMonitorUsage(obj, &info), "GetObjectMonitorUsage");
 
   if (info.owner != nullptr) {
-    LOG("ERROR: owner is not NULL\n");
+    LOG("ERROR: owner is not nullptr\n");
     result = false;
   }
   if (info.entry_count != 0) {

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetSetLocal/libValueGetSetLocal.cpp
@@ -57,7 +57,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 static void log_value(JNIEnv *jni, jobject value) {
   jclass cls = jni->GetObjectClass(value);
   if (cls == nullptr) {
-    LOG("ERROR: value class is NULL\n");
+    LOG("ERROR: value class is nullptr\n");
     return;
   }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007/objmonusage007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage007/objmonusage007.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-static jvmtiEnv *jvmti = NULL;
+static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
 static jint result = PASSED;
 static jboolean printdump = JNI_FALSE;
@@ -53,12 +53,12 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if (options != NULL && strcmp(options, "printdump") == 0) {
+    if (options != nullptr && strcmp(options, "printdump") == 0) {
         printdump = JNI_TRUE;
     }
 
     res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
-    if (res != JNI_OK || jvmti == NULL) {
+    if (res != JNI_OK || jvmti == nullptr) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
     }
@@ -117,7 +117,7 @@ Java_nsk_jvmti_GetObjectMonitorUsage_objmonusage007_check(JNIEnv *env,
     }
 
     if (printdump == JNI_TRUE) {
-        if (inf.owner == NULL) {
+        if (inf.owner == nullptr) {
             printf(">>>     owner: none (0x0)\n");
         } else {
             jvmti->GetThreadInfo(inf.owner, &tinf);


### PR DESCRIPTION
Removed remaining "NULL"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350641](https://bugs.openjdk.org/browse/JDK-8350641): [lworld] NULL rather than nullptr still in Valhalla project repo (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1377/head:pull/1377` \
`$ git checkout pull/1377`

Update a local copy of the PR: \
`$ git checkout pull/1377` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1377`

View PR using the GUI difftool: \
`$ git pr show -t 1377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1377.diff">https://git.openjdk.org/valhalla/pull/1377.diff</a>

</details>
