### PR TITLE
8350872: [lworld] Field is flattened although -XX:-UseFieldFlattening is set

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -40,6 +40,10 @@
 static LayoutKind field_layout_selection(FieldInfo field_info, Array<InlineLayoutInfo>* inline_layout_info_array,
                                          bool use_atomic_flat) {
 
+  if (!UseFieldFlattening) {
+    return LayoutKind::REFERENCE;
+  }
+
   if (field_info.field_flags().is_injected()) {
     // don't flatten injected fields
     return LayoutKind::REFERENCE;
@@ -1112,7 +1116,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
     // Next step is to compute the characteristics for a layout enabling atomic updates
     if (UseAtomicValueFlattening) {
       int atomic_size = _payload_size_in_bytes == 0 ? 0 : round_up_power_of_2(_payload_size_in_bytes);
-      if (atomic_size <= (int)MAX_ATOMIC_OP_SIZE && UseFieldFlattening) {
+      if (atomic_size <= (int)MAX_ATOMIC_OP_SIZE) {
         _atomic_layout_size_in_bytes = atomic_size;
       }
     }
@@ -1153,7 +1157,7 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
       // Now that the null marker is there, the size of the nullable layout must computed (remember, must be atomic too)
       int new_raw_size = _layout->last_block()->offset() - _layout->first_field_block()->offset();
       int nullable_size = round_up_power_of_2(new_raw_size);
-      if (nullable_size <= (int)MAX_ATOMIC_OP_SIZE && UseFieldFlattening) {
+      if (nullable_size <= (int)MAX_ATOMIC_OP_SIZE) {
         _nullable_layout_size_in_bytes = nullable_size;
         _null_marker_offset = null_marker_offset;
       } else {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -827,3 +827,5 @@ java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 # valhalla
 jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java 8328777 generic-all
+valhalla/valuetypes/NullRestrictedTest.java 8350961 generic-all
+


### PR DESCRIPTION
Fix behavior of -UseFieldFlattening.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8350872](https://bugs.openjdk.org/browse/JDK-8350872): [lworld] Field is flattened although -XX:-UseFieldFlattening is set (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1386/head:pull/1386` \
`$ git checkout pull/1386`

Update a local copy of the PR: \
`$ git checkout pull/1386` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1386`

View PR using the GUI difftool: \
`$ git pr show -t 1386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1386.diff">https://git.openjdk.org/valhalla/pull/1386.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/valhalla/pull/1386#issuecomment-2691148276)
</details>
