### PR TITLE
8351483:  [lworld] Field offset verification fails

### DIFF
--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -1106,7 +1106,9 @@ void FieldLayoutBuilder::compute_inline_class_layout() {
   // From this, additional layouts will be computed: atomic and nullable layouts
   // Once those additional layouts are computed, the raw layout might need some adjustments
 
-  if (!_is_abstract_value) { // Flat layouts are only for concrete value classes
+  bool vm_uses_flattening = UseFieldFlattening || UseArrayFlattening;
+
+  if (!_is_abstract_value && vm_uses_flattening) { // Flat layouts are only for concrete value classes
     // Validation of the non atomic layout
     if (UseNonAtomicValueFlattening && !AlwaysAtomicAccesses && (!_must_be_atomic || _is_naturally_atomic)) {
       _non_atomic_layout_size_in_bytes = _payload_size_in_bytes;

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -5530,7 +5530,7 @@ void JavaClasses::check_offsets() {
 
   CHECK_OFFSET("java/lang/Boolean",   java_lang_boxing_object, value, "Z");
   CHECK_OFFSET("java/lang/Character", java_lang_boxing_object, value, "C");
-  if (Arguments::enable_preview() && UseNullableValueFlattening && UseFieldFlattening) {
+  if (Arguments::enable_preview() && UseNullableValueFlattening && (UseFieldFlattening || UseArrayFlattening)) {
     CHECK_LONG_OFFSET("java/lang/Float",     java_lang_boxing_object, value, "F");
   } else {
     CHECK_OFFSET("java/lang/Float",     java_lang_boxing_object, value, "F");
@@ -5538,7 +5538,7 @@ void JavaClasses::check_offsets() {
   CHECK_LONG_OFFSET("java/lang/Double", java_lang_boxing_object, value, "D");
   CHECK_OFFSET("java/lang/Byte",      java_lang_boxing_object, value, "B");
   CHECK_OFFSET("java/lang/Short",     java_lang_boxing_object, value, "S");
-  if (Arguments::enable_preview() && UseNullableValueFlattening && UseFieldFlattening) {
+  if (Arguments::enable_preview() && UseNullableValueFlattening && (UseFieldFlattening || UseArrayFlattening)) {
     CHECK_LONG_OFFSET("java/lang/Integer",   java_lang_boxing_object, value, "I");
   } else {
     CHECK_OFFSET("java/lang/Integer",   java_lang_boxing_object, value, "I");

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WrappersOffsetTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/WrappersOffsetTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:-UseFieldFlattening -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:-UseFieldFlattening -XX:-UseArrayFlattening -XX:+UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:-UseFieldFlattening -XX:+UseArrayFlattening -XX:-UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:+UseFieldFlattening -XX:-UseArrayFlattening -XX:-UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:+UseFieldFlattening -XX:-UseArrayFlattening -XX:+UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:-UseFieldFlattening -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening WrappersOffsetTest
+ */
+
+ /*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:+UseFieldFlattening -XX:+UseArrayFlattening -XX:-UseNullableValueFlattening WrappersOffsetTest
+ */
+
+/*
+ * @test
+ * @summary Test verification of wrappers classes' field offset with various layout
+ * @enablePreview
+ * @run main/othervm -XX:+UseFieldFlattening -XX:+UseArrayFlattening -XX:+UseNullableValueFlattening WrappersOffsetTest
+ */
+
+public class WrappersOffsetTest {
+    public static void main(String[] args) {
+        // The test just ensures that wrappers classes are loaded
+        // The verification code is inside the JVM (javaClasses.cpp)
+        // and is executed in VM debug builds
+        Boolean z = Boolean.valueOf(true);
+        Byte b = Byte.valueOf((byte)1);
+        Character c = Character.valueOf('c');
+        Short s = Short.valueOf((short)2);
+        Integer i = Integer.valueOf(3);
+        Float f = Float.valueOf(0.4f);
+        Long l = Long.valueOf(5L);
+        Double d = Double.valueOf(0.6);
+    }
+}


### PR DESCRIPTION
Fixing generation of flat layouts, to generate them only if some flattening is enabled.
Fixing the wrapper classes offsets verification code.
