### PR TITLE
8351006: [lworld] Refactor LoadNode::Identity of an InlineType into can_see_stored_value

### DIFF
--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -517,6 +517,7 @@ class LoadNNode : public LoadNode {
 public:
   LoadNNode(Node *c, Node *mem, Node *adr, const TypePtr *at, const Type* t, MemOrd mo, ControlDependency control_dependency = DependsOnlyOnTest)
     : LoadNode(c, mem, adr, at, t, mo, control_dependency) {}
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return Op_RegN; }
   virtual int store_Opcode() const { return Op_StoreN; }


### PR DESCRIPTION
Hi,

This patch moves the logic of `LoadNode::Identity` that tries to look through an `InlineTypeNode` to `can_see_stored_value`. This also fixes 2 issues:

- `Identity` should not return a new node
- `LoadUS` from a `short` is not a mismatched access and hence can return a wrong value

Please take a look and leave your reviews, thanks a lot.