### PR TITLE
8348970: [lworld] Runtime: Update Valhalla with UseCompactObjectHeaders for oop->klass load/stores

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6948,14 +6948,20 @@ int MacroAssembler::store_inline_type_fields_to_buf(ciInlineKlass* vk, bool from
   if (UseTLAB) {
     // 2. Initialize buffered inline instance header
     Register buffer_obj = rax;
-    movptr(Address(buffer_obj, oopDesc::mark_offset_in_bytes()), (intptr_t)markWord::inline_type_prototype().value());
-    xorl(r13, r13);
-    store_klass_gap(buffer_obj, r13);
-    if (vk == nullptr) {
-      // store_klass corrupts rbx(klass), so save it in r13 for later use (interpreter case only).
-      mov(r13, rbx);
+    if (UseCompactObjectHeaders) {
+      Register mark_word = r13;
+      movptr(mark_word, Address(rbx, Klass::prototype_header_offset()));
+      movptr(Address(buffer_obj, oopDesc::mark_offset_in_bytes ()), mark_word);
+    } else {
+      movptr(Address(buffer_obj, oopDesc::mark_offset_in_bytes()), (intptr_t)markWord::inline_type_prototype().value());
+      xorl(r13, r13);
+      store_klass_gap(buffer_obj, r13);
+      if (vk == nullptr) {
+        // store_klass corrupts rbx(klass), so save it in r13 for later use (interpreter case only).
+        mov(r13, rbx);
+      }
+      store_klass(buffer_obj, rbx, rscratch1);
     }
-    store_klass(buffer_obj, rbx, rscratch1);
     // 3. Initialize its fields with an inline class specific handler
     if (vk != nullptr) {
       call(RuntimeAddress(vk->pack_handler())); // no need for call info as this will not safepoint.

--- a/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
@@ -67,7 +67,7 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
     oopDesc::release_set_mark(mem, _klass->prototype_header().set_marked());
   } else {
     if (EnableValhalla) {
-      arrayOopDesc::set_mark(mem, Klass::default_prototype_header(_klass).set_marked());
+      arrayOopDesc::set_mark(mem, _klass->prototype_header().set_marked());
     } else {
       arrayOopDesc::set_mark(mem, markWord::prototype().set_marked());
     }

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -94,8 +94,8 @@ Method* ArrayKlass::uncached_lookup_method(const Symbol* name,
   return super()->uncached_lookup_method(name, signature, OverpassLookupMode::skip, private_mode);
 }
 
-ArrayKlass::ArrayKlass(Symbol* name, KlassKind kind) :
-  Klass(kind),
+ArrayKlass::ArrayKlass(Symbol* name, KlassKind kind, markWord prototype_header) :
+Klass(kind, prototype_header),
   _dimension(1),
   _higher_dimension(nullptr),
   _lower_dimension(nullptr) {

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -53,7 +53,7 @@ class ArrayKlass: public Klass {
   // Constructors
   // The constructor with the Symbol argument does the real array
   // initialization, the other is a dummy
-  ArrayKlass(Symbol* name, KlassKind kind);
+  ArrayKlass(Symbol* name, KlassKind kind, markWord prototype_header = markWord::prototype());
   ArrayKlass();
 
   // Create array_name for element klass

--- a/src/hotspot/share/oops/flatArrayKlass.cpp
+++ b/src/hotspot/share/oops/flatArrayKlass.cpp
@@ -54,7 +54,7 @@
 
 // Allocation...
 
-FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk) : ArrayKlass(name, Kind) {
+FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk) : ArrayKlass(name, Kind, markWord::flat_array_prototype(lk)) {
   assert(element_klass->is_inline_klass(), "Expected Inline");
   assert(lk == NON_ATOMIC_FLAT || lk == ATOMIC_FLAT || lk == NULLABLE_ATOMIC_FLAT, "Must be a flat layout");
 
@@ -65,13 +65,6 @@ FlatArrayKlass::FlatArrayKlass(Klass* element_klass, Symbol* name, LayoutKind lk
   set_layout_helper(array_layout_helper(InlineKlass::cast(element_klass), lk));
   assert(is_array_klass(), "sanity");
   assert(is_flatArray_klass(), "sanity");
-
-#ifdef _LP64
-  set_prototype_header(markWord::flat_array_prototype(lk));
-#else
-  fatal("Not supported yet");
-  set_prototype_header(markWord::inline_type_prototype());
-#endif
 
 #ifdef ASSERT
   assert(layout_helper_is_array(layout_helper()), "Must be");

--- a/src/hotspot/share/oops/inlineKlass.cpp
+++ b/src/hotspot/share/oops/inlineKlass.cpp
@@ -52,8 +52,7 @@
 
   // Constructor
 InlineKlass::InlineKlass(const ClassFileParser& parser)
-    : InstanceKlass(parser, InlineKlass::Kind) {
-  set_prototype_header(markWord::inline_type_prototype());
+    : InstanceKlass(parser, InlineKlass::Kind, markWord::inline_type_prototype()) {
   assert(is_inline_klass(), "sanity");
   assert(prototype_header().is_inline_type(), "sanity");
 }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -69,6 +69,7 @@
 #include "oops/instanceOop.hpp"
 #include "oops/instanceStackChunkKlass.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/markWord.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/recordComponent.hpp"
@@ -586,8 +587,8 @@ InstanceKlass::InstanceKlass() {
   assert(CDSConfig::is_dumping_static_archive() || CDSConfig::is_using_archive(), "only for CDS");
 }
 
-InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassKind kind, ReferenceType reference_type) :
-  Klass(kind),
+InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassKind kind, markWord prototype_header, ReferenceType reference_type) :
+  Klass(kind, prototype_header),
   _nest_members(nullptr),
   _nest_host(nullptr),
   _permitted_subclasses(nullptr),

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -207,7 +207,7 @@ class InstanceKlass: public Klass {
   static const KlassKind Kind = InstanceKlassKind;
 
  protected:
-  InstanceKlass(const ClassFileParser& parser, KlassKind kind = Kind, ReferenceType reference_type = REF_NONE);
+  InstanceKlass(const ClassFileParser& parser, KlassKind kind = Kind, markWord prototype = markWord::prototype(), ReferenceType reference_type = REF_NONE);
 
   void* operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, bool use_class_space, TRAPS) throw();
 

--- a/src/hotspot/share/oops/instanceRefKlass.cpp
+++ b/src/hotspot/share/oops/instanceRefKlass.cpp
@@ -62,7 +62,7 @@ static ReferenceType determine_reference_type(const ClassFileParser& parser) {
 }
 
 InstanceRefKlass::InstanceRefKlass(const ClassFileParser& parser)
-  : InstanceKlass(parser, Kind, determine_reference_type(parser)) {}
+  : InstanceKlass(parser, Kind, markWord::prototype(), determine_reference_type(parser)) {}
 
 void InstanceRefKlass::update_nonstatic_oop_maps(Klass* k) {
   // Clear the nonstatic oop-map entries corresponding to referent

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -207,7 +207,7 @@ public:
 
 protected:
 
-  Klass(KlassKind kind);
+  Klass(KlassKind kind, markWord prototype_header = markWord::prototype());
   Klass();
 
  public:
@@ -745,6 +745,7 @@ public:
   bool is_cloneable() const;
   void set_is_cloneable();
 
+  static inline markWord make_prototype_header(const Klass* kls, markWord prototype = markWord::prototype());
   inline markWord prototype_header() const;
   inline void set_prototype_header(markWord header);
   static ByteSize prototype_header_offset() { return in_ByteSize(offset_of(Klass, _prototype_header)); }

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -62,7 +62,7 @@ inline bool Klass::is_loader_alive() const {
 inline markWord Klass::make_prototype_header(const Klass* kls, markWord prototype) {
   if (UseCompactObjectHeaders) {
     // With compact object headers, the narrow Klass ID is part of the mark word.
-    // We therfore seed the mark word with the narrow Klass ID.
+    // We therefore seed the mark word with the narrow Klass ID.
     // Note that only those Klass that can be instantiated have a narrow Klass ID.
     // For those who don't, we leave the klass bits empty and assert if someone
     // tries to use those.

--- a/src/hotspot/share/oops/objArrayKlass.cpp
+++ b/src/hotspot/share/oops/objArrayKlass.cpp
@@ -37,6 +37,7 @@
 #include "oops/arrayKlass.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/markWord.hpp"
 #include "oops/objArrayKlass.inline.hpp"
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oop.inline.hpp"
@@ -109,7 +110,8 @@ ObjArrayKlass* ObjArrayKlass::allocate_objArray_klass(ClassLoaderData* loader_da
   return oak;
 }
 
-ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name, bool null_free) : ArrayKlass(name, Kind) {
+ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name, bool null_free) :
+ArrayKlass(name, Kind, null_free ? markWord::null_free_array_prototype() : markWord::prototype()) {
   set_dimension(n);
   set_element_klass(element_klass);
 
@@ -134,10 +136,7 @@ ObjArrayKlass::ObjArrayKlass(int n, Klass* element_klass, Symbol* name, bool nul
     assert(n == 1, "Bytecode does not support null-free multi-dim");
     lh = layout_helper_set_null_free(lh);
 #ifdef _LP64
-    set_prototype_header(markWord::null_free_array_prototype());
     assert(prototype_header().is_null_free_array(), "sanity");
-#else
-    set_prototype_header(markWord::inline_type_prototype());
 #endif
   }
   set_layout_helper(lh);


### PR DESCRIPTION
Added prototype header to Klass constructor for the various Valhalla layouts

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8348970](https://bugs.openjdk.org/browse/JDK-8348970): [lworld] Runtime: Update Valhalla with UseCompactObjectHeaders for oop-&gt;klass load/stores (**Sub-task** - P4)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - Committer) ⚠️ Review applies to [99cb2603](https://git.openjdk.org/valhalla/pull/1382/files/99cb26038b7a14d68f5014655a36464bfa8d50ad)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1382/head:pull/1382` \
`$ git checkout pull/1382`

Update a local copy of the PR: \
`$ git checkout pull/1382` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1382`

View PR using the GUI difftool: \
`$ git pr show -t 1382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1382.diff">https://git.openjdk.org/valhalla/pull/1382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1382#issuecomment-2687755535)
</details>
