### PR TITLE
Adjustment and new API for VarHandles

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -105,8 +105,10 @@ public:
   f(UseFieldFlattening) \
   f(InlineTypePassFieldsAsArgs) \
   f(InlineTypeReturnedAsFields) \
+  f(UseNonAtomicValueFlattening) \
   f(UseAtomicValueFlattening) \
   f(UseNullableValueFlattening)
+
 
 class CDSMustMatchFlags {
 private:

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -49,6 +49,11 @@ static LayoutKind field_layout_selection(FieldInfo field_info, Array<InlineLayou
     return LayoutKind::REFERENCE;
   }
 
+  if (field_info.access_flags().is_volatile()) {
+    // volatile is used as a keyword to prevent flattening
+    return LayoutKind::REFERENCE;
+  }
+
   if (inline_layout_info_array == nullptr || inline_layout_info_array->adr_at(field_info.index())->klass() == nullptr) {
     // field's type is not a known value class, using a reference
     return LayoutKind::REFERENCE;
@@ -59,7 +64,7 @@ static LayoutKind field_layout_selection(FieldInfo field_info, Array<InlineLayou
 
   if (field_info.field_flags().is_null_free_inline_type()) {
     assert(vk->is_implicitly_constructible(), "null-free fields must be implicitly constructible");
-    if (vk->must_be_atomic() || field_info.access_flags().is_volatile() || AlwaysAtomicAccesses) {
+    if (vk->must_be_atomic() || AlwaysAtomicAccesses) {
       if (vk->is_naturally_atomic() && vk->has_non_atomic_layout()) return LayoutKind::NON_ATOMIC_FLAT;
       return (vk->has_atomic_layout() && use_atomic_flat) ? LayoutKind::ATOMIC_FLAT : LayoutKind::REFERENCE;
     } else {

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -1109,6 +1109,9 @@ JVM_IsFlatArray(JNIEnv *env, jobject obj);
 JNIEXPORT jboolean JNICALL
 JVM_IsNullRestrictedArray(JNIEnv *env, jobject obj);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsAtomicArray(JNIEnv *env, jobject obj);
+
 /* Generics reflection support.
  *
  * Returns information about the given class's EnclosingMethod

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -488,6 +488,23 @@ JVM_ENTRY(jboolean, JVM_IsNullRestrictedArray(JNIEnv *env, jobject obj))
   return oop->is_null_free_array();
 JVM_END
 
+JVM_ENTRY(jboolean, JVM_IsAtomicArray(JNIEnv *env, jobject obj))
+  // There are multiple cases where an array can/must support atomic access:
+  //   - the array is a reference array
+  //   - the array uses an atomic flat layout: NULLABLE_ATOMIC_FLAT or ATOMIC_FLAT
+  //   - the array is flat and its component type is naturally atomic
+  arrayOop oop = arrayOop(JNIHandles::resolve_non_null(obj));
+  if (oop->is_objArray()) return true;
+  if (oop->is_flatArray()) {
+    FlatArrayKlass* fak = FlatArrayKlass::cast(oop->klass());
+    if (fak->layout_kind() == LayoutKind::ATOMIC_FLAT || fak->layout_kind() == LayoutKind::NULLABLE_ATOMIC_FLAT) {
+      return true;
+    }
+    if (fak->element_klass()->is_naturally_atomic()) return true;
+  }
+  return false;
+JVM_END
+
 // java.lang.Runtime /////////////////////////////////////////////////////////////////////////
 
 extern volatile jint vm_created;

--- a/src/java.base/share/classes/jdk/internal/value/ValueClass.java
+++ b/src/java.base/share/classes/jdk/internal/value/ValueClass.java
@@ -133,4 +133,9 @@ public class ValueClass {
      * {@return true if the given array is a null-restricted array}
      */
     public static native boolean isNullRestrictedArray(Object array);
+
+    /**
+     * {@return true if the given array uses a layout designed for atomic accesses }
+     */
+    public static native boolean isAtomicArray(Object array);
 }

--- a/src/java.base/share/native/libjava/ValueClass.c
+++ b/src/java.base/share/native/libjava/ValueClass.c
@@ -63,3 +63,8 @@ Java_jdk_internal_value_ValueClass_isNullRestrictedArray(JNIEnv *env, jclass cls
     return JVM_IsNullRestrictedArray(env, obj);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_value_ValueClass_isAtomicArray(JNIEnv *env, jclass cls, jobject obj)
+{
+    return JVM_IsAtomicArray(env, obj);
+}

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayQueryTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/ArrayQueryTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test ValueClass APIs to get array properties
+ * @library /test/lib
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.vm.annotation
+ *          java.base/jdk.internal.value
+ * @enablePreview
+ * @run main/othervm -XX:+UseArrayFlattening -XX:+UseFieldFlattening
+ *           -XX:+UseNonAtomicValueFlattening -XX:+UseNullableValueFlattening -XX:+UseAtomicValueFlattening
+ *           ArrayQueryTest
+ */
+
+
+ import jdk.internal.value.ValueClass;
+ import jdk.internal.vm.annotation.ImplicitlyConstructible;
+ import jdk.internal.vm.annotation.LooselyConsistentValue;
+ import jdk.test.lib.Asserts;
+
+
+ public class ArrayQueryTest {
+
+    @ImplicitlyConstructible
+    static value class SmallValue {
+        short i = 0;
+        short j = 0;
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class WeakValue {
+        short i = 0;
+        short j = 0;
+    }
+
+    @ImplicitlyConstructible
+    static value class NaturallyAtomic {
+        int i = 0;
+    }
+
+    @ImplicitlyConstructible
+    @LooselyConsistentValue
+    static value class BigValue {
+        long l0 = 0L;
+        long l1 = 0L;
+        long l2 = 0L;
+    }
+
+    public static void main(String[] args) {
+        SmallValue[] array0 = new SmallValue[10];
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array0)));
+        Asserts.assertFalse(ValueClass.isFlatArray(array0));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array0));
+
+        Object[] array1 = ValueClass.newNullRestrictedAtomicArray(SmallValue.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array1)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array1));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array1));
+
+        Object[] array2 = ValueClass.newNullableAtomicArray(SmallValue.class, 10);
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array2)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array2));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array2));
+
+        Object[] array3 = ValueClass.newNullRestrictedArray(WeakValue.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array3)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array3));
+        Asserts.assertFalse(ValueClass.isAtomicArray(array3));
+
+        Object[] array4 = ValueClass.newNullRestrictedAtomicArray(WeakValue.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array4)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array4));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array4));
+
+        Object[] array5 = ValueClass.newNullRestrictedAtomicArray(NaturallyAtomic.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array5)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array5));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array5));
+
+        Object[] array6 = ValueClass.newNullRestrictedArray(BigValue.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array6)));
+        Asserts.assertTrue(ValueClass.isFlatArray(array6));
+        Asserts.assertFalse(ValueClass.isAtomicArray(array6));
+
+        Object[] array7 = ValueClass.newNullRestrictedAtomicArray(BigValue.class, 10);
+        Asserts.assertTrue(ValueClass.isNullRestrictedArray((array7)));
+        Asserts.assertFalse(ValueClass.isFlatArray(array7));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array7));
+
+        Object[] array8 = ValueClass.newNullableAtomicArray(BigValue.class, 10);
+        Asserts.assertFalse(ValueClass.isNullRestrictedArray((array8)));
+        Asserts.assertFalse(ValueClass.isFlatArray(array8));
+        Asserts.assertTrue(ValueClass.isAtomicArray(array8));
+    }
+
+ }

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/TestLayoutFlags.java
@@ -164,11 +164,8 @@ public class TestLayoutFlags {
     static public void check_1(FieldLayoutAnalyzer fla) {
         FieldLayoutAnalyzer.ClassLayout cl = fla.getClassLayoutFromName("TestLayoutFlags$Container1");
         FieldLayoutAnalyzer.FieldBlock f0 = cl.getFieldFromName("val0", false);
-        if (useAtomicFlat) {
-            Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.ATOMIC_FLAT, f0.layoutKind());
-        } else {
-            Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f0.layoutKind());
-        }
+        // volatile fields are never flattened
+        Asserts.assertEquals(FieldLayoutAnalyzer.LayoutKind.NON_FLAT, f0.layoutKind());
     }
 
     static class Container2 {


### PR DESCRIPTION
A few changes related to the work to fix the VarHandles code.
The keyword volatile is now a signal to prevent field flattening.
A new API in ValueClass allows Java code to query the atomicity characteristics of an array.
