### PR TITLE
8351217: [lworld] instance field initializers should be executed immediately upon entry to a non-this-calling constructor

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -559,7 +559,8 @@ public class Gen extends JCTree.Visitor {
             // Find the super() invocation and append the given initializer code.
             if (md.sym.owner.isValueClass() || md.sym.owner.hasStrict()) {
                 rewriteInitializersIfNeeded(md, initCode);
-                TreeInfo.mapSuperCalls(md.body, supercall -> make.Block(0, initCode.append(supercall).appendList(initBlocks)));
+                md.body.stats = initCode.appendList(md.body.stats);
+                TreeInfo.mapSuperCalls(md.body, supercall -> make.Block(0, initBlocks.prepend(supercall)));
             } else {
                 TreeInfo.mapSuperCalls(md.body, supercall -> make.Block(0, initCode.prepend(supercall)));
             }

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -54,6 +54,8 @@ import com.sun.tools.classfile.ConstantPool;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_Class_info;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_Fieldref_info;
 import com.sun.tools.classfile.ConstantPool.CONSTANT_Methodref_info;
+import com.sun.tools.classfile.ConstantPool.CONSTANT_NameAndType_info;
+import com.sun.tools.classfile.ConstantPool.CPRefInfo;
 import com.sun.tools.classfile.Field;
 import com.sun.tools.classfile.Instruction;
 import com.sun.tools.classfile.Method;
@@ -1117,6 +1119,35 @@ class ValueObjectCompilationTests extends CompilationTestCase {
             );
         } finally {
             setCompileOptions(previousOptions);
+        }
+
+        source =
+            """
+            value class V {
+                int i = 1;
+                int y;
+                V() {
+                    y = 2;
+                }
+            }
+            """;
+        dir = assertOK(true, source);
+        File fileEntry = dir.listFiles()[0];
+        ClassFile classFile = ClassFile.read(fileEntry);
+        expectedCodeSequence = "putfield i,putfield y,";
+        for (Method method : classFile.methods) {
+            if (method.getName(classFile.constant_pool).equals("<init>")) {
+                Code_attribute code = (Code_attribute)method.attributes.get("Code");
+                String foundCodeSequence = "";
+                for (Instruction inst: code.getInstructions()) {
+                    if (inst.getMnemonic().equals("putfield")) {
+                        CPRefInfo refInfo = (CPRefInfo)classFile.constant_pool.get(inst.getShort(1));
+                        CONSTANT_NameAndType_info nameAndType = refInfo.getNameAndTypeInfo();
+                        foundCodeSequence += inst.getMnemonic() + " " + nameAndType.getName() + ",";
+                    }
+                }
+                Assert.check(foundCodeSequence.equals(expectedCodeSequence), foundCodeSequence);
+            }
         }
     }
 


### PR DESCRIPTION
this PR is fixing a bug in javac. For code like:
```
value class V {
    int i = 1;
    int y;

    V() {
        y = 2;
    }
}
```
javac is generating the constructor as:
```
V() {
    y = 2;
    i = 1;
    super();
}
```
it should be:
```
V() {
    i = 1;
    y = 2;
    super();
}
```