### PR TITLE
8350763: [lworld] InlineKlass::flat_array_klass hits assert(has_non_atomic_layout()) failed: Must be

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -435,7 +435,7 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedArray(JNIEnv *env, jclass elmClass, jint 
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not implicitly constructible");
   }
   oop array = nullptr;
-  if (vk->flat_array()) {
+  if (vk->flat_array() && vk->has_non_atomic_layout()) {
     array = oopFactory::new_flatArray(vk, len, LayoutKind::NON_ATOMIC_FLAT, CHECK_NULL);
   } else {
     array = oopFactory::new_null_free_objArray(vk, len, CHECK_NULL);
@@ -453,10 +453,10 @@ JVM_ENTRY(jarray, JVM_NewNullRestrictedAtomicArray(JNIEnv *env, jclass elmClass,
     THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(), "Element class is not implicitly constructible");
   }
   oop array = nullptr;
-  if (UseArrayFlattening && vk->has_atomic_layout()) {
-    array = oopFactory::new_flatArray(vk, len, LayoutKind::ATOMIC_FLAT, CHECK_NULL);
-  } else if (UseArrayFlattening && vk->is_naturally_atomic()) {
+  if (UseArrayFlattening && vk->is_naturally_atomic() && vk->has_non_atomic_layout()) {
     array = oopFactory::new_flatArray(vk, len, LayoutKind::NON_ATOMIC_FLAT, CHECK_NULL);
+  } else if (UseArrayFlattening && vk->has_atomic_layout()) {
+    array = oopFactory::new_flatArray(vk, len, LayoutKind::ATOMIC_FLAT, CHECK_NULL);
   } else {
     array = oopFactory::new_null_free_objArray(vk, len, CHECK_NULL);
   }


### PR DESCRIPTION
Check layout availability before creating a flat array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350763](https://bugs.openjdk.org/browse/JDK-8350763): [lworld] InlineKlass::flat_array_klass hits assert(has_non_atomic_layout()) failed: Must be (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1380/head:pull/1380` \
`$ git checkout pull/1380`

Update a local copy of the PR: \
`$ git checkout pull/1380` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1380`

View PR using the GUI difftool: \
`$ git pr show -t 1380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1380.diff">https://git.openjdk.org/valhalla/pull/1380.diff</a>

</details>
