### PR TITLE
[lworld] ValueGetObjectHashCodeTest needs -XX:+UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/GetObjectHashCode/ValueGetObjectHashCodeTest.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @run main/othervm/native -agentlib:ValueGetObjectHashCodeTest
- *                          -XX:+PrintInlineLayout
+ *                          -XX:+UnlockDiagnosticVMOptions -XX:+PrintInlineLayout
  *                          ValueGetObjectHashCodeTest
  */
 


### PR DESCRIPTION
Test added with [JDK-8348743](https://bugs.openjdk.org/browse/JDK-8348743) (paging @alexmenkov) fails with release builds because:

```
Error: VM option 'PrintInlineLayout' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.
Error: The unlock option must precede 'PrintInlineLayout'.
Improperly specified VM option 'PrintInlineLayout'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1381/head:pull/1381` \
`$ git checkout pull/1381`

Update a local copy of the PR: \
`$ git checkout pull/1381` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1381`

View PR using the GUI difftool: \
`$ git pr show -t 1381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1381.diff">https://git.openjdk.org/valhalla/pull/1381.diff</a>

</details>
