### PR TITLE
8351951: [lworld] javac should issue an error if a strict instance field has not been initialized before the super invocation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -328,7 +328,7 @@ public class Attr extends JCTree.Visitor {
         }
 
         if (!env.info.ctorPrologue &&
-                v.owner.isValueClass() &&
+                v.isStrict() &&
                 v.owner.kind == TYP &&
                 v.owner == env.enclClass.sym &&
                 (v.flags() & STATIC) == 0 &&

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2215,12 +2215,13 @@ public class Flow {
             return
                 sym.pos >= startPos &&
                 ((sym.owner.kind == MTH || sym.owner.kind == VAR ||
-                isFinalUninitializedField(sym)));
+                isFinalOrStrictUninitializedField(sym)));
         }
 
-        boolean isFinalUninitializedField(VarSymbol sym) {
+        boolean isFinalOrStrictUninitializedField(VarSymbol sym) {
             return sym.owner.kind == TYP &&
-                   ((sym.flags() & (FINAL | HASINIT | PARAMETER)) == FINAL &&
+                   (((sym.flags() & (FINAL | HASINIT | PARAMETER)) == FINAL ||
+                     (sym.flags() & (STRICT | HASINIT | PARAMETER)) == STRICT) &&
                    classDef.sym.isEnclosedBy((ClassSymbol)sym.owner));
         }
 
@@ -3101,7 +3102,7 @@ public class Flow {
                 else if (name == names._this) {
                     for (int address = firstadr; address < nextadr; address++) {
                         VarSymbol sym = vardecls[address].sym;
-                        if (isFinalUninitializedField(sym) && !sym.isStatic())
+                        if (isFinalOrStrictUninitializedField(sym) && !sym.isStatic())
                             letInit(tree.pos(), sym);
                     }
                 }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictFinalInstanceFieldsTest.java
@@ -37,6 +37,8 @@ public class StrictFinalInstanceFieldsTest {
         System.out.println(c);
 
         // Field not initialized before super call
+        /*
+        // javac is flagging the error at compile time
         try {
             BadChild0 bc0 = new BadChild0();
             System.out.println(bc0);
@@ -59,6 +61,7 @@ public class StrictFinalInstanceFieldsTest {
             }
             e.printStackTrace();
         }
+        */
 
         // Test constructor with control flow. Should pass
         Child1 c1 = new Child1(true, false);
@@ -126,8 +129,9 @@ class BadChild0 extends Parent {
     // Should fail with "All strict final fields must be initialized before super()"
     BadChild0() {
         x = 1;
-        super();
         y = 1;
+        super();
+        // was y = 1;
     }
 
     int get_x() { return x; }
@@ -149,8 +153,9 @@ class BadChild1 extends Parent {
     // Should fail with "All strict final fields must be initialized before super()"
     BadChild1() {
         y = 1;
-        super();
         x = 1;
+        super();
+        // was x = 1;
     }
 
     int get_x() { return x; }

--- a/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
+++ b/test/langtools/tools/javac/valhalla/value-objects/ValueObjectCompilationTests.java
@@ -759,7 +759,7 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                     """
                     import jdk.internal.vm.annotation.Strict;
                     class Test {
-                        @Strict int i;
+                        @Strict int i = 0;
                     }
                     """,
                     """
@@ -1092,6 +1092,26 @@ class ValueObjectCompilationTests extends CompilationTestCase {
                         @Strict
                         @NullRestricted
                         SValue val3 = new SValue();
+                    }
+                    """
+            );
+            assertFail("compiler.err.var.not.initialized.in.default.constructor",
+                    """
+                    import jdk.internal.vm.annotation.Strict;
+                    class Test {
+                        @Strict int i;
+                    }
+                    """
+            );
+            assertFail("compiler.err.cant.ref.after.ctor.called",
+                    """
+                    import jdk.internal.vm.annotation.Strict;
+                    class Test {
+                        @Strict int i;
+                        Test() {
+                            super();
+                            i = 0;
+                        }
                     }
                     """
             );


### PR DESCRIPTION
javac is not issuing an error if a strict instance field is not initialized before the super invocation, this PR is fixing this issue

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8351951](https://bugs.openjdk.org/browse/JDK-8351951): [lworld] javac should issue an error if a strict instance field has not been initialized before the super invocation (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/valhalla.git pull/1398/head:pull/1398` \
`$ git checkout pull/1398`

Update a local copy of the PR: \
`$ git checkout pull/1398` \
`$ git pull https://git.openjdk.org/valhalla.git pull/1398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1398`

View PR using the GUI difftool: \
`$ git pr show -t 1398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/valhalla/pull/1398.diff">https://git.openjdk.org/valhalla/pull/1398.diff</a>

</details>
