### PR TITLE
8351979: Improve verification error messages for strict fields

### DIFF
--- a/src/hotspot/share/classfile/stackMapFrame.hpp
+++ b/src/hotspot/share/classfile/stackMapFrame.hpp
@@ -214,6 +214,7 @@ class StackMapFrame : public ResourceObj {
     return compatible;
   }
 
+  void unsatisfied_strict_fields_error(InstanceKlass* ik, int bci);
   static void print_strict_fields(AssertUnsetFieldTable* table);
 
   // Set locals and stack types to bogus

--- a/src/hotspot/share/classfile/stackMapTable.cpp
+++ b/src/hotspot/share/classfile/stackMapTable.cpp
@@ -264,7 +264,7 @@ StackMapFrame* StackMapReader::next_helper(TRAPS) {
         StackMapFrame::print_strict_fields(_prev_frame->assert_unset_fields());
         _prev_frame->verifier()->verify_error(
             ErrorContext::bad_strict_fields(_prev_frame->offset(), _prev_frame),
-            "Strict fields not a subset of initial strict instance fields");
+            "Strict fields not a subset of initial strict instance fields: %s:%s", name->as_C_string(), sig->as_C_string());
       } else {
         new_fields->put(tmp, false);
       }

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -481,6 +481,9 @@ void ErrorContext::reason_details(outputStream* ss) const {
     case BAD_LOCAL_INDEX:
       ss->print("Local index %d is invalid", _type.index());
       break;
+    case BAD_STRICT_FIELDS:
+      ss->print("Invalid use of strict instance fields");
+      break;
     case LOCALS_SIZE_MISMATCH:
       ss->print("Current frame's local size doesn't match stackmap.");
       break;
@@ -2420,7 +2423,7 @@ void ClassVerifier::verify_field_instructions(RawBytecodeStream* bcs,
               log_info(verification)("Attempting to initialize field not found in initial strict instance fields: %s%s",
                                      fd.name()->as_C_string(), fd.signature()->as_C_string());
               verify_error(ErrorContext::bad_strict_fields(bci, current_frame),
-                           "Initializing unknown strict field");
+                           "Initializing unknown strict field: %s:%s", fd.name()->as_C_string(), fd.signature()->as_C_string());
             }
           }
         }
@@ -2717,7 +2720,7 @@ void ClassVerifier::verify_invoke_init(
       if (!current_frame->verify_unset_fields_satisfied()) {
         log_info(verification)("Strict instance fields not initialized");
         StackMapFrame::print_strict_fields(current_frame->assert_unset_fields());
-        verify_error(ErrorContext::bad_code(bci), "All strict final fields must be initialized before super()");
+        current_frame->unsatisfied_strict_fields_error(current_class(), bci);
       }
     }
 


### PR DESCRIPTION
This patch adds more detail to the verifier errors throws when there are problems with strict instance fields. The class name and one field name is now printed. Verified with tier 1-3 tests.