### PR TITLE
8350961: [lworld] Some VarHandles tests fail when field flattening is not applied

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandle.java.template
@@ -108,6 +108,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -116,6 +121,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Volatile(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -124,6 +134,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Opaque(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -132,6 +147,11 @@ final class VarHandle$Type$s {
             FieldInstanceReadOnly handle = (FieldInstanceReadOnly)ob;
             $type$ value = UNSAFE.get$Type$Acquire(Objects.requireNonNull(handle.receiverType.cast(holder)),
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -474,6 +494,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -482,6 +507,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Volatile(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -490,6 +520,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Opaque(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 
@@ -498,6 +533,11 @@ final class VarHandle$Type$s {
             FieldStaticReadOnly handle = (FieldStaticReadOnly) ob.target();
             $type$ value = UNSAFE.get$Type$Acquire(handle.base,
                                  handle.fieldOffset{#if[FlatValue]?, handle.layout, handle.fieldType});
+#if[Reference]
+            if (value == null && handle.checkedFieldType instanceof NullRestrictedCheckedType) {
+                return ValueClass.zeroInstance(handle.fieldType);
+            }
+#end[Reference]
             return value;
         }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -827,5 +827,4 @@ java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
-valhalla/valuetypes/NullRestrictedTest.java 8350961 generic-all
 


### PR DESCRIPTION
#1340 removed null masking for references incorrectly before strict field checks are in place. As a result, we have to mask nulls to default values before the default value concept is gone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350961](https://bugs.openjdk.org/browse/JDK-8350961): [lworld] Some VarHandles tests fail when field flattening is not applied (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1385/head:pull/1385` \
`$ git checkout pull/1385`

Update a local copy of the PR: \
`$ git checkout pull/1385` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1385`

View PR using the GUI difftool: \
`$ git pr show -t 1385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1385.diff">https://git.openjdk.org/valhalla/pull/1385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1385#issuecomment-2691131306)
</details>
