### PR TITLE
8350630: [lworld] ObjBufferAllocator::initialize fails with assert(has_klass_gap()) failed: precondition

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -390,7 +390,7 @@ oop ObjAllocator::initialize(HeapWord* mem) const {
 }
 
 oop ObjBufferAllocator::initialize(HeapWord* mem) const {
-  oopDesc::set_klass_gap(mem, 0);
+  mem_clear(mem);
   return finish(mem);
 }
 


### PR DESCRIPTION
Small fix to adjust Valhalla memory allocator to new code from mainline.
More details in the CR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350630](https://bugs.openjdk.org/browse/JDK-8350630): [lworld] ObjBufferAllocator::initialize fails with assert(has_klass_gap()) failed: precondition (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1379/head:pull/1379` \
`$ git checkout pull/1379`

Update a local copy of the PR: \
`$ git checkout pull/1379` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1379`

View PR using the GUI difftool: \
`$ git pr show -t 1379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1379.diff">https://git.openjdk.org/valhalla/pull/1379.diff</a>

</details>
